### PR TITLE
chore: update deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d306121baf53310a3fd342d88dc0824f6bbeace68347593658525565abee8"
+checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.5"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced1892c55c910c1219e98d6fc8d71f6bddba7905866ce740066d8bfea859312"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
  "atty",
  "bitflags",
@@ -407,16 +407,6 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebca5e1e931005a5d90cc90831a22619c94fdeb645435c22eae52956dee29675"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cs_serde_cbor"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7b77425566bdb3932243a292a4b072e1e34fb93aba95926f8d4a3b6ce542c5"
-dependencies = [
- "half",
  "serde",
 ]
 
@@ -905,7 +895,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#c02a9018cbf236ae70215cd8ebe23d9a87a974f5"
+source = "git+https://github.com/filecoin-project/ref-fvm#0692d5bbb4d7ca588278a3544a48504a7f5ed0ee"
 dependencies = [
  "ahash",
  "anyhow",
@@ -920,7 +910,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#c02a9018cbf236ae70215cd8ebe23d9a87a974f5"
+source = "git+https://github.com/filecoin-project/ref-fvm#0692d5bbb4d7ca588278a3544a48504a7f5ed0ee"
 dependencies = [
  "cs_serde_bytes",
  "fvm_shared",
@@ -931,7 +921,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_car"
 version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#c02a9018cbf236ae70215cd8ebe23d9a87a974f5"
+source = "git+https://github.com/filecoin-project/ref-fvm#0692d5bbb4d7ca588278a3544a48504a7f5ed0ee"
 dependencies = [
  "cid",
  "futures",
@@ -944,7 +934,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#c02a9018cbf236ae70215cd8ebe23d9a87a974f5"
+source = "git+https://github.com/filecoin-project/ref-fvm#0692d5bbb4d7ca588278a3544a48504a7f5ed0ee"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -952,6 +942,7 @@ dependencies = [
  "cs_serde_bytes",
  "forest_hash_utils",
  "fvm_shared",
+ "libipld-core",
  "once_cell",
  "serde",
  "sha2",
@@ -961,7 +952,7 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#c02a9018cbf236ae70215cd8ebe23d9a87a974f5"
+source = "git+https://github.com/filecoin-project/ref-fvm#0692d5bbb4d7ca588278a3544a48504a7f5ed0ee"
 dependencies = [
  "cid",
  "fvm_shared",
@@ -974,7 +965,7 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#c02a9018cbf236ae70215cd8ebe23d9a87a974f5"
+source = "git+https://github.com/filecoin-project/ref-fvm#0692d5bbb4d7ca588278a3544a48504a7f5ed0ee"
 dependencies = [
  "anyhow",
  "bimap",
@@ -983,7 +974,6 @@ dependencies = [
  "chrono",
  "cid",
  "cs_serde_bytes",
- "cs_serde_cbor",
  "data-encoding",
  "data-encoding-macro",
  "lazy_static",
@@ -994,6 +984,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+ "serde_ipld_dagcbor",
  "serde_repr",
  "serde_tuple",
  "thiserror",
@@ -1154,6 +1145,21 @@ name = "libc"
 version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+
+[[package]]
+name = "libipld-core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdd758764f9680a818af33c31db733eb7c45224715d8816b9dcf0548c75f7c5"
+dependencies = [
+ "anyhow",
+ "cid",
+ "core2",
+ "multibase",
+ "multihash",
+ "serde",
+ "thiserror",
+]
 
 [[package]]
 name = "log"


### PR DESCRIPTION
We check the lockfile into the repo, so we need to keep this up-to-date.