### PR TITLE
More verified registry tests

### DIFF
--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -1,0 +1,188 @@
+#![deny(unused_must_use)] // Force unwrapping Result<_, Err>
+
+use fvm_shared::address::Address;
+use fvm_shared::bigint::bigint_ser::BigIntDe;
+use fvm_shared::blockstore::MemoryBlockstore;
+use fvm_shared::encoding::RawBytes;
+use fvm_shared::{MethodNum, HAMT_BIT_WIDTH};
+use lazy_static::lazy_static;
+
+use fil_actor_verifreg::{
+    Actor as VerifregActor, AddVerifierClientParams, AddVerifierParams, DataCap, Method, State,
+};
+use fil_actors_runtime::test_utils::*;
+use fil_actors_runtime::{
+    make_empty_map, make_map_with_root_and_bitwidth, ActorError, Map, SYSTEM_ACTOR_ADDR,
+};
+
+lazy_static! {
+    pub static ref ROOT_ADDR: Address = Address::new_id(101);
+}
+
+pub fn new_runtime() -> MockRuntime {
+    MockRuntime {
+        receiver: *ROOT_ADDR,
+        caller: *SYSTEM_ACTOR_ADDR,
+        caller_type: *SYSTEM_ACTOR_CODE_ID,
+        ..Default::default()
+    }
+}
+
+pub fn new_harness() -> (Harness, MockRuntime) {
+    let mut rt = new_runtime();
+    let h = Harness { root: *ROOT_ADDR };
+    h.construct_and_verify(&mut rt, &h.root);
+    return (h, rt);
+}
+
+pub struct Harness {
+    pub root: Address,
+}
+
+impl Harness {
+    pub fn construct_and_verify(&self, rt: &mut MockRuntime, root_param: &Address) {
+        rt.expect_validate_caller_addr(vec![*SYSTEM_ACTOR_ADDR]);
+        let ret = rt
+            .call::<VerifregActor>(
+                Method::Constructor as MethodNum,
+                &RawBytes::serialize(root_param).unwrap(),
+            )
+            .unwrap();
+
+        assert_eq!(RawBytes::default(), ret);
+        rt.verify();
+
+        let empty_map = make_empty_map::<_, ()>(&rt.store, HAMT_BIT_WIDTH).flush().unwrap();
+        let state: State = rt.get_state().unwrap();
+        assert_eq!(self.root, state.root_key);
+        assert_eq!(empty_map, state.verified_clients);
+        assert_eq!(empty_map, state.verifiers);
+    }
+
+    pub fn add_verifier(
+        &self,
+        rt: &mut MockRuntime,
+        verifier: &Address,
+        allowance: &DataCap,
+    ) -> Result<(), ActorError> {
+        rt.expect_validate_caller_addr(vec![self.root]);
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.root);
+        let params = AddVerifierParams { address: *verifier, allowance: allowance.clone() };
+        let ret = rt.call::<VerifregActor>(
+            Method::AddVerifier as MethodNum,
+            &RawBytes::serialize(params).unwrap(),
+        )?;
+        assert_eq!(RawBytes::default(), ret);
+        rt.verify();
+
+        self.assert_verifier_allowance(rt, &verifier, allowance);
+        Ok(())
+    }
+
+    pub fn remove_verifier(
+        &self,
+        rt: &mut MockRuntime,
+        verifier: &Address,
+    ) -> Result<(), ActorError> {
+        rt.expect_validate_caller_addr(vec![self.root]);
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.root);
+        let ret = rt.call::<VerifregActor>(
+            Method::RemoveVerifier as MethodNum,
+            &RawBytes::serialize(verifier).unwrap(),
+        )?;
+        assert_eq!(RawBytes::default(), ret);
+        rt.verify();
+
+        self.assert_verifier_removed(rt, verifier);
+        Ok(())
+    }
+
+    pub fn assert_verifier_allowance(
+        &self,
+        rt: &MockRuntime,
+        verifier: &Address,
+        allowance: &DataCap,
+    ) {
+        let verifier_id_addr = rt.get_id_address(verifier).unwrap();
+        assert_eq!(*allowance, self.get_verifier_allowance(rt, &verifier_id_addr));
+    }
+
+    pub fn get_verifier_allowance(&self, rt: &MockRuntime, verifier: &Address) -> DataCap {
+        let verifiers = load_verifiers(&rt);
+        let BigIntDe(allowance) = verifiers.get(&verifier.to_bytes()).unwrap().unwrap();
+        return allowance.clone();
+    }
+
+    pub fn assert_verifier_removed(&self, rt: &MockRuntime, verifier: &Address) {
+        let verifier_id_addr = rt.get_id_address(verifier).unwrap();
+        let verifiers = load_verifiers(&rt);
+        assert_eq!(false, verifiers.contains_key(&verifier_id_addr.to_bytes()).unwrap())
+    }
+
+    pub fn add_client(
+        &self,
+        rt: &mut MockRuntime,
+        verifier: &Address,
+        client: &Address,
+        allowance: &DataCap,
+        expected_allowance: &DataCap,
+    ) -> Result<(), ActorError> {
+        rt.expect_validate_caller_any();
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *verifier);
+        let params = AddVerifierClientParams { address: *client, allowance: allowance.clone() };
+        let ret = rt.call::<VerifregActor>(
+            Method::AddVerifiedClient as MethodNum,
+            &RawBytes::serialize(params).unwrap(),
+        )?;
+        assert_eq!(RawBytes::default(), ret);
+        rt.verify();
+
+        // Confirm the verifier was added to state.
+        let client_id_addr = rt.get_id_address(&client).unwrap();
+        assert_eq!(*expected_allowance, self.get_client_allowance(rt, &client_id_addr));
+        Ok(())
+    }
+
+    pub fn assert_client_allowance(&self, rt: &MockRuntime, client: &Address, allowance: &DataCap) {
+        let client_id_addr = rt.get_id_address(client).unwrap();
+        assert_eq!(*allowance, self.get_client_allowance(rt, &client_id_addr));
+    }
+
+    pub fn get_client_allowance(&self, rt: &MockRuntime, client: &Address) -> DataCap {
+        let clients = load_clients(&rt);
+        let BigIntDe(allowance) = clients.get(&client.to_bytes()).unwrap().unwrap();
+        return allowance.clone();
+    }
+
+    pub fn add_verifier_and_client(
+        &self,
+        rt: &mut MockRuntime,
+        verifier: &Address,
+        client: &Address,
+        verifier_allowance: &DataCap,
+        client_allowance: &DataCap,
+    ) {
+        self.add_verifier(rt, verifier, verifier_allowance).unwrap();
+        self.add_client(rt, verifier, client, client_allowance, client_allowance).unwrap();
+    }
+
+    pub fn check_state(&self) {
+        // TODO: https://github.com/filecoin-project/builtin-actors/issues/44
+    }
+}
+
+fn load_verifiers(rt: &MockRuntime) -> Map<MemoryBlockstore, BigIntDe> {
+    let state: State = rt.get_state().unwrap();
+    make_map_with_root_and_bitwidth::<_, BigIntDe>(&state.verifiers, &rt.store, HAMT_BIT_WIDTH)
+        .unwrap()
+}
+
+fn load_clients(rt: &MockRuntime) -> Map<MemoryBlockstore, BigIntDe> {
+    let state: State = rt.get_state().unwrap();
+    make_map_with_root_and_bitwidth::<_, BigIntDe>(
+        &state.verified_clients,
+        &rt.store,
+        HAMT_BIT_WIDTH,
+    )
+    .unwrap()
+}

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -75,7 +75,7 @@ impl Harness {
         assert_eq!(RawBytes::default(), ret);
         rt.verify();
 
-        self.assert_verifier_allowance(rt, &verifier, allowance);
+        self.assert_verifier_allowance(rt, verifier, allowance);
         Ok(())
     }
 
