### PR TITLE
chore: release bundler v1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_bundler"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ fil_actor_init = { version = "8.0.0-alpha.1", path = "./actors/init" }
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "./actors/runtime" }
 
 [build-dependencies]
-fil_actor_bundler = { version = "1.0.2", path = "./bundler" }
+fil_actor_bundler = { version = "1.0.3", path = "./bundler" }
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 
 

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_bundler"
 description = "An IPLD CAR bundling tool for Wasm bytecode"
-version = "1.0.2"
+version = "1.0.3"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"


### PR DESCRIPTION
This version removes the identity hash feature to avoid panics.