### PR TITLE
Initialise rustfmt.toml and set use_small_heuristics to max.

### DIFF
--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -45,9 +45,7 @@ impl Actor {
         RT: Runtime<BS>,
     {
         rt.validate_immediate_caller_is(std::iter::once(&*SYSTEM_ACTOR_ADDR))?;
-        rt.create(&State {
-            entries: params.entries,
-        })?;
+        rt.create(&State { entries: params.entries })?;
         Ok(())
     }
     /// Executes built-in periodic actions, run at every Epoch.

--- a/actors/cron/tests/cron_actor_test.rs
+++ b/actors/cron/tests/cron_actor_test.rs
@@ -30,26 +30,12 @@ fn construct_with_empty_entries() {
 fn construct_with_entries() {
     let mut rt = construct_runtime();
 
-    let entry1 = Entry {
-        receiver: Address::new_id(1001),
-        method_num: 1001,
-    };
-    let entry2 = Entry {
-        receiver: Address::new_id(1002),
-        method_num: 1002,
-    };
-    let entry3 = Entry {
-        receiver: Address::new_id(1003),
-        method_num: 1003,
-    };
-    let entry4 = Entry {
-        receiver: Address::new_id(1004),
-        method_num: 1004,
-    };
+    let entry1 = Entry { receiver: Address::new_id(1001), method_num: 1001 };
+    let entry2 = Entry { receiver: Address::new_id(1002), method_num: 1002 };
+    let entry3 = Entry { receiver: Address::new_id(1003), method_num: 1003 };
+    let entry4 = Entry { receiver: Address::new_id(1004), method_num: 1004 };
 
-    let params = ConstructorParams {
-        entries: vec![entry1, entry2, entry3, entry4],
-    };
+    let params = ConstructorParams { entries: vec![entry1, entry2, entry3, entry4] };
 
     construct_and_verify(&mut rt, &params);
 
@@ -69,30 +55,13 @@ fn epoch_tick_with_empty_entries() {
 fn epoch_tick_with_entries() {
     let mut rt = construct_runtime();
 
-    let entry1 = Entry {
-        receiver: Address::new_id(1001),
-        method_num: 1001,
-    };
-    let entry2 = Entry {
-        receiver: Address::new_id(1002),
-        method_num: 1002,
-    };
-    let entry3 = Entry {
-        receiver: Address::new_id(1003),
-        method_num: 1003,
-    };
-    let entry4 = Entry {
-        receiver: Address::new_id(1004),
-        method_num: 1004,
-    };
+    let entry1 = Entry { receiver: Address::new_id(1001), method_num: 1001 };
+    let entry2 = Entry { receiver: Address::new_id(1002), method_num: 1002 };
+    let entry3 = Entry { receiver: Address::new_id(1003), method_num: 1003 };
+    let entry4 = Entry { receiver: Address::new_id(1004), method_num: 1004 };
 
     let params = ConstructorParams {
-        entries: vec![
-            entry1.clone(),
-            entry2.clone(),
-            entry3.clone(),
-            entry4.clone(),
-        ],
+        entries: vec![entry1.clone(), entry2.clone(), entry3.clone(), entry4.clone()],
     };
 
     construct_and_verify(&mut rt, &params);
@@ -136,9 +105,7 @@ fn epoch_tick_with_entries() {
 
 fn construct_and_verify(rt: &mut MockRuntime, params: &ConstructorParams) {
     rt.expect_validate_caller_addr(vec![*SYSTEM_ACTOR_ADDR]);
-    let ret = rt
-        .call::<CronActor>(1, &RawBytes::serialize(&params).unwrap())
-        .unwrap();
+    let ret = rt.call::<CronActor>(1, &RawBytes::serialize(&params).unwrap()).unwrap();
     assert_eq!(RawBytes::default(), ret);
     rt.verify();
 }

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -45,10 +45,7 @@ impl Actor {
         let sys_ref: &Address = &SYSTEM_ACTOR_ADDR;
         rt.validate_immediate_caller_is(std::iter::once(sys_ref))?;
         let state = State::new(rt.store(), params.network_name).map_err(|e| {
-            e.downcast_default(
-                ExitCode::ErrIllegalState,
-                "failed to construct init actor state",
-            )
+            e.downcast_default(ExitCode::ErrIllegalState, "failed to construct init actor state")
         })?;
 
         rt.create(&state)?;
@@ -66,15 +63,9 @@ impl Actor {
 
         log::trace!("called exec; params.code_cid: {:?}", &params.code_cid);
 
-        let caller_code = rt
-            .get_actor_code_cid(&rt.message().caller())
-            .ok_or_else(|| {
-                actor_error!(
-                    ErrIllegalState,
-                    "no code for caller as {}",
-                    rt.message().caller()
-                )
-            })?;
+        let caller_code = rt.get_actor_code_cid(&rt.message().caller()).ok_or_else(|| {
+            actor_error!(ErrIllegalState, "no code for caller as {}", rt.message().caller())
+        })?;
 
         log::trace!("caller code CID: {:?}", &caller_code);
 
@@ -96,10 +87,9 @@ impl Actor {
         // Allocate an ID for this actor.
         // Store mapping of pubkey or actor address to actor ID
         let id_address: ActorID = rt.transaction(|s: &mut State, rt| {
-            s.map_address_to_new_id(rt.store(), &robust_address)
-                .map_err(|e| {
-                    e.downcast_default(ExitCode::ErrIllegalState, "failed to allocate ID address")
-                })
+            s.map_address_to_new_id(rt.store(), &robust_address).map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to allocate ID address")
+            })
         })?;
 
         // Create an empty actor
@@ -114,10 +104,7 @@ impl Actor {
         )
         .map_err(|err| err.wrap("constructor failed"))?;
 
-        Ok(ExecReturn {
-            id_address: Address::new_id(id_address),
-            robust_address,
-        })
+        Ok(ExecReturn { id_address: Address::new_id(id_address), robust_address })
     }
 }
 

--- a/actors/init/src/state.rs
+++ b/actors/init/src/state.rs
@@ -26,11 +26,7 @@ impl State {
         let empty_map = make_empty_map::<_, ()>(store, HAMT_BIT_WIDTH)
             .flush()
             .map_err(|e| anyhow!("failed to create empty map: {}", e))?;
-        Ok(Self {
-            address_map: empty_map,
-            next_id: FIRST_NON_SINGLETON_ADDR,
-            network_name,
-        })
+        Ok(Self { address_map: empty_map, next_id: FIRST_NON_SINGLETON_ADDR, network_name })
     }
 
     /// Allocates a new ID address and stores a mapping of the argument address to it.

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -61,9 +61,7 @@ fn create_2_payment_channels() {
         let expected_id_addr = Address::new_id(expected_id);
         rt.expect_create_actor(*PAYCH_ACTOR_CODE_ID, expected_id);
 
-        let fake_params = ConstructorParams {
-            network_name: String::from("fake_param"),
-        };
+        let fake_params = ConstructorParams { network_name: String::from("fake_param") };
 
         // expect anne creating a payment channel to trigger a send to the payment channels constructor
         let balance = TokenAmount::from(100u8);
@@ -79,14 +77,8 @@ fn create_2_payment_channels() {
 
         let exec_ret = exec_and_verify(&mut rt, *PAYCH_ACTOR_CODE_ID, &fake_params).unwrap();
         let exec_ret: ExecReturn = RawBytes::deserialize(&exec_ret).unwrap();
-        assert_eq!(
-            unique_address, exec_ret.robust_address,
-            "Robust Address does not match"
-        );
-        assert_eq!(
-            expected_id_addr, exec_ret.id_address,
-            "Id address does not match"
-        );
+        assert_eq!(unique_address, exec_ret.robust_address, "Robust Address does not match");
+        assert_eq!(expected_id_addr, exec_ret.id_address, "Id address does not match");
 
         let state: State = rt.get_state().unwrap();
         let returned_address = state
@@ -113,9 +105,7 @@ fn create_storage_miner() {
     let expected_id_addr = Address::new_id(expected_id);
     rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id);
 
-    let fake_params = ConstructorParams {
-        network_name: String::from("fake_param"),
-    };
+    let fake_params = ConstructorParams { network_name: String::from("fake_param") };
 
     rt.expect_send(
         expected_id_addr,
@@ -144,10 +134,7 @@ fn create_storage_miner() {
     let unknown_addr = Address::new_actor(b"flurbo");
 
     let returned_address = state.resolve_address(&rt.store, &unknown_addr).unwrap();
-    assert_eq!(
-        returned_address, None,
-        "Addresses should have not been found"
-    );
+    assert_eq!(returned_address, None, "Addresses should have not been found");
 }
 
 #[test]
@@ -168,9 +155,7 @@ fn create_multisig_actor() {
     let expected_id_addr = Address::new_id(expected_id);
     rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id);
 
-    let fake_params = ConstructorParams {
-        network_name: String::from("fake_param"),
-    };
+    let fake_params = ConstructorParams { network_name: String::from("fake_param") };
     // Expect a send to the multisig actor constructor
     rt.expect_send(
         expected_id_addr,
@@ -184,14 +169,8 @@ fn create_multisig_actor() {
     // Return should have been successful. Check the returned addresses
     let exec_ret = exec_and_verify(&mut rt, *MULTISIG_ACTOR_CODE_ID, &fake_params).unwrap();
     let exec_ret: ExecReturn = RawBytes::deserialize(&exec_ret).unwrap();
-    assert_eq!(
-        unique_address, exec_ret.robust_address,
-        "Robust address does not macth"
-    );
-    assert_eq!(
-        expected_id_addr, exec_ret.id_address,
-        "Id address does not match"
-    );
+    assert_eq!(unique_address, exec_ret.robust_address, "Robust address does not macth");
+    assert_eq!(expected_id_addr, exec_ret.id_address, "Id address does not match");
 }
 
 #[test]
@@ -211,9 +190,7 @@ fn sending_constructor_failure() {
     let expected_id_addr = Address::new_id(expected_id);
     rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id);
 
-    let fake_params = ConstructorParams {
-        network_name: String::from("fake_param"),
-    };
+    let fake_params = ConstructorParams { network_name: String::from("fake_param") };
     rt.expect_send(
         expected_id_addr,
         METHOD_CONSTRUCTOR,
@@ -237,20 +214,14 @@ fn sending_constructor_failure() {
     let state: State = rt.get_state().unwrap();
 
     let returned_address = state.resolve_address(&rt.store, &unique_address).unwrap();
-    assert_eq!(
-        returned_address, None,
-        "Addresses should have not been found"
-    );
+    assert_eq!(returned_address, None, "Addresses should have not been found");
 }
 
 fn construct_and_verify(rt: &mut MockRuntime) {
     rt.expect_validate_caller_addr(vec![*SYSTEM_ACTOR_ADDR]);
-    let params = ConstructorParams {
-        network_name: "mock".to_string(),
-    };
-    let ret = rt
-        .call::<InitActor>(METHOD_CONSTRUCTOR, &RawBytes::serialize(&params).unwrap())
-        .unwrap();
+    let params = ConstructorParams { network_name: "mock".to_string() };
+    let ret =
+        rt.call::<InitActor>(METHOD_CONSTRUCTOR, &RawBytes::serialize(&params).unwrap()).unwrap();
 
     assert_eq!(RawBytes::default(), ret);
     rt.verify();
@@ -258,9 +229,8 @@ fn construct_and_verify(rt: &mut MockRuntime) {
     let state_data: State = rt.get_state().unwrap();
 
     // Gets the Result(CID)
-    let empty_map = Multimap::from_root(&rt.store, &state_data.address_map, HAMT_BIT_WIDTH, 3)
-        .unwrap()
-        .root();
+    let empty_map =
+        Multimap::from_root(&rt.store, &state_data.address_map, HAMT_BIT_WIDTH, 3).unwrap().root();
 
     assert_eq!(empty_map.unwrap(), state_data.address_map);
     assert_eq!(FIRST_NON_SINGLETON_ADDR, state_data.next_id);
@@ -276,15 +246,11 @@ where
     S: Serialize,
 {
     rt.expect_validate_caller_any();
-    let exec_params = ExecParams {
-        code_cid: code_id,
-        constructor_params: RawBytes::serialize(params).unwrap(),
-    };
+    let exec_params =
+        ExecParams { code_cid: code_id, constructor_params: RawBytes::serialize(params).unwrap() };
 
-    let ret = rt.call::<InitActor>(
-        Method::Exec as u64,
-        &RawBytes::serialize(&exec_params).unwrap(),
-    );
+    let ret =
+        rt.call::<InitActor>(Method::Exec as u64, &RawBytes::serialize(&exec_params).unwrap());
 
     rt.verify();
     ret

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -69,26 +69,20 @@ fn simple_construction() {
 
     assert_eq!(
         RawBytes::default(),
-        rt.call::<MarketActor>(METHOD_CONSTRUCTOR, &RawBytes::default(),)
-            .unwrap()
+        rt.call::<MarketActor>(METHOD_CONSTRUCTOR, &RawBytes::default(),).unwrap()
     );
 
     rt.verify();
 
     let store = &rt.store;
 
-    let empty_balance_table = make_empty_map::<_, BigIntDe>(store, BALANCE_TABLE_BITWIDTH)
-        .flush()
-        .unwrap();
-    let empty_map = make_empty_map::<_, ()>(store, HAMT_BIT_WIDTH)
-        .flush()
-        .unwrap();
-    let empty_proposals_array = Amt::<(), _>::new_with_bit_width(store, PROPOSALS_AMT_BITWIDTH)
-        .flush()
-        .unwrap();
-    let empty_states_array = Amt::<(), _>::new_with_bit_width(store, STATES_AMT_BITWIDTH)
-        .flush()
-        .unwrap();
+    let empty_balance_table =
+        make_empty_map::<_, BigIntDe>(store, BALANCE_TABLE_BITWIDTH).flush().unwrap();
+    let empty_map = make_empty_map::<_, ()>(store, HAMT_BIT_WIDTH).flush().unwrap();
+    let empty_proposals_array =
+        Amt::<(), _>::new_with_bit_width(store, PROPOSALS_AMT_BITWIDTH).flush().unwrap();
+    let empty_states_array =
+        Amt::<(), _>::new_with_bit_width(store, STATES_AMT_BITWIDTH).flush().unwrap();
     let empty_multimap = SetMultimap::new(store).root().unwrap();
 
     let state_data: State = rt.get_state().unwrap();
@@ -214,13 +208,7 @@ fn withdraw_provider_to_owner() {
     let provider_addr = Address::new_id(PROVIDER_ID);
 
     let amount = TokenAmount::from(20u8);
-    add_provider_funds(
-        &mut rt,
-        provider_addr,
-        owner_addr,
-        worker_addr,
-        amount.clone(),
-    );
+    add_provider_funds(&mut rt, provider_addr, owner_addr, worker_addr, amount.clone());
 
     assert_eq!(amount, get_escrow_balance(&rt, &provider_addr).unwrap());
 
@@ -238,24 +226,16 @@ fn withdraw_provider_to_owner() {
         ExitCode::Ok,
     );
 
-    let params = WithdrawBalanceParams {
-        provider_or_client: provider_addr,
-        amount: withdraw_amount,
-    };
+    let params =
+        WithdrawBalanceParams { provider_or_client: provider_addr, amount: withdraw_amount };
 
     assert!(rt
-        .call::<MarketActor>(
-            Method::WithdrawBalance as u64,
-            &RawBytes::serialize(params).unwrap(),
-        )
+        .call::<MarketActor>(Method::WithdrawBalance as u64, &RawBytes::serialize(params).unwrap(),)
         .is_ok());
 
     rt.verify();
 
-    assert_eq!(
-        get_escrow_balance(&rt, &provider_addr).unwrap(),
-        TokenAmount::from(19u8)
-    );
+    assert_eq!(get_escrow_balance(&rt, &provider_addr).unwrap(), TokenAmount::from(19u8));
 }
 
 #[ignore]
@@ -285,24 +265,15 @@ fn withdraw_non_provider() {
         ExitCode::Ok,
     );
 
-    let params = WithdrawBalanceParams {
-        provider_or_client: client_addr,
-        amount: withdraw_amount,
-    };
+    let params = WithdrawBalanceParams { provider_or_client: client_addr, amount: withdraw_amount };
 
     assert!(rt
-        .call::<MarketActor>(
-            Method::WithdrawBalance as u64,
-            &RawBytes::serialize(params).unwrap(),
-        )
+        .call::<MarketActor>(Method::WithdrawBalance as u64, &RawBytes::serialize(params).unwrap(),)
         .is_ok());
 
     rt.verify();
 
-    assert_eq!(
-        get_escrow_balance(&rt, &client_addr).unwrap(),
-        TokenAmount::from(19u8)
-    );
+    assert_eq!(get_escrow_balance(&rt, &client_addr).unwrap(), TokenAmount::from(19u8));
 }
 
 #[ignore]
@@ -329,24 +300,15 @@ fn client_withdraw_more_than_available() {
         ExitCode::Ok,
     );
 
-    let params = WithdrawBalanceParams {
-        provider_or_client: client_addr,
-        amount: withdraw_amount,
-    };
+    let params = WithdrawBalanceParams { provider_or_client: client_addr, amount: withdraw_amount };
 
     assert!(rt
-        .call::<MarketActor>(
-            Method::WithdrawBalance as u64,
-            &RawBytes::serialize(params).unwrap(),
-        )
+        .call::<MarketActor>(Method::WithdrawBalance as u64, &RawBytes::serialize(params).unwrap(),)
         .is_ok());
 
     rt.verify();
 
-    assert_eq!(
-        get_escrow_balance(&rt, &client_addr).unwrap(),
-        TokenAmount::from(0u8)
-    );
+    assert_eq!(get_escrow_balance(&rt, &client_addr).unwrap(), TokenAmount::from(0u8));
 }
 
 #[ignore]
@@ -359,13 +321,7 @@ fn worker_withdraw_more_than_available() {
     let provider_addr = Address::new_id(PROVIDER_ID);
 
     let amount = TokenAmount::from(20u8);
-    add_provider_funds(
-        &mut rt,
-        provider_addr,
-        owner_addr,
-        worker_addr,
-        amount.clone(),
-    );
+    add_provider_funds(&mut rt, provider_addr, owner_addr, worker_addr, amount.clone());
 
     assert_eq!(amount, get_escrow_balance(&rt, &provider_addr).unwrap());
 
@@ -383,24 +339,16 @@ fn worker_withdraw_more_than_available() {
         ExitCode::Ok,
     );
 
-    let params = WithdrawBalanceParams {
-        provider_or_client: provider_addr,
-        amount: withdraw_amount,
-    };
+    let params =
+        WithdrawBalanceParams { provider_or_client: provider_addr, amount: withdraw_amount };
 
     assert!(rt
-        .call::<MarketActor>(
-            Method::WithdrawBalance as u64,
-            &RawBytes::serialize(params).unwrap(),
-        )
+        .call::<MarketActor>(Method::WithdrawBalance as u64, &RawBytes::serialize(params).unwrap(),)
         .is_ok());
 
     rt.verify();
 
-    assert_eq!(
-        get_escrow_balance(&rt, &provider_addr).unwrap(),
-        TokenAmount::from(0u8)
-    );
+    assert_eq!(get_escrow_balance(&rt, &provider_addr).unwrap(), TokenAmount::from(0u8));
 }
 
 fn expect_provider_control_address(
@@ -440,10 +388,7 @@ fn add_provider_funds(
     expect_provider_control_address(rt, provider, owner, worker);
 
     assert!(rt
-        .call::<MarketActor>(
-            Method::AddBalance as u64,
-            &RawBytes::serialize(provider).unwrap(),
-        )
+        .call::<MarketActor>(Method::AddBalance as u64, &RawBytes::serialize(provider).unwrap(),)
         .is_ok());
 
     rt.verify();
@@ -459,10 +404,7 @@ fn add_participant_funds(rt: &mut MockRuntime, addr: Address, amount: TokenAmoun
     rt.expect_validate_caller_type(vec![*ACCOUNT_ACTOR_CODE_ID, *MULTISIG_ACTOR_CODE_ID]);
 
     assert!(rt
-        .call::<MarketActor>(
-            Method::AddBalance as u64,
-            &RawBytes::serialize(addr).unwrap(),
-        )
+        .call::<MarketActor>(Method::AddBalance as u64, &RawBytes::serialize(addr).unwrap(),)
         .is_ok());
 
     rt.verify();
@@ -474,8 +416,7 @@ fn construct_and_verify(rt: &mut MockRuntime) {
     rt.expect_validate_caller_addr(vec![*SYSTEM_ACTOR_ADDR]);
     assert_eq!(
         RawBytes::default(),
-        rt.call::<MarketActor>(METHOD_CONSTRUCTOR, &RawBytes::default(),)
-            .unwrap()
+        rt.call::<MarketActor>(METHOD_CONSTRUCTOR, &RawBytes::default(),).unwrap()
     );
     rt.verify();
 }

--- a/actors/miner/src/bitfield_queue.rs
+++ b/actors/miner/src/bitfield_queue.rs
@@ -20,10 +20,7 @@ pub struct BitFieldQueue<'db, BS> {
 
 impl<'db, BS: Blockstore> BitFieldQueue<'db, BS> {
     pub fn new(store: &'db BS, root: &Cid, quant: QuantSpec) -> Result<Self, AmtError> {
-        Ok(Self {
-            amt: Array::load(root, store)?,
-            quant,
-        })
+        Ok(Self { amt: Array::load(root, store)?, quant })
     }
 
     /// Adds values to the queue entry for an epoch.
@@ -104,8 +101,7 @@ impl<'db, BS: Blockstore> BitFieldQueue<'db, BS> {
         while let Some(&(epoch, _)) = iter.peek() {
             self.add_to_queue_values(
                 epoch,
-                iter.peeking_take_while(|&(e, _)| e == epoch)
-                    .map(|(_, v)| v),
+                iter.peeking_take_while(|&(e, _)| e == epoch).map(|(_, v)| v),
             )?;
         }
 

--- a/actors/miner/src/deadline_assignment.rs
+++ b/actors/miner/src/deadline_assignment.rs
@@ -105,8 +105,7 @@ fn cmp(a: &DeadlineAssignmentInfo, b: &DeadlineAssignmentInfo, partition_size: u
         .then_with(|| {
             // Ok, we'll end up with the same number of partitions any which way we
             // go. Try to fill up a partition instead of opening a new one.
-            a.is_full_now(partition_size)
-                .cmp(&b.is_full_now(partition_size))
+            a.is_full_now(partition_size).cmp(&b.is_full_now(partition_size))
         })
         .then_with(|| {
             // Either we have two open partitions, or neither deadline has an open

--- a/actors/miner/src/deadline_info.rs
+++ b/actors/miner/src/deadline_info.rs
@@ -149,9 +149,6 @@ impl DeadlineInfo {
     }
 
     pub fn quant_spec(&self) -> QuantSpec {
-        QuantSpec {
-            unit: self.w_post_proving_period,
-            offset: self.last(),
-        }
+        QuantSpec { unit: self.w_post_proving_period, offset: self.last() }
     }
 }

--- a/actors/miner/src/deadlines.rs
+++ b/actors/miner/src/deadlines.rs
@@ -58,10 +58,7 @@ impl Deadlines {
             }
         }
 
-        Err(anyhow::anyhow!(
-            "sector {} not due at any deadline",
-            sector_number
-        ))
+        Err(anyhow::anyhow!("sector {} not due at any deadline", sector_number))
     }
 }
 
@@ -84,10 +81,7 @@ pub fn deadline_is_mutable(
 }
 
 pub fn quant_spec_for_deadline(policy: &Policy, di: &DeadlineInfo) -> QuantSpec {
-    QuantSpec {
-        unit: policy.wpost_proving_period,
-        offset: di.last(),
-    }
+    QuantSpec { unit: policy.wpost_proving_period, offset: di.last() }
 }
 
 // Returns true if optimistically accepted posts submitted to the given deadline
@@ -142,18 +136,10 @@ pub fn new_deadline_info_from_offset_and_epoch(
     period_start_seed: ChainEpoch,
     current_epoch: ChainEpoch,
 ) -> DeadlineInfo {
-    let q = QuantSpec {
-        unit: policy.wpost_proving_period,
-        offset: period_start_seed,
-    };
+    let q = QuantSpec { unit: policy.wpost_proving_period, offset: period_start_seed };
     let current_period_start = q.quantize_down(current_epoch);
     let current_deadline_idx = ((current_epoch - current_period_start)
         / policy.wpost_challenge_window) as u64
         % policy.wpost_period_deadlines;
-    new_deadline_info(
-        policy,
-        current_period_start,
-        current_deadline_idx,
-        current_epoch,
-    )
+    new_deadline_info(policy, current_period_start, current_deadline_idx, current_epoch)
 }

--- a/actors/miner/src/expiration_queue.rs
+++ b/actors/miner/src/expiration_queue.rs
@@ -163,10 +163,7 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
     /// Epochs provided to subsequent method calls will be quantized upwards to quanta mod offsetSeed before being
     /// written to/read from queue entries.
     pub fn new(store: &'db BS, root: &Cid, quant: QuantSpec) -> Result<Self, AmtError> {
-        Ok(Self {
-            amt: Array::load(root, store)?,
-            quant,
-        })
+        Ok(Self { amt: Array::load(root, store)?, quant })
     }
 
     /// Adds a collection of sectors to their on-time target expiration entries (quantized).
@@ -426,10 +423,7 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
         })?;
 
         if !remaining.is_empty() {
-            return Err(anyhow!(
-                "sectors not found in expiration queue: {:?}",
-                remaining
-            ));
+            return Err(anyhow!("sectors not found in expiration queue: {:?}", remaining));
         }
 
         // Re-schedule the removed sectors to their target expiration.
@@ -586,10 +580,7 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
         })?;
 
         if !remaining.is_empty() {
-            return Err(anyhow!(
-                "sectors not found in expiration queue: {:?}",
-                remaining
-            ));
+            return Err(anyhow!("sectors not found in expiration queue: {:?}", remaining));
         }
 
         Ok((removed, recovering_power))
@@ -643,13 +634,7 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
         let mut expiration_set = self.may_get(epoch)?;
 
         expiration_set
-            .add(
-                on_time_sectors,
-                early_sectors,
-                pledge,
-                active_power,
-                faulty_power,
-            )
+            .add(on_time_sectors, early_sectors, pledge, active_power, faulty_power)
             .map_err(|e| anyhow!("failed to add expiration values for epoch {}: {}", epoch, e))?;
 
         self.must_update(epoch, expiration_set)?;
@@ -673,20 +658,10 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
             .ok_or_else(|| anyhow!("missing expected expiration set at epoch {}", epoch))?
             .clone();
         expiration_set
-            .remove(
-                on_time_sectors,
-                early_sectors,
-                pledge,
-                active_power,
-                faulty_power,
-            )
+            .remove(on_time_sectors, early_sectors, pledge, active_power, faulty_power)
             .map_err(|e| {
-                anyhow!(
-                    "failed to remove expiration values for queue epoch {}: {}",
-                    epoch,
-                    e
-                )
-            })?;
+            anyhow!("failed to remove expiration values for queue epoch {}: {}", epoch, e)
+        })?;
 
         self.must_update_or_delete(epoch, expiration_set)?;
         Ok(())
@@ -906,10 +881,7 @@ fn group_new_sectors_by_declared_expiration<'a>(
 
     for sector in sectors {
         let q_expiration = quant.quantize_up(sector.expiration);
-        sectors_by_expiration
-            .entry(q_expiration)
-            .or_default()
-            .push(sector);
+        sectors_by_expiration.entry(q_expiration).or_default().push(sector);
     }
 
     // The result is sorted by expiration because the BTreeMap iterates in sorted order.
@@ -972,10 +944,7 @@ fn group_expiration_set(
 fn check_no_early_sectors(set: &BTreeSet<u64>, es: &ExpirationSet) -> anyhow::Result<()> {
     for u in es.early_sectors.iter() {
         if set.contains(&(u as u64)) {
-            return Err(anyhow!(
-                "Invalid attempt to group sector {} with an early expiration",
-                u
-            ));
+            return Err(anyhow!("Invalid attempt to group sector {} with an early expiration", u));
         }
     }
     Ok(())

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -183,10 +183,7 @@ impl Actor {
             params.window_post_proof_type,
         )?;
         let info_cid = rt.store().put_cbor(&info, Blake2b256).map_err(|e| {
-            e.downcast_default(
-                ExitCode::ErrIllegalState,
-                "failed to construct illegal state",
-            )
+            e.downcast_default(ExitCode::ErrIllegalState, "failed to construct illegal state")
         })?;
 
         let st =
@@ -291,10 +288,7 @@ impl Actor {
         // * deserialized over the wire? If so, a workaround will be needed
 
         if !matches!(new_address.protocol(), Protocol::ID) {
-            return Err(actor_error!(
-                ErrIllegalArgument,
-                "owner address must be an ID address"
-            ));
+            return Err(actor_error!(ErrIllegalArgument, "owner address must be an ID address"));
         }
 
         rt.transaction(|state: &mut State, rt| {
@@ -344,9 +338,7 @@ impl Actor {
             let mut info = get_miner_info(rt.store(), state)?;
 
             rt.validate_immediate_caller_is(
-                info.control_addresses
-                    .iter()
-                    .chain(&[info.worker, info.owner]),
+                info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
 
             info.peer_id = params.new_id;
@@ -374,9 +366,7 @@ impl Actor {
             let mut info = get_miner_info(rt.store(), state)?;
 
             rt.validate_immediate_caller_is(
-                info.control_addresses
-                    .iter()
-                    .chain(&[info.worker, info.owner]),
+                info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
 
             info.multi_address = params.new_multi_addrs;
@@ -449,9 +439,7 @@ impl Actor {
             })?;
 
             rt.validate_immediate_caller_is(
-                info.control_addresses
-                    .iter()
-                    .chain(&[info.worker, info.owner]),
+                info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
 
             // Verify that the miner has passed exactly 1 proof.
@@ -548,23 +536,18 @@ impl Actor {
                 &[],
             )?;
             if comm_rand != params.chain_commit_rand {
-                return Err(actor_error!(
-                    ErrIllegalArgument,
-                    "post commit randomness mismatched"
-                ));
+                return Err(actor_error!(ErrIllegalArgument, "post commit randomness mismatched"));
             }
 
             let sectors = Sectors::load(rt.store(), &state.sectors).map_err(|e| {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to load sectors")
             })?;
 
-            let mut deadlines = state
-                .load_deadlines(rt.store())
-                .map_err(|e| e.wrap("failed to load deadlines"))?;
+            let mut deadlines =
+                state.load_deadlines(rt.store()).map_err(|e| e.wrap("failed to load deadlines"))?;
 
-            let mut deadline = deadlines
-                .load_deadline(rt.policy(), rt.store(), params.deadline)
-                .map_err(|e| {
+            let mut deadline =
+                deadlines.load_deadline(rt.policy(), rt.store(), params.deadline).map_err(|e| {
                     e.downcast_default(
                         ExitCode::ErrIllegalState,
                         format!("failed to load deadline {}", params.deadline),
@@ -641,14 +624,14 @@ impl Actor {
             }
 
             let deadline_idx = params.deadline;
-            deadlines
-                .update_deadline(policy, rt.store(), params.deadline, &deadline)
-                .map_err(|e| {
+            deadlines.update_deadline(policy, rt.store(), params.deadline, &deadline).map_err(
+                |e| {
                     e.downcast_default(
                         ExitCode::ErrIllegalState,
                         format!("failed to update deadline {}", deadline_idx),
                     )
-                })?;
+                },
+            )?;
 
             state.save_deadlines(rt.store(), deadlines).map_err(|e| {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to save deadlines")
@@ -664,14 +647,9 @@ impl Actor {
         request_update_power(rt, post_result.power_delta)?;
 
         let state: State = rt.state()?;
-        state
-            .check_balance_invariants(&rt.current_balance())
-            .map_err(|e| {
-                ActorError::new(
-                    ErrBalanceInvariantBroken,
-                    format!("balance invariants broken: {}", e),
-                )
-            })?;
+        state.check_balance_invariants(&rt.current_balance()).map_err(|e| {
+            ActorError::new(ErrBalanceInvariantBroken, format!("balance invariants broken: {}", e))
+        })?;
 
         Ok(())
     }
@@ -725,14 +703,11 @@ impl Actor {
         let state: State = rt.state()?;
         let info = get_miner_info(rt.store(), &state)?;
         rt.validate_immediate_caller_is(
-            info.control_addresses
-                .iter()
-                .chain(&[info.worker, info.owner]),
+            info.control_addresses.iter().chain(&[info.worker, info.owner]),
         )?;
         let store = rt.store();
-        let precommits = state
-            .get_all_precommitted_sectors(store, sector_numbers)
-            .map_err(|e| {
+        let precommits =
+            state.get_all_precommitted_sectors(store, sector_numbers).map_err(|e| {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to get precommits")
             })?;
 
@@ -868,14 +843,9 @@ impl Actor {
             ));
         }
         burn_funds(rt, aggregate_fee)?;
-        state
-            .check_balance_invariants(&rt.current_balance())
-            .map_err(|e| {
-                ActorError::new(
-                    ErrBalanceInvariantBroken,
-                    format!("balance invariants broken: {}", e),
-                )
-            })?;
+        state.check_balance_invariants(&rt.current_balance()).map_err(|e| {
+            ActorError::new(ErrBalanceInvariantBroken, format!("balance invariants broken: {}", e))
+        })?;
         Ok(())
     }
 
@@ -903,9 +873,7 @@ impl Actor {
         let info = get_miner_info(rt.store(), &state)?;
 
         rt.validate_immediate_caller_is(
-            info.control_addresses
-                .iter()
-                .chain(&[info.owner, info.worker]),
+            info.control_addresses.iter().chain(&[info.owner, info.worker]),
         )?;
 
         let sector_store = rt.store().clone();
@@ -928,10 +896,7 @@ impl Actor {
         for update in params.updates.iter() {
             let set = sector_numbers.get(update.sector_number);
             if set {
-                info!(
-                    "duplicate sector being updated {}, skipping",
-                    update.sector_number,
-                );
+                info!("duplicate sector being updated {}, skipping", update.sector_number,);
                 continue;
             }
 
@@ -947,18 +912,12 @@ impl Actor {
             }
 
             if update.deals.is_empty() {
-                info!(
-                    "must have deals to update, skipping sector {}",
-                    update.sector_number,
-                );
+                info!("must have deals to update, skipping sector {}", update.sector_number,);
                 continue;
             }
 
             if update.deals.len() as u64 > sector_deals_max(rt.policy(), info.sector_size) {
-                info!(
-                    "more deals than policy allows, skipping sector {}",
-                    update.sector_number,
-                );
+                info!("more deals than policy allows, skipping sector {}", update.sector_number,);
                 continue;
             }
 
@@ -1008,10 +967,7 @@ impl Actor {
                 )
                 .map_err(|_| actor_error!(ErrIllegalArgument, "error checking sector health"))?
             {
-                info!(
-                    "sector isn't healthy, skipping sector {}",
-                    update.sector_number
-                );
+                info!("sector isn't healthy, skipping sector {}", update.sector_number);
                 continue;
             }
 
@@ -1019,18 +975,12 @@ impl Actor {
             let sector_info = if let Ok(value) = res {
                 value
             } else {
-                info!(
-                    "failed to get sector, skipping sector {}",
-                    update.sector_number
-                );
+                info!("failed to get sector, skipping sector {}", update.sector_number);
                 continue;
             };
 
             if !sector_info.deal_ids.is_empty() {
-                info!(
-                    "cannot update sector with deals, skipping sector {}",
-                    update.sector_number
-                );
+                info!("cannot update sector with deals, skipping sector {}", update.sector_number);
                 continue;
             }
 
@@ -1054,10 +1004,7 @@ impl Actor {
 
             let expiration = sector_info.expiration;
             let seal_proof = sector_info.seal_proof;
-            validated_updates.push(UpdateAndSectorInfo {
-                update,
-                sector_info,
-            });
+            validated_updates.push(UpdateAndSectorInfo { update, sector_info });
 
             sectors_deals.push(ext::market::SectorDeals {
                 deal_ids: update.deals.clone(),
@@ -1111,15 +1058,12 @@ impl Actor {
                 deadlines_to_load.push(dl);
             }
 
-            decls_by_deadline
-                .entry(dl)
-                .or_default()
-                .push(UpdateWithDetails {
-                    update: with_sector_info.update,
-                    sector_info: &with_sector_info.sector_info,
-                    deal_weight: &deal_weights.sectors[i],
-                    unsealed_cid: unsealed_sector_cids[i],
-                });
+            decls_by_deadline.entry(dl).or_default().push(UpdateWithDetails {
+                update: with_sector_info.update,
+                sector_info: &with_sector_info.sector_info,
+                deal_weight: &deal_weights.sectors[i],
+                unsealed_cid: unsealed_sector_cids[i],
+            });
         }
 
         let rew = request_current_epoch_block_reward(rt)?;
@@ -1429,9 +1373,8 @@ impl Actor {
                 // This operation REMOVES the PoSt from the snapshot so
                 // it can't be disputed again. If this method fails,
                 // this operation must be rolled back.
-                let (partitions, proofs) = dl_current
-                    .take_post_proofs(rt.store(), params.post_index)
-                    .map_err(|e| {
+                let (partitions, proofs) =
+                    dl_current.take_post_proofs(rt.store(), params.post_index).map_err(|e| {
                         e.downcast_default(
                             ExitCode::ErrIllegalState,
                             "failed to load proof for dispute",
@@ -1461,10 +1404,7 @@ impl Actor {
                         )
                     })?;
                 let sector_infos = sectors
-                    .load_for_proof(
-                        &dispute_info.all_sector_nos,
-                        &dispute_info.ignored_sector_nos,
-                    )
+                    .load_for_proof(&dispute_info.all_sector_nos, &dispute_info.ignored_sector_nos)
                     .map_err(|e| {
                         e.downcast_default(
                             ExitCode::ErrIllegalState,
@@ -1474,10 +1414,7 @@ impl Actor {
 
                 // Check proof, we fail if validation succeeds.
                 if verify_windowed_post(rt, target_deadline.challenge, &sector_infos, proofs)? {
-                    return Err(actor_error!(
-                        ErrIllegalArgument,
-                        "failed to dispute valid post"
-                    ));
+                    return Err(actor_error!(ErrIllegalArgument, "failed to dispute valid post"));
                 } else {
                     info!("Successfully disputed post- window post was invalid");
                 }
@@ -1511,10 +1448,9 @@ impl Actor {
                         )
                     })?;
 
-                st.save_deadlines(rt.store(), deadlines_current)
-                    .map_err(|e| {
-                        e.downcast_default(ExitCode::ErrIllegalState, "failed to save deadlines")
-                    })?;
+                st.save_deadlines(rt.store(), deadlines_current).map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to save deadlines")
+                })?;
 
                 // --- penalties ---
 
@@ -1560,12 +1496,7 @@ impl Actor {
 
         request_update_power(rt, power_delta)?;
         if !to_reward.is_zero() {
-            if let Err(e) = rt.send(
-                reporter,
-                METHOD_SEND,
-                RawBytes::default(),
-                to_reward.clone(),
-            ) {
+            if let Err(e) = rt.send(reporter, METHOD_SEND, RawBytes::default(), to_reward.clone()) {
                 error!("failed to send reward: {}", e);
                 to_burn += to_reward;
             }
@@ -1575,13 +1506,9 @@ impl Actor {
         notify_pledge_changed(rt, &pledge_delta)?;
 
         let st: State = rt.state()?;
-        st.check_balance_invariants(&rt.current_balance())
-            .map_err(|e| {
-                ActorError::new(
-                    ErrBalanceInvariantBroken,
-                    format!("balance invariants broken: {}", e),
-                )
-            })?;
+        st.check_balance_invariants(&rt.current_balance()).map_err(|e| {
+            ActorError::new(ErrBalanceInvariantBroken, format!("balance invariants broken: {}", e))
+        })?;
         Ok(())
     }
 
@@ -1596,9 +1523,7 @@ impl Actor {
         BS: Blockstore,
         RT: Runtime<BS>,
     {
-        let batch_params = PreCommitSectorBatchParams {
-            sectors: vec![params],
-        };
+        let batch_params = PreCommitSectorBatchParams { sectors: vec![params] };
         Self::pre_commit_sector_batch(rt, batch_params)
     }
 
@@ -1663,10 +1588,7 @@ impl Actor {
             // Skip checking if CID is defined because it cannot be so in Rust
 
             if !is_sealed_sector(&precommit.sealed_cid) {
-                return Err(actor_error!(
-                    ErrIllegalArgument,
-                    "sealed CID had wrong prefix"
-                ));
+                return Err(actor_error!(ErrIllegalArgument, "sealed CID had wrong prefix"));
             }
             if precommit.seal_rand_epoch >= curr_epoch {
                 return Err(actor_error!(
@@ -1689,12 +1611,7 @@ impl Actor {
             // This could make sector maximum lifetime validation more lenient if the maximum sector limit isn't hit first.
             let max_activation = curr_epoch
                 + max_prove_commit_duration(rt.policy(), precommit.seal_proof).unwrap_or_default();
-            validate_expiration(
-                rt,
-                max_activation,
-                precommit.expiration,
-                precommit.seal_proof,
-            )?;
+            validate_expiration(rt, max_activation, precommit.expiration, precommit.seal_proof)?;
 
             if precommit.replace_capacity {
                 return Err(actor_error!(
@@ -1847,22 +1764,15 @@ impl Actor {
         })?;
         burn_funds(rt, fee_to_burn)?;
         let state: State = rt.state()?;
-        state
-            .check_balance_invariants(&rt.current_balance())
-            .map_err(|e| {
-                ActorError::new(
-                    ErrBalanceInvariantBroken,
-                    format!("balance invariant broken: {}", e),
-                )
-            })?;
+        state.check_balance_invariants(&rt.current_balance()).map_err(|e| {
+            ActorError::new(ErrBalanceInvariantBroken, format!("balance invariant broken: {}", e))
+        })?;
         if needs_cron {
             let new_dl_info = state.deadline_info(rt.policy(), curr_epoch);
             enroll_cron_event(
                 rt,
                 new_dl_info.last(),
-                CronEventPayload {
-                    event_type: CRON_EVENT_PROVING_DEADLINE,
-                },
+                CronEventPayload { event_type: CRON_EVENT_PROVING_DEADLINE },
             )?;
         }
         Ok(())
@@ -1882,10 +1792,7 @@ impl Actor {
         rt.validate_immediate_caller_accept_any()?;
 
         if params.sector_number > MAX_SECTOR_NUMBER {
-            return Err(actor_error!(
-                ErrIllegalArgument,
-                "sector number greater than maximum"
-            ));
+            return Err(actor_error!(ErrIllegalArgument, "sector number greater than maximum"));
         }
 
         let sector_number = params.sector_number;
@@ -1983,9 +1890,8 @@ impl Actor {
         let st: State = rt.state()?;
         let store = rt.store();
         // This skips missing pre-commits.
-        let precommited_sectors = st
-            .find_precommitted_sectors(store, &params.sectors)
-            .map_err(|e| {
+        let precommited_sectors =
+            st.find_precommitted_sectors(store, &params.sectors).map_err(|e| {
                 e.downcast_default(
                     ExitCode::ErrIllegalState,
                     "failed to load pre-committed sectors",
@@ -2011,10 +1917,7 @@ impl Actor {
         rt.validate_immediate_caller_accept_any()?;
 
         if params.sector_number > MAX_SECTOR_NUMBER {
-            return Err(actor_error!(
-                ErrIllegalArgument,
-                "sector number out of range"
-            ));
+            return Err(actor_error!(ErrIllegalArgument, "sector number out of range"));
         }
 
         let st: State = rt.state()?;
@@ -2026,11 +1929,9 @@ impl Actor {
                 params.sector_number,
                 e
             )),
-            Ok(None) => Err(actor_error!(
-                ErrNotFound,
-                "sector {} not proven",
-                params.sector_number
-            )),
+            Ok(None) => {
+                Err(actor_error!(ErrNotFound, "sector {} not proven", params.sector_number))
+            }
             Ok(Some(_sector)) => Ok(()),
         }
     }
@@ -2115,16 +2016,13 @@ impl Actor {
             let info = get_miner_info(rt.store(), state)?;
             let nv = rt.network_version();
             rt.validate_immediate_caller_is(
-                info.control_addresses
-                    .iter()
-                    .chain(&[info.worker, info.owner]),
+                info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
 
             let store = rt.store();
 
-            let mut deadlines = state
-                .load_deadlines(rt.store())
-                .map_err(|e| e.wrap("failed to load deadlines"))?;
+            let mut deadlines =
+                state.load_deadlines(rt.store()).map_err(|e| e.wrap("failed to load deadlines"))?;
 
             // Group declarations by deadline, and remember iteration order.
             //
@@ -2151,9 +2049,8 @@ impl Actor {
 
             for deadline_idx in deadlines_to_load {
                 let policy = rt.policy();
-                let mut deadline = deadlines
-                    .load_deadline(policy, store, deadline_idx)
-                    .map_err(|e| {
+                let mut deadline =
+                    deadlines.load_deadline(policy, store, deadline_idx).map_err(|e| {
                         e.downcast_default(
                             ExitCode::ErrIllegalState,
                             format!("failed to load deadline {}", deadline_idx),
@@ -2174,10 +2071,7 @@ impl Actor {
                 let mut epochs_to_reschedule = Vec::<ChainEpoch>::new();
 
                 for decl in &mut decls_by_deadline[deadline_idx as usize] {
-                    let key = PartitionKey {
-                        deadline: deadline_idx,
-                        partition: decl.partition,
-                    };
+                    let key = PartitionKey { deadline: deadline_idx, partition: decl.partition };
 
                     let mut partition = partitions
                         .get(decl.partition)
@@ -2288,9 +2182,7 @@ impl Actor {
                     let not_exists = matches!(prev_epoch_partitions, Entry::Vacant(_));
 
                     // Add declaration partition
-                    prev_epoch_partitions
-                        .or_insert_with(Vec::new)
-                        .push(decl.partition);
+                    prev_epoch_partitions.or_insert_with(Vec::new).push(decl.partition);
                     if not_exists {
                         // reschedule epoch if the partition for new epoch didn't already exist
                         epochs_to_reschedule.push(decl.new_expiration);
@@ -2307,9 +2199,8 @@ impl Actor {
                 // Record partitions in deadline expiration queue
                 for epoch in epochs_to_reschedule {
                     let p_idxs = partitions_by_new_epoch.get(&epoch).unwrap();
-                    deadline
-                        .add_expiration_partitions(store, epoch, p_idxs, quant)
-                        .map_err(|e| {
+                    deadline.add_expiration_partitions(store, epoch, p_idxs, quant).map_err(
+                        |e| {
                             e.downcast_default(
                                 ExitCode::ErrIllegalState,
                                 format!(
@@ -2318,17 +2209,16 @@ impl Actor {
                                     deadline_idx, epoch
                                 ),
                             )
-                        })?;
+                        },
+                    )?;
                 }
 
-                deadlines
-                    .update_deadline(policy, store, deadline_idx, &deadline)
-                    .map_err(|e| {
-                        e.downcast_default(
-                            ExitCode::ErrIllegalState,
-                            format!("failed to save deadline {}", deadline_idx),
-                        )
-                    })?;
+                deadlines.update_deadline(policy, store, deadline_idx, &deadline).map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to save deadline {}", deadline_idx),
+                    )
+                })?;
             }
 
             state.sectors = sectors.amt.flush().map_err(|e| {
@@ -2395,32 +2285,23 @@ impl Actor {
             let deadline = term.deadline;
             let partition = term.partition;
 
-            to_process
-                .add(rt.policy(), deadline, partition, term.sectors)
-                .map_err(|e| {
-                    actor_error!(
-                        ErrIllegalArgument,
-                        "failed to process deadline {}, partition {}: {}",
-                        deadline,
-                        partition,
-                        e
-                    )
-                })?;
+            to_process.add(rt.policy(), deadline, partition, term.sectors).map_err(|e| {
+                actor_error!(
+                    ErrIllegalArgument,
+                    "failed to process deadline {}, partition {}: {}",
+                    deadline,
+                    partition,
+                    e
+                )
+            })?;
         }
 
         {
             let policy = rt.policy();
             to_process
-                .check(
-                    policy.addressed_partitions_max,
-                    policy.addressed_sectors_max,
-                )
+                .check(policy.addressed_partitions_max, policy.addressed_sectors_max)
                 .map_err(|e| {
-                    actor_error!(
-                        ErrIllegalArgument,
-                        "cannot process requested parameters: {}",
-                        e
-                    )
+                    actor_error!(ErrIllegalArgument, "cannot process requested parameters: {}", e)
                 })?;
         }
 
@@ -2430,18 +2311,15 @@ impl Actor {
             let info = get_miner_info(rt.store(), state)?;
 
             rt.validate_immediate_caller_is(
-                info.control_addresses
-                    .iter()
-                    .chain(&[info.worker, info.owner]),
+                info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
 
             let store = rt.store();
             let curr_epoch = rt.curr_epoch();
             let mut power_delta = PowerPair::zero();
 
-            let mut deadlines = state
-                .load_deadlines(store)
-                .map_err(|e| e.wrap("failed to load deadlines"))?;
+            let mut deadlines =
+                state.load_deadlines(store).map_err(|e| e.wrap("failed to load deadlines"))?;
 
             // We're only reading the sectors, so there's no need to save this back.
             // However, we still want to avoid re-loading this array per-partition.
@@ -2466,9 +2344,8 @@ impl Actor {
                 }
 
                 let quant = state.quant_spec_for_deadline(rt.policy(), deadline_idx);
-                let mut deadline = deadlines
-                    .load_deadline(rt.policy(), store, deadline_idx)
-                    .map_err(|e| {
+                let mut deadline =
+                    deadlines.load_deadline(rt.policy(), store, deadline_idx).map_err(|e| {
                         e.downcast_default(
                             ExitCode::ErrIllegalState,
                             format!("failed to load deadline {}", deadline_idx),
@@ -2495,14 +2372,14 @@ impl Actor {
                 state.early_terminations.set(deadline_idx);
                 power_delta -= &removed_power;
 
-                deadlines
-                    .update_deadline(rt.policy(), store, deadline_idx, &deadline)
-                    .map_err(|e| {
+                deadlines.update_deadline(rt.policy(), store, deadline_idx, &deadline).map_err(
+                    |e| {
                         e.downcast_default(
                             ExitCode::ErrIllegalState,
                             format!("failed to update deadline {}", deadline_idx),
                         )
-                    })?;
+                    },
+                )?;
             }
 
             state.save_deadlines(store, deadlines).map_err(|e| {
@@ -2530,14 +2407,9 @@ impl Actor {
             schedule_early_termination_work(rt)?;
         }
         let state: State = rt.state()?;
-        state
-            .check_balance_invariants(&rt.current_balance())
-            .map_err(|e| {
-                ActorError::new(
-                    ErrBalanceInvariantBroken,
-                    format!("balance invariant broken: {}", e),
-                )
-            })?;
+        state.check_balance_invariants(&rt.current_balance()).map_err(|e| {
+            ActorError::new(ErrBalanceInvariantBroken, format!("balance invariant broken: {}", e))
+        })?;
 
         request_update_power(rt, power_delta)?;
         Ok(TerminateSectorsReturn { done: !more })
@@ -2566,32 +2438,23 @@ impl Actor {
             let deadline = term.deadline;
             let partition = term.partition;
 
-            to_process
-                .add(rt.policy(), deadline, partition, term.sectors)
-                .map_err(|e| {
-                    actor_error!(
-                        ErrIllegalArgument,
-                        "failed to process deadline {}, partition {}: {}",
-                        deadline,
-                        partition,
-                        e
-                    )
-                })?;
+            to_process.add(rt.policy(), deadline, partition, term.sectors).map_err(|e| {
+                actor_error!(
+                    ErrIllegalArgument,
+                    "failed to process deadline {}, partition {}: {}",
+                    deadline,
+                    partition,
+                    e
+                )
+            })?;
         }
 
         {
             let policy = rt.policy();
             to_process
-                .check(
-                    policy.addressed_partitions_max,
-                    policy.addressed_sectors_max,
-                )
+                .check(policy.addressed_partitions_max, policy.addressed_sectors_max)
                 .map_err(|e| {
-                    actor_error!(
-                        ErrIllegalArgument,
-                        "cannot process requested parameters: {}",
-                        e
-                    )
+                    actor_error!(ErrIllegalArgument, "cannot process requested parameters: {}", e)
                 })?;
         }
 
@@ -2599,16 +2462,13 @@ impl Actor {
             let info = get_miner_info(rt.store(), state)?;
 
             rt.validate_immediate_caller_is(
-                info.control_addresses
-                    .iter()
-                    .chain(&[info.worker, info.owner]),
+                info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
 
             let store = rt.store();
 
-            let mut deadlines = state
-                .load_deadlines(store)
-                .map_err(|e| e.wrap("failed to load deadlines"))?;
+            let mut deadlines =
+                state.load_deadlines(store).map_err(|e| e.wrap("failed to load deadlines"))?;
 
             let sectors = Sectors::load(store, &state.sectors).map_err(|e| {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to load sectors array")
@@ -2642,9 +2502,8 @@ impl Actor {
                     )
                 })?;
 
-                let mut deadline = deadlines
-                    .load_deadline(policy, store, deadline_idx)
-                    .map_err(|e| {
+                let mut deadline =
+                    deadlines.load_deadline(policy, store, deadline_idx).map_err(|e| {
                         e.downcast_default(
                             ExitCode::ErrIllegalState,
                             format!("failed to load deadline {}", deadline_idx),
@@ -2669,14 +2528,12 @@ impl Actor {
                         )
                     })?;
 
-                deadlines
-                    .update_deadline(policy, store, deadline_idx, &deadline)
-                    .map_err(|e| {
-                        e.downcast_default(
-                            ExitCode::ErrIllegalState,
-                            format!("failed to store deadline {} partitions", deadline_idx),
-                        )
-                    })?;
+                deadlines.update_deadline(policy, store, deadline_idx, &deadline).map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to store deadline {} partitions", deadline_idx),
+                    )
+                })?;
 
                 new_fault_power_total += &deadline_power_delta;
             }
@@ -2724,32 +2581,23 @@ impl Actor {
             let deadline = term.deadline;
             let partition = term.partition;
 
-            to_process
-                .add(rt.policy(), deadline, partition, term.sectors)
-                .map_err(|e| {
-                    actor_error!(
-                        ErrIllegalArgument,
-                        "failed to process deadline {}, partition {}: {}",
-                        deadline,
-                        partition,
-                        e
-                    )
-                })?;
+            to_process.add(rt.policy(), deadline, partition, term.sectors).map_err(|e| {
+                actor_error!(
+                    ErrIllegalArgument,
+                    "failed to process deadline {}, partition {}: {}",
+                    deadline,
+                    partition,
+                    e
+                )
+            })?;
         }
 
         {
             let policy = rt.policy();
             to_process
-                .check(
-                    policy.addressed_partitions_max,
-                    policy.addressed_sectors_max,
-                )
+                .check(policy.addressed_partitions_max, policy.addressed_sectors_max)
                 .map_err(|e| {
-                    actor_error!(
-                        ErrIllegalArgument,
-                        "cannot process requested parameters: {}",
-                        e
-                    )
+                    actor_error!(ErrIllegalArgument, "cannot process requested parameters: {}", e)
                 })?;
         }
 
@@ -2761,9 +2609,7 @@ impl Actor {
             let info = get_miner_info(rt.store(), state)?;
 
             rt.validate_immediate_caller_is(
-                info.control_addresses
-                    .iter()
-                    .chain(&[info.worker, info.owner]),
+                info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
 
             if consensus_fault_active(&info, rt.curr_epoch()) {
@@ -2775,9 +2621,8 @@ impl Actor {
 
             let store = rt.store();
 
-            let mut deadlines = state
-                .load_deadlines(store)
-                .map_err(|e| e.wrap("failed to load deadlines"))?;
+            let mut deadlines =
+                state.load_deadlines(store).map_err(|e| e.wrap("failed to load deadlines"))?;
 
             let sectors = Sectors::load(store, &state.sectors).map_err(|e| {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to load sectors array")
@@ -2809,9 +2654,8 @@ impl Actor {
                     )
                 })?;
 
-                let mut deadline = deadlines
-                    .load_deadline(policy, store, deadline_idx)
-                    .map_err(|e| {
+                let mut deadline =
+                    deadlines.load_deadline(policy, store, deadline_idx).map_err(|e| {
                         e.downcast_default(
                             ExitCode::ErrIllegalState,
                             format!("failed to load deadline {}", deadline_idx),
@@ -2827,14 +2671,12 @@ impl Actor {
                         )
                     })?;
 
-                deadlines
-                    .update_deadline(policy, store, deadline_idx, &deadline)
-                    .map_err(|e| {
-                        e.downcast_default(
-                            ExitCode::ErrIllegalState,
-                            format!("failed to store deadline {}", deadline_idx),
-                        )
-                    })?;
+                deadlines.update_deadline(policy, store, deadline_idx, &deadline).map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to store deadline {}", deadline_idx),
+                    )
+                })?;
             }
 
             state.save_deadlines(store, deadlines).map_err(|e| {
@@ -2846,14 +2688,9 @@ impl Actor {
 
         burn_funds(rt, fee_to_burn)?;
         let state: State = rt.state()?;
-        state
-            .check_balance_invariants(&rt.current_balance())
-            .map_err(|e| {
-                ActorError::new(
-                    ErrBalanceInvariantBroken,
-                    format!("balance invariants broken: {}", e),
-                )
-            })?;
+        state.check_balance_invariants(&rt.current_balance()).map_err(|e| {
+            ActorError::new(ErrBalanceInvariantBroken, format!("balance invariants broken: {}", e))
+        })?;
 
         // Power is not restored yet, but when the recovered sectors are successfully PoSted.
         Ok(())
@@ -2885,11 +2722,7 @@ impl Actor {
         }
 
         let partitions = params.partitions.validate().map_err(|e| {
-            actor_error!(
-                ErrIllegalArgument,
-                "failed to parse partitions bitfield: {}",
-                e
-            )
+            actor_error!(ErrIllegalArgument, "failed to parse partitions bitfield: {}", e)
         })?;
         let partition_count = partitions.len();
 
@@ -2899,9 +2732,7 @@ impl Actor {
             let info = get_miner_info(rt.store(), state)?;
 
             rt.validate_immediate_caller_is(
-                info.control_addresses
-                    .iter()
-                    .chain(&[info.worker, info.owner]),
+                info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
 
             let store = rt.store();
@@ -2935,28 +2766,22 @@ impl Actor {
             }
 
             let quant = state.quant_spec_for_deadline(policy, params_deadline);
-            let mut deadlines = state
-                .load_deadlines(store)
-                .map_err(|e| e.wrap("failed to load deadlines"))?;
+            let mut deadlines =
+                state.load_deadlines(store).map_err(|e| e.wrap("failed to load deadlines"))?;
 
-            let mut deadline = deadlines
-                .load_deadline(policy, store, params_deadline)
-                .map_err(|e| {
+            let mut deadline =
+                deadlines.load_deadline(policy, store, params_deadline).map_err(|e| {
                     e.downcast_default(
                         ExitCode::ErrIllegalState,
                         format!("failed to load deadline {}", params_deadline),
                     )
                 })?;
 
-            let (live, dead, removed_power) = deadline
-                .remove_partitions(store, partitions, quant)
-                .map_err(|e| {
+            let (live, dead, removed_power) =
+                deadline.remove_partitions(store, partitions, quant).map_err(|e| {
                     e.downcast_default(
                         ExitCode::ErrIllegalState,
-                        format!(
-                            "failed to remove partitions from deadline {}",
-                            params_deadline
-                        ),
+                        format!("failed to remove partitions from deadline {}", params_deadline),
                     )
                 })?;
 
@@ -2993,14 +2818,12 @@ impl Actor {
                 ));
             }
 
-            deadlines
-                .update_deadline(policy, store, params_deadline, &deadline)
-                .map_err(|e| {
-                    e.downcast_default(
-                        ExitCode::ErrIllegalState,
-                        format!("failed to update deadline {}", params_deadline),
-                    )
-                })?;
+            deadlines.update_deadline(policy, store, params_deadline, &deadline).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    format!("failed to update deadline {}", params_deadline),
+                )
+            })?;
 
             state.save_deadlines(store, deadlines).map_err(|e| {
                 e.downcast_default(
@@ -3056,9 +2879,7 @@ impl Actor {
             let info = get_miner_info(rt.store(), state)?;
 
             rt.validate_immediate_caller_is(
-                info.control_addresses
-                    .iter()
-                    .chain(&[info.worker, info.owner]),
+                info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
 
             state.allocate_sector_numbers(
@@ -3100,15 +2921,9 @@ impl Actor {
 
             // This ensures the miner has sufficient funds to lock up amountToLock.
             // This should always be true if reward actor sends reward funds with the message.
-            let unlocked_balance = st
-                .get_unlocked_balance(&rt.current_balance())
-                .map_err(|e| {
-                    actor_error!(
-                        ErrIllegalState,
-                        "failed to calculate unlocked balance: {}",
-                        e
-                    )
-                })?;
+            let unlocked_balance = st.get_unlocked_balance(&rt.current_balance()).map_err(|e| {
+                actor_error!(ErrIllegalState, "failed to calculate unlocked balance: {}", e)
+            })?;
 
             if unlocked_balance < reward_to_lock {
                 return Err(actor_error!(
@@ -3127,11 +2942,7 @@ impl Actor {
                     locked_reward_vesting_spec,
                 )
                 .map_err(|e| {
-                    actor_error!(
-                        ErrIllegalState,
-                        "failed to lock funds in vesting table: {}",
-                        e
-                    )
+                    actor_error!(ErrIllegalState, "failed to lock funds in vesting table: {}", e)
                 })?;
             pledge_delta_total -= &newly_vested;
             pledge_delta_total += &reward_to_lock;
@@ -3159,13 +2970,9 @@ impl Actor {
         notify_pledge_changed(rt, &pledge_delta_total)?;
         burn_funds(rt, to_burn)?;
         let st: State = rt.state()?;
-        st.check_balance_invariants(&rt.current_balance())
-            .map_err(|e| {
-                ActorError::new(
-                    ErrBalanceInvariantBroken,
-                    format!("balance invariants broken: {}", e),
-                )
-            })?;
+        st.check_balance_invariants(&rt.current_balance()).map_err(|e| {
+            ActorError::new(ErrBalanceInvariantBroken, format!("balance invariants broken: {}", e))
+        })?;
         Ok(())
     }
 
@@ -3269,14 +3076,9 @@ impl Actor {
         notify_pledge_changed(rt, &pledge_delta)?;
 
         let state: State = rt.state()?;
-        state
-            .check_balance_invariants(&rt.current_balance())
-            .map_err(|e| {
-                ActorError::new(
-                    ErrBalanceInvariantBroken,
-                    format!("balance invariants broken: {}", e),
-                )
-            })?;
+        state.check_balance_invariants(&rt.current_balance()).map_err(|e| {
+            ActorError::new(ErrBalanceInvariantBroken, format!("balance invariants broken: {}", e))
+        })?;
         Ok(())
     }
 
@@ -3315,18 +3117,16 @@ impl Actor {
                 }
 
                 // Unlock vested funds so we can spend them.
-                let newly_vested = state
-                    .unlock_vested_funds(rt.store(), rt.curr_epoch())
-                    .map_err(|e| {
+                let newly_vested =
+                    state.unlock_vested_funds(rt.store(), rt.curr_epoch()).map_err(|e| {
                         e.downcast_default(ExitCode::ErrIllegalState, "Failed to vest fund")
                     })?;
 
                 // available balance already accounts for fee debt so it is correct to call
                 // this before RepayDebts. We would have to
                 // subtract fee debt explicitly if we called this after.
-                let available_balance = state
-                    .get_available_balance(&rt.current_balance())
-                    .map_err(|e| {
+                let available_balance =
+                    state.get_available_balance(&rt.current_balance()).map_err(|e| {
                         actor_error!(
                             ErrIllegalState,
                             format!("failed to calculate available balance: {}", e)
@@ -3337,13 +3137,7 @@ impl Actor {
                 // and repay fee debt now.
                 let fee_to_burn = repay_debts_or_abort(rt, state)?;
 
-                Ok((
-                    info,
-                    newly_vested,
-                    fee_to_burn,
-                    available_balance,
-                    state.clone(),
-                ))
+                Ok((info, newly_vested, fee_to_burn, available_balance, state.clone()))
             })?;
 
         let amount_withdrawn = std::cmp::min(&available_balance, &params.amount_requested);
@@ -3364,28 +3158,16 @@ impl Actor {
         }
 
         if amount_withdrawn.is_positive() {
-            rt.send(
-                info.owner,
-                METHOD_SEND,
-                RawBytes::default(),
-                amount_withdrawn.clone(),
-            )?;
+            rt.send(info.owner, METHOD_SEND, RawBytes::default(), amount_withdrawn.clone())?;
         }
 
         burn_funds(rt, fee_to_burn)?;
         notify_pledge_changed(rt, &newly_vested.neg())?;
 
-        state
-            .check_balance_invariants(&rt.current_balance())
-            .map_err(|e| {
-                ActorError::new(
-                    ErrBalanceInvariantBroken,
-                    format!("balance invariants broken: {}", e),
-                )
-            })?;
-        Ok(WithdrawBalanceReturn {
-            amount_withdrawn: amount_withdrawn.clone(),
-        })
+        state.check_balance_invariants(&rt.current_balance()).map_err(|e| {
+            ActorError::new(ErrBalanceInvariantBroken, format!("balance invariants broken: {}", e))
+        })?;
+        Ok(WithdrawBalanceReturn { amount_withdrawn: amount_withdrawn.clone() })
     }
 
     fn repay_debt<BS, RT>(rt: &mut RT) -> Result<(), ActorError>
@@ -3396,9 +3178,7 @@ impl Actor {
         let (from_vesting, from_balance, state) = rt.transaction(|state: &mut State, rt| {
             let info = get_miner_info(rt.store(), state)?;
             rt.validate_immediate_caller_is(
-                info.control_addresses
-                    .iter()
-                    .chain(&[info.worker, info.owner]),
+                info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
 
             // Repay as much fee debt as possible.
@@ -3419,14 +3199,9 @@ impl Actor {
         notify_pledge_changed(rt, &from_vesting.neg())?;
         burn_funds(rt, burn_amount)?;
 
-        state
-            .check_balance_invariants(&rt.current_balance())
-            .map_err(|e| {
-                ActorError::new(
-                    ErrBalanceInvariantBroken,
-                    format!("balance invariants broken: {}", e),
-                )
-            })?;
+        state.check_balance_invariants(&rt.current_balance()).map_err(|e| {
+            ActorError::new(ErrBalanceInvariantBroken, format!("balance invariants broken: {}", e))
+        })?;
         Ok(())
     }
 
@@ -3443,10 +3218,7 @@ impl Actor {
         let payload: CronEventPayload = from_slice(&params.event_payload).map_err(|e| {
             actor_error!(
                 ErrIllegalState,
-                format!(
-                    "failed to unmarshal miner cron payload into expected structure: {}",
-                    e
-                )
+                format!("failed to unmarshal miner cron payload into expected structure: {}", e)
             )
         })?;
 
@@ -3466,21 +3238,13 @@ impl Actor {
                 }
             }
             _ => {
-                error!(
-                    "onDeferredCronEvent invalid event type: {}",
-                    payload.event_type
-                );
+                error!("onDeferredCronEvent invalid event type: {}", payload.event_type);
             }
         };
         let state: State = rt.state()?;
-        state
-            .check_balance_invariants(&rt.current_balance())
-            .map_err(|e| {
-                ActorError::new(
-                    ErrBalanceInvariantBroken,
-                    format!("balance invariants broken: {}", e),
-                )
-            })?;
+        state.check_balance_invariants(&rt.current_balance()).map_err(|e| {
+            ActorError::new(ErrBalanceInvariantBroken, format!("balance invariants broken: {}", e))
+        })?;
         Ok(())
     }
 }
@@ -3521,13 +3285,7 @@ where
             // before the cron callback fires.
             if result.is_empty() {
                 info!("no early terminations (maybe cron callback hasn't happened yet?)");
-                return Ok((
-                    result,
-                    more,
-                    Vec::new(),
-                    TokenAmount::zero(),
-                    TokenAmount::zero(),
-                ));
+                return Ok((result, more, Vec::new(), TokenAmount::zero(), TokenAmount::zero()));
             }
 
             let info = get_miner_info(rt.store(), state)?;
@@ -3682,11 +3440,9 @@ where
         // That way, don't re-schedule a cron callback if one is already scheduled.
         had_early_terminations = have_pending_early_terminations(state);
 
-        let result = state
-            .advance_deadline(policy, rt.store(), rt.curr_epoch())
-            .map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to advance deadline")
-            })?;
+        let result = state.advance_deadline(policy, rt.store(), rt.curr_epoch()).map_err(|e| {
+            e.downcast_default(ExitCode::ErrIllegalState, "failed to advance deadline")
+        })?;
 
         // Faults detected by this missed PoSt pay no penalty, but sectors that were already faulty
         // and remain faulty through this deadline pay the fault fee.
@@ -3741,15 +3497,10 @@ where
         enroll_cron_event(
             rt,
             new_deadline_info.last(),
-            CronEventPayload {
-                event_type: CRON_EVENT_PROVING_DEADLINE,
-            },
+            CronEventPayload { event_type: CRON_EVENT_PROVING_DEADLINE },
         )?;
     } else {
-        info!(
-            "miner {} going inactive, deadline cron discontinued",
-            rt.message().receiver()
-        )
+        info!("miner {} going inactive, deadline cron discontinued", rt.message().receiver())
     }
 
     // Record whether or not we _have_ early terminations now.
@@ -3821,11 +3572,7 @@ where
     // total sector lifetime cannot exceed SectorMaximumLifetime for the sector's seal proof
     let max_lifetime = seal_proof_sector_maximum_lifetime(policy, seal_proof, rt.network_version())
         .ok_or_else(|| {
-            actor_error!(
-                ErrIllegalArgument,
-                "unrecognized seal proof type {:?}",
-                seal_proof
-            )
+            actor_error!(ErrIllegalArgument, "unrecognized seal proof type {:?}", seal_proof)
         })?;
     if expiration - activation > max_lifetime {
         return Err(actor_error!(
@@ -3859,11 +3606,7 @@ where
             )
         })?
         .ok_or_else(|| {
-            actor_error!(
-                ErrNotFound,
-                "no such sector {} to replace",
-                params.replace_sector_number
-            )
+            actor_error!(ErrNotFound, "no such sector {} to replace", params.replace_sector_number)
         })?;
 
     if !replace_sector.deal_ids.is_empty() {
@@ -3877,10 +3620,8 @@ where
     // From network version 7, the new sector's seal type must have the same Window PoSt proof type as the one
     // being replaced, rather than be exactly the same seal type.
     // This permits replacing sectors with V1 seal types with V1_1 seal types.
-    let replace_w_post_proof = replace_sector
-        .seal_proof
-        .registered_window_post_proof()
-        .map_err(|e| {
+    let replace_w_post_proof =
+        replace_sector.seal_proof.registered_window_post_proof().map_err(|e| {
             actor_error!(
                 ErrIllegalState,
                 "failed to lookup Window PoSt proof type for sector seal proof {:?}: {}",
@@ -3888,17 +3629,14 @@ where
                 e
             )
         })?;
-    let new_w_post_proof = params
-        .seal_proof
-        .registered_window_post_proof()
-        .map_err(|e| {
-            actor_error!(
-                ErrIllegalArgument,
-                "failed to lookup Window PoSt proof type for new seal proof {:?}: {}",
-                replace_sector.seal_proof,
-                e
-            )
-        })?;
+    let new_w_post_proof = params.seal_proof.registered_window_post_proof().map_err(|e| {
+        actor_error!(
+            ErrIllegalArgument,
+            "failed to lookup Window PoSt proof type for new seal proof {:?}: {}",
+            replace_sector.seal_proof,
+            e
+        )
+    })?;
 
     if replace_w_post_proof != new_w_post_proof {
         return Err(actor_error!(
@@ -3950,10 +3688,8 @@ where
     let payload = RawBytes::serialize(cb)
         .map_err(|e| ActorError::from(e).wrap("failed to serialize payload: {}"))?;
 
-    let ser_params = RawBytes::serialize(ext::power::EnrollCronEventParams {
-        event_epoch,
-        payload,
-    })?;
+    let ser_params =
+        RawBytes::serialize(ext::power::EnrollCronEventParams { event_epoch, payload })?;
     rt.send(
         *STORAGE_POWER_ACTOR_ADDR,
         ext::power::ENROLL_CRON_EVENT_METHOD,
@@ -4024,9 +3760,7 @@ where
     enroll_cron_event(
         rt,
         rt.curr_epoch() + 1,
-        CronEventPayload {
-            event_type: CRON_EVENT_PROCESS_EARLY_TERMINATIONS,
-        },
+        CronEventPayload { event_type: CRON_EVENT_PROCESS_EARLY_TERMINATIONS },
     )
 }
 
@@ -4073,12 +3807,8 @@ where
         .collect();
 
     // get public inputs
-    let pv_info = WindowPoStVerifyInfo {
-        randomness,
-        proofs,
-        challenged_sectors,
-        prover: miner_actor_id,
-    };
+    let pv_info =
+        WindowPoStVerifyInfo { randomness, proofs, challenged_sectors, prover: miner_actor_id };
 
     // verify the post proof
     rt.verify_post(&pv_info).map_err(|e| {
@@ -4140,10 +3870,7 @@ where
 
     Ok(SealVerifyInfo {
         registered_proof: params.registered_seal_proof,
-        sector_id: SectorID {
-            miner: miner_actor_id,
-            number: params.sector_num,
-        },
+        sector_id: SectorID { miner: miner_actor_id, number: params.sector_num },
         deal_ids: params.deal_ids,
         interactive_randomness,
         proof: params.proof,
@@ -4350,18 +4077,9 @@ where
     BS: Blockstore,
     RT: Runtime<BS>,
 {
-    log::debug!(
-        "storage provder {} burning {}",
-        rt.message().receiver(),
-        amount
-    );
+    log::debug!("storage provder {} burning {}", rt.message().receiver(), amount);
     if amount.is_positive() {
-        rt.send(
-            *BURNT_FUNDS_ACTOR_ADDR,
-            METHOD_SEND,
-            RawBytes::default(),
-            amount,
-        )?;
+        rt.send(*BURNT_FUNDS_ACTOR_ADDR, METHOD_SEND, RawBytes::default(), amount)?;
     }
     Ok(())
 }
@@ -4465,9 +4183,7 @@ fn validate_partition_contains_sectors(
     partition: &Partition,
     sectors: &mut UnvalidatedBitField,
 ) -> anyhow::Result<()> {
-    let sectors = sectors
-        .validate()
-        .map_err(|e| anyhow!("failed to check sectors: {}", e))?;
+    let sectors = sectors.validate().map_err(|e| anyhow!("failed to check sectors: {}", e))?;
 
     // Check that the declared sectors are actually assigned to the partition.
     if partition.sectors.contains_all(sectors) {
@@ -4519,15 +4235,9 @@ fn power_for_sector(sector_size: SectorSize, sector: &SectorOnChainInfo) -> Powe
 
 /// Returns the sum of the raw byte and quality-adjusted power for sectors.
 fn power_for_sectors(sector_size: SectorSize, sectors: &[SectorOnChainInfo]) -> PowerPair {
-    let qa = sectors
-        .iter()
-        .map(|s| qa_power_for_sector(sector_size, s))
-        .sum();
+    let qa = sectors.iter().map(|s| qa_power_for_sector(sector_size, s)).sum();
 
-    PowerPair {
-        raw: BigInt::from(sector_size as u64) * BigInt::from(sectors.len()),
-        qa,
-    }
+    PowerPair { raw: BigInt::from(sector_size as u64) * BigInt::from(sectors.len()), qa }
 }
 
 fn get_miner_info<BS>(store: &BS, state: &State) -> Result<MinerInfo, ActorError>
@@ -4579,10 +4289,7 @@ where
     RT: Runtime<BS>,
 {
     let res = state.repay_debts(&rt.current_balance()).map_err(|e| {
-        e.downcast_default(
-            ExitCode::ErrIllegalState,
-            "unlocked balance can not repay fee debt",
-        )
+        e.downcast_default(ExitCode::ErrIllegalState, "unlocked balance can not repay fee debt")
     })?;
     info!("RepayDebtsOrAbort was called and succeeded");
     Ok(res)
@@ -4698,10 +4405,7 @@ where
 
     // When all prove commits have failed abort early
     if valid_pre_commits.is_empty() {
-        return Err(actor_error!(
-            ErrIllegalArgument,
-            "all prove commits failed to validate"
-        ));
+        return Err(actor_error!(ErrIllegalArgument, "all prove commits failed to validate"));
     }
 
     let (total_pledge, newly_vested) = rt.transaction(|state: &mut State, rt| {
@@ -4787,14 +4491,9 @@ where
             e.downcast_default(ExitCode::ErrIllegalState, "failed to put new sectors")
         })?;
 
-        state
-            .delete_precommitted_sectors(store, &new_sector_numbers)
-            .map_err(|e| {
-                e.downcast_default(
-                    ExitCode::ErrIllegalState,
-                    "failed to delete precommited sectors",
-                )
-            })?;
+        state.delete_precommitted_sectors(store, &new_sector_numbers).map_err(|e| {
+            e.downcast_default(ExitCode::ErrIllegalState, "failed to delete precommited sectors")
+        })?;
 
         state
             .assign_sectors_to_deadlines(
@@ -4819,15 +4518,9 @@ where
             .add_pre_commit_deposit(&(-deposit_to_unlock))
             .map_err(|e| actor_error!(ErrIllegalState, "failed to add precommit deposit: {}", e))?;
 
-        let unlocked_balance = state
-            .get_unlocked_balance(&rt.current_balance())
-            .map_err(|e| {
-                actor_error!(
-                    ErrIllegalState,
-                    "failed to calculate unlocked balance: {}",
-                    e
-                )
-            })?;
+        let unlocked_balance = state.get_unlocked_balance(&rt.current_balance()).map_err(|e| {
+            actor_error!(ErrIllegalState, "failed to calculate unlocked balance: {}", e)
+        })?;
         if unlocked_balance < total_pledge {
             return Err(actor_error!(
                 ErrInsufficientFunds,
@@ -4841,14 +4534,9 @@ where
             .add_initial_pledge(&total_pledge)
             .map_err(|e| actor_error!(ErrIllegalState, "failed to add initial pledge: {}", e))?;
 
-        state
-            .check_balance_invariants(&rt.current_balance())
-            .map_err(|e| {
-                ActorError::new(
-                    ErrBalanceInvariantBroken,
-                    format!("balance invariant broken: {}", e),
-                )
-            })?;
+        state.check_balance_invariants(&rt.current_balance()).map_err(|e| {
+            ActorError::new(ErrBalanceInvariantBroken, format!("balance invariant broken: {}", e))
+        })?;
 
         Ok((total_pledge, newly_vested))
     })?;

--- a/actors/miner/src/monies.rs
+++ b/actors/miner/src/monies.rs
@@ -295,22 +295,14 @@ pub fn aggregate_prove_commit_network_fee(
     aggregate_size: i64,
     base_fee: &TokenAmount,
 ) -> TokenAmount {
-    aggregate_network_fee(
-        aggregate_size,
-        &ESTIMATED_SINGLE_PROVE_COMMIT_GAS_USAGE,
-        base_fee,
-    )
+    aggregate_network_fee(aggregate_size, &ESTIMATED_SINGLE_PROVE_COMMIT_GAS_USAGE, base_fee)
 }
 
 pub fn aggregate_pre_commit_network_fee(
     aggregate_size: i64,
     base_fee: &TokenAmount,
 ) -> TokenAmount {
-    aggregate_network_fee(
-        aggregate_size,
-        &ESTIMATED_SINGLE_PRE_COMMIT_GAS_USAGE,
-        base_fee,
-    )
+    aggregate_network_fee(aggregate_size, &ESTIMATED_SINGLE_PRE_COMMIT_GAS_USAGE, base_fee)
 }
 
 pub fn aggregate_network_fee(

--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -22,10 +22,7 @@ use super::{PowerPair, BASE_REWARD_FOR_DISPUTED_WINDOW_POST};
 /// The maximum number of partitions that may be required to be loaded in a single invocation,
 /// when all the sector infos for the partitions will be loaded.
 pub fn load_partitions_sectors_max(policy: &Policy, partition_sector_count: u64) -> u64 {
-    cmp::min(
-        policy.addressed_sectors_max / partition_sector_count,
-        policy.addressed_partitions_max,
-    )
+    cmp::min(policy.addressed_sectors_max / partition_sector_count, policy.addressed_partitions_max)
 }
 
 /// Prefix for sealed sector CIDs (CommR).
@@ -143,12 +140,7 @@ pub fn qa_power_for_weight(
 /// Returns the quality-adjusted power for a sector.
 pub fn qa_power_for_sector(size: SectorSize, sector: &SectorOnChainInfo) -> StoragePower {
     let duration = sector.expiration - sector.activation;
-    qa_power_for_weight(
-        size,
-        duration,
-        &sector.deal_weight,
-        &sector.verified_deal_weight,
-    )
+    qa_power_for_weight(size, duration, &sector.deal_weight, &sector.verified_deal_weight)
 }
 
 /// Determine maximum number of deal miner's sector can hold

--- a/actors/miner/src/sector_map.rs
+++ b/actors/miner/src/sector_map.rs
@@ -22,24 +22,15 @@ impl DeadlineSectorMap {
     /// contained within the map, and returns an error if they exceed the given
     /// maximums.
     pub fn check(&mut self, max_partitions: u64, max_sectors: u64) -> anyhow::Result<()> {
-        let (partition_count, sector_count) = self
-            .count()
-            .map_err(|e| anyhow!("failed to count sectors: {:?}", e))?;
+        let (partition_count, sector_count) =
+            self.count().map_err(|e| anyhow!("failed to count sectors: {:?}", e))?;
 
         if partition_count > max_partitions {
-            return Err(anyhow!(
-                "too many partitions {}, max {}",
-                partition_count,
-                max_partitions
-            ));
+            return Err(anyhow!("too many partitions {}, max {}", partition_count, max_partitions));
         }
 
         if sector_count > max_sectors {
-            return Err(anyhow!(
-                "too many sectors {}, max {}",
-                sector_count,
-                max_sectors
-            ));
+            return Err(anyhow!("too many sectors {}, max {}", sector_count, max_sectors));
         }
 
         Ok(())
@@ -47,22 +38,19 @@ impl DeadlineSectorMap {
 
     /// Counts the number of partitions & sectors within the map.
     pub fn count(&mut self) -> anyhow::Result<(/* partitions */ u64, /* sectors */ u64)> {
-        self.0.iter_mut().try_fold(
-            (0_u64, 0_u64),
-            |(partitions, sectors), (deadline_idx, pm)| {
-                let (partition_count, sector_count) = pm
-                    .count()
-                    .map_err(|e| anyhow!("when counting deadline {}: {:?}", deadline_idx, e))?;
-                Ok((
-                    partitions
-                        .checked_add(partition_count)
-                        .ok_or_else(|| anyhow!("integer overflow when counting partitions"))?,
-                    sectors
-                        .checked_add(sector_count)
-                        .ok_or_else(|| anyhow!("integer overflow when counting sectors"))?,
-                ))
-            },
-        )
+        self.0.iter_mut().try_fold((0_u64, 0_u64), |(partitions, sectors), (deadline_idx, pm)| {
+            let (partition_count, sector_count) = pm
+                .count()
+                .map_err(|e| anyhow!("when counting deadline {}: {:?}", deadline_idx, e))?;
+            Ok((
+                partitions
+                    .checked_add(partition_count)
+                    .ok_or_else(|| anyhow!("integer overflow when counting partitions"))?,
+                sectors
+                    .checked_add(sector_count)
+                    .ok_or_else(|| anyhow!("integer overflow when counting sectors"))?,
+            ))
+        })
     }
 
     /// Records the given sector bitfield at the given deadline/partition index.
@@ -77,10 +65,7 @@ impl DeadlineSectorMap {
             return Err(anyhow!("invalid deadline {}", deadline_idx));
         }
 
-        self.0
-            .entry(deadline_idx)
-            .or_default()
-            .add(partition_idx, sector_numbers)
+        self.0.entry(deadline_idx).or_default().add(partition_idx, sector_numbers)
     }
 
     /// Records the given sectors at the given deadline/partition index.
@@ -121,10 +106,7 @@ impl PartitionSectorMap {
         partition_idx: u64,
         sector_numbers: Vec<u64>,
     ) -> anyhow::Result<()> {
-        self.add(
-            partition_idx,
-            sector_numbers.into_iter().collect::<BitField>().into(),
-        )
+        self.add(partition_idx, sector_numbers.into_iter().collect::<BitField>().into())
     }
     /// Records the given sector bitfield at the given partition index, merging
     /// it with any existing bitfields if necessary.
@@ -152,21 +134,14 @@ impl PartitionSectorMap {
 
     /// Counts the number of partitions & sectors within the map.
     pub fn count(&mut self) -> anyhow::Result<(/* partitions */ u64, /* sectors */ u64)> {
-        let sectors = self
-            .0
-            .iter_mut()
-            .try_fold(0_u64, |sectors, (partition_idx, bf)| {
-                let validated = bf.validate().map_err(|e| {
-                    anyhow!(
-                        "failed to parse bitmap for partition {}: {}",
-                        partition_idx,
-                        e
-                    )
-                })?;
-                sectors
-                    .checked_add(validated.len() as u64)
-                    .ok_or_else(|| anyhow!("integer overflow when counting sectors"))
+        let sectors = self.0.iter_mut().try_fold(0_u64, |sectors, (partition_idx, bf)| {
+            let validated = bf.validate().map_err(|e| {
+                anyhow!("failed to parse bitmap for partition {}: {}", partition_idx, e)
             })?;
+            sectors
+                .checked_add(validated.len() as u64)
+                .ok_or_else(|| anyhow!("integer overflow when counting sectors"))
+        })?;
         Ok((self.0.len() as u64, sectors))
     }
 

--- a/actors/miner/src/vesting_state.rs
+++ b/actors/miner/src/vesting_state.rs
@@ -67,11 +67,8 @@ impl VestingFunds {
 
             epoch += spec.step_duration;
 
-            let vest_epoch = QuantSpec {
-                unit: spec.quantization,
-                offset: proving_period_start,
-            }
-            .quantize_up(epoch);
+            let vest_epoch = QuantSpec { unit: spec.quantization, offset: proving_period_start }
+                .quantize_up(epoch);
 
             let elapsed = vest_epoch - vest_begin;
             let target_vest = if elapsed < spec.vest_period {
@@ -84,10 +81,7 @@ impl VestingFunds {
             let vest_this_time = &target_vest - &vested_so_far;
             vested_so_far = target_vest;
 
-            Some(VestingFund {
-                epoch: vest_epoch,
-                amount: vest_this_time,
-            })
+            Some(VestingFund { epoch: vest_epoch, amount: vest_this_time })
         });
 
         // Take the old funds array and replace it with a new one.
@@ -96,17 +90,15 @@ impl VestingFunds {
 
         // Fill back in the funds array, merging existing and new schedule.
         self.funds.extend(
-            old_funds
-                .into_iter()
-                .merge_join_by(new_funds, |a, b| a.epoch.cmp(&b.epoch))
-                .map(|item| match item {
+            old_funds.into_iter().merge_join_by(new_funds, |a, b| a.epoch.cmp(&b.epoch)).map(
+                |item| match item {
                     EitherOrBoth::Left(a) => a,
                     EitherOrBoth::Right(b) => b,
-                    EitherOrBoth::Both(a, b) => VestingFund {
-                        epoch: a.epoch,
-                        amount: a.amount + b.amount,
-                    },
-                }),
+                    EitherOrBoth::Both(a, b) => {
+                        VestingFund { epoch: a.epoch, amount: a.amount + b.amount }
+                    }
+                },
+            ),
         );
     }
 

--- a/actors/miner/tests/miner_actor_test_construction.rs
+++ b/actors/miner/tests/miner_actor_test_construction.rs
@@ -42,18 +42,10 @@ fn prepare_env() -> TestEnv {
     };
 
     env.rt.receiver = env.receiver;
-    env.rt
-        .actor_code_cids
-        .insert(env.owner, *ACCOUNT_ACTOR_CODE_ID);
-    env.rt
-        .actor_code_cids
-        .insert(env.worker, *ACCOUNT_ACTOR_CODE_ID);
-    env.rt
-        .actor_code_cids
-        .insert(env.control_addrs[0], *ACCOUNT_ACTOR_CODE_ID);
-    env.rt
-        .actor_code_cids
-        .insert(env.control_addrs[1], *ACCOUNT_ACTOR_CODE_ID);
+    env.rt.actor_code_cids.insert(env.owner, *ACCOUNT_ACTOR_CODE_ID);
+    env.rt.actor_code_cids.insert(env.worker, *ACCOUNT_ACTOR_CODE_ID);
+    env.rt.actor_code_cids.insert(env.control_addrs[0], *ACCOUNT_ACTOR_CODE_ID);
+    env.rt.actor_code_cids.insert(env.control_addrs[1], *ACCOUNT_ACTOR_CODE_ID);
     env.rt.hash_func = Box::new(blake2b_256);
     env.rt.caller = *INIT_ACTOR_ADDR;
     env.rt.caller_type = *INIT_ACTOR_CODE_ID;
@@ -88,10 +80,7 @@ fn simple_construction() {
 
     let result = env
         .rt
-        .call::<Actor>(
-            Method::Constructor as u64,
-            &RawBytes::serialize(params).unwrap(),
-        )
+        .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
         .unwrap();
     assert_eq!(result.bytes().len(), 0);
     env.rt.verify();
@@ -104,10 +93,7 @@ fn simple_construction() {
     assert_eq!(env.control_addrs, info.control_addresses);
     assert_eq!(env.peer_id, info.peer_id);
     assert_eq!(env.multiaddrs, info.multi_address);
-    assert_eq!(
-        RegisteredPoStProof::StackedDRGWindow32GiBV1,
-        info.window_post_proof_type
-    );
+    assert_eq!(RegisteredPoStProof::StackedDRGWindow32GiBV1, info.window_post_proof_type);
     assert_eq!(SectorSize::_32GiB, info.sector_size);
     assert_eq!(2349, info.window_post_partition_sectors);
 
@@ -123,12 +109,7 @@ fn simple_construction() {
     let dl_idx = (env.rt.epoch - proving_period_start) / env.rt.policy.wpost_challenge_window;
     assert_eq!(dl_idx as u64, state.current_deadline);
 
-    let deadlines = env
-        .rt
-        .store
-        .get_cbor::<Deadlines>(&state.deadlines)
-        .unwrap()
-        .unwrap();
+    let deadlines = env.rt.store.get_cbor::<Deadlines>(&state.deadlines).unwrap().unwrap();
     for i in 0..env.rt.policy.wpost_period_deadlines {
         let c = deadlines.due[i as usize];
         let deadline = env.rt.store.get_cbor::<Deadline>(&c).unwrap().unwrap();
@@ -154,12 +135,8 @@ fn control_addresses_are_resolved_during_construction() {
     let control2id = Address::new_id(655);
 
     env.control_addrs = vec![control1, control2];
-    env.rt
-        .actor_code_cids
-        .insert(control1id, *ACCOUNT_ACTOR_CODE_ID);
-    env.rt
-        .actor_code_cids
-        .insert(control2id, *ACCOUNT_ACTOR_CODE_ID);
+    env.rt.actor_code_cids.insert(control1id, *ACCOUNT_ACTOR_CODE_ID);
+    env.rt.actor_code_cids.insert(control2id, *ACCOUNT_ACTOR_CODE_ID);
     env.rt.id_addresses.insert(control1, control1id);
     env.rt.id_addresses.insert(control2, control2id);
 
@@ -176,10 +153,7 @@ fn control_addresses_are_resolved_during_construction() {
 
     let result = env
         .rt
-        .call::<Actor>(
-            Method::Constructor as u64,
-            &RawBytes::serialize(params).unwrap(),
-        )
+        .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
         .unwrap();
     assert_eq!(result.bytes().len(), 0);
     env.rt.verify();
@@ -198,9 +172,7 @@ fn fails_if_control_address_is_not_an_account_actor() {
 
     let control1 = Address::new_id(501);
     env.control_addrs = vec![control1];
-    env.rt
-        .actor_code_cids
-        .insert(control1, *PAYCH_ACTOR_CODE_ID);
+    env.rt.actor_code_cids.insert(control1, *PAYCH_ACTOR_CODE_ID);
 
     let params = constructor_params(&env);
     env.rt.expect_validate_caller_addr(vec![*INIT_ACTOR_ADDR]);
@@ -215,10 +187,7 @@ fn fails_if_control_address_is_not_an_account_actor() {
 
     let result = env
         .rt
-        .call::<Actor>(
-            Method::Constructor as u64,
-            &RawBytes::serialize(params).unwrap(),
-        )
+        .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
         .unwrap_err();
     assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
     env.rt.verify();
@@ -234,10 +203,7 @@ fn test_construct_with_invalid_peer_id() {
 
     let result = env
         .rt
-        .call::<Actor>(
-            Method::Constructor as u64,
-            &RawBytes::serialize(params).unwrap(),
-        )
+        .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
         .unwrap_err();
     assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
     env.rt.verify();
@@ -256,10 +222,7 @@ fn fails_if_control_addresses_exceeds_maximum_length() {
 
     let result = env
         .rt
-        .call::<Actor>(
-            Method::Constructor as u64,
-            &RawBytes::serialize(params).unwrap(),
-        )
+        .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
         .unwrap_err();
     assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
     env.rt.verify();
@@ -270,8 +233,7 @@ fn test_construct_with_large_multiaddr() {
     let mut env = prepare_env();
     env.multiaddrs = Vec::new();
     for _ in 0..100 {
-        env.multiaddrs
-            .push(BytesDe(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]));
+        env.multiaddrs.push(BytesDe(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]));
     }
 
     let params = constructor_params(&env);
@@ -279,10 +241,7 @@ fn test_construct_with_large_multiaddr() {
 
     let result = env
         .rt
-        .call::<Actor>(
-            Method::Constructor as u64,
-            &RawBytes::serialize(params).unwrap(),
-        )
+        .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
         .unwrap_err();
     assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
     env.rt.verify();
@@ -300,10 +259,7 @@ fn test_construct_with_empty_multiaddr() {
 
     let result = env
         .rt
-        .call::<Actor>(
-            Method::Constructor as u64,
-            &RawBytes::serialize(params).unwrap(),
-        )
+        .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
         .unwrap_err();
     assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
     env.rt.verify();

--- a/actors/miner/tests/miner_actor_test_peer_info.rs
+++ b/actors/miner/tests/miner_actor_test_peer_info.rs
@@ -55,10 +55,7 @@ fn can_set_multiple_multiaddrs() {
     let h = util::ActorHarness::new(0);
 
     h.construct_and_verify(&mut rt);
-    h.set_multiaddr(
-        &mut rt,
-        vec![BytesDe(vec![1, 3, 3, 7]), BytesDe(vec![2, 4, 4, 8])],
-    );
+    h.set_multiaddr(&mut rt, vec![BytesDe(vec![1, 3, 3, 7]), BytesDe(vec![2, 4, 4, 8])]);
 
     util::check_state_invariants(&rt);
 }

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -57,11 +57,7 @@ impl ActorHarness {
     pub fn new(proving_period_offset: ChainEpoch) -> ActorHarness {
         let owner = Address::new_id(100);
         let worker = Address::new_id(101);
-        let control_addrs = vec![
-            Address::new_id(999),
-            Address::new_id(998),
-            Address::new_id(997),
-        ];
+        let control_addrs = vec![Address::new_id(999), Address::new_id(998), Address::new_id(997)];
         let worker_key = new_bls_addr(0);
         let receiver = Address::new_id(1000);
         let rwd = TokenAmount::from(10_000_000_000_000_000_000i128);
@@ -103,10 +99,8 @@ impl ActorHarness {
             multi_addresses: vec![],
         };
 
-        rt.actor_code_cids
-            .insert(self.owner, *ACCOUNT_ACTOR_CODE_ID);
-        rt.actor_code_cids
-            .insert(self.worker, *ACCOUNT_ACTOR_CODE_ID);
+        rt.actor_code_cids.insert(self.owner, *ACCOUNT_ACTOR_CODE_ID);
+        rt.actor_code_cids.insert(self.worker, *ACCOUNT_ACTOR_CODE_ID);
         for a in self.control_addrs.iter() {
             rt.actor_code_cids.insert(*a, *ACCOUNT_ACTOR_CODE_ID);
         }
@@ -123,19 +117,14 @@ impl ActorHarness {
         );
 
         let result = rt
-            .call::<Actor>(
-                Method::Constructor as u64,
-                &RawBytes::serialize(params).unwrap(),
-            )
+            .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
             .unwrap();
         assert_eq!(result.bytes().len(), 0);
         rt.verify();
     }
 
     pub fn set_peer_id(self: &Self, rt: &mut MockRuntime, new_id: Vec<u8>) {
-        let params = ChangePeerIDParams {
-            new_id: new_id.clone(),
-        };
+        let params = ChangePeerIDParams { new_id: new_id.clone() };
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
 
@@ -145,10 +134,7 @@ impl ActorHarness {
         rt.expect_validate_caller_addr(caller_addrs);
 
         let result = rt
-            .call::<Actor>(
-                Method::ChangePeerID as u64,
-                &RawBytes::serialize(params).unwrap(),
-            )
+            .call::<Actor>(Method::ChangePeerID as u64, &RawBytes::serialize(params).unwrap())
             .unwrap();
         assert_eq!(result.bytes().len(), 0);
         rt.verify();
@@ -160,26 +146,19 @@ impl ActorHarness {
     }
 
     pub fn set_peer_id_fail(self: &Self, rt: &mut MockRuntime, new_id: Vec<u8>) {
-        let params = ChangePeerIDParams {
-            new_id: new_id.clone(),
-        };
+        let params = ChangePeerIDParams { new_id: new_id.clone() };
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
 
         let result = rt
-            .call::<Actor>(
-                Method::ChangePeerID as u64,
-                &RawBytes::serialize(params).unwrap(),
-            )
+            .call::<Actor>(Method::ChangePeerID as u64, &RawBytes::serialize(params).unwrap())
             .unwrap_err();
         assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
         rt.verify();
     }
 
     pub fn set_multiaddr(self: &Self, rt: &mut MockRuntime, new_multiaddrs: Vec<BytesDe>) {
-        let params = ChangeMultiaddrsParams {
-            new_multi_addrs: new_multiaddrs.clone(),
-        };
+        let params = ChangeMultiaddrsParams { new_multi_addrs: new_multiaddrs.clone() };
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
 
@@ -189,10 +168,7 @@ impl ActorHarness {
         rt.expect_validate_caller_addr(caller_addrs);
 
         let result = rt
-            .call::<Actor>(
-                Method::ChangeMultiaddrs as u64,
-                &RawBytes::serialize(params).unwrap(),
-            )
+            .call::<Actor>(Method::ChangeMultiaddrs as u64, &RawBytes::serialize(params).unwrap())
             .unwrap();
         assert_eq!(result.bytes().len(), 0);
         rt.verify();
@@ -204,17 +180,12 @@ impl ActorHarness {
     }
 
     pub fn set_multiaddr_fail(self: &Self, rt: &mut MockRuntime, new_multiaddrs: Vec<BytesDe>) {
-        let params = ChangeMultiaddrsParams {
-            new_multi_addrs: new_multiaddrs.clone(),
-        };
+        let params = ChangeMultiaddrsParams { new_multi_addrs: new_multiaddrs.clone() };
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
 
         let result = rt
-            .call::<Actor>(
-                Method::ChangeMultiaddrs as u64,
-                &RawBytes::serialize(params).unwrap(),
-            )
+            .call::<Actor>(Method::ChangeMultiaddrs as u64, &RawBytes::serialize(params).unwrap())
             .unwrap_err();
         assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
         rt.verify();
@@ -226,9 +197,8 @@ impl ActorHarness {
     ) -> (Address, Address, Vec<Address>) {
         rt.expect_validate_caller_any();
 
-        let result = rt
-            .call::<Actor>(Method::ControlAddresses as u64, &RawBytes::default())
-            .unwrap();
+        let result =
+            rt.call::<Actor>(Method::ControlAddresses as u64, &RawBytes::default()).unwrap();
         rt.verify();
 
         let value = result.deserialize::<GetControlAddressesReturn>().unwrap();

--- a/actors/multisig/src/state.rs
+++ b/actors/multisig/src/state.rs
@@ -112,10 +112,7 @@ impl State {
         curr_epoch: ChainEpoch,
     ) -> anyhow::Result<()> {
         if amount_to_spend < &0.into() {
-            return Err(anyhow!(
-                "amount to spend {} less than zero",
-                amount_to_spend
-            ));
+            return Err(anyhow!("amount to spend {} less than zero", amount_to_spend));
         }
         if &balance < amount_to_spend {
             return Err(anyhow!(

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -109,11 +109,7 @@ impl Actor {
         let st: State = rt.state()?;
 
         rt.validate_immediate_caller_is([st.from, st.to].iter())?;
-        let signer = if rt.message().caller() == st.from {
-            st.to
-        } else {
-            st.from
-        };
+        let signer = if rt.message().caller() == st.from { st.to } else { st.from };
         let sv = params.sv;
 
         // Pull signature from signed voucher
@@ -130,10 +126,7 @@ impl Actor {
         }
 
         if params.secret.len() > MAX_SECRET_SIZE {
-            return Err(actor_error!(
-                ErrIllegalArgument,
-                "secret must be at most 256 bytes long"
-            ));
+            return Err(actor_error!(ErrIllegalArgument, "secret must be at most 256 bytes long"));
         }
 
         // Generate unsigned bytes
@@ -346,10 +339,7 @@ where
     }
 
     ls.get(id).map_err(|e| {
-        e.downcast_default(
-            ExitCode::ErrIllegalState,
-            format!("failed to load lane {}", id),
-        )
+        e.downcast_default(ExitCode::ErrIllegalState, format!("failed to load lane {}", id))
     })
 }
 

--- a/actors/paych/tests/paych_actor_test.rs
+++ b/actors/paych/tests/paych_actor_test.rs
@@ -89,8 +89,7 @@ mod paych_constructor {
     fn create_paych_actor_test() {
         let caller_addr = Address::new_id(TEST_CALLER_ADDR);
         let mut rt = construct_runtime();
-        rt.actor_code_cids
-            .insert(caller_addr, *ACCOUNT_ACTOR_CODE_ID);
+        rt.actor_code_cids.insert(caller_addr, *ACCOUNT_ACTOR_CODE_ID);
         construct_and_verify(&mut rt, Address::new_id(TEST_PAYER_ADDR), caller_addr);
     }
 
@@ -146,10 +145,8 @@ mod paych_constructor {
             };
 
             rt.expect_validate_caller_type(vec![*INIT_ACTOR_CODE_ID]);
-            let params = ConstructorParams {
-                to: test_case.paych_addr,
-                from: Address::new_id(10001),
-            };
+            let params =
+                ConstructorParams { to: test_case.paych_addr, from: Address::new_id(10001) };
             expect_error(
                 &mut rt,
                 METHOD_CONSTRUCTOR,
@@ -309,11 +306,8 @@ mod create_lane_tests {
             rt.expect_validate_caller_addr(vec![payer_addr, payee_addr]);
 
             if test_case.sig.is_some() && test_case.secret_preimage.is_empty() {
-                let exp_exit_code = if !test_case.verify_sig {
-                    Err(anyhow!("bad signature"))
-                } else {
-                    Ok(())
-                };
+                let exp_exit_code =
+                    if !test_case.verify_sig { Err(anyhow!("bad signature")) } else { Ok(()) };
                 rt.expect_verify_signature(ExpectedVerifySig {
                     sig: sv.clone().signature.unwrap(),
                     signer: payer_addr,
@@ -380,10 +374,7 @@ mod update_channel_state_redeem {
         );
 
         rt.verify();
-        let exp_ls = LaneState {
-            redeemed: BigInt::from(9),
-            nonce: 2,
-        };
+        let exp_ls = LaneState { redeemed: BigInt::from(9), nonce: 2 };
         let exp_state = PState {
             from: state.from,
             to: state.to,
@@ -477,10 +468,7 @@ mod merge_tests {
         sv.lane = 0;
         let merge_nonce = merge_to.nonce + 10;
 
-        sv.merges = vec![Merge {
-            lane: 1,
-            nonce: merge_nonce,
-        }];
+        sv.merges = vec![Merge { lane: 1, nonce: merge_nonce }];
         let payee_addr = Address::new_id(PAYEE_ID);
         rt.expect_verify_signature(ExpectedVerifySig {
             sig: sv.clone().signature.unwrap(),
@@ -495,25 +483,16 @@ mod merge_tests {
             &RawBytes::serialize(UpdateChannelStateParams::from(sv.clone())).unwrap(),
         );
         rt.verify();
-        let exp_merge_to = LaneState {
-            redeemed: sv.amount.clone(),
-            nonce: sv.nonce,
-        };
-        let exp_merge_from = LaneState {
-            redeemed: merge_from.redeemed.clone(),
-            nonce: merge_nonce,
-        };
+        let exp_merge_to = LaneState { redeemed: sv.amount.clone(), nonce: sv.nonce };
+        let exp_merge_from =
+            LaneState { redeemed: merge_from.redeemed.clone(), nonce: merge_nonce };
         let redeemed = &merge_from.redeemed + &merge_to.redeemed;
         let exp_delta = &sv.amount - &redeemed;
         state.to_send = exp_delta + &state.to_send;
 
         state.lane_states = construct_lane_state_amt(
             &rt,
-            vec![
-                exp_merge_to,
-                exp_merge_from,
-                get_lane_state(&rt, &state.lane_states, 2),
-            ],
+            vec![exp_merge_to, exp_merge_from, get_lane_state(&rt, &state.lane_states, 2)],
         );
 
         verify_state(&mut rt, Some(num_lanes), state);
@@ -567,10 +546,7 @@ mod merge_tests {
 
             sv.lane = 0;
             sv.nonce = tc.voucher;
-            sv.merges = vec![Merge {
-                lane: tc.lane,
-                nonce: tc.merge,
-            }];
+            sv.merges = vec![Merge { lane: tc.lane, nonce: tc.merge }];
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, state.from);
             failure_end(&mut rt, sv, tc.exit);
         }
@@ -584,10 +560,7 @@ mod merge_tests {
 
         sv.lane = 0;
         sv.nonce = 10;
-        sv.merges = vec![Merge {
-            lane: 999,
-            nonce: sv.nonce,
-        }];
+        sv.merges = vec![Merge { lane: 999, nonce: sv.nonce }];
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, state.from);
         rt.expect_validate_caller_addr(vec![state.from, state.to]);
         rt.expect_verify_signature(ExpectedVerifySig {
@@ -700,16 +673,8 @@ fn update_channel_settling() {
             exp_min_settle_height: state.min_settle_height,
             exp_settling_at: state.settling_at,
         },
-        TestCase {
-            min_settle: 2,
-            exp_min_settle_height: 2,
-            exp_settling_at: state.settling_at,
-        },
-        TestCase {
-            min_settle: 12,
-            exp_min_settle_height: 12,
-            exp_settling_at: state.settling_at,
-        },
+        TestCase { min_settle: 2, exp_min_settle_height: 2, exp_settling_at: state.settling_at },
+        TestCase { min_settle: 12, exp_min_settle_height: 12, exp_settling_at: state.settling_at },
         TestCase {
             min_settle: state.settling_at + 1,
             exp_min_settle_height: state.settling_at + 1,
@@ -727,11 +692,7 @@ fn update_channel_settling() {
             plaintext: ucp.sv.signing_bytes().unwrap(),
             result: Ok(()),
         });
-        call(
-            &mut rt,
-            Method::UpdateChannelState as u64,
-            &RawBytes::serialize(&ucp).unwrap(),
-        );
+        call(&mut rt, Method::UpdateChannelState as u64, &RawBytes::serialize(&ucp).unwrap());
         let new_state: PState = rt.get_state().unwrap();
         assert_eq!(tc.exp_settling_at, new_state.settling_at);
         assert_eq!(tc.exp_min_settle_height, new_state.min_settle_height);
@@ -757,11 +718,7 @@ mod secret_preimage {
             result: Ok(()),
         });
 
-        call(
-            &mut rt,
-            Method::UpdateChannelState as u64,
-            &RawBytes::serialize(ucp).unwrap(),
-        );
+        call(&mut rt, Method::UpdateChannelState as u64, &RawBytes::serialize(ucp).unwrap());
 
         rt.verify();
     }
@@ -772,10 +729,7 @@ mod secret_preimage {
 
         let state: PState = rt.get_state().unwrap();
 
-        let mut ucp = UpdateChannelStateParams {
-            secret: b"Profesr".to_vec(),
-            sv: sv.clone(),
-        };
+        let mut ucp = UpdateChannelStateParams { secret: b"Profesr".to_vec(), sv: sv.clone() };
         let mut mag = b"Magneto".to_vec();
         mag.append(&mut vec![0; 25]);
         ucp.sv.secret_pre_image = mag;
@@ -852,11 +806,7 @@ mod actor_settle {
             plaintext: sv.signing_bytes().unwrap(),
             result: Ok(()),
         });
-        call(
-            &mut rt,
-            Method::UpdateChannelState as u64,
-            &RawBytes::serialize(&ucp).unwrap(),
-        );
+        call(&mut rt, Method::UpdateChannelState as u64, &RawBytes::serialize(&ucp).unwrap());
 
         state = rt.get_state().unwrap();
         assert_eq!(state.settling_at, 0);
@@ -1050,16 +1000,9 @@ fn require_add_new_lane(rt: &mut MockRuntime, param: LaneParams) -> SignedVouche
 }
 
 fn construct_and_verify(rt: &mut MockRuntime, sender: Address, receiver: Address) {
-    let params = ConstructorParams {
-        from: sender,
-        to: receiver,
-    };
+    let params = ConstructorParams { from: sender, to: receiver };
     rt.expect_validate_caller_type(vec![*INIT_ACTOR_CODE_ID]);
-    call(
-        rt,
-        METHOD_CONSTRUCTOR,
-        &RawBytes::serialize(&params).unwrap(),
-    );
+    call(rt, METHOD_CONSTRUCTOR, &RawBytes::serialize(&params).unwrap());
     rt.verify();
     verify_initial_state(rt, sender, receiver);
 }

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -72,10 +72,7 @@ impl Actor {
         rt.validate_immediate_caller_is(std::iter::once(&*SYSTEM_ACTOR_ADDR))?;
 
         let st = State::new(rt.store()).map_err(|e| {
-            e.downcast_default(
-                ExitCode::ErrIllegalState,
-                "Failed to create power actor state",
-            )
+            e.downcast_default(ExitCode::ErrIllegalState, "Failed to create power actor state")
         })?;
         rt.create(&st)?;
         Ok(())
@@ -103,10 +100,7 @@ impl Actor {
 
         let miner_actor_code_cid = rt.get_code_cid_for_type(Type::Miner);
 
-        let ext::init::ExecReturn {
-            id_address,
-            robust_address,
-        } = rt
+        let ext::init::ExecReturn { id_address, robust_address } = rt
             .send(
                 *INIT_ACTOR_ADDR,
                 ext::init::EXEC_METHOD,
@@ -141,25 +135,21 @@ impl Actor {
             })?;
             st.miner_count += 1;
 
-            st.update_stats_for_new_miner(window_post_proof_type)
-                .map_err(|e| {
-                    actor_error!(
-                        ErrIllegalState,
-                        "failed to update power stats for new miner {}: {}",
-                        &id_address,
-                        e
-                    )
-                })?;
+            st.update_stats_for_new_miner(window_post_proof_type).map_err(|e| {
+                actor_error!(
+                    ErrIllegalState,
+                    "failed to update power stats for new miner {}: {}",
+                    &id_address,
+                    e
+                )
+            })?;
 
             st.claims = claims.flush().map_err(|e| {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to flush claims")
             })?;
             Ok(())
         })?;
-        Ok(CreateMinerReturn {
-            id_address,
-            robust_address,
-        })
+        Ok(CreateMinerReturn { id_address, robust_address })
     }
 
     /// Adds or removes claimed power for the calling actor.
@@ -236,10 +226,9 @@ impl Actor {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to load cron events")
             })?;
 
-            st.append_cron_event(&mut events, params.event_epoch, miner_event)
-                .map_err(|e| {
-                    e.downcast_default(ExitCode::ErrIllegalState, "failed to enroll cron event")
-                })?;
+            st.append_cron_event(&mut events, params.event_epoch, miner_event).map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to enroll cron event")
+            })?;
 
             st.cron_event_queue = events.root().map_err(|e| {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to flush cron events")
@@ -279,9 +268,7 @@ impl Actor {
             // Can assume delta is one since cron is invoked every epoch.
             st.update_smoothed_estimate(1);
 
-            Ok(RawBytes::serialize(&BigIntSer(
-                &st.this_epoch_raw_byte_power,
-            )))
+            Ok(RawBytes::serialize(&BigIntSer(&st.this_epoch_raw_byte_power)))
         })?;
 
         // Update network KPA in reward actor
@@ -344,21 +331,15 @@ impl Actor {
                 })?
             } else {
                 debug!("ProofValidationBatch created");
-                Multimap::new(
-                    rt.store(),
-                    HAMT_BIT_WIDTH,
-                    PROOF_VALIDATION_BATCH_AMT_BITWIDTH,
-                )
+                Multimap::new(rt.store(), HAMT_BIT_WIDTH, PROOF_VALIDATION_BATCH_AMT_BITWIDTH)
             };
             let miner_addr = rt.message().caller();
-            let arr = mmap
-                .get::<SealVerifyInfo>(&miner_addr.to_bytes())
-                .map_err(|e| {
-                    e.downcast_default(
-                        ExitCode::ErrIllegalState,
-                        format!("failed to get seal verify infos at addr {}", miner_addr),
-                    )
-                })?;
+            let arr = mmap.get::<SealVerifyInfo>(&miner_addr.to_bytes()).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    format!("failed to get seal verify infos at addr {}", miner_addr),
+                )
+            })?;
             if let Some(arr) = arr {
                 if arr.count() >= MAX_MINER_PROVE_COMMITS_PER_EPOCH {
                     return Err(actor_error!(ErrTooManyProveCommits;
@@ -367,16 +348,12 @@ impl Actor {
                 }
             }
 
-            mmap.add(miner_addr.to_bytes().into(), seal_info)
-                .map_err(|e| {
-                    e.downcast_default(ExitCode::ErrIllegalState, "failed to insert proof into set")
-                })?;
+            mmap.add(miner_addr.to_bytes().into(), seal_info).map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to insert proof into set")
+            })?;
 
             let mmrc = mmap.root().map_err(|e| {
-                e.downcast_default(
-                    ExitCode::ErrIllegalState,
-                    "failed to flush proofs batch map",
-                )
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush proofs batch map")
             })?;
 
             rt.charge_gas("OnSubmitVerifySeal", GAS_ON_SUBMIT_VERIFY_SEAL);
@@ -495,18 +472,14 @@ impl Actor {
                 result
             })
             .map_err(|e| {
-                format!(
-                    "failed to do transaction in process batch proof verifies: {}",
-                    e
-                )
+                format!("failed to do transaction in process batch proof verifies: {}", e)
             })?;
         if let Some(st_err) = st_err {
             return Err(st_err);
         }
 
-        let res = rt
-            .batch_verify_seals(&infos)
-            .map_err(|e| format!("failed to batch verify: {}", e))?;
+        let res =
+            rt.batch_verify_seals(&infos).map_err(|e| format!("failed to batch verify: {}", e))?;
 
         let mut res_iter = infos.iter().zip(res.iter().copied());
         for (m, count) in miners {
@@ -541,10 +514,7 @@ impl Actor {
                 .map_err(|e| format!("failed to serialize ConfirmSectorProofsParams: {}", e))?,
                 Default::default(),
             ) {
-                error!(
-                    "failed to confirm sector proof validity to {}, error code {}",
-                    m, e
-                );
+                error!("failed to confirm sector proof validity to {}, error code {}", m, e);
             }
         }
         Ok(())
@@ -591,14 +561,9 @@ impl Actor {
 
                 for evt in epoch_events.into_iter() {
                     let miner_has_claim =
-                        claims
-                            .contains_key(&evt.miner_addr.to_bytes())
-                            .map_err(|e| {
-                                e.downcast_default(
-                                    ExitCode::ErrIllegalState,
-                                    "failed to look up claim",
-                                )
-                            })?;
+                        claims.contains_key(&evt.miner_addr.to_bytes()).map_err(|e| {
+                            e.downcast_default(ExitCode::ErrIllegalState, "failed to look up claim")
+                        })?;
                     if !miner_has_claim {
                         debug!("skipping cron event for unknown miner: {}", evt.miner_addr);
                         continue;
@@ -640,10 +605,7 @@ impl Actor {
             // Failures are unexpected here but will result in removal of miner power
             // A log message would really help here.
             if let Err(e) = res {
-                error!(
-                    "OnDeferredCronEvent failed for miner {}: res {}",
-                    event.miner_addr, e
-                );
+                error!("OnDeferredCronEvent failed for miner {}: res {}", event.miner_addr, e);
                 failed_miner_crons.push(event.miner_addr)
             }
         }

--- a/actors/power/src/state.rs
+++ b/actors/power/src/state.rs
@@ -82,10 +82,7 @@ impl State {
         let empty_mmap = Multimap::new(store, CRON_QUEUE_HAMT_BITWIDTH, CRON_QUEUE_AMT_BITWIDTH)
             .root()
             .map_err(|e| {
-                e.downcast_default(
-                    ExitCode::ErrIllegalState,
-                    "Failed to get empty multimap cid",
-                )
+                e.downcast_default(ExitCode::ErrIllegalState, "Failed to get empty multimap cid")
             })?;
         Ok(State {
             cron_event_queue: empty_mmap,
@@ -230,15 +227,9 @@ impl State {
 
     pub fn current_total_power(&self) -> (StoragePower, StoragePower) {
         if self.miner_above_min_power_count < CONSENSUS_MINER_MIN_MINERS {
-            (
-                self.total_bytes_committed.clone(),
-                self.total_qa_bytes_committed.clone(),
-            )
+            (self.total_bytes_committed.clone(), self.total_qa_bytes_committed.clone())
         } else {
-            (
-                self.total_raw_byte_power.clone(),
-                self.total_quality_adj_power.clone(),
-            )
+            (self.total_raw_byte_power.clone(), self.total_quality_adj_power.clone())
         }
     }
 
@@ -316,10 +307,7 @@ impl State {
                 None => {
                     return Ok(());
                 }
-                Some(claim) => (
-                    claim.raw_byte_power.clone(),
-                    claim.quality_adj_power.clone(),
-                ),
+                Some(claim) => (claim.raw_byte_power.clone(), claim.quality_adj_power.clone()),
             };
 
         // Subtract from stats to remove power

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -65,10 +65,7 @@ impl Actor {
             rt.create(&State::new(power))?;
             Ok(())
         } else {
-            Err(actor_error!(
-                ErrIllegalArgument,
-                "argument should not be nil"
-            ))
+            Err(actor_error!(ErrIllegalArgument, "argument should not be nil"))
         }
     }
 
@@ -93,11 +90,7 @@ impl Actor {
         rt.validate_immediate_caller_is(std::iter::once(&*SYSTEM_ACTOR_ADDR))?;
         let prior_balance = rt.current_balance();
         if params.penalty.sign() == Sign::Minus {
-            return Err(actor_error!(
-                ErrIllegalArgument,
-                "negative penalty {}",
-                params.penalty
-            ));
+            return Err(actor_error!(ErrIllegalArgument, "negative penalty {}", params.penalty));
         }
         if params.gas_reward.sign() == Sign::Minus {
             return Err(actor_error!(
@@ -115,11 +108,7 @@ impl Actor {
             ));
         }
         if params.win_count <= 0 {
-            return Err(actor_error!(
-                ErrIllegalArgument,
-                "invalid win count {}",
-                params.win_count
-            ));
+            return Err(actor_error!(ErrIllegalArgument, "invalid win count {}", params.win_count));
         }
 
         let miner_addr = rt
@@ -165,10 +154,7 @@ impl Actor {
         }
 
         // if this fails, we can assume the miner is responsible and avoid failing here.
-        let reward_params = ext::miner::ApplyRewardParams {
-            reward: total_reward.clone(),
-            penalty,
-        };
+        let reward_params = ext::miner::ApplyRewardParams { reward: total_reward.clone(), penalty };
         let res = rt.send(
             miner_addr,
             ext::miner::APPLY_REWARDS_METHOD,
@@ -181,12 +167,8 @@ impl Actor {
                 total_reward,
                 e.exit_code()
             );
-            let res = rt.send(
-                *BURNT_FUNDS_ACTOR_ADDR,
-                METHOD_SEND,
-                RawBytes::default(),
-                total_reward,
-            );
+            let res =
+                rt.send(*BURNT_FUNDS_ACTOR_ADDR, METHOD_SEND, RawBytes::default(), total_reward);
             if let Err(e) = res {
                 error!(
                     "failed to send unsent reward to the burnt funds actor, code: {:?}",

--- a/actors/reward/src/state.rs
+++ b/actors/reward/src/state.rs
@@ -137,11 +137,8 @@ impl State {
     }
 
     pub(super) fn update_smoothed_estimates(&mut self, delta: ChainEpoch) {
-        let filter_reward = AlphaBetaFilter::load(
-            &self.this_epoch_reward_smoothed,
-            &DEFAULT_ALPHA,
-            &DEFAULT_BETA,
-        );
+        let filter_reward =
+            AlphaBetaFilter::load(&self.this_epoch_reward_smoothed, &DEFAULT_ALPHA, &DEFAULT_BETA);
         self.this_epoch_reward_smoothed =
             filter_reward.next_estimate(&self.this_epoch_reward, delta);
     }

--- a/actors/reward/tests/reward_actor_test.rs
+++ b/actors/reward/tests/reward_actor_test.rs
@@ -40,10 +40,7 @@ mod construction_tests {
         assert_eq!(ChainEpoch::from(0), state.epoch);
         assert_eq!(start_realized_power, state.cumsum_realized);
         assert_eq!(*EPOCH_ZERO_REWARD, state.this_epoch_reward);
-        assert_eq!(
-            &*BASELINE_INITIAL_VALUE - 1,
-            state.this_epoch_baseline_power
-        );
+        assert_eq!(&*BASELINE_INITIAL_VALUE - 1, state.this_epoch_baseline_power);
         assert_eq!(&*BASELINE_INITIAL_VALUE, &state.effective_baseline_power);
     }
 
@@ -297,14 +294,8 @@ mod test_this_epoch_reward {
 
         let resp: ThisEpochRewardReturn = this_epoch_reward(&mut rt);
 
-        assert_eq!(
-            state.this_epoch_baseline_power,
-            resp.this_epoch_baseline_power
-        );
-        assert_eq!(
-            state.this_epoch_reward_smoothed,
-            resp.this_epoch_reward_smoothed
-        );
+        assert_eq!(state.this_epoch_baseline_power, resp.this_epoch_baseline_power);
+        assert_eq!(state.this_epoch_reward_smoothed, resp.this_epoch_reward_smoothed);
     }
 }
 
@@ -373,13 +364,9 @@ fn award_block_reward(
         );
     }
 
-    let params = RawBytes::serialize(AwardBlockRewardParams {
-        miner,
-        penalty,
-        gas_reward,
-        win_count,
-    })
-    .unwrap();
+    let params =
+        RawBytes::serialize(AwardBlockRewardParams { miner, penalty, gas_reward, win_count })
+            .unwrap();
 
     let serialized_bytes = rt.call::<RewardActor>(Method::AwardBlockReward as u64, &params)?;
 
@@ -389,9 +376,8 @@ fn award_block_reward(
 
 fn this_epoch_reward(rt: &mut MockRuntime) -> ThisEpochRewardReturn {
     rt.expect_validate_caller_any();
-    let serialized_result = rt
-        .call::<RewardActor>(Method::ThisEpochReward as u64, &RawBytes::default())
-        .unwrap();
+    let serialized_result =
+        rt.call::<RewardActor>(Method::ThisEpochReward as u64, &RawBytes::default()).unwrap();
     let resp: ThisEpochRewardReturn = RawBytes::deserialize(&serialized_result).unwrap();
     rt.verify();
     resp
@@ -402,8 +388,6 @@ fn update_network_kpi(rt: &mut MockRuntime, curr_raw_power: &StoragePower) {
     rt.expect_validate_caller_addr(vec![*STORAGE_POWER_ACTOR_ADDR]);
 
     let params = &RawBytes::serialize(BigIntSer(curr_raw_power)).unwrap();
-    assert!(rt
-        .call::<RewardActor>(Method::UpdateNetworkKPI as u64, params)
-        .is_ok());
+    assert!(rt.call::<RewardActor>(Method::UpdateNetworkKPI as u64, params).is_ok());
     rt.verify();
 }

--- a/actors/runtime/src/actor_error.rs
+++ b/actors/runtime/src/actor_error.rs
@@ -42,20 +42,14 @@ impl ActorError {
 // TODO former EncodingError
 impl From<fvm_shared::encoding::Error> for ActorError {
     fn from(e: fvm_shared::encoding::Error) -> Self {
-        Self {
-            exit_code: ExitCode::ErrSerialization,
-            msg: e.to_string(),
-        }
+        Self { exit_code: ExitCode::ErrSerialization, msg: e.to_string() }
     }
 }
 
 // TODO former CborError
 impl From<fvm_shared::encoding::error::Error> for ActorError {
     fn from(e: fvm_shared::encoding::error::Error) -> Self {
-        Self {
-            exit_code: ExitCode::ErrSerialization,
-            msg: e.to_string(),
-        }
+        Self { exit_code: ExitCode::ErrSerialization, msg: e.to_string() }
     }
 }
 
@@ -95,10 +89,7 @@ impl From<fvm_sdk::error::NoStateError> for ActorError {
 /// to ActorErrors. This facilitates propagation.
 impl From<ExitCode> for ActorError {
     fn from(e: ExitCode) -> Self {
-        ActorError {
-            exit_code: e,
-            msg: "".to_string(),
-        }
+        ActorError { exit_code: e, msg: "".to_string() }
     }
 }
 

--- a/actors/runtime/src/builtin/shared.rs
+++ b/actors/runtime/src/builtin/shared.rs
@@ -23,18 +23,8 @@ where
     }
 
     // send 0 balance to the account so an ID address for it is created and then try to resolve
-    rt.send(
-        *address,
-        METHOD_SEND,
-        Default::default(),
-        Default::default(),
-    )
-    .map_err(|e| {
-        e.wrap(&format!(
-            "failed to send zero balance to address {}",
-            address
-        ))
-    })?;
+    rt.send(*address, METHOD_SEND, Default::default(), Default::default())
+        .map_err(|e| e.wrap(&format!("failed to send zero balance to address {}", address)))?;
 
     rt.resolve_address(address).ok_or_else(|| {
         anyhow::anyhow!(

--- a/actors/runtime/src/runtime/actor_blockstore.rs
+++ b/actors/runtime/src/runtime/actor_blockstore.rs
@@ -28,10 +28,8 @@ impl fvm_shared::blockstore::Blockstore for ActorBlockstore {
             .map_err(|e| actor_error!(ErrSerialization, e.to_string()))?;
         let k2 = self.put(code, &Block::new(k.codec(), block))?;
         if k != &k2 {
-            Err(
-                actor_error!(ErrSerialization; "put block with cid {} but has cid {}", k, k2)
-                    .into(),
-            )
+            Err(actor_error!(ErrSerialization; "put block with cid {} but has cid {}", k, k2)
+                .into())
         } else {
             Ok(())
         }

--- a/actors/runtime/src/runtime/fvm.rs
+++ b/actors/runtime/src/runtime/fvm.rs
@@ -136,8 +136,7 @@ where
 
         let caller_cid = {
             let caller_addr = self.message().caller();
-            self.get_actor_code_cid(&caller_addr)
-                .expect("failed to lookup caller code")
+            self.get_actor_code_cid(&caller_addr).expect("failed to lookup caller code")
         };
 
         match self.resolve_builtin_actor_type(&caller_cid) {
@@ -184,10 +183,7 @@ where
             ErrorNumber::LimitExceeded => {
                 actor_error!(ErrIllegalArgument; "randomness lookback exceeded: {}", e)
             }
-            e => panic!(
-                "get chain randomness failed with an unexpected error: {}",
-                e
-            ),
+            e => panic!("get chain randomness failed with an unexpected error: {}", e),
         })
     }
 
@@ -203,10 +199,7 @@ where
                 ErrorNumber::LimitExceeded => {
                     actor_error!(ErrIllegalArgument; "randomness lookback exceeded: {}", e)
                 }
-                e => panic!(
-                    "get chain randomness failed with an unexpected error: {}",
-                    e
-                ),
+                e => panic!("get chain randomness failed with an unexpected error: {}", e),
             },
         )
     }
@@ -433,9 +426,7 @@ pub fn trampoline<C: ActorCode>(params: u32) -> u32 {
     let method = fvm::message::method_number();
     let params = if params > 0 {
         log::debug!("fetching parameters block: {}", params);
-        let params = fvm::message::params_raw(params)
-            .expect("params block invalid")
-            .1;
+        let params = fvm::message::params_raw(params).expect("params block invalid").1;
         RawBytes::new(params)
     } else {
         RawBytes::default()
@@ -453,10 +444,7 @@ pub fn trampoline<C: ActorCode>(params: u32) -> u32 {
     // We do this after handling the error, because the actor may have encountered an error before
     // it even could validate the caller.
     if !rt.caller_validated {
-        fvm::vm::abort(
-            ExitCode::SysErrIllegalActor as u32,
-            Some("failed to validate caller"),
-        )
+        fvm::vm::abort(ExitCode::SysErrIllegalActor as u32, Some("failed to validate caller"))
     }
 
     // Then handle the return value.

--- a/actors/runtime/src/runtime/mod.rs
+++ b/actors/runtime/src/runtime/mod.rs
@@ -239,10 +239,7 @@ pub trait Syscalls {
     ) -> Result<Option<ConsensusFault>, anyhow::Error>;
 
     fn batch_verify_seals(&self, batch: &[SealVerifyInfo]) -> anyhow::Result<Vec<bool>> {
-        Ok(batch
-            .iter()
-            .map(|si| self.verify_seal(si).is_ok())
-            .collect())
+        Ok(batch.iter().map(|si| self.verify_seal(si).is_ok()).collect())
     }
 
     fn verify_aggregate_seals(

--- a/actors/runtime/src/runtime/policy.rs
+++ b/actors/runtime/src/runtime/policy.rs
@@ -183,12 +183,8 @@ impl Default for Policy {
 
         #[cfg(feature = "devnet")]
         {
-            policy
-                .valid_pre_commit_proof_type
-                .insert(RegisteredSealProof::StackedDRG2KiBV1);
-            policy
-                .valid_pre_commit_proof_type
-                .insert(RegisteredSealProof::StackedDRG2KiBV1P1);
+            policy.valid_pre_commit_proof_type.insert(RegisteredSealProof::StackedDRG2KiBV1);
+            policy.valid_pre_commit_proof_type.insert(RegisteredSealProof::StackedDRG2KiBV1P1);
         };
 
         policy

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -129,10 +129,7 @@ impl Expectations {
         self.expect_verify_consensus_fault = None;
     }
     fn verify(&mut self) {
-        assert!(
-            !self.expect_validate_caller_any,
-            "expected ValidateCallerAny, not received"
-        );
+        assert!(!self.expect_validate_caller_any, "expected ValidateCallerAny, not received");
         assert!(
             self.expect_validate_caller_addr.is_none(),
             "expected ValidateCallerAddr {:?}, not received",
@@ -283,10 +280,7 @@ pub fn expect_abort<T: fmt::Debug>(exit_code: ExitCode, res: Result<T, ActorErro
 
 impl MockRuntime {
     fn require_in_call(&self) {
-        assert!(
-            self.in_call,
-            "invalid runtime invocation outside of method call",
-        )
+        assert!(self.in_call, "invalid runtime invocation outside of method call",)
     }
     fn put<C: Cbor>(&self, o: &C) -> Result<Cid, ActorError> {
         Ok(self.store.put_cbor(&o, Code::Blake2b256).unwrap())
@@ -317,10 +311,7 @@ impl MockRuntime {
 
     #[allow(dead_code)]
     pub fn expect_verify_signature(&self, exp: ExpectedVerifySig) {
-        self.expectations
-            .borrow_mut()
-            .expect_verify_sigs
-            .push_back(exp);
+        self.expectations.borrow_mut().expect_verify_sigs.push_back(exp);
     }
 
     #[allow(dead_code)]
@@ -355,9 +346,7 @@ impl MockRuntime {
 
     #[allow(dead_code)]
     pub fn expect_compute_unsealed_sector_cid(&self, exp: ExpectComputeUnsealedSectorCid) {
-        self.expectations
-            .borrow_mut()
-            .expect_compute_unsealed_sector_cid = Some(exp);
+        self.expectations.borrow_mut().expect_compute_unsealed_sector_cid = Some(exp);
     }
 
     #[allow(dead_code)]
@@ -409,17 +398,14 @@ impl MockRuntime {
         send_return: RawBytes,
         exit_code: ExitCode,
     ) {
-        self.expectations
-            .borrow_mut()
-            .expect_sends
-            .push_back(ExpectedMessage {
-                to,
-                method,
-                params,
-                value,
-                send_return,
-                exit_code,
-            })
+        self.expectations.borrow_mut().expect_sends.push_back(ExpectedMessage {
+            to,
+            method,
+            params,
+            value,
+            send_return,
+            exit_code,
+        })
     }
 
     #[allow(dead_code)]
@@ -534,10 +520,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
     {
         self.require_in_call();
         assert!(
-            self.expectations
-                .borrow_mut()
-                .expect_validate_caller_type
-                .is_some(),
+            self.expectations.borrow_mut().expect_validate_caller_type.is_some(),
             "unexpected validate caller code"
         );
 
@@ -551,11 +534,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
         let types: Vec<Cid> = types.into_iter().map(find_by_type).collect();
         assert_eq!(
             &types,
-            self.expectations
-                .borrow_mut()
-                .expect_validate_caller_type
-                .as_ref()
-                .unwrap(),
+            self.expectations.borrow_mut().expect_validate_caller_type.as_ref().unwrap(),
             "unexpected validate caller code {:?}, expected {:?}",
             types,
             self.expectations.borrow_mut().expect_validate_caller_type
@@ -570,10 +549,8 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
 
         self.expectations.borrow_mut().expect_validate_caller_type = None;
 
-        Err(
-            actor_error!(ErrForbidden; "caller type {:?} forbidden, allowed: {:?}",
-                self.caller_type, types),
-        )
+        Err(actor_error!(ErrForbidden; "caller type {:?} forbidden, allowed: {:?}",
+                self.caller_type, types))
     }
 
     fn current_balance(&self) -> TokenAmount {
@@ -623,11 +600,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
     }
 
     fn state<C: Cbor>(&self) -> Result<C, ActorError> {
-        Ok(self
-            .store
-            .get_cbor(self.state.as_ref().unwrap())
-            .unwrap()
-            .unwrap())
+        Ok(self.store.get_cbor(self.state.as_ref().unwrap()).unwrap().unwrap())
     }
 
     fn transaction<C, RT, F>(&mut self, f: F) -> Result<RT, ActorError>
@@ -671,12 +644,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
             params
         );
 
-        let expected_msg = self
-            .expectations
-            .borrow_mut()
-            .expect_sends
-            .pop_front()
-            .unwrap();
+        let expected_msg = self.expectations.borrow_mut().expect_sends.pop_front().unwrap();
 
         assert!(expected_msg.to == to && expected_msg.method == method && expected_msg.params == params && expected_msg.value == value,
                 "expectedMessage being sent does not match expectation.\nMessage -\t to: {:?} method: {:?} value: {:?} params: {:?}\nExpected -\t {:?}",
@@ -701,10 +669,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
 
     fn new_actor_address(&mut self) -> Result<Address, ActorError> {
         self.require_in_call();
-        let ret = *self
-            .new_actor_addr
-            .as_ref()
-            .expect("unexpected call to new actor address");
+        let ret = *self.new_actor_addr.as_ref().expect("unexpected call to new actor address");
         self.new_actor_addr = None;
         Ok(ret)
     }
@@ -735,11 +700,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
             panic!("unexpected call to delete actor: {}", addr);
         }
         if exp_act.as_ref().unwrap() != addr {
-            panic!(
-                "attempt to delete wrong actor. Expected: {}, got: {}",
-                exp_act.unwrap(),
-                addr
-            );
+            panic!("attempt to delete wrong actor. Expected: {}, got: {}", exp_act.unwrap(), addr);
         }
         Ok(())
     }
@@ -786,11 +747,7 @@ impl Syscalls for MockRuntime {
                 hex::encode(plaintext)
             );
         }
-        let exp = self
-            .expectations
-            .borrow_mut()
-            .expect_verify_sigs
-            .pop_front();
+        let exp = self.expectations.borrow_mut().expect_verify_sigs.pop_front();
         if let Some(exp) = exp {
             if exp.sig != *signature || exp.signer != *signer || &exp.plaintext[..] != plaintext {
                 panic!(
@@ -825,12 +782,8 @@ impl Syscalls for MockRuntime {
         reg: RegisteredSealProof,
         pieces: &[PieceInfo],
     ) -> anyhow::Result<Cid> {
-        let exp = self
-            .expectations
-            .borrow_mut()
-            .expect_compute_unsealed_sector_cid
-            .take()
-            .ok_or_else(
+        let exp =
+            self.expectations.borrow_mut().expect_compute_unsealed_sector_cid.take().ok_or_else(
                 || actor_error!(ErrIllegalState; "Unexpected syscall to ComputeUnsealedSectorCID"),
             )?;
 
@@ -847,52 +800,35 @@ impl Syscalls for MockRuntime {
         }
 
         if exp.exit_code != ExitCode::Ok {
-            return Err(anyhow!(ActorError::new(
-                exp.exit_code,
-                "Expected Failure".to_string(),
-            )));
+            return Err(anyhow!(ActorError::new(exp.exit_code, "Expected Failure".to_string(),)));
         }
         Ok(exp.cid)
     }
     fn verify_seal(&self, seal: &SealVerifyInfo) -> anyhow::Result<()> {
-        let exp = self
-            .expectations
-            .borrow_mut()
-            .expect_verify_seal
-            .take()
-            .ok_or_else(|| actor_error!(ErrIllegalState; "Unexpected syscall to verify seal"))?;
+        let exp =
+            self.expectations.borrow_mut().expect_verify_seal.take().ok_or_else(
+                || actor_error!(ErrIllegalState; "Unexpected syscall to verify seal"),
+            )?;
 
         if exp.seal != *seal {
-            return Err(anyhow!(
-                actor_error!(ErrIllegalState; "Unexpected seal verification"),
-            ));
+            return Err(anyhow!(actor_error!(ErrIllegalState; "Unexpected seal verification"),));
         }
         if exp.exit_code != ExitCode::Ok {
-            return Err(anyhow!(ActorError::new(
-                exp.exit_code,
-                "Expected Failure".to_string(),
-            )));
+            return Err(anyhow!(ActorError::new(exp.exit_code, "Expected Failure".to_string(),)));
         }
         Ok(())
     }
     fn verify_post(&self, post: &WindowPoStVerifyInfo) -> anyhow::Result<()> {
-        let exp = self
-            .expectations
-            .borrow_mut()
-            .expect_verify_post
-            .take()
-            .ok_or_else(|| actor_error!(ErrIllegalState; "Unexpected syscall to verify PoSt"))?;
+        let exp =
+            self.expectations.borrow_mut().expect_verify_post.take().ok_or_else(
+                || actor_error!(ErrIllegalState; "Unexpected syscall to verify PoSt"),
+            )?;
 
         if exp.post != *post {
-            return Err(anyhow!(
-                actor_error!(ErrIllegalState; "Unexpected PoSt verification"),
-            ));
+            return Err(anyhow!(actor_error!(ErrIllegalState; "Unexpected PoSt verification"),));
         }
         if exp.exit_code != ExitCode::Ok {
-            return Err(anyhow!(ActorError::new(
-                exp.exit_code,
-                "Expected Failure".to_string(),
-            )));
+            return Err(anyhow!(ActorError::new(exp.exit_code, "Expected Failure".to_string(),)));
         }
         Ok(())
     }
@@ -902,14 +838,9 @@ impl Syscalls for MockRuntime {
         h2: &[u8],
         extra: &[u8],
     ) -> anyhow::Result<Option<ConsensusFault>> {
-        let exp = self
-            .expectations
-            .borrow_mut()
-            .expect_verify_consensus_fault
-            .take()
-            .ok_or_else(
-                || actor_error!(ErrIllegalState; "Unexpected syscall to verify_consensus_fault"),
-            )?;
+        let exp = self.expectations.borrow_mut().expect_verify_consensus_fault.take().ok_or_else(
+            || actor_error!(ErrIllegalState; "Unexpected syscall to verify_consensus_fault"),
+        )?;
         if exp.require_correct_input {
             if exp.block_header_1 != h1 {
                 return Err(anyhow!(actor_error!(ErrIllegalState; "Header 1 mismatch")));
@@ -918,16 +849,11 @@ impl Syscalls for MockRuntime {
                 return Err(anyhow!(actor_error!(ErrIllegalState; "Header 2 mismatch")));
             }
             if exp.block_header_extra != extra {
-                return Err(anyhow!(
-                    actor_error!(ErrIllegalState; "Header extra mismatch"),
-                ));
+                return Err(anyhow!(actor_error!(ErrIllegalState; "Header extra mismatch"),));
             }
         }
         if exp.exit_code != ExitCode::Ok {
-            return Err(anyhow!(ActorError::new(
-                exp.exit_code,
-                "Expected Failure".to_string(),
-            )));
+            return Err(anyhow!(ActorError::new(exp.exit_code, "Expected Failure".to_string(),)));
         }
         Ok(exp.fault)
     }

--- a/actors/runtime/src/util/balance_table.rs
+++ b/actors/runtime/src/util/balance_table.rs
@@ -26,11 +26,7 @@ where
 
     /// Initializes a balance table from a root Cid
     pub fn from_root(bs: &'a BS, cid: &Cid) -> Result<Self, Error> {
-        Ok(Self(make_map_with_root_and_bitwidth(
-            cid,
-            bs,
-            BALANCE_TABLE_BITWIDTH,
-        )?))
+        Ok(Self(make_map_with_root_and_bitwidth(cid, bs, BALANCE_TABLE_BITWIDTH)?))
     }
 
     /// Retrieve root from balance table

--- a/actors/runtime/src/util/chaos/mod.rs
+++ b/actors/runtime/src/util/chaos/mod.rs
@@ -58,15 +58,9 @@ impl Actor {
 
         let result = rt.send(arg.to, arg.method, arg.params, arg.value);
         if let Err(e) = result {
-            Ok(SendReturn {
-                return_value: RawBytes::default(),
-                code: e.exit_code(),
-            })
+            Ok(SendReturn { return_value: RawBytes::default(), code: e.exit_code() })
         } else {
-            Ok(SendReturn {
-                return_value: result.unwrap(),
-                code: ExitCode::Ok,
-            })
+            Ok(SendReturn { return_value: result.unwrap(), code: ExitCode::Ok })
         }
     }
 
@@ -124,11 +118,7 @@ impl Actor {
     {
         rt.validate_immediate_caller_accept_any()?;
         // TODO Temporarily fine to use default as Undefined Cid, but may need to change in the future
-        let actor_cid = if arg.undef_cid {
-            Cid::default()
-        } else {
-            arg.cid
-        };
+        let actor_cid = if arg.undef_cid { Cid::default() } else { arg.cid };
 
         let actor_address = arg.actor_id;
 

--- a/actors/runtime/src/util/downcast.rs
+++ b/actors/runtime/src/util/downcast.rs
@@ -80,10 +80,7 @@ fn downcast_util(error: anyhow::Error) -> anyhow::Result<ActorError> {
     // Check if error is Encoding error, if so return `ErrSerialization`
     let error = match error.downcast::<EncodingError>() {
         Ok(enc_error) => {
-            return Ok(ActorError::new(
-                ExitCode::ErrSerialization,
-                enc_error.to_string(),
-            ))
+            return Ok(ActorError::new(ExitCode::ErrSerialization, enc_error.to_string()))
         }
         Err(other) => other,
     };
@@ -92,10 +89,7 @@ fn downcast_util(error: anyhow::Error) -> anyhow::Result<ActorError> {
     // future proof.
     let error = match error.downcast::<CborError>() {
         Ok(enc_error) => {
-            return Ok(ActorError::new(
-                ExitCode::ErrSerialization,
-                enc_error.to_string(),
-            ))
+            return Ok(ActorError::new(ExitCode::ErrSerialization, enc_error.to_string()))
         }
         Err(other) => other,
     };

--- a/actors/runtime/src/util/multimap.rs
+++ b/actors/runtime/src/util/multimap.rs
@@ -30,10 +30,7 @@ where
         outer_bitwidth: u32,
         inner_bitwidth: u32,
     ) -> Result<Self, Error> {
-        Ok(Self(
-            make_map_with_root_and_bitwidth(cid, bs, outer_bitwidth)?,
-            inner_bitwidth,
-        ))
+        Ok(Self(make_map_with_root_and_bitwidth(cid, bs, outer_bitwidth)?, inner_bitwidth))
     }
 
     /// Retrieve root from the multimap.
@@ -53,8 +50,7 @@ where
             .unwrap_or_else(|| Array::new_with_bit_width(self.0.store(), self.1));
 
         // Set value at next index
-        arr.set(arr.count(), value)
-            .map_err(|e| anyhow::anyhow!(e))?;
+        arr.set(arr.count(), value).map_err(|e| anyhow::anyhow!(e))?;
 
         // flush to get new array root to put in hamt
         let new_root = arr.flush().map_err(|e| anyhow::anyhow!(e))?;
@@ -71,9 +67,9 @@ where
         V: DeserializeOwned + Serialize,
     {
         match self.0.get(key)? {
-            Some(cid) => Ok(Some(
-                Array::load(cid, *self.0.store()).map_err(|e| anyhow::anyhow!(e))?,
-            )),
+            Some(cid) => {
+                Ok(Some(Array::load(cid, *self.0.store()).map_err(|e| anyhow::anyhow!(e))?))
+            }
             None => Ok(None),
         }
     }
@@ -82,9 +78,7 @@ where
     #[inline]
     pub fn remove_all(&mut self, key: &[u8]) -> Result<(), Error> {
         // Remove entry from table
-        self.0
-            .delete(key)?
-            .ok_or("failed to delete from multimap")?;
+        self.0.delete(key)?.ok_or("failed to delete from multimap")?;
 
         Ok(())
     }

--- a/actors/runtime/src/util/unmarshallable.rs
+++ b/actors/runtime/src/util/unmarshallable.rs
@@ -13,9 +13,7 @@ impl Serialize for UnmarshallableCBOR {
     where
         S: Serializer,
     {
-        Err(ser::Error::custom(
-            "Automatic fail when serializing UnmarshallableCBOR",
-        ))
+        Err(ser::Error::custom("Automatic fail when serializing UnmarshallableCBOR"))
     }
 }
 
@@ -24,9 +22,7 @@ impl<'de> Deserialize<'de> for UnmarshallableCBOR {
     where
         D: Deserializer<'de>,
     {
-        Err(de::Error::custom(
-            "Automatic fail when deserializing UnmarshallableCBOR",
-        ))
+        Err(de::Error::custom("Automatic fail when deserializing UnmarshallableCBOR"))
     }
 }
 

--- a/actors/runtime/tests/alpha_beta_filter_test.rs
+++ b/actors/runtime/tests/alpha_beta_filter_test.rs
@@ -57,12 +57,7 @@ fn assert_err_bound(
     let analytic = ecsor(delta, t0, num, denom);
     let iterative = iterative_cum_sum_of_ratio(num, denom, t0, delta);
     let actual_err = per_million_error(&analytic, &iterative);
-    assert!(
-        actual_err < err_bound,
-        "Values are {} and {}",
-        actual_err,
-        err_bound
-    );
+    assert!(actual_err < err_bound, "Values are {} and {}", actual_err, err_bound);
 }
 
 // Returns an estimate with position val and velocity 0
@@ -141,26 +136,14 @@ fn constant_estimate() {
 fn both_positive_velocity() {
     let num_estimate = testing_estimate(BigInt::from(111), BigInt::from(12));
     let denom_estimate = testing_estimate(BigInt::from(3456), BigInt::from(8));
-    assert_err_bound(
-        &num_estimate,
-        &denom_estimate,
-        10_000,
-        0,
-        BigInt::from(ERR_BOUND),
-    );
+    assert_err_bound(&num_estimate, &denom_estimate, 10_000, 0, BigInt::from(ERR_BOUND));
 }
 
 #[test]
 fn flipped_signs() {
     let num_estimate = testing_estimate(BigInt::from(1_000_000), BigInt::from(-100));
     let denom_estimate = testing_estimate(BigInt::from(70_000), BigInt::from(1000));
-    assert_err_bound(
-        &num_estimate,
-        &denom_estimate,
-        100_000,
-        0,
-        BigInt::from(ERR_BOUND),
-    );
+    assert_err_bound(&num_estimate, &denom_estimate, 100_000, 0, BigInt::from(ERR_BOUND));
 }
 
 #[test]

--- a/actors/runtime/tests/balance_table_test.rs
+++ b/actors/runtime/tests/balance_table_test.rs
@@ -22,26 +22,10 @@ fn total() {
         total: u64,
     }
     let test_vectors = [
-        TotalTestCase {
-            amount: 10,
-            addr: &addr1,
-            total: 10,
-        },
-        TotalTestCase {
-            amount: 20,
-            addr: &addr1,
-            total: 30,
-        },
-        TotalTestCase {
-            amount: 40,
-            addr: &addr2,
-            total: 70,
-        },
-        TotalTestCase {
-            amount: 50,
-            addr: &addr2,
-            total: 120,
-        },
+        TotalTestCase { amount: 10, addr: &addr1, total: 10 },
+        TotalTestCase { amount: 20, addr: &addr1, total: 30 },
+        TotalTestCase { amount: 40, addr: &addr2, total: 70 },
+        TotalTestCase { amount: 50, addr: &addr2, total: 120 },
     ];
 
     for t in test_vectors.iter() {

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -85,10 +85,7 @@ impl Actor {
         rt.validate_immediate_caller_is(std::iter::once(&st.root_key))?;
 
         if verifier == st.root_key {
-            return Err(actor_error!(
-                ErrIllegalArgument,
-                "Rootkey cannot be added as verifier"
-            ));
+            return Err(actor_error!(ErrIllegalArgument, "Rootkey cannot be added as verifier"));
         }
 
         rt.transaction(|st: &mut State, rt| {
@@ -109,14 +106,12 @@ impl Actor {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
             })?;
 
-            let found = verified_clients
-                .contains_key(&verifier.to_bytes())
-                .map_err(|e| {
-                    e.downcast_default(
-                        ExitCode::ErrIllegalState,
-                        format!("failed to get client state for {}", verifier),
-                    )
-                })?;
+            let found = verified_clients.contains_key(&verifier.to_bytes()).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    format!("failed to get client state for {}", verifier),
+                )
+            })?;
             if found {
                 return Err(actor_error!(
                     ErrIllegalArgument,
@@ -125,14 +120,9 @@ impl Actor {
                 ));
             }
 
-            verifiers
-                .set(
-                    verifier.to_bytes().into(),
-                    BigIntDe(params.allowance.clone()),
-                )
-                .map_err(|e| {
-                    e.downcast_default(ExitCode::ErrIllegalState, "failed to add verifier")
-                })?;
+            verifiers.set(verifier.to_bytes().into(), BigIntDe(params.allowance.clone())).map_err(
+                |e| e.downcast_default(ExitCode::ErrIllegalState, "failed to add verifier"),
+            )?;
             st.verifiers = verifiers.flush().map_err(|e| {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verifiers")
             })?;
@@ -214,10 +204,7 @@ impl Actor {
 
         let st: State = rt.state()?;
         if client == st.root_key {
-            return Err(actor_error!(
-                ErrIllegalArgument,
-                "Rootkey cannot be added as verifier"
-            ));
+            return Err(actor_error!(ErrIllegalArgument, "Rootkey cannot be added as verifier"));
         }
 
         rt.transaction(|st: &mut State, rt| {
@@ -272,14 +259,12 @@ impl Actor {
             }
             let new_verifier_cap = verifier_cap - &params.allowance;
 
-            verifiers
-                .set(verifier.to_bytes().into(), BigIntDe(new_verifier_cap))
-                .map_err(|e| {
-                    e.downcast_default(
-                        ExitCode::ErrIllegalState,
-                        format!("Failed to update new verifier cap for {}", verifier),
-                    )
-                })?;
+            verifiers.set(verifier.to_bytes().into(), BigIntDe(new_verifier_cap)).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    format!("Failed to update new verifier cap for {}", verifier),
+                )
+            })?;
 
             let client_cap = verified_clients.get(&client.to_bytes()).map_err(|e| {
                 e.downcast_default(
@@ -295,9 +280,8 @@ impl Actor {
                 params.allowance
             };
 
-            verified_clients
-                .set(client.to_bytes().into(), BigIntDe(client_cap.clone()))
-                .map_err(|e| {
+            verified_clients.set(client.to_bytes().into(), BigIntDe(client_cap.clone())).map_err(
+                |e| {
                     e.downcast_default(
                         ExitCode::ErrIllegalState,
                         format!(
@@ -305,16 +289,14 @@ impl Actor {
                             client, client_cap,
                         ),
                     )
-                })?;
+                },
+            )?;
 
             st.verifiers = verifiers.flush().map_err(|e| {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verifiers")
             })?;
             st.verified_clients = verified_clients.flush().map_err(|e| {
-                e.downcast_default(
-                    ExitCode::ErrIllegalState,
-                    "failed to flush verified clients",
-                )
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verified clients")
             })?;
 
             Ok(())
@@ -403,21 +385,18 @@ impl Actor {
                         )
                     })?;
             } else {
-                verified_clients
-                    .set(client.to_bytes().into(), BigIntDe(new_vc_cap))
-                    .map_err(|e| {
+                verified_clients.set(client.to_bytes().into(), BigIntDe(new_vc_cap)).map_err(
+                    |e| {
                         e.downcast_default(
                             ExitCode::ErrIllegalState,
                             format!("Failed to update verified client {}", client),
                         )
-                    })?;
+                    },
+                )?;
             }
 
             st.verified_clients = verified_clients.flush().map_err(|e| {
-                e.downcast_default(
-                    ExitCode::ErrIllegalState,
-                    "failed to flush verified clients",
-                )
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verified clients")
             })?;
             Ok(())
         })?;
@@ -450,10 +429,7 @@ impl Actor {
 
         let st: State = rt.state()?;
         if client == st.root_key {
-            return Err(actor_error!(
-                ErrIllegalArgument,
-                "Cannot restore allowance for Rootkey"
-            ));
+            return Err(actor_error!(ErrIllegalArgument, "Cannot restore allowance for Rootkey"));
         }
 
         rt.transaction(|st: &mut State, rt| {
@@ -497,20 +473,15 @@ impl Actor {
 
             // Update to new cap
             let new_vc_cap = vc_cap + &params.deal_size;
-            verified_clients
-                .set(client.to_bytes().into(), BigIntDe(new_vc_cap))
-                .map_err(|e| {
-                    e.downcast_default(
-                        ExitCode::ErrIllegalState,
-                        format!("Failed to put verified client {}", client),
-                    )
-                })?;
-
-            st.verified_clients = verified_clients.flush().map_err(|e| {
+            verified_clients.set(client.to_bytes().into(), BigIntDe(new_vc_cap)).map_err(|e| {
                 e.downcast_default(
                     ExitCode::ErrIllegalState,
-                    "failed to flush verified clients",
+                    format!("Failed to put verified client {}", client),
                 )
+            })?;
+
+            st.verified_clients = verified_clients.flush().map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verified clients")
             })?;
             Ok(())
         })?;

--- a/actors/verifreg/src/state.rs
+++ b/actors/verifreg/src/state.rs
@@ -22,11 +22,7 @@ impl State {
             .flush()
             .map_err(|e| anyhow::anyhow!("Failed to create empty map: {}", e))?;
 
-        Ok(State {
-            root_key,
-            verifiers: empty_map,
-            verified_clients: empty_map,
-        })
+        Ok(State { root_key, verifiers: empty_map, verified_clients: empty_map })
     }
 }
 

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -51,9 +51,7 @@ mod construction {
     #[test]
     fn construct_with_root_id() {
         let mut rt = construct_runtime();
-        let h = Harness {
-            root: Address::new_id(101),
-        };
+        let h = Harness { root: Address::new_id(101) };
         h.construct_and_verify(&mut rt, &h.root);
         h.check_state();
     }
@@ -61,9 +59,7 @@ mod construction {
     #[test]
     fn construct_resolves_non_id() {
         let mut rt = construct_runtime();
-        let h = Harness {
-            root: Address::new_id(101),
-        };
+        let h = Harness { root: Address::new_id(101) };
         let root_pubkey = Address::new_bls(&[7u8; BLS_PUB_LEN]).unwrap();
         rt.id_addresses.insert(root_pubkey, h.root);
         h.construct_and_verify(&mut rt, &root_pubkey);
@@ -183,8 +179,7 @@ mod verifiers {
     #[test]
     fn add_verifier_id_address() {
         let (h, mut rt) = make_harness();
-        h.add_verifier(&mut rt, &Address::new_id(201), &VERIFIER_ALLOWANCE)
-            .unwrap();
+        h.add_verifier(&mut rt, &Address::new_id(201), &VERIFIER_ALLOWANCE).unwrap();
         h.check_state();
     }
 
@@ -194,8 +189,7 @@ mod verifiers {
         let pubkey_addr = Address::new_secp256k1(&[0u8; 65]).unwrap();
         rt.id_addresses.insert(pubkey_addr, Address::new_id(201));
 
-        h.add_verifier(&mut rt, &pubkey_addr, &VERIFIER_ALLOWANCE)
-            .unwrap();
+        h.add_verifier(&mut rt, &pubkey_addr, &VERIFIER_ALLOWANCE).unwrap();
         h.check_state();
     }
 }
@@ -219,9 +213,7 @@ impl Harness {
         assert_eq!(RawBytes::default(), ret);
         rt.verify();
 
-        let empty_map = make_empty_map::<_, ()>(&rt.store, HAMT_BIT_WIDTH)
-            .flush()
-            .unwrap();
+        let empty_map = make_empty_map::<_, ()>(&rt.store, HAMT_BIT_WIDTH).flush().unwrap();
 
         let state: State = rt.get_state().unwrap();
 
@@ -238,10 +230,7 @@ impl Harness {
     ) -> Result<(), ActorError> {
         rt.expect_validate_caller_addr(vec![self.root]);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.root);
-        let params = AddVerifierParams {
-            address: *verifier,
-            allowance: allowance.clone(),
-        };
+        let params = AddVerifierParams { address: *verifier, allowance: allowance.clone() };
         let ret = rt.call::<VerifregActor>(
             Method::AddVerifier as MethodNum,
             &RawBytes::serialize(params).unwrap(),
@@ -251,10 +240,7 @@ impl Harness {
 
         // Confirm the verifier was added to state.
         let verifier_id_addr = rt.get_id_address(&verifier).unwrap();
-        assert_eq!(
-            *allowance,
-            self.get_verifier_allowance(rt, &verifier_id_addr)
-        );
+        assert_eq!(*allowance, self.get_verifier_allowance(rt, &verifier_id_addr));
         Result::Ok(())
     }
 
@@ -280,10 +266,7 @@ impl Harness {
     ) -> Result<(), ActorError> {
         rt.expect_validate_caller_any();
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *verifier);
-        let params = AddVerifierClientParams {
-            address: *client,
-            allowance: allowance.clone(),
-        };
+        let params = AddVerifierClientParams { address: *client, allowance: allowance.clone() };
         let ret = rt.call::<VerifregActor>(
             Method::AddVerifiedClient as MethodNum,
             &RawBytes::serialize(params).unwrap(),
@@ -293,10 +276,7 @@ impl Harness {
 
         // Confirm the verifier was added to state.
         let client_id_addr = rt.get_id_address(&client).unwrap();
-        assert_eq!(
-            *expected_allowance,
-            self.get_client_allowance(rt, &client_id_addr)
-        );
+        assert_eq!(*expected_allowance, self.get_client_allowance(rt, &client_id_addr));
         Result::Ok(())
     }
 
@@ -321,8 +301,7 @@ impl Harness {
         client_allowance: &DataCap,
     ) {
         self.add_verifier(rt, verifier, verifier_allowance).unwrap();
-        self.add_client(rt, verifier, client, client_allowance, client_allowance)
-            .unwrap();
+        self.add_client(rt, verifier, client, client_allowance, client_allowance).unwrap();
     }
 
     fn check_state(&self) {

--- a/build.rs
+++ b/build.rs
@@ -43,10 +43,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:warning=out_dir: {:?}", &out_dir);
 
     // Compute the package names.
-    let packages = ACTORS
-        .iter()
-        .map(|(pkg, _)| String::from("fil_actor_") + pkg)
-        .collect::<Vec<String>>();
+    let packages =
+        ACTORS.iter().map(|(pkg, _)| String::from("fil_actor_") + pkg).collect::<Vec<String>>();
 
     let manifest_path =
         Path::new(&std::env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR unset"))
@@ -61,10 +59,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .arg("--profile=wasm")
         .arg("--locked")
         .arg("--manifest-path=".to_owned() + manifest_path.to_str().unwrap())
-        .env(
-            "RUSTFLAGS",
-            "-Ctarget-feature=+crt-static -Clink-arg=--export-table",
-        )
+        .env("RUSTFLAGS", "-Ctarget-feature=+crt-static -Clink-arg=--export-table")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         // We are supposed to only generate artifacts under OUT_DIR,
@@ -115,15 +110,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         let cid = bundler
             .add_from_file((*id).try_into().unwrap(), Some(&forced_cid), &bytecode_path)
             .unwrap_or_else(|err| {
-                panic!(
-                    "failed to add file {:?} to bundle for actor {}: {}",
-                    bytecode_path, id, err
-                )
+                panic!("failed to add file {:?} to bundle for actor {}: {}", bytecode_path, id, err)
             });
-        println!(
-            "cargo:warning=added actor {} to bundle with CID {}",
-            id, cid
-        );
+        println!("cargo:warning=added actor {} to bundle with CID {}", id, cid);
     }
     bundler.finish().expect("failed to finish bundle");
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+use_small_heuristics = "Max"


### PR DESCRIPTION
Hey team, I quite dislike the "small" heuristics that rustfmt implements. Forcing struct literals and function definitions/calls that easy fit on one line onto three or more costs a lot of vertical density.
Unfortunately it seems like its implementation leaves no room for developer discretion. That is, if the `use_small_heuristics` is set to `Max` then things that fit on one line are forced onto one line. The dev has no room to choose.

This PR shows the effect of setting it to `Max`.