### PR TITLE
Build configuration to deny unused results

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+rustflags = [
+    # Force unwrapping Result<_, Err>, especially for tests.
+    "-D", "unused_must_use",
+]

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -1,5 +1,3 @@
-#![deny(unused_must_use)] // Force unwrapping Result<_, Err>
-
 use std::borrow::Borrow;
 
 use cid::Cid;

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -1,5 +1,3 @@
-#![deny(unused_must_use)] // Force unwrapping Result<_, Err>
-
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::BytesDe;
 use fvm_shared::sector::{RegisteredPoStProof, StoragePower};

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -1,5 +1,3 @@
-#![deny(unused_must_use)] // Force unwrapping Result<_, Err>
-
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser::BigIntDe;
 use fvm_shared::blockstore::MemoryBlockstore;

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -1,5 +1,3 @@
-#![deny(unused_must_use)] // Force unwrapping Result<_, Err>
-
 use fvm_shared::address::Address;
 use lazy_static::lazy_static;
 


### PR DESCRIPTION
This prevents code (especially tests) from accidentally discarding a Result containing an error, such as from an actor call.

I found a way to set this project-wide rather than per file. I think it's appropriate to do so for this whole project, actor code and test code.

Closes #100. [This guide](https://github.com/rust-unofficial/patterns/blob/main/anti_patterns/deny-warnings.md) lists a raft of other warnings which we might consider denying in actor code (while cautioning against a blanket deny-all-warnings configuration). It might be worth following through with them too.