### PR TITLE
rename actor modules to fil_actor...

### DIFF
--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fvm_actor_account"
+name = "fil_actor_account"
 description = "Builtin account actor for Filecoin"
 version = "1.0.0"
 license = "MIT OR Apache-2.0"

--- a/actors/account/tests/account_actor_test.rs
+++ b/actors/account/tests/account_actor_test.rs
@@ -3,7 +3,7 @@
 
 use actors_runtime::builtin::SYSTEM_ACTOR_ADDR;
 use actors_runtime::test_utils::*;
-use fvm_actor_account::{Actor as AccountActor, State};
+use fil_actor_account::{Actor as AccountActor, State};
 use fvm_shared::address::Address;
 use fvm_shared::encoding::RawBytes;
 use fvm_shared::error::ExitCode;

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fvm_actor_cron"
+name = "fil_actor_cron"
 description = "Builtin cron actor for Filecoin"
 version = "1.0.0"
 license = "MIT OR Apache-2.0"

--- a/actors/cron/tests/cron_actor_test.rs
+++ b/actors/cron/tests/cron_actor_test.rs
@@ -3,7 +3,7 @@
 
 use actors_runtime::test_utils::*;
 use actors_runtime::SYSTEM_ACTOR_ADDR;
-use fvm_actor_cron::{Actor as CronActor, ConstructorParams, Entry, State};
+use fil_actor_cron::{Actor as CronActor, ConstructorParams, Entry, State};
 use fvm_shared::address::Address;
 use fvm_shared::encoding::RawBytes;
 use fvm_shared::error::ExitCode;

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fvm_actor_init"
+name = "fil_actor_init"
 description = "Builtin init actor for Filecoin"
 version = "1.0.0"
 license = "MIT OR Apache-2.0"

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -6,7 +6,7 @@ use actors_runtime::{
     ActorError, Multimap, FIRST_NON_SINGLETON_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use cid::Cid;
-use fvm_actor_init::{
+use fil_actor_init::{
     Actor as InitActor, ConstructorParams, ExecParams, ExecReturn, Method, State,
 };
 use fvm_shared::address::Address;

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fvm_actor_market"
+name = "fil_actor_market"
 description = "Builtin market actor for Filecoin"
 version = "1.0.0"
 license = "MIT OR Apache-2.0"

--- a/actors/market/src/ext.rs
+++ b/actors/market/src/ext.rs
@@ -21,7 +21,7 @@ pub mod miner {
 pub mod verifreg {
     use super::*;
 
-    // based on fvm_actor_verifreg
+    // based on fil_actor_verifreg
     pub const USE_BYTES_METHOD: u64 = 5;
     pub const RESTORE_BYTES_METHOD: u64 = 6;
     pub type UseBytesParams = BytesParams;

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -10,7 +10,7 @@ use actors_runtime::{
     make_empty_map, ActorError, BalanceTable, SetMultimap, STORAGE_MARKET_ACTOR_ADDR,
     SYSTEM_ACTOR_ADDR,
 };
-use fvm_actor_market::{
+use fil_actor_market::{
     ext, Actor as MarketActor, Method, State, WithdrawBalanceParams, PROPOSALS_AMT_BITWIDTH,
     STATES_AMT_BITWIDTH,
 };

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fvm_actor_miner"
+name = "fil_actor_miner"
 description = "Builtin miner actor for Filecoin"
 version = "1.0.0"
 license = "MIT OR Apache-2.0"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fvm_actor_multisig"
+name = "fil_actor_multisig"
 description = "Builtin multisig actor for Filecoin"
 version = "1.0.0"
 license = "MIT OR Apache-2.0"

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fvm_actor_paych"
+name = "fil_actor_paych"
 description = "Builtin paych actor for Filecoin"
 version = "1.0.0"
 license = "MIT OR Apache-2.0"

--- a/actors/paych/tests/paych_actor_test.rs
+++ b/actors/paych/tests/paych_actor_test.rs
@@ -9,7 +9,7 @@ use actors_runtime::INIT_ACTOR_ADDR;
 use anyhow::anyhow;
 use cid::Cid;
 use derive_builder::Builder;
-use fvm_actor_paych::{
+use fil_actor_paych::{
     Actor as PaychActor, ConstructorParams, LaneState, Merge, Method, ModVerifyParams,
     PaymentVerifyParams, SignedVoucher, State as PState, UpdateChannelStateParams, MAX_LANE,
     SETTLE_DELAY,

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fvm_actor_power"
+name = "fil_actor_power"
 description = "Builtin power actor for Filecoin"
 version = "1.0.0"
 license = "MIT OR Apache-2.0"

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fvm_actor_reward"
+name = "fil_actor_reward"
 description = "Builtin reward actor for Filecoin"
 version = "1.0.0"
 license = "MIT OR Apache-2.0"

--- a/actors/reward/tests/reward_actor_test.rs
+++ b/actors/reward/tests/reward_actor_test.rs
@@ -6,7 +6,7 @@ use actors_runtime::{
     ActorError, BURNT_FUNDS_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
     SYSTEM_ACTOR_ADDR,
 };
-use fvm_actor_reward::{
+use fil_actor_reward::{
     ext, Actor as RewardActor, AwardBlockRewardParams, Method, State, ThisEpochRewardReturn,
     BASELINE_INITIAL_VALUE, PENALTY_MULTIPLIER,
 };

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fvm_actor_system"
+name = "fil_actor_system"
 description = "Builtin system actor for Filecoin"
 version = "1.0.0"
 license = "MIT OR Apache-2.0"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fvm_actor_verifreg"
+name = "fil_actor_verifreg"
 description = "Builtin verifreg actor for Filecoin"
 version = "1.0.0"
 license = "MIT OR Apache-2.0"

--- a/bundle/Cargo.toml
+++ b/bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "filecoin_canonical_actors_bundle"
-description = "Bundle containing Filecoin canonical actors"
+name = "fil_builtin_actors_bundle"
+description = "Bundle of FVM-compatible Wasm bytecode for Filecoin builtin actors"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/bundle/build.rs
+++ b/bundle/build.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Compute the package names.
     let packages = ACTORS
         .iter()
-        .map(|(pkg, _)| String::from("fvm_actor_") + pkg)
+        .map(|(pkg, _)| String::from("fil_actor_") + pkg)
         .collect::<Vec<String>>();
 
     let manifest_path = {
@@ -105,7 +105,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     for (pkg, id) in ACTORS {
         let bytecode_path = Path::new(&out_dir)
             .join("wasm32-unknown-unknown/wasm")
-            .join(format!("fvm_actor_{}.wasm", pkg));
+            .join(format!("fil_actor_{}.wasm", pkg));
 
         // This actor version uses forced CIDs.
         let forced_cid = {


### PR DESCRIPTION
These actors do not _belong_ to the FVM, they belong to the Filecoin protocol. So it makes little sense to namespace them under `fvm_`. Yes, they are built to work on top of the FVM, but that's an implementation detail that should not surface in crate naming. It _may_ have been useful discriminator if crates.io had non-FVM versions of these actors, but they were never published as individual crates by Forest.