### PR TITLE
refactor: don't rename package

### DIFF
--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.2.0", default-features = false }
-bitfield = { version = "0.2.0", package = "fvm_ipld_bitfield" }
+fvm_ipld_bitfield = { version = "0.2.0" }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 ahash = "0.7.6"

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -3,13 +3,13 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use bitfield::BitField;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
     actor_error, wasm_trampoline, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR,
     CRON_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
     VERIFIED_REGISTRY_ACTOR_ADDR,
 };
+use fvm_ipld_bitfield::BitField;
 use fvm_shared::actor::builtin::{Type, CALLER_TYPES_SIGNABLE};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -1,9 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use bitfield::BitField;
 use cid::Cid;
 use fil_actors_runtime::{Array, DealWeight};
+use fvm_ipld_bitfield::BitField;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "7.0.0", path = "../runtime" }
 fvm_shared = { version = "0.2.0", default-features = false }
-bitfield = { version = "0.2.1", package = "fvm_ipld_bitfield" }
+fvm_ipld_bitfield = { version = "0.2.1" }
 fvm_ipld_amt = { version = "0.2.0", features = ["go-interop"] }
 fvm_ipld_hamt = "0.2.0"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/miner/src/bitfield_queue.rs
+++ b/actors/miner/src/bitfield_queue.rs
@@ -3,10 +3,10 @@
 
 use std::convert::TryInto;
 
-use bitfield::BitField;
 use cid::Cid;
 use fil_actors_runtime::{ActorDowncast, Array};
 use fvm_ipld_amt::Error as AmtError;
+use fvm_ipld_bitfield::BitField;
 use fvm_shared::blockstore::Blockstore;
 use fvm_shared::clock::{ChainEpoch, QuantSpec};
 use itertools::Itertools;

--- a/actors/miner/src/deadline_state.rs
+++ b/actors/miner/src/deadline_state.rs
@@ -5,11 +5,11 @@ use std::cmp;
 use std::collections::BTreeSet;
 
 use anyhow::anyhow;
-use bitfield::BitField;
 use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{actor_error, ActorDowncast, ActorError, Array};
+use fvm_ipld_bitfield::BitField;
 use fvm_shared::blockstore::{Blockstore, CborStore};
 use fvm_shared::clock::{ChainEpoch, QuantSpec};
 use fvm_shared::econ::TokenAmount;

--- a/actors/miner/src/expiration_queue.rs
+++ b/actors/miner/src/expiration_queue.rs
@@ -5,11 +5,11 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryInto;
 
 use anyhow::anyhow;
-use bitfield::BitField;
 use cid::Cid;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{ActorDowncast, Array};
 use fvm_ipld_amt::{Error as AmtError, ValueMut};
+use fvm_ipld_bitfield::BitField;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::blockstore::Blockstore;
 use fvm_shared::clock::{ChainEpoch, QuantSpec};

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -7,7 +7,6 @@ use std::iter;
 use std::ops::Neg;
 
 use anyhow::anyhow;
-use bitfield::{BitField, UnvalidatedBitField, Validate};
 pub use bitfield_queue::*;
 use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
 use cid::multihash::Code;
@@ -22,6 +21,7 @@ use fil_actors_runtime::{
     actor_error, wasm_trampoline, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR,
     INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
 };
+use fvm_ipld_bitfield::{BitField, UnvalidatedBitField, Validate};
 use fvm_shared::address::{Address, Payload, Protocol};
 use fvm_shared::bigint::bigint_ser::BigIntSer;
 use fvm_shared::bigint::{BigInt, Integer};

--- a/actors/miner/src/partition_state.rs
+++ b/actors/miner/src/partition_state.rs
@@ -5,10 +5,10 @@ use std::convert::TryInto;
 use std::ops::{self, Neg};
 
 use anyhow::anyhow;
-use bitfield::{BitField, UnvalidatedBitField, Validate};
 use cid::Cid;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{actor_error, ActorDowncast, Array};