@@ -108,14 +108,14 @@ impl Harness {
     }
 
     pub fn get_verifier_allowance(&self, rt: &MockRuntime, verifier: &Address) -> DataCap {
-        let verifiers = load_verifiers(&rt);
+        let verifiers = load_verifiers(rt);
         let BigIntDe(allowance) = verifiers.get(&verifier.to_bytes()).unwrap().unwrap();
         return allowance.clone();
     }
 
     pub fn assert_verifier_removed(&self, rt: &MockRuntime, verifier: &Address) {
         let verifier_id_addr = rt.get_id_address(verifier).unwrap();
-        let verifiers = load_verifiers(&rt);
+        let verifiers = load_verifiers(rt);
         assert_eq!(false, verifiers.contains_key(&verifier_id_addr.to_bytes()).unwrap())
     }
 
@@ -138,8 +138,7 @@ impl Harness {
         rt.verify();
 
         // Confirm the verifier was added to state.
-        let client_id_addr = rt.get_id_address(&client).unwrap();
-        assert_eq!(*expected_allowance, self.get_client_allowance(rt, &client_id_addr));
+        self.assert_client_allowance(rt, client, expected_allowance);
         Ok(())
     }
 

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -175,8 +175,10 @@ mod verifiers {
         let verifier = Address::new_id(201);
         h.add_verifier(&mut rt, &verifier, &VERIFIER_ALLOWANCE).unwrap();
 
+        let caller = Address::new_id(501);
         rt.expect_validate_caller_addr(vec![h.root]);
-        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(501));
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, caller);
+        assert_ne!(h.root, caller);
         expect_abort(
             ExitCode::SysErrForbidden,
             rt.call::<VerifregActor>(

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -2,10 +2,7 @@
 
 use lazy_static::lazy_static;
 
-use fil_actor_verifreg::{
-    DataCap,
-    MINIMUM_VERIFIED_DEAL_SIZE,
-};
+use fil_actor_verifreg::{DataCap, MINIMUM_VERIFIED_DEAL_SIZE};
 
 mod harness;
 
@@ -21,8 +18,8 @@ mod construction {
     use fvm_shared::MethodNum;
 
     use fil_actor_verifreg::{Actor as VerifregActor, Method};
-    use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
     use fil_actors_runtime::test_utils::*;
+    use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
 
     use crate::harness;
     use harness::*;
@@ -62,11 +59,11 @@ mod construction {
 }
 
 mod verifiers {
-    use fvm_shared::{METHOD_SEND, MethodNum};
     use fvm_shared::address::{Address, BLS_PUB_LEN};
     use fvm_shared::econ::TokenAmount;
     use fvm_shared::encoding::RawBytes;
     use fvm_shared::error::ExitCode;
+    use fvm_shared::{MethodNum, METHOD_SEND};
 
     use fil_actor_verifreg::{
         Actor as VerifregActor, AddVerifierParams, DataCap, Method, MINIMUM_VERIFIED_DEAL_SIZE,
@@ -222,11 +219,11 @@ mod verifiers {
 }
 
 mod clients {
-    use fvm_shared::{METHOD_SEND, MethodNum};
     use fvm_shared::address::{Address, BLS_PUB_LEN};
     use fvm_shared::econ::TokenAmount;
     use fvm_shared::encoding::RawBytes;
     use fvm_shared::error::ExitCode;
+    use fvm_shared::{MethodNum, METHOD_SEND};
 
     use fil_actor_verifreg::{
         Actor as VerifregActor, AddVerifierClientParams, DataCap, Method,
@@ -234,7 +231,7 @@ mod clients {
     };
     use fil_actors_runtime::test_utils::*;
 
-    use crate::{CLIENT_ALLOWANCE, harness, VERIFIER_ALLOWANCE};
+    use crate::{harness, CLIENT_ALLOWANCE, VERIFIER_ALLOWANCE};
     use harness::*;
 
     #[test]

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -1,23 +1,25 @@
 #![deny(unused_must_use)] // Force unwrapping Result<_, Err>
 
+use fvm_shared::{HAMT_BIT_WIDTH, MethodNum};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser::BigIntDe;
+use fvm_shared::blockstore::MemoryBlockstore;
 use fvm_shared::encoding::RawBytes;
-use fvm_shared::{MethodNum, HAMT_BIT_WIDTH};
 use lazy_static::lazy_static;
 
 use fil_actor_verifreg::{
-    Actor as VerifregActor, AddVerifierClientParams, AddVerifierParams, DataCap, Method, State,
-    MINIMUM_VERIFIED_DEAL_SIZE,
+    Actor as VerifregActor, AddVerifierClientParams, AddVerifierParams, DataCap, Method, MINIMUM_VERIFIED_DEAL_SIZE,
+    State,
+};
+use fil_actors_runtime::{
+    ActorError, make_empty_map, make_map_with_root_and_bitwidth, Map, SYSTEM_ACTOR_ADDR,
 };
 use fil_actors_runtime::test_utils::*;
-use fil_actors_runtime::{
-    make_empty_map, make_map_with_root_and_bitwidth, ActorError, SYSTEM_ACTOR_ADDR,
-};
 
 lazy_static! {
     static ref ROOT_ADDR: Address = Address::new_id(101);
     static ref VERIFIER_ALLOWANCE: DataCap = MINIMUM_VERIFIED_DEAL_SIZE.clone() + DataCap::from(42);
+    static ref CLIENT_ALLOWANCE: DataCap = VERIFIER_ALLOWANCE.clone() - DataCap::from(1);
 }
 
 fn construct_runtime() -> MockRuntime {
@@ -43,8 +45,8 @@ mod construction {
     use fvm_shared::MethodNum;
 
     use fil_actor_verifreg::{Actor as VerifregActor, Method};
-    use fil_actors_runtime::test_utils::*;
     use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
+    use fil_actors_runtime::test_utils::*;
 
     use crate::{construct_runtime, Harness};
 
@@ -83,11 +85,11 @@ mod construction {
 }
 
 mod verifiers {
-    use fvm_shared::address::Address;
+    use fvm_shared::{METHOD_SEND, MethodNum};
+    use fvm_shared::address::{Address, BLS_PUB_LEN};
     use fvm_shared::econ::TokenAmount;
     use fvm_shared::encoding::RawBytes;
     use fvm_shared::error::ExitCode;
-    use fvm_shared::{MethodNum, METHOD_SEND};
 
     use fil_actor_verifreg::{
         Actor as VerifregActor, AddVerifierParams, DataCap, Method, MINIMUM_VERIFIED_DEAL_SIZE,
@@ -107,7 +109,7 @@ mod verifiers {
             allowance: VERIFIER_ALLOWANCE.clone(),
         };
         expect_abort(
-            ExitCode::ErrForbidden,
+            ExitCode::SysErrForbidden,
             rt.call::<VerifregActor>(
                 Method::AddVerifier as MethodNum,
                 &RawBytes::serialize(params).unwrap(),
@@ -192,6 +194,270 @@ mod verifiers {
         h.add_verifier(&mut rt, &pubkey_addr, &VERIFIER_ALLOWANCE).unwrap();
         h.check_state();
     }
+
+    #[test]
+    fn remove_requires_root() {
+        let (h, mut rt) = make_harness();
+        let verifier = Address::new_id(201);
+        h.add_verifier(&mut rt, &verifier, &VERIFIER_ALLOWANCE).unwrap();
+
+        rt.expect_validate_caller_addr(vec![h.root]);
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(501));
+        expect_abort(
+            ExitCode::SysErrForbidden,
+            rt.call::<VerifregActor>(
+                Method::RemoveVerifier as MethodNum,
+                &RawBytes::serialize(verifier).unwrap(),
+            ),
+        );
+        h.check_state();
+    }
+
+    #[test]
+    fn remove_requires_verifier_exists() {
+        let (h, mut rt) = make_harness();
+        let verifier = Address::new_id(501);
+        expect_abort(ExitCode::ErrIllegalArgument, h.remove_verifier(&mut rt, &verifier));
+        h.check_state();
+    }
+
+    #[test]
+    fn remove_verifier() {
+        let (h, mut rt) = make_harness();
+        let verifier = Address::new_id(201);
+        h.add_verifier(&mut rt, &verifier, &VERIFIER_ALLOWANCE).unwrap();
+        h.remove_verifier(&mut rt, &verifier).unwrap();
+        h.check_state();
+    }
+
+    #[test]
+    fn remove_verifier_id_address() {
+        let (h, mut rt) = make_harness();
+        let verifier_pubkey = Address::new_bls(&[1u8; BLS_PUB_LEN]).unwrap();
+        let verifier_id = Address::new_id(201);
+        rt.id_addresses.insert(verifier_pubkey, verifier_id);
+        // Add using pubkey address.
+        h.add_verifier(&mut rt, &verifier_pubkey, &VERIFIER_ALLOWANCE).unwrap();
+        // Remove using ID address.
+        h.remove_verifier(&mut rt, &verifier_id).unwrap();
+        h.check_state();
+    }
+}
+
+mod clients {
+    use fvm_shared::{METHOD_SEND, MethodNum};
+    use fvm_shared::address::{Address, BLS_PUB_LEN};
+    use fvm_shared::econ::TokenAmount;
+    use fvm_shared::encoding::RawBytes;
+    use fvm_shared::error::ExitCode;
+
+    use fil_actor_verifreg::{
+        Actor as VerifregActor, AddVerifierClientParams, DataCap, Method,
+        MINIMUM_VERIFIED_DEAL_SIZE,
+    };
+    use fil_actors_runtime::test_utils::*;
+
+    use crate::{CLIENT_ALLOWANCE, make_harness, VERIFIER_ALLOWANCE};
+
+    #[test]
+    fn many_verifiers_and_clients() {
+        let (h, mut rt) = make_harness();
+        let verifier1 = Address::new_id(201);
+        let verifier2 = Address::new_id(202);
+
+        // Each verifier has enough allowance for two clients.
+        let verifier_allowance = CLIENT_ALLOWANCE.clone() + CLIENT_ALLOWANCE.clone();
+        h.add_verifier(&mut rt, &verifier1, &verifier_allowance).unwrap();
+        h.add_verifier(&mut rt, &verifier2, &verifier_allowance).unwrap();
+
+        let client1 = Address::new_id(301);
+        let client2 = Address::new_id(302);
+        h.add_client(&mut rt, &verifier1, &client1, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE).unwrap();
+        h.add_client(&mut rt, &verifier1, &client2, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE).unwrap();
+
+        let client3 = Address::new_id(303);
+        let client4 = Address::new_id(304);
+        h.add_client(&mut rt, &verifier2, &client3, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE).unwrap();
+        h.add_client(&mut rt, &verifier2, &client4, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE).unwrap();
+
+        // all clients should exist and verifiers should have no more allowance left
+        h.assert_client_allowance(&rt, &client1, &CLIENT_ALLOWANCE);
+        h.assert_client_allowance(&rt, &client2, &CLIENT_ALLOWANCE);
+        h.assert_client_allowance(&rt, &client3, &CLIENT_ALLOWANCE);
+        h.assert_client_allowance(&rt, &client4, &CLIENT_ALLOWANCE);
+        h.assert_verifier_allowance(&rt, &verifier1, &DataCap::from(0));
+        h.assert_verifier_allowance(&rt, &verifier2, &DataCap::from(0));
+        h.check_state();
+    }
+
+    #[test]
+    fn verifier_allowance_exhausted() {
+        let (h, mut rt) = make_harness();
+        let verifier = Address::new_id(201);
+        // Verifier only has allowance for one client.
+        h.add_verifier(&mut rt, &verifier, &CLIENT_ALLOWANCE).unwrap();
+
+        let client1 = Address::new_id(301);
+        h.add_client(&mut rt, &verifier, &client1, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE).unwrap();
+        let client2 = Address::new_id(302);
+        expect_abort(
+            ExitCode::ErrIllegalArgument,
+            h.add_client(&mut rt, &verifier, &client2, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE),
+        );
+
+        // One client should exist and verifier should have no more allowance left.
+        h.assert_client_allowance(&rt, &client1, &CLIENT_ALLOWANCE);
+        h.assert_verifier_allowance(&rt, &verifier, &DataCap::from(0));
+        h.check_state();
+    }
+
+    #[test]
+    fn resolves_client_address() {
+        let (h, mut rt) = make_harness();
+
+        let client_pubkey = Address::new_bls(&[7u8; BLS_PUB_LEN]).unwrap();
+        let client_id = Address::new_id(301);
+        rt.id_addresses.insert(client_pubkey, client_id);
+
+        let verifier = Address::new_id(201);
+        h.add_verifier(&mut rt, &verifier, &VERIFIER_ALLOWANCE).unwrap();
+        h.add_client(&mut rt, &verifier, &client_pubkey, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE)
+            .unwrap();
+
+        // Adding another verified client with the same ID address increments
+        // the data cap which has already been granted.
+        h.add_verifier(&mut rt, &verifier, &VERIFIER_ALLOWANCE).unwrap();
+        let expected_allowance = CLIENT_ALLOWANCE.clone() + CLIENT_ALLOWANCE.clone();
+        h.add_client(&mut rt, &verifier, &client_id, &CLIENT_ALLOWANCE, &expected_allowance)
+            .unwrap();
+        h.check_state();
+    }
+
+    #[test]
+    fn minimum_allowance_ok() {
+        let (h, mut rt) = make_harness();
+        let verifier = Address::new_id(201);
+        h.add_verifier(&mut rt, &verifier, &VERIFIER_ALLOWANCE).unwrap();
+
+        let client = Address::new_id(301);
+        let allowance = MINIMUM_VERIFIED_DEAL_SIZE.clone();
+        h.add_client(&mut rt, &verifier, &client, &allowance, &allowance).unwrap();
+        h.check_state();
+    }
+
+    #[test]
+    fn rejects_unresolved_address() {
+        let (h, mut rt) = make_harness();
+        let verifier = Address::new_id(201);
+        h.add_verifier(&mut rt, &verifier, &VERIFIER_ALLOWANCE).unwrap();
+
+        let client = Address::new_bls(&[7u8; BLS_PUB_LEN]).unwrap();
+        // Expect runtime to attempt to create the actor, but don't add it to the mock's
+        // address resolution table.
+        rt.expect_send(
+            client,
+            METHOD_SEND,
+            RawBytes::default(),
+            TokenAmount::default(),
+            RawBytes::default(),
+            ExitCode::Ok,
+        );
+
+        expect_abort(
+            ExitCode::ErrIllegalState,
+            h.add_client(&mut rt, &verifier, &client, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE),
+        );
+        h.check_state();
+    }
+
+    #[test]
+    fn rejects_allowance_below_minimum() {
+        let (h, mut rt) = make_harness();
+        let verifier = Address::new_id(201);
+        h.add_verifier(&mut rt, &verifier, &VERIFIER_ALLOWANCE).unwrap();
+
+        let client = Address::new_id(301);
+        let allowance = MINIMUM_VERIFIED_DEAL_SIZE.clone() - DataCap::from(1);
+        expect_abort(
+            ExitCode::ErrIllegalArgument,
+            h.add_client(&mut rt, &verifier, &client, &allowance, &allowance),
+        );
+        h.check_state();
+    }
+
+    #[test]
+    fn rejects_non_verifier_caller() {
+        let (h, mut rt) = make_harness();
+        let verifier = Address::new_id(201);
+        h.add_verifier(&mut rt, &verifier, &VERIFIER_ALLOWANCE).unwrap();
+
+        let client = Address::new_id(301);
+        let caller = Address::new_id(209);
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, caller);
+        rt.expect_validate_caller_any();
+        let params =
+            AddVerifierClientParams { address: client, allowance: CLIENT_ALLOWANCE.clone() };
+        expect_abort(
+            ExitCode::ErrNotFound,
+            rt.call::<VerifregActor>(
+                Method::AddVerifiedClient as MethodNum,
+                &RawBytes::serialize(params).unwrap(),
+            ),
+        );
+        h.check_state();
+    }
+
+    #[test]
+    fn rejects_allowance_greater_than_verifier_cap() {
+        let (h, mut rt) = make_harness();
+        let verifier = Address::new_id(201);
+        h.add_verifier(&mut rt, &verifier, &VERIFIER_ALLOWANCE).unwrap();
+
+        let allowance = VERIFIER_ALLOWANCE.clone() + DataCap::from(1);
+        expect_abort(
+            ExitCode::ErrIllegalArgument,
+            h.add_client(&mut rt, &verifier, &h.root, &allowance, &allowance),
+        );
+        h.check_state();
+    }
+
+    #[test]
+    fn rejects_root_as_client() {
+        let (h, mut rt) = make_harness();
+        let verifier = Address::new_id(201);
+        h.add_verifier(&mut rt, &verifier, &VERIFIER_ALLOWANCE).unwrap();
+        expect_abort(
+            ExitCode::ErrIllegalArgument,
+            h.add_client(&mut rt, &verifier, &h.root, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE),
+        );
+        h.check_state();
+    }
+
+    #[test]
+    fn rejects_verifier_as_client() {
+        let (h, mut rt) = make_harness();
+        let verifier = Address::new_id(201);
+        h.add_verifier(&mut rt, &verifier, &VERIFIER_ALLOWANCE).unwrap();
+        expect_abort(
+            ExitCode::ErrIllegalArgument,
+            h.add_client(&mut rt, &verifier, &verifier, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE),
+        );
+
+        let another_verifier = Address::new_id(202);
+        h.add_verifier(&mut rt, &another_verifier, &VERIFIER_ALLOWANCE).unwrap();
+        expect_abort(
+            ExitCode::ErrIllegalArgument,
+            h.add_client(
+                &mut rt,
+                &verifier,
+                &another_verifier,
+                &CLIENT_ALLOWANCE,
+                &CLIENT_ALLOWANCE,
+            ),
+        );
+
+        h.check_state();
+    }
 }
 
 ///// Test harness /////
@@ -238,22 +504,39 @@ impl Harness {
         assert_eq!(RawBytes::default(), ret);
         rt.verify();
 
-        // Confirm the verifier was added to state.
-        let verifier_id_addr = rt.get_id_address(&verifier).unwrap();
+        self.assert_verifier_allowance(rt, &verifier, allowance);
+        Ok(())
+    }
+
+    fn remove_verifier(&self, rt: &mut MockRuntime, verifier: &Address) -> Result<(), ActorError> {
+        rt.expect_validate_caller_addr(vec![self.root]);
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.root);
+        let ret = rt.call::<VerifregActor>(
+            Method::RemoveVerifier as MethodNum,
+            &RawBytes::serialize(verifier).unwrap(),
+        )?;
+        assert_eq!(RawBytes::default(), ret);
+        rt.verify();
+
+        self.assert_verifier_removed(rt, verifier);
+        Ok(())
+    }
+
+    fn assert_verifier_allowance(&self, rt: &MockRuntime, verifier: &Address, allowance: &DataCap) {
+        let verifier_id_addr = rt.get_id_address(verifier).unwrap();
         assert_eq!(*allowance, self.get_verifier_allowance(rt, &verifier_id_addr));
-        Result::Ok(())
     }
 
     fn get_verifier_allowance(&self, rt: &MockRuntime, verifier: &Address) -> DataCap {
-        let state: State = rt.get_state().unwrap();
-        let verifiers = make_map_with_root_and_bitwidth::<_, BigIntDe>(
-            &state.verifiers,
-            &rt.store,
-            HAMT_BIT_WIDTH,
-        )
-        .unwrap();
+        let verifiers = load_verifiers(&rt);
         let BigIntDe(allowance) = verifiers.get(&verifier.to_bytes()).unwrap().unwrap();
         return allowance.clone();
+    }
+
+    fn assert_verifier_removed(&self, rt: &MockRuntime, verifier: &Address) {
+        let verifier_id_addr = rt.get_id_address(verifier).unwrap();
+        let verifiers = load_verifiers(&rt);
+        assert_eq!(false, verifiers.contains_key(&verifier_id_addr.to_bytes()).unwrap())
     }
 
     fn add_client(
@@ -280,14 +563,13 @@ impl Harness {
         Result::Ok(())
     }
 
+    fn assert_client_allowance(&self, rt: &MockRuntime, client: &Address, allowance: &DataCap) {
+        let client_id_addr = rt.get_id_address(client).unwrap();
+        assert_eq!(*allowance, self.get_client_allowance(rt, &client_id_addr));
+    }
+
     fn get_client_allowance(&self, rt: &MockRuntime, client: &Address) -> DataCap {
-        let state: State = rt.get_state().unwrap();
-        let clients = make_map_with_root_and_bitwidth::<_, BigIntDe>(
-            &state.verified_clients,
-            &rt.store,
-            HAMT_BIT_WIDTH,
-        )
-        .unwrap();
+        let clients = load_clients(&rt);
         let BigIntDe(allowance) = clients.get(&client.to_bytes()).unwrap().unwrap();
         return allowance.clone();
     }
@@ -307,4 +589,20 @@ impl Harness {
     fn check_state(&self) {
         // TODO: https://github.com/filecoin-project/builtin-actors/issues/44
     }
+}
+
+fn load_verifiers(rt: &MockRuntime) -> Map<MemoryBlockstore, BigIntDe> {
+    let state: State = rt.get_state().unwrap();
+    make_map_with_root_and_bitwidth::<_, BigIntDe>(&state.verifiers, &rt.store, HAMT_BIT_WIDTH)
+        .unwrap()
+}
+
+fn load_clients(rt: &MockRuntime) -> Map<MemoryBlockstore, BigIntDe> {
+    let state: State = rt.get_state().unwrap();
+    make_map_with_root_and_bitwidth::<_, BigIntDe>(
+        &state.verified_clients,
+        &rt.store,
+        HAMT_BIT_WIDTH,
+    )
+    .unwrap()
 }


### PR DESCRIPTION
A few notes
- Fixed a bug in the mock runtime that returned the wrong `ErrForbidden` from caller verification
- Extracted the test harness into a submodule of the tests module, following the pattern [described in the Rust Book here](https://doc.rust-lang.org/book/ch11-03-test-organization.html#submodules-in-integration-tests).