### PR TITLE
Second msig test and expect_abort helpers

### DIFF
--- a/actors/multisig/src/types.rs
+++ b/actors/multisig/src/types.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 /// SignersMax is the maximum number of signers allowed in a multisig. If more
 /// are required, please use a combining tree of multisigs.
-pub(super) const SIGNERS_MAX: usize = 256;
+pub const SIGNERS_MAX: usize = 256;
 
 /// Transaction ID type
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -1,7 +1,7 @@
 // use cid::Cid;
 use fil_actor_multisig::{Actor as MultisigActor, ConstructorParams, Method, SIGNERS_MAX};
 use fil_actors_runtime::test_utils::*;
-use fil_actors_runtime::{ActorError, INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR};
+use fil_actors_runtime::{INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR};
 use fvm_shared::address::Address;
 // use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::RawBytes;
@@ -31,12 +31,10 @@ fn test_construction_fail_to_construct_multisig_actor_with_0_signers() {
 
     expect_abort(
         ExitCode::ErrIllegalArgument,
-        || -> Result<RawBytes, ActorError> {
-            rt.call::<MultisigActor>(
-                Method::Constructor as u64,
-                &RawBytes::serialize(&zero_signer_params).unwrap(),
-            )
-        },
+        rt.call::<MultisigActor>(
+            Method::Constructor as u64,
+            &RawBytes::serialize(&zero_signer_params).unwrap(),
+        ),
     );
     rt.verify();
 }
@@ -60,12 +58,10 @@ fn test_construction_fail_to_construct_multisig_with_more_than_max_signers() {
     rt.set_caller(*INIT_ACTOR_CODE_ID, *INIT_ACTOR_ADDR);
     expect_abort(
         ExitCode::ErrIllegalArgument,
-        || -> Result<RawBytes, ActorError> {
-            rt.call::<MultisigActor>(
-                Method::Constructor as u64,
-                &RawBytes::serialize(&over_max_signers_params).unwrap(),
-            )
-        },
+        rt.call::<MultisigActor>(
+            Method::Constructor as u64,
+            &RawBytes::serialize(&over_max_signers_params).unwrap(),
+        ),
     );
     rt.verify();
 }

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -1,7 +1,7 @@
 // use cid::Cid;
-use fil_actor_multisig::{Actor as MultisigActor, ConstructorParams, Method};
+use fil_actor_multisig::{Actor as MultisigActor, ConstructorParams, Method, SIGNERS_MAX};
 use fil_actors_runtime::test_utils::*;
-use fil_actors_runtime::{INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR};
+use fil_actors_runtime::{ActorError, INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR};
 use fvm_shared::address::Address;
 // use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::RawBytes;
@@ -28,17 +28,44 @@ fn test_construction_fail_to_construct_multisig_actor_with_0_signers() {
     };
     rt.expect_validate_caller_addr(vec![*INIT_ACTOR_ADDR]);
     rt.set_caller(*INIT_ACTOR_CODE_ID, *INIT_ACTOR_ADDR);
-    let ret = rt.call::<MultisigActor>(
-        Method::Constructor as u64,
-        &RawBytes::serialize(&zero_signer_params).unwrap(),
+
+    expect_abort(
+        ExitCode::ErrIllegalArgument,
+        || -> Result<RawBytes, ActorError> {
+            rt.call::<MultisigActor>(
+                Method::Constructor as u64,
+                &RawBytes::serialize(&zero_signer_params).unwrap(),
+            )
+        },
     );
     rt.verify();
-    let error = ret.expect_err("constructor with no signers should have failed");
-    let error_exit_code = error.exit_code();
+}
 
-    assert_eq!(
-        error_exit_code,
+#[test]
+fn test_construction_fail_to_construct_multisig_with_more_than_max_signers() {
+    let mut rt = construct_runtime();
+    let mut signers = Vec::new();
+    let mut i: u64 = 0;
+    while i <= SIGNERS_MAX as u64 {
+        signers.push(Address::new_id(i + 1000));
+        i = i + 1;
+    }
+    let over_max_signers_params = ConstructorParams {
+        signers: signers,
+        num_approvals_threshold: 1,
+        unlock_duration: 1,
+        start_epoch: 0,
+    };
+    rt.expect_validate_caller_addr(vec![*INIT_ACTOR_ADDR]);
+    rt.set_caller(*INIT_ACTOR_CODE_ID, *INIT_ACTOR_ADDR);
+    expect_abort(
         ExitCode::ErrIllegalArgument,
-        "Exit Code that is returned is not ErrIllegalArgument"
+        || -> Result<RawBytes, ActorError> {
+            rt.call::<MultisigActor>(
+                Method::Constructor as u64,
+                &RawBytes::serialize(&over_max_signers_params).unwrap(),
+            )
+        },
     );
+    rt.verify();
 }

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -245,29 +245,25 @@ pub struct ExpectComputeUnsealedSectorCid {
     exit_code: ExitCode,
 }
 
-pub fn expect_abort_contains_message<F: FnOnce() -> Result<RawBytes, ActorError>>(
-    exit_code: ExitCode,
+
+pub fn expect_abort_contains_message(
+    expect_exit_code: ExitCode,
     expect_msg: &str,
-    f: F,
+    res: Result<RawBytes, ActorError>,
 ) {
-    let res = f();
-    assert!(
-        res.is_err(),
-        "expected abort with exit code {} but call succeeded",
-        exit_code
-    );
-    let err = res.expect_err("unreachable, checked result is error before unwrapping");
+    let err = res.expect_err(&format!("expected abort with exit code {}, but call succeeded", expect_exit_code));
+    assert_eq!(err.exit_code(), expect_exit_code, "expected failure with exit code {}, but failed with exit code {}", expect_exit_code, err.exit_code());
     let err_msg = err.msg();
     assert!(
         err.msg().contains(expect_msg),
         "expected err message  {} to contain {}",
         err_msg,
-        expect_msg
+        expect_msg,
     );
 }
 
-pub fn expect_abort<F: FnOnce() -> Result<RawBytes, ActorError>>(exit_code: ExitCode, f: F) {
-    expect_abort_contains_message(exit_code, "", f);
+pub fn expect_abort(exit_code: ExitCode, res: Result<RawBytes, ActorError>) {
+    expect_abort_contains_message(exit_code, "", res);
 }
 
 impl MockRuntime {

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -245,6 +245,31 @@ pub struct ExpectComputeUnsealedSectorCid {
     exit_code: ExitCode,
 }
 
+pub fn expect_abort_contains_message<F: FnOnce() -> Result<RawBytes, ActorError>>(
+    exit_code: ExitCode,
+    expect_msg: &str,
+    f: F,
+) {
+    let res = f();
+    assert!(
+        res.is_err(),
+        "expected abort with exit code {} but call succeeded",
+        exit_code
+    );
+    let err = res.expect_err("unreachable, checked result is error before unwrapping");
+    let err_msg = err.msg();
+    assert!(
+        err.msg().contains(expect_msg),
+        "expected err message  {} to contain {}",
+        err_msg,
+        expect_msg
+    );
+}
+
+pub fn expect_abort<F: FnOnce() -> Result<RawBytes, ActorError>>(exit_code: ExitCode, f: F) {
+    expect_abort_contains_message(exit_code, "", f);
+}
+
 impl MockRuntime {
     fn require_in_call(&self) {
         assert!(

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -245,14 +245,22 @@ pub struct ExpectComputeUnsealedSectorCid {
     exit_code: ExitCode,
 }
 
-
 pub fn expect_abort_contains_message(
     expect_exit_code: ExitCode,
     expect_msg: &str,
     res: Result<RawBytes, ActorError>,
 ) {
-    let err = res.expect_err(&format!("expected abort with exit code {}, but call succeeded", expect_exit_code));
-    assert_eq!(err.exit_code(), expect_exit_code, "expected failure with exit code {}, but failed with exit code {}", expect_exit_code, err.exit_code());
+    let err = res.expect_err(&format!(
+        "expected abort with exit code {}, but call succeeded",
+        expect_exit_code
+    ));
+    assert_eq!(
+        err.exit_code(),
+        expect_exit_code,
+        "expected failure with exit code {}, but failed with exit code {}",
+        expect_exit_code,
+        err.exit_code()
+    );
     let err_msg = err.msg();
     assert!(
         err.msg().contains(expect_msg),


### PR DESCRIPTION
Addresses #58 adding expect abort and expect abort contains message helper functions.  This makes it easier to translate go tests by using the same error checking pattern.  Trying it out on an existing multisig test it makes things more compact and nice imo.

I ran into the borrow checker when trying to implement these on the mock runtime since the closures they call need mutable references to the runtime since they are always going to run `rt.call`.  Conveniently the rust mock runtime's call function handles state rollback (where expect abort does in go) so the expect abort methods need 0 runtime state and implementing these as free functions works out fine.  But I'm open to suggestions on any nice ways to get past the borrow checker and get these on the mock runtime.

Also this PR adds one more multisig test, 86 to go!