+use fvm_ipld_bitfield::{BitField, UnvalidatedBitField, Validate};
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::blockstore::Blockstore;
 use fvm_shared::clock::{ChainEpoch, QuantSpec, NO_QUANTIZATION};

--- a/actors/miner/src/sector_map.rs
+++ b/actors/miner/src/sector_map.rs
@@ -4,7 +4,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::anyhow;
-use bitfield::{BitField, UnvalidatedBitField, Validate};
+use fvm_ipld_bitfield::{BitField, UnvalidatedBitField, Validate};
 use serde::{Deserialize, Serialize};
 
 use fil_actors_runtime::runtime::Policy;

--- a/actors/miner/src/sectors.rs
+++ b/actors/miner/src/sectors.rs
@@ -4,10 +4,10 @@
 use std::collections::BTreeSet;
 
 use anyhow::anyhow;
-use bitfield::BitField;
 use cid::Cid;
 use fil_actors_runtime::{actor_error, ActorDowncast, ActorError, Array};
 use fvm_ipld_amt::Error as AmtError;
+use fvm_ipld_bitfield::{BitField, Validate};
 use fvm_shared::blockstore::Blockstore;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::{SectorNumber, MAX_SECTOR_NUMBER};
@@ -25,7 +25,7 @@ impl<'db, BS: Blockstore> Sectors<'db, BS> {
 
     pub fn load_sector<'a>(
         &self,
-        sector_numbers: impl bitfield::Validate<'a>,
+        sector_numbers: impl Validate<'a>,
     ) -> Result<Vec<SectorOnChainInfo>, ActorError> {
         let sector_numbers = match sector_numbers.validate() {
             Ok(sector_numbers) => sector_numbers,

--- a/actors/miner/src/sectors.rs
+++ b/actors/miner/src/sectors.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 use cid::Cid;
 use fil_actors_runtime::{actor_error, ActorDowncast, ActorError, Array};
 use fvm_ipld_amt::Error as AmtError;
-use fvm_ipld_bitfield::{BitField, Validate};
+use fvm_ipld_bitfield::BitField;
 use fvm_shared::blockstore::Blockstore;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::{SectorNumber, MAX_SECTOR_NUMBER};
@@ -25,7 +25,7 @@ impl<'db, BS: Blockstore> Sectors<'db, BS> {
 
     pub fn load_sector<'a>(
         &self,
-        sector_numbers: impl Validate<'a>,
+        sector_numbers: impl fvm_ipld_bitfield::Validate<'a>,
     ) -> Result<Vec<SectorOnChainInfo>, ActorError> {
         let sector_numbers = match sector_numbers.validate() {
             Ok(sector_numbers) => sector_numbers,

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::ops::Neg;
 
 use anyhow::anyhow;
-use bitfield::BitField;
 use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_runtime::runtime::Policy;
@@ -14,6 +13,7 @@ use fil_actors_runtime::{
     ActorError, Array,
 };
 use fvm_ipld_amt::Error as AmtError;
+use fvm_ipld_bitfield::BitField;
 use fvm_ipld_hamt::Error as HamtError;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;

--- a/actors/miner/src/termination.rs
+++ b/actors/miner/src/termination.rs
@@ -4,7 +4,7 @@
 use std::collections::BTreeMap;
 use std::ops::AddAssign;
 
-use bitfield::BitField;
+use fvm_ipld_bitfield::BitField;
 use fvm_shared::clock::ChainEpoch;
 
 #[derive(Default)]

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -1,9 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use bitfield::UnvalidatedBitField;
 use cid::Cid;
 use fil_actors_runtime::DealWeight;
+use fvm_ipld_bitfield::UnvalidatedBitField;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;


### PR DESCRIPTION
Instead of renaming `fvm_ipld_bitfield` to `bitfield`, use its original
name. This also makes patching easier.