### PR TITLE
chore: release bundler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ fil_actor_system = { version = "7.0.0", path = "./actors/system" }
 fil_actor_init = { version = "7.0.0", path = "./actors/init" }
 
 [build-dependencies]
-fil_actor_bundler = { version = "1.0.1", path = "./bundler" }
+fil_actor_bundler = { version = "1.0.2", path = "./bundler" }
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 
 [workspace]

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_bundler"
 description = "An IPLD CAR bundling tool for Wasm bytecode"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"


### PR DESCRIPTION
We need a new release that uses the released FVM.