### PR TITLE
Fix prove replica update multi dline bug

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1078,7 +1078,7 @@ impl Actor {
             let mut deadlines = state
                 .load_deadlines(rt.store())?;
 
-            let mut new_sectors = vec![SectorOnChainInfo::default(); validated_updates.len()];
+            let mut new_sectors = vec![SectorOnChainInfo::default()];
             for &dl_idx in deadlines_to_load.iter() {
                 let mut deadline = deadlines
                     .load_deadline(rt.policy(),rt.store(), dl_idx)
@@ -1100,7 +1100,7 @@ impl Actor {
 
                 let quant = state.quant_spec_for_deadline(rt.policy(),dl_idx);
 
-                for (i, with_details) in decls_by_deadline[&dl_idx].iter().enumerate() {
+                for with_details in decls_by_deadline[&dl_idx].iter().enumerate() {
                     let update_proof_type = with_details.sector_info.seal_proof
                         .registered_update_proof()
                         .map_err(|_|
@@ -1247,7 +1247,7 @@ impl Actor {
                         })?;
 
                     succeeded.push(new_sector_info.sector_number);
-                    new_sectors[i] = new_sector_info;
+                    new_sectors.push(new_sector_info);
                 }
 
                 deadline.partitions = partitions.flush().map_err(|e| {

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1100,7 +1100,7 @@ impl Actor {
 
                 let quant = state.quant_spec_for_deadline(rt.policy(),dl_idx);
 
-                for (_, with_details ) in decls_by_deadline[&dl_idx].iter().enumerate() {
+                for with_details in &decls_by_deadline[&dl_idx] {
                     let update_proof_type = with_details.sector_info.seal_proof
                         .registered_update_proof()
                         .map_err(|_|

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1276,6 +1276,14 @@ impl Actor {
                     validated_updates.len()
                 ));
             }
+            if new_sectors.len() != validated_updates.len() {
+                return Err(actor_error!(
+                    ErrIllegalState,
+                    "unexpected new_sectors len {} != {}",
+                    new_sectors.len(),
+                    validated_updates.len()
+                ));
+            }
 
             // Overwrite sector infos.
             sectors.store(new_sectors).map_err(|e| {

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1100,7 +1100,7 @@ impl Actor {
 
                 let quant = state.quant_spec_for_deadline(rt.policy(),dl_idx);
 
-                for with_details in decls_by_deadline[&dl_idx].iter().enumerate() {
+                for (_, with_details ) in decls_by_deadline[&dl_idx].iter().enumerate() {
                     let update_proof_type = with_details.sector_info.seal_proof
                         .registered_update_proof()
                         .map_err(|_|


### PR DESCRIPTION
Mirror fix in specs-actors [here](https://github.com/filecoin-project/specs-actors/pull/1582).

When PRU specifies multiple deadlines this should not cause failure.

Calling out no merge because this is consensus breaking.  This goes in wherever the v8 changes are merging.