### PR TITLE
Use environment variables to configure the network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.22"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote",
  "syn",
@@ -771,7 +771,6 @@ dependencies = [
  "fil_actor_system",
  "fil_actor_verifreg",
  "fil_actors_runtime",
- "toml",
 ]
 
 [[package]]
@@ -1377,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.16"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -1576,9 +1575,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "ebd69e719f31e88618baa1eaa6ee2de5c9a1c004f1e9ecdb58e8352a13f20a01"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,25 +29,9 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 
 
 [features]
-default = [
-    "fil_actors_runtime/sector-32g",
-    "fil_actors_runtime/sector-64g",
-]
-caterpillarnet = [
-    "fil_actors_runtime/sector-512m",
-    "fil_actors_runtime/sector-32g",
-    "fil_actors_runtime/sector-64g",
-    "fil_actors_runtime/small-deals",
-    "fil_actors_runtime/short-precommit",
-    "fil_actors_runtime/min-power-2g",
-]
-devnet = [
-    "fil_actors_runtime/sector-2k",
-    "fil_actors_runtime/sector-8m",
-    "fil_actors_runtime/small-deals",
-    "fil_actors_runtime/short-precommit",
-    "fil_actors_runtime/min-power-2k",
-]
+default = []
+caterpillarnet = []
+devnet = []
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ fil_actors_runtime = { version = "7.0.6-alpha.1", path = "./actors/runtime" }
 [build-dependencies]
 fil_actor_bundler = { version = "1.0.2", path = "./bundler" }
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-toml = "0.5.8"
 
 
 [features]

--- a/actors/runtime/build.rs
+++ b/actors/runtime/build.rs
@@ -1,0 +1,27 @@
+static NETWORKS: &[(&str, &[&str])] = &[
+    ("default", &["sector-32g", "sector-64g"]),
+    (
+        "caterpillarnet",
+        &[
+            "sector-512m",
+            "sector-32g",
+            "sector-64g",
+            "small-deals",
+            "short-precommit",
+            "min-power-2g",
+        ],
+    ),
+    ("devnet", &["sector-2k", "sector-8m", "small-deals", "short-precommit", "min-power-2k"]),
+];
+const NETWORK_ENV: &str = "BUILD_FIL_NETWORK";
+
+fn main() {
+    let network = std::env::var(NETWORK_ENV).ok();
+    println!("cargo:rerun-if-env-changed={}", NETWORK_ENV);
+
+    let network = network.as_deref().unwrap_or("default");
+    let features = NETWORKS.iter().find(|(k, _)| k == &network).expect("unknown network").1;
+    for feature in features {
+        println!("cargo:rustc-cfg=feature=\"{}\"", feature);
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,11 @@
 use cid::multihash::Multihash;
 use cid::Cid;
 use fil_actor_bundler::Bundler;
-use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::thread;
-use toml::value::Table;
 
 /// Cargo package for an actor.
 type Package = str;
@@ -53,41 +51,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             .join("Cargo.toml");
     println!("cargo:warning=manifest_path={:?}", &manifest_path);
 
-    // Extract relevent features for the actors. This is far from perfect, bit it's "good enough"
-    // for what we're doing here.
-    let features = {
-        let mut cargo_toml: Table = toml::from_str(
-            &std::fs::read_to_string(&manifest_path).expect("failed to read Cargo.toml"),
-        )
-        .expect("failed to parse Cargo.toml");
-
-        if let Some(features_table) = cargo_toml.remove("features") {
-            let features_table: HashMap<String, Vec<String>> =
-                features_table.try_into().expect("failed to parse features table");
-
-            // Extract the features from the environment.
-            let features = std::env::vars_os()
-                .filter_map(|(key, _)| {
-                    key.to_str()
-                        .and_then(|k| k.strip_prefix("CARGO_FEATURE_"))
-                        .map(|k| k.to_owned())
-                })
-                .collect::<HashSet<_>>();
-
-            // Collect the transitive features. This is a best-effort operation because cargo messes
-            // with the feature names when it stores them in the environment, but it's good enough
-            // for our purposes here.
-            features_table
-                .into_iter()
-                .filter(|(k, _)| features.contains(&k.to_uppercase().replace('-', "_")))
-                .flat_map(|(_, v)| v)
-                .collect::<Vec<_>>()
-                .join(",")
-        } else {
-            String::new()
-        }
-    };
-
     // Cargo build command for all actors at once.
     let mut cmd = Command::new(&cargo);
     cmd.arg("build")
@@ -95,7 +58,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         .arg("--target=wasm32-unknown-unknown")
         .arg("--profile=wasm")
         .arg("--locked")
-        .arg("--features=".to_owned() + &features)
         .arg("--manifest-path=".to_owned() + manifest_path.to_str().unwrap())
         .env("RUSTFLAGS", "-Ctarget-feature=+crt-static -Clink-arg=--export-table")
         .stdout(Stdio::piped())

--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,32 @@ const ACTORS: &[(&Package, &ID)] = &[
 
 const IPLD_RAW: u64 = 0x55;
 const FORCED_CID_PREFIX: &str = "fil/7/";
+const NETWORK_ENV: &str = "BUILD_FIL_NETWORK";
+
+/// Returns the configured network name, checking both the environment and feature flags.
+fn network_name() -> String {
+    let env_network = std::env::var_os(NETWORK_ENV);
+
+    let cfg_network = if cfg!(feature = "caterpillarnet") {
+        Some("caterpillarnet")
+    } else if cfg!(feature = "devnet") {
+        Some("devnet")
+    } else {
+        None
+    };
+
+    // Make sure they match if they're both set. Otherwise, pick the one that's set, or fallback on
+    // "default".
+    match (cfg_network, &env_network) {
+        (Some(from_feature), Some(from_env)) => {
+            assert_eq!(from_feature, from_env, "different target network configured via the features than via the {} environment variable", NETWORK_ENV);
+            from_feature
+        }
+        (Some(net), None) => net,
+        (None, Some(net)) => net.to_str().expect("network name not utf8"),
+        (None, None) => "default",
+    }.to_owned()
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Cargo executable location.
@@ -51,6 +77,13 @@ fn main() -> Result<(), Box<dyn Error>> {
             .join("Cargo.toml");
     println!("cargo:warning=manifest_path={:?}", &manifest_path);
 
+    // Determine the network name.
+    let network_name = network_name();
+    println!("cargo:warning=network name: {}", network_name);
+
+    // Make sure we re-build if the network name changes.
+    println!("cargo:rerun-if-env-changed={}", NETWORK_ENV);
+
     // Cargo build command for all actors at once.
     let mut cmd = Command::new(&cargo);
     cmd.arg("build")
@@ -60,6 +93,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .arg("--locked")
         .arg("--manifest-path=".to_owned() + manifest_path.to_str().unwrap())
         .env("RUSTFLAGS", "-Ctarget-feature=+crt-static -Clink-arg=--export-table")
+        .env(NETWORK_ENV, network_name)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         // We are supposed to only generate artifacts under OUT_DIR,


### PR DESCRIPTION
We can now configure the current network by either:

1. Specifying the correct network as a feature flag on the bundle.
2. Or by setting the `BUILD_FIL_NETWORK` environment variable to the correct network name (at build time).

Possible network names are:

- devnet
- caterpillarnet
- default

Importantly, the _runtime_ crate no longer cares about the devnet/caterpillarnet features. Instead, it looks for the `BUILD_FIL_NETWORK` environment variable, and configures itself (via a build script).

If we decide that we don't need it, we can simplify further by removing the bundle-level feature entirely (using _only_ the environment variable).