### PR TITLE
feat: improve makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/usr/bin/env bash
 
 ORDERED_PACKAGES:=fil_actors_runtime \
-				  fil_actor_account \
+                  fil_actor_account \
                   fil_actor_cron \
                   fil_actor_init \
                   fil_actor_market \
@@ -14,6 +14,47 @@ ORDERED_PACKAGES:=fil_actors_runtime \
                   fil_actor_verifreg \
                   fil_builtin_actors_bundle
 
+# How much to "bump" the version by on release.
+BUMP ?= patch
+
+# Print out the current "bundle" version.
+version:
+	@cargo metadata -q --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "fil_builtin_actors_bundle") | .version'
+
+# Run cargo check
+check:
+	cargo check --workspace --tests --benches --lib --bins --examples
+
+# Run cargo test (checking first)
+test: check
+	cargo test --workspace
+
+# Release a new version. Specify the version "bump" with BUMP
+release: check_clean check_deps test
+	echo "$(ORDERED_PACKAGES)" | xargs -n1 cargo set-version --bump $(BUMP) -p
+	cargo update --workspace
+	@echo "Bumped actors to version $$($(MAKE) --quiet version)"
+
+# Publish the current version to crates.io
 publish:
 	echo "$(ORDERED_PACKAGES)" | xargs -n1 cargo publish -p
-.PHONY: publish
+
+# Check if the working tree is clean.
+check_clean:
+	@git diff --quiet || { \
+		echo "Working tree dirty, please commit any changes first."; \
+		exit 1; \
+	}
+
+# Check if we have the required deps.
+check_deps:
+	@which jq >/dev/null 2>&1 || { \
+		echo "Please install jq"; \
+		exit 1; \
+	}
+	@which cargo-set-version >/dev/null 2>&1 || { \
+		echo "Please install cargo-edit: 'cargo install cargo-edit'."; \
+		exit 1; \
+	}
+
+.PHONY: check_clean check_deps test publish check

--- a/README.md
+++ b/README.md
@@ -54,6 +54,36 @@ under the `BUNDLE_CAR` public const, for easier consumption by Rust code.
 Precompiled actor bundles may also be provided as release binaries in this repo,
 if requested by implementors.
 
+## Releasing
+
+First install `jq` (with your favorite package manager) and `cargo-edit` (with `cargo install
+cargo-edit`).
+
+To cut a new patch version, run:
+
+```bash
+make release
+```
+
+To cut a major version, append `BUMP=major`
+
+```bash
+make release BUMP=major
+```
+
+These commands will:
+
+1. Run all tests/checks.
+2. Bump the version of the actor runtime, all actors, and the actor bundle.
+3. Update runtime/actor versions in workspace crates.
+
+When you're happy, commit the version bump changes.
+
+Run `make publish` to publish all packages to crates.io. This will likely take a while as
+it re-builds everything from scratch for validation (multiple times).
+
+Finally, repeat the "release" step with `make release BUMP=alpha`, and commit that.
+
 ## Instructions for client implementations
 
 ### Obtaining an actors bundle


### PR DESCRIPTION
- Add targets for test/check
- Add a target for bumping versions and releasing.
- Explicitly use GNU make because the default make implementation on macos is garbage.