### PR TITLE
Backport manifest v1 bundler to release/v6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
+checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
 dependencies = [
  "async-channel",
  "async-global-executor",
@@ -144,9 +144,9 @@ checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046e47d4b2d391b1f6f8b407b1deb8dee56c1852ccd868becf2710f601b5f427"
+checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
 dependencies = [
  "async-channel",
  "async-task",
@@ -374,18 +374,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -412,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
  "quote",
  "syn",
@@ -567,6 +567,7 @@ dependencies = [
  "fvm_shared",
  "num-traits",
  "rand",
+ "serde",
  "serde_ipld_dagcbor",
  "serde_json",
  "tempfile",
@@ -908,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_bitfield"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1af49e67e51d326297440c0250f2012dd0f9d19b2ebec5c26b0c8d5171b540"
+checksum = "075a50062801672269626dabfe211a9f01487c08d6fbd1677a4e550a2b864fad"
 dependencies = [
  "cs_serde_bytes",
  "fvm_shared",
@@ -953,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce94d50a234db99c4fb445ad74e1520d0f35c934bd5d543625dbab14a157b53f"
+checksum = "903fa0cda6338b8f1371a95ca698969376084effd7a7ee29eb18758c2565d356"
 dependencies = [
  "cid",
  "fvm_shared",
@@ -967,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab18d5c021bdca31f7b8719d540c157d3af8a116a1b1dfc2f7c09ff901a2606"
+checksum = "0ee9d14e8700cc796800d89b4e9bd1c886e1735e6a07c760b54cd8730c680b3e"
 dependencies = [
  "anyhow",
  "bimap",
@@ -1007,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1146,9 +1147,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libipld-core"
@@ -1167,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
  "value-bag",
@@ -1373,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
@@ -1412,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
 dependencies = [
  "bitflags",
 ]
@@ -1445,12 +1446,11 @@ dependencies = [
 
 [[package]]
 name = "serde-big-array"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b20e7752957bbe9661cff4e0bb04d183d0948cdab2ea58cdb9df36a61dfe62"
+checksum = "cd31f59f6fe2b0c055371bb2f16d7f0aa7d8881676c04a55b1596d1a17cd10a4"
 dependencies = [
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -1475,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "serde_ipld_dagcbor"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "762aec89078f8714aed28e2ab810fabaf5562ab6706fda85e28b37bc307fa242"
+checksum = "950f35fcae42dd9268d9253eb8f846dcef4d66e4e7d56494f38c8eb13e16d87b"
 dependencies = [
  "cid",
  "half",
@@ -1572,9 +1572,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "6.0.6", path = "../runtime" }
-fvm_shared = { version = "0.2.0", default-features = false }
+fvm_shared = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "6.0.6", path = "../runtime" }
-fvm_shared = { version = "0.2.0", default-features = false }
+fvm_shared = { version = "0.2.2", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "6.0.6", path = "../runtime" }
-fvm_shared = { version = "0.2.0", default-features = false }
+fvm_shared = { version = "0.2.2", default-features = false }
 fvm_ipld_hamt = "0.2.0"
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "6.0.6", path = "../runtime" }
-fvm_shared = { version = "0.2.0", default-features = false }
+fvm_shared = { version = "0.2.2", default-features = false }
 bitfield = { version = "0.2.0", package = "fvm_ipld_bitfield" }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "6.0.6", path = "../runtime" }
-fvm_shared = { version = "0.2.0", default-features = false }
+fvm_shared = { version = "0.2.2", default-features = false }
 bitfield = { version = "0.2.0", package = "fvm_ipld_bitfield" }
 fvm_ipld_amt = { version = "0.2.0", features = ["go-interop"] }
 fvm_ipld_hamt = "0.2.0"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "6.0.6", path = "../runtime" }
-fvm_shared = { version = "0.2.0", default-features = false }
+fvm_shared = { version = "0.2.2", default-features = false }
 fvm_ipld_hamt = "0.2.0"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "6.0.6", path = "../runtime" }
-fvm_shared = { version = "0.2.0", default-features = false }
+fvm_shared = { version = "0.2.2", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "6.0.6", path = "../runtime" }
-fvm_shared = { version = "0.2.0", default-features = false }
+fvm_shared = { version = "0.2.2", default-features = false }
 fvm_ipld_hamt = "0.2.0"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "6.0.6", path = "../runtime" }
-fvm_shared = { version = "0.2.0", default-features = false }
+fvm_shared = { version = "0.2.2", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 [dependencies]
 fvm_ipld_hamt = "0.2.0"
 fvm_ipld_amt = { version = "0.2.0", features = ["go-interop"] }
-fvm_shared = { version = "0.2.0", default-features = false }
+fvm_shared = { version = "0.2.2", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "6.0.6", path = "../runtime" }
-fvm_shared = { version = "0.2.0", default-features = false }
+fvm_shared = { version = "0.2.2", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "6.0.6", path = "../runtime" }
-fvm_shared = { version = "0.2.0", default-features = false }
+fvm_shared = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -11,7 +11,7 @@ publish = false # We only publish this from "master".
 
 [dependencies]
 clap = { version = "3.1.6", features = ["derive"] }
-fvm_shared = "0.2.0"
+fvm_shared = "0.2.2"
 fvm_ipld_car = "0.2.0"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 async-std = "1.10.0"
@@ -19,6 +19,7 @@ futures = "0.3.21"
 anyhow = "1.0.56"
 serde_ipld_dagcbor = "0.1.0"
 serde_json = "1.0.79"
+serde = { version = "1.0.136", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/bundler/src/lib.rs
+++ b/bundler/src/lib.rs
@@ -93,16 +93,27 @@ impl Bundler {
         let manifest_payload: Vec<(String, Cid)> =
             self.added.iter().map(|(t, c)| (t.into(), *c)).collect();
         let manifest_data = serde_ipld_dagcbor::to_vec(&manifest_payload)?;
-        let manifest_link = self
-            .blockstore
-            .put(Code::Blake2b256, &Block { codec: DAG_CBOR, data: &manifest_data })?;
+        let manifest_link = self.blockstore.put(
+            Code::Blake2b256,
+            &Block {
+                codec: DAG_CBOR,
+                data: &manifest_data,
+            },
+        )?;
 
-        let manifest = Manifest { version: 1, data: manifest_link };
+        let manifest = Manifest {
+            version: 1,
+            data: manifest_link,
+        };
         let manifest_bytes = serde_ipld_dagcbor::to_vec(&manifest)?;
 
-        let root = self
-            .blockstore
-            .put(Code::Blake2b256, &Block { codec: DAG_CBOR, data: &manifest_bytes })?;
+        let root = self.blockstore.put(
+            Code::Blake2b256,
+            &Block {
+                codec: DAG_CBOR,
+                data: &manifest_bytes,
+            },
+        )?;
 
         // Create a CAR header.
         let car = CarHeader {
@@ -214,8 +225,10 @@ fn test_bundler() {
     let manifest_data = bs.get(&manifest.data).unwrap().unwrap();
     let manifest_vec: Vec<(String, Cid)> =
         serde_ipld_dagcbor::from_slice(manifest_data.as_slice()).unwrap();
-    let manifest: BTreeMap<ActorType, Cid> =
-        manifest_vec.iter().map(|(s, c)| (ActorType::try_from(s.as_str()).unwrap(), *c)).collect();
+    let manifest: BTreeMap<ActorType, Cid> = manifest_vec
+        .iter()
+        .map(|(s, c)| (ActorType::try_from(s.as_str()).unwrap(), *c))
+        .collect();
 
     // Verify the manifest contains what we expect.
     for (i, cid) in cids.into_iter().enumerate() {

--- a/bundler/src/lib.rs
+++ b/bundler/src/lib.rs
@@ -10,9 +10,10 @@ use anyhow::Result;
 use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_car::CarHeader;
-use fvm_shared::actor;
-use fvm_shared::actor::builtin::Manifest;
+use fvm_shared::actor::builtin::Type as ActorType;
 use fvm_shared::blockstore::{Block, Blockstore, MemoryBlockstore};
+use fvm_shared::encoding::tuple::*;
+use fvm_shared::encoding::Cbor;
 use fvm_shared::encoding::DAG_CBOR;
 
 const IPLD_RAW: u64 = 0x55;
@@ -26,7 +27,7 @@ pub struct Bundler {
     /// Staging blockstore.
     blockstore: MemoryBlockstore,
     /// Tracks the mapping of actors to Cids. Inverted when writing. Allows overriding.
-    added: BTreeMap<fvm_shared::actor::builtin::Type, Cid>,
+    added: BTreeMap<ActorType, Cid>,
     /// Path of the output bundle.
     bundle_dst: PathBuf,
 }
@@ -46,7 +47,7 @@ impl Bundler {
     /// Adds bytecode from a byte slice.
     pub fn add_from_bytes(
         &mut self,
-        actor_type: actor::builtin::Type,
+        actor_type: ActorType,
         forced_cid: Option<&Cid>,
         bytecode: &[u8],
     ) -> Result<Cid> {
@@ -73,7 +74,7 @@ impl Bundler {
     /// Adds bytecode from a file.
     pub fn add_from_file<P: AsRef<Path>>(
         &mut self,
-        actor_type: actor::builtin::Type,
+        actor_type: ActorType,
         forced_cid: Option<&Cid>,
         bytecode_path: P,
     ) -> Result<Cid> {
@@ -89,21 +90,19 @@ impl Bundler {
     async fn write_car(self) -> Result<()> {
         let mut out = async_std::fs::File::create(&self.bundle_dst).await?;
 
-        // Invert the actor index so that it's CID => Type.
-        let manifest: Manifest = self
-            .added
-            .into_iter()
-            .map(|(typ, cid)| (cid, typ))
-            .collect();
+        let manifest_payload: Vec<(String, Cid)> =
+            self.added.iter().map(|(t, c)| (t.into(), *c)).collect();
+        let manifest_data = serde_ipld_dagcbor::to_vec(&manifest_payload)?;
+        let manifest_link = self
+            .blockstore
+            .put(Code::Blake2b256, &Block { codec: DAG_CBOR, data: &manifest_data })?;
 
+        let manifest = Manifest { version: 1, data: manifest_link };
         let manifest_bytes = serde_ipld_dagcbor::to_vec(&manifest)?;
-        let root = self.blockstore.put(
-            Code::Blake2b256,
-            &Block {
-                codec: DAG_CBOR,
-                data: &manifest_bytes,
-            },
-        )?;
+
+        let root = self
+            .blockstore
+            .put(Code::Blake2b256, &Block { codec: DAG_CBOR, data: &manifest_bytes })?;
 
         // Create a CAR header.
         let car = CarHeader {
@@ -118,8 +117,11 @@ impl Bundler {
         // Add the root payload.
         tx.send((root, manifest_bytes)).await.unwrap();
 
+        // Add the manifest payload.
+        tx.send((manifest_link, manifest_data)).await.unwrap();
+
         // Add the bytecodes.
-        for cid in manifest.iter().map(|(cid, _)| cid) {
+        for cid in self.added.iter().map(|(_, cid)| cid) {
             println!("adding cid {} to bundle CAR", cid);
             let data = self.blockstore.get(cid).unwrap().unwrap();
             tx.send((*cid, data)).await.unwrap();
@@ -132,6 +134,17 @@ impl Bundler {
         Ok(())
     }
 }
+
+/// The Manifest struct is the versioned envelope for builtin actor manifests.
+/// The only currently supported version is 1, which encodes the data as a tuple
+/// of strings (actor names) and actor code cids.
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+pub struct Manifest {
+    pub version: u32,
+    pub data: Cid,
+}
+
+impl Cbor for Manifest {}
 
 #[test]
 fn test_bundler() {
@@ -157,7 +170,7 @@ fn test_bundler() {
                 Multihash::wrap(0, format!("actor-{}", i).as_bytes()).unwrap(),
             )
         });
-        let typ = actor::builtin::Type::from_i32(i + 1).unwrap();
+        let typ = ActorType::from_i32(i + 1).unwrap();
         let cid = bundler
             .add_from_bytes(
                 typ,
@@ -192,15 +205,23 @@ fn test_bundler() {
 
     // The single root represents the manifest.
     let manifest_cid = roots[0];
-    let manifest_data = bs.get(&manifest_cid).unwrap().unwrap();
+    let manifest_bytes = bs.get(&manifest_cid).unwrap().unwrap();
 
     // Deserialize the manifest.
-    let manifest: Manifest = serde_ipld_dagcbor::from_slice(manifest_data.as_slice()).unwrap();
+    let manifest: Manifest = serde_ipld_dagcbor::from_slice(manifest_bytes.as_slice()).unwrap();
+    assert_eq!(manifest.version, 1);
+
+    let manifest_data = bs.get(&manifest.data).unwrap().unwrap();
+    let manifest_vec: Vec<(String, Cid)> =
+        serde_ipld_dagcbor::from_slice(manifest_data.as_slice()).unwrap();
+    let manifest: BTreeMap<ActorType, Cid> =
+        manifest_vec.iter().map(|(s, c)| (ActorType::try_from(s.as_str()).unwrap(), *c)).collect();
 
     // Verify the manifest contains what we expect.
     for (i, cid) in cids.into_iter().enumerate() {
-        let typ = actor::builtin::Type::from_i32((i + 1) as i32).unwrap();
-        assert_eq!(manifest.get_by_left(&cid).unwrap(), &typ);
+        let typ = ActorType::from_i32((i + 1) as i32).unwrap();
+        assert_eq!(manifest.get(&typ).unwrap(), &cid);
+
         // Verify that the last 5 CIDs are really forced CIDs.
         if i > 5 {
             let expected = Cid::new_v1(


### PR DESCRIPTION
Companion to #145 
Cherrypicks and backports the new bundler from https://github.com/filecoin-project/builtin-actors/pull/132