### PR TITLE
chore: switch to released fvm and publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "6.0.2"
+version = "6.0.4"
 dependencies = [
  "fil_actors_runtime",
  "fvm_shared",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_bundler"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "6.0.2"
+version = "6.0.4"
 dependencies = [
  "fil_actors_runtime",
  "fvm_shared",
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "6.0.2"
+version = "6.0.4"
 dependencies = [
  "anyhow",
  "cid",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "6.0.2"
+version = "6.0.4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "6.0.2"
+version = "6.0.4"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "6.0.2"
+version = "6.0.4"
 dependencies = [
  "anyhow",
  "cid",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "6.0.2"
+version = "6.0.4"
 dependencies = [
  "anyhow",
  "cid",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power"
-version = "6.0.2"
+version = "6.0.4"
 dependencies = [
  "anyhow",
  "cid",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "6.0.2"
+version = "6.0.4"
 dependencies = [
  "fil_actors_runtime",
  "fvm_shared",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "6.0.2"
+version = "6.0.4"
 dependencies = [
  "fil_actors_runtime",
  "fvm_shared",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "6.0.2"
+version = "6.0.4"
 dependencies = [
  "anyhow",
  "cid",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "6.0.2"
+version = "6.0.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -894,8 +894,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_amt"
-version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#0692d5bbb4d7ca588278a3544a48504a7f5ed0ee"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2390a9be38948b76ee749da692a342e70000bce9cfc988e90c64729a915962e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -909,8 +910,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_bitfield"
-version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#0692d5bbb4d7ca588278a3544a48504a7f5ed0ee"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1af49e67e51d326297440c0250f2012dd0f9d19b2ebec5c26b0c8d5171b540"
 dependencies = [
  "cs_serde_bytes",
  "fvm_shared",
@@ -920,8 +922,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_car"
-version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#0692d5bbb4d7ca588278a3544a48504a7f5ed0ee"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce7ed46e948d0e83894d77dcb9b351615ef7ee15dc2a09b35fe9878d8cca5e5c"
 dependencies = [
  "cid",
  "futures",
@@ -933,8 +936,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_hamt"
-version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#0692d5bbb4d7ca588278a3544a48504a7f5ed0ee"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4f07857e1978ce116716012ea6a675803fea00fb36504c307656f935f32578"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -951,8 +955,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#0692d5bbb4d7ca588278a3544a48504a7f5ed0ee"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce94d50a234db99c4fb445ad74e1520d0f35c934bd5d543625dbab14a157b53f"
 dependencies = [
  "cid",
  "fvm_shared",
@@ -964,8 +969,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#0692d5bbb4d7ca588278a3544a48504a7f5ed0ee"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab18d5c021bdca31f7b8719d540c157d3af8a116a1b1dfc2f7c09ff901a2606"
 dependencies = [
  "anyhow",
  "bimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,21 +10,21 @@ keywords = ["filecoin", "web3", "wasm"]
 exclude = ["examples", ".github"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fil_actor_account = { version = "6.0.2", path = "./actors/account" }
-fil_actor_verifreg = { version = "6.0.2", path = "./actors/verifreg" }
-fil_actor_cron = { version = "6.0.2", path = "./actors/cron" }
-fil_actor_market = { version = "6.0.2", path = "./actors/market" }
-fil_actor_multisig = { version = "6.0.2", path = "./actors/multisig" }
-fil_actor_paych = { version = "6.0.2", path = "./actors/paych" }
-fil_actor_power = { version = "6.0.2", path = "./actors/power" }
-fil_actor_miner = { version = "6.0.2", path = "./actors/miner" }
-fil_actor_reward = { version = "6.0.2", path = "./actors/reward" }
-fil_actor_system = { version = "6.0.2", path = "./actors/system" }
-fil_actor_init = { version = "6.0.2", path = "./actors/init" }
+fil_actor_account = { version = "6.0.4", path = "./actors/account" }
+fil_actor_verifreg = { version = "6.0.4", path = "./actors/verifreg" }
+fil_actor_cron = { version = "6.0.4", path = "./actors/cron" }
+fil_actor_market = { version = "6.0.4", path = "./actors/market" }
+fil_actor_multisig = { version = "6.0.4", path = "./actors/multisig" }
+fil_actor_paych = { version = "6.0.4", path = "./actors/paych" }
+fil_actor_power = { version = "6.0.4", path = "./actors/power" }
+fil_actor_miner = { version = "6.0.4", path = "./actors/miner" }
+fil_actor_reward = { version = "6.0.4", path = "./actors/reward" }
+fil_actor_system = { version = "6.0.4", path = "./actors/system" }
+fil_actor_init = { version = "6.0.4", path = "./actors/init" }
 
 [build-dependencies]
-fil_actor_bundler = { version = "1.0.1", path = "./bundler" }
-cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
+fil_actor_bundler = { version = "1.0.2", path = "./bundler" }
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 
 [workspace]
 members = [

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_account"
 description = "Builtin account actor for Filecoin"
-version = "6.0.2"
+version = "6.0.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -13,12 +13,12 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
-serde = { version = "1.0", features = ["derive"] }
-num-traits = "0.2"
-num-derive = "0.3.0"
+fil_actors_runtime = { version = "6.0.4", path = "../runtime" }
+fvm_shared = { version = "0.2.0", default-features = false }
+serde = { version = "1.0.136", features = ["derive"] }
+num-traits = "0.2.14"
+num-derive = "0.3.3"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
+fil_actors_runtime = { version = "6.0.4", path = "../runtime", features = ["test_utils"] }
 

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_cron"
 description = "Builtin cron actor for Filecoin"
-version = "6.0.2"
+version = "6.0.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,12 +14,12 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
-num-traits = "0.2"
-num-derive = "0.3.0"
-log = "0.4.8"
-serde = { version = "1.0", features = ["derive"] }
+fil_actors_runtime = { version = "6.0.4", path = "../runtime" }
+fvm_shared = { version = "0.2.0", default-features = false }
+num-traits = "0.2.14"
+num-derive = "0.3.3"
+log = "0.4.14"
+serde = { version = "1.0.136", features = ["derive"] }
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
+fil_actors_runtime = { version = "6.0.4", path = "../runtime", features = ["test_utils"] }

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_init"
 description = "Builtin init actor for Filecoin"
-version = "6.0.2"
+version = "6.0.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,12 +14,12 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
-fvm_ipld_hamt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm" }
-serde = { version = "1.0", features = ["derive"] }
-num-traits = "0.2"
-num-derive = "0.3.0"
-cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
-anyhow = "1.0.51"
+fil_actors_runtime = { version = "6.0.4", path = "../runtime" }
+fvm_shared = { version = "0.2.0", default-features = false }
+fvm_ipld_hamt = "0.2.0"
+serde = { version = "1.0.136", features = ["derive"] }
+num-traits = "0.2.14"
+num-derive = "0.3.3"
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+anyhow = "1.0.56"
 log = "0.4.14"

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_market"
 description = "Builtin market actor for Filecoin"
-version = "6.0.2"
+version = "6.0.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,17 +14,17 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
-bitfield = { version = "0.1.0", package = "fvm_ipld_bitfield", git = "https://github.com/filecoin-project/ref-fvm" }
-num-traits = "0.2"
-num-derive = "0.3.0"
-ahash = "0.7"
-serde = { version = "1.0", features = ["derive"] }
-cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
-log = "0.4.8"
-anyhow = "1.0.51"
+fil_actors_runtime = { version = "6.0.4", path = "../runtime" }
+fvm_shared = { version = "0.2.0", default-features = false }
+bitfield = { version = "0.2.0", package = "fvm_ipld_bitfield" }
+num-traits = "0.2.14"
+num-derive = "0.3.3"
+ahash = "0.7.6"
+serde = { version = "1.0.136", features = ["derive"] }
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+log = "0.4.14"
+anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
-fvm_ipld_amt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", features = ["go-interop"]}
+fil_actors_runtime = { version = "6.0.4", path = "../runtime", features = ["test_utils"] }
+fvm_ipld_amt = { version = "0.2.0", features = ["go-interop"] }

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_miner"
 description = "Builtin miner actor for Filecoin"
-version = "6.0.2"
+version = "6.0.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,23 +14,23 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
-bitfield = { version = "0.1.0", package = "fvm_ipld_bitfield", git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_ipld_amt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", features = ["go-interop"]}
-fvm_ipld_hamt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm" }
-serde = { version = "1.0", features = ["derive"] }
-cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
-num-traits = "0.2"
-num-derive = "0.3.0"
+fil_actors_runtime = { version = "6.0.4", path = "../runtime" }
+fvm_shared = { version = "0.2.0", default-features = false }
+bitfield = { version = "0.2.0", package = "fvm_ipld_bitfield" }
+fvm_ipld_amt = { version = "0.2.0", features = ["go-interop"] }
+fvm_ipld_hamt = "0.2.0"
+serde = { version = "1.0.136", features = ["derive"] }
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+num-traits = "0.2.14"
+num-derive = "0.3.3"
 lazy_static = "1.4.0"
-log = "0.4.8"
-byteorder = "1.3.4"
-anyhow = "1.0.51"
+log = "0.4.14"
+byteorder = "1.4.3"
+anyhow = "1.0.56"
 itertools = "0.10.3"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
-fil_actor_account = { version = "6.0.2", path = "../account" }
-rand = { version = "0.8.5" }
-cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
+fil_actors_runtime = { version = "6.0.4", path = "../runtime", features = ["test_utils"] }
+fil_actor_account = { version = "6.0.4", path = "../account" }
+rand = "0.8.5"
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_multisig"
 description = "Builtin multisig actor for Filecoin"
-version = "6.0.2"
+version = "6.0.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,16 +14,16 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
-fvm_ipld_hamt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm" }
-num-traits = "0.2"
-num-derive = "0.3.0"
-cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
-indexmap = { version = "1.7.0", features = ["serde-1"] }
-integer-encoding = { version = "3.0", default-features = false }
-serde = { version = "1.0", features = ["derive"] }
-anyhow = "1.0.51"
+fil_actors_runtime = { version = "6.0.4", path = "../runtime" }
+fvm_shared = { version = "0.2.0", default-features = false }
+fvm_ipld_hamt = "0.2.0"
+num-traits = "0.2.14"
+num-derive = "0.3.3"
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+indexmap = { version = "1.8.0", features = ["serde-1"] }
+integer-encoding = { version = "3.0.3", default-features = false }
+serde = { version = "1.0.136", features = ["derive"] }
+anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
+fil_actors_runtime = { version = "6.0.4", path = "../runtime", features = ["test_utils"] }

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_paych"
 description = "Builtin paych actor for Filecoin"
-version = "6.0.2"
+version = "6.0.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,15 +14,15 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
-num-traits = "0.2"
-num-derive = "0.3.0"
-serde = { version = "1.0", features = ["derive"] }
-cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
-anyhow = "1.0.51"
+fil_actors_runtime = { version = "6.0.4", path = "../runtime" }
+fvm_shared = { version = "0.2.0", default-features = false }
+num-traits = "0.2.14"
+num-derive = "0.3.3"
+serde = { version = "1.0.136", features = ["derive"] }
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
-fvm_ipld_amt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", features = ["go-interop"]}
-derive_builder = "0.10"
+fil_actors_runtime = { version = "6.0.4", path = "../runtime", features = ["test_utils"] }
+fvm_ipld_amt = { version = "0.2.0", features = ["go-interop"] }
+derive_builder = "0.10.2"

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_power"
 description = "Builtin power actor for Filecoin"
-version = "6.0.2"
+version = "6.0.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,15 +14,15 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
-fvm_ipld_hamt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm" }
-num-traits = "0.2"
-num-derive = "0.3.0"
-log = "0.4.8"
-indexmap = { version = "1.7.0", features = ["serde-1"] }
-cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
-integer-encoding = { version = "3.0", default-features = false }
+fil_actors_runtime = { version = "6.0.4", path = "../runtime" }
+fvm_shared = { version = "0.2.0", default-features = false }
+fvm_ipld_hamt = "0.2.0"
+num-traits = "0.2.14"
+num-derive = "0.3.3"
+log = "0.4.14"
+indexmap = { version = "1.8.0", features = ["serde-1"] }
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+integer-encoding = { version = "3.0.3", default-features = false }
 lazy_static = "1.4.0"
-serde = { version = "1.0", features = ["derive"] }
-anyhow = "1.0.51"
+serde = { version = "1.0.136", features = ["derive"] }
+anyhow = "1.0.56"

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_reward"
 description = "Builtin reward actor for Filecoin"
-version = "6.0.2"
+version = "6.0.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,13 +14,13 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
-num-traits = "0.2"
-num-derive = "0.3.0"
-log = "0.4.8"
+fil_actors_runtime = { version = "6.0.4", path = "../runtime" }
+fvm_shared = { version = "0.2.0", default-features = false }
+num-traits = "0.2.14"
+num-derive = "0.3.3"
+log = "0.4.14"
 lazy_static = "1.4.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.136", features = ["derive"] }
 
 [dev-dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime", features = ["test_utils"] }
+fil_actors_runtime = { version = "6.0.4", path = "../runtime", features = ["test_utils"] }

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -1,40 +1,40 @@
 [package]
 name = "fil_actors_runtime"
 description = "System actors for the Filecoin protocol"
-version = "6.0.2"
+version = "6.0.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
 repository = "https://github.com/filecoin-project/builtin-actors"
 
 [dependencies]
-fvm_ipld_hamt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_ipld_amt = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", features = ["go-interop"]}
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
-num-traits = "0.2"
-num-derive = "0.3.0"
-serde = { version = "1.0", features = ["derive"] }
+fvm_ipld_hamt = "0.2.0"
+fvm_ipld_amt = { version = "0.2.0", features = ["go-interop"] }
+fvm_shared = { version = "0.2.0", default-features = false }
+num-traits = "0.2.14"
+num-derive = "0.3.3"
+serde = { version = "1.0.136", features = ["derive"] }
 lazy_static = "1.4.0"
 unsigned-varint = "0.7.1"
-integer-encoding = { version = "3.0", default-features = false }
-byteorder = "1.3.4"
-cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
+integer-encoding = { version = "3.0.3", default-features = false }
+byteorder = "1.4.3"
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.1", default-features = false, features = ["identity"] }
-base64 = "0.13"
-log = "0.4.8"
-indexmap = { version = "1.7.0", features = ["serde-1"] }
+base64 = "0.13.0"
+log = "0.4.14"
+indexmap = { version = "1.8.0", features = ["serde-1"] }
 thiserror = "1.0.30"
 # enforce wasm compat
-getrandom = { version = "0.2", features = ["js"] }
-hex = { version = "0.4.2", optional = true }
-anyhow = "1.0.51"
+getrandom = { version = "0.2.5", features = ["js"] }
+hex = { version = "0.4.3", optional = true }
+anyhow = "1.0.56"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm" }
+fvm_sdk = "0.2.0"
 
 [dev-dependencies]
-derive_builder = "0.10"
-hex = "0.4.2"
+derive_builder = "0.10.2"
+hex = "0.4.3"
 
 [features]
 default = []

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_system"
 description = "Builtin system actor for Filecoin"
-version = "6.0.2"
+version = "6.0.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,8 +14,8 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
-num-traits = "0.2"
-num-derive = "0.3.0"
-serde = { version = "1.0", features = ["derive"] }
+fil_actors_runtime = { version = "6.0.4", path = "../runtime" }
+fvm_shared = { version = "0.2.0", default-features = false }
+num-traits = "0.2.14"
+num-derive = "0.3.3"
+serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_verifreg"
 description = "Builtin verifreg actor for Filecoin"
-version = "6.0.2"
+version = "6.0.4"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,11 +14,11 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "6.0.2", path = "../runtime" }
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm", default-features = false }
-serde = { version = "1.0", features = ["derive"] }
-num-traits = "0.2"
-num-derive = "0.3.0"
-cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
-lazy_static = "1.4"
-anyhow = "1.0.51"
+fil_actors_runtime = { version = "6.0.4", path = "../runtime" }
+fvm_shared = { version = "0.2.0", default-features = false }
+serde = { version = "1.0.136", features = ["derive"] }
+num-traits = "0.2.14"
+num-derive = "0.3.3"
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+lazy_static = "1.4.0"
+anyhow = "1.0.56"

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "fil_actor_bundler"
 description = "An IPLD CAR bundling tool for Wasm bytecode"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
+publish = false # We only publish this from "master".
 
 [dependencies]
-clap = { version= "3.0.14", features = ["derive"] }
-fvm_shared = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_ipld_car = { version = "0.1.0", git = "https://github.com/filecoin-project/ref-fvm" }
-cid = { version = "0.8.2", default-features = false, features = ["serde-codec"] }
+clap = { version = "3.1.6", features = ["derive"] }
+fvm_shared = "0.2.0"
+fvm_ipld_car = "0.2.0"
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.1", default-features = false, features = ["identity"] }
-async-std = { version = "1.10.0" }
+async-std = "1.10.0"
 futures = "0.3.21"
-anyhow = "1.0.53"
+anyhow = "1.0.56"
 serde_ipld_dagcbor = "0.1.0"
 serde_json = "1.0.79"
 


### PR DESCRIPTION
This:

- Ensures that we use the correct IPLD version everywhere by switching to the latest FVM version.
- Avoids publishing the bundler crate from "old" releases...
- Skips 6.0.3 so the bundle and actor versions are identical.

NOTE: I think we'll want to move the bundler into a new repo. Keeping it here is going to be a _pain_.