### PR TITLE
chore: release v7 versions of all actors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "6.0.2"
+version = "7.0.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_shared",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "6.0.2"
+version = "7.0.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_shared",
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "6.0.2"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "6.0.2"
+version = "7.0.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "6.0.2"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "6.0.2"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "6.0.2"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power"
-version = "6.0.2"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "6.0.2"
+version = "7.0.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_shared",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "6.0.2"
+version = "7.0.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_shared",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "6.0.2"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "6.0.2"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "6.0.3"
+version = "7.0.0"
 dependencies = [
  "cid",
  "fil_actor_account",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_builtin_actors_bundle"
 description = "Bundle of FVM-compatible Wasm bytecode for Filecoin builtin actors"
-version = "6.0.3"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -10,17 +10,17 @@ keywords = ["filecoin", "web3", "wasm"]
 exclude = ["examples", ".github"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fil_actor_account = { version = "6.0.2", path = "./actors/account" }
-fil_actor_verifreg = { version = "6.0.2", path = "./actors/verifreg" }
-fil_actor_cron = { version = "6.0.2", path = "./actors/cron" }
-fil_actor_market = { version = "6.0.2", path = "./actors/market" }
-fil_actor_multisig = { version = "6.0.2", path = "./actors/multisig" }
-fil_actor_paych = { version = "6.0.2", path = "./actors/paych" }
-fil_actor_power = { version = "6.0.2", path = "./actors/power" }
-fil_actor_miner = { version = "6.0.2", path = "./actors/miner" }
-fil_actor_reward = { version = "6.0.2", path = "./actors/reward" }
-fil_actor_system = { version = "6.0.2", path = "./actors/system" }
-fil_actor_init = { version = "6.0.2", path = "./actors/init" }
+fil_actor_account = { version = "7.0.0", path = "./actors/account" }
+fil_actor_verifreg = { version = "7.0.0", path = "./actors/verifreg" }
+fil_actor_cron = { version = "7.0.0", path = "./actors/cron" }
+fil_actor_market = { version = "7.0.0", path = "./actors/market" }
+fil_actor_multisig = { version = "7.0.0", path = "./actors/multisig" }
+fil_actor_paych = { version = "7.0.0", path = "./actors/paych" }
+fil_actor_power = { version = "7.0.0", path = "./actors/power" }
+fil_actor_miner = { version = "7.0.0", path = "./actors/miner" }
+fil_actor_reward = { version = "7.0.0", path = "./actors/reward" }
+fil_actor_system = { version = "7.0.0", path = "./actors/system" }
+fil_actor_init = { version = "7.0.0", path = "./actors/init" }
 
 [build-dependencies]
 fil_actor_bundler = { version = "1.0.1", path = "./bundler" }

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_account"
 description = "Builtin account actor for Filecoin"
-version = "6.0.2"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -13,12 +13,12 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 num-traits = "0.2"
 num-derive = "0.3.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime", features = ["test_utils"] }
 

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_cron"
 description = "Builtin cron actor for Filecoin"
-version = "6.0.2"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
 num-traits = "0.2"
 num-derive = "0.3.0"
@@ -22,4 +22,4 @@ log = "0.4.8"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime", features = ["test_utils"] }

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_init"
 description = "Builtin init actor for Filecoin"
-version = "6.0.2"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
 fvm_ipld_hamt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm" }
 serde = { version = "1.0", features = ["derive"] }

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_market"
 description = "Builtin market actor for Filecoin"
-version = "6.0.2"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
 bitfield = { version = "0.1.0", package = "fvm_ipld_bitfield", git = "https://github.com/filecoin-project/ref-fvm" }
 num-traits = "0.2"
@@ -26,5 +26,5 @@ log = "0.4.8"
 anyhow = "1.0.51"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime", features = ["test_utils"] }
 fvm_ipld_amt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", features = ["go-interop"]}

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_miner"
 description = "Builtin miner actor for Filecoin"
-version = "6.0.2"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
 bitfield = { version = "0.1.0", package = "fvm_ipld_bitfield", git = "https://github.com/filecoin-project/ref-fvm" }
 fvm_ipld_amt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", features = ["go-interop"]}
@@ -30,7 +30,7 @@ anyhow = "1.0.51"
 itertools = "0.10.3"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
-fil_actor_account = { version = "6.0.2", path = "../account" }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime", features = ["test_utils"] }
+fil_actor_account = { version = "7.0.0", path = "../account" }
 rand = { version = "0.8.5" }
 cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_multisig"
 description = "Builtin multisig actor for Filecoin"
-version = "6.0.2"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
 fvm_ipld_hamt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm" }
 num-traits = "0.2"
@@ -26,4 +26,4 @@ serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0.51"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime", features = ["test_utils"] }

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_paych"
 description = "Builtin paych actor for Filecoin"
-version = "6.0.2"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
 num-traits = "0.2"
 num-derive = "0.3.0"
@@ -23,6 +23,6 @@ cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] 
 anyhow = "1.0.51"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime", features = ["test_utils"] }
 fvm_ipld_amt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", features = ["go-interop"]}
 derive_builder = "0.10"

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_power"
 description = "Builtin power actor for Filecoin"
-version = "6.0.2"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
 fvm_ipld_hamt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm" }
 num-traits = "0.2"

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_reward"
 description = "Builtin reward actor for Filecoin"
-version = "6.0.2"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
 num-traits = "0.2"
 num-derive = "0.3.0"
@@ -23,4 +23,4 @@ lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime", features = ["test_utils"] }

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actors_runtime"
 description = "System actors for the Filecoin protocol"
-version = "6.0.2"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_system"
 description = "Builtin system actor for Filecoin"
-version = "6.0.2"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
 num-traits = "0.2"
 num-derive = "0.3.0"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_verifreg"
 description = "Builtin verifreg actor for Filecoin"
-version = "6.0.2"
+version = "7.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
+fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 num-traits = "0.2"


### PR DESCRIPTION
The magic command is:

`cargo set-version --exclude fil_actor_bundler --workspace --bump major`

(from the cargo-edit crate)

edit: this is the kind of magic command that looks like it works, but doesn't.