### PR TITLE
fix(Makefile): add a delay between cargo publish steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,7 @@ set-version: check-clean deps-release check test
 
 # Publish the current version to crates.io
 publish:
-	echo "$(ORDERED_PACKAGES)" | xargs -n1 cargo publish -p "$$pkg"
-	done
+	for pkg in "$(ORDERED_PACKAGES)"; do cargo publish -p "$$pkg" && sleep 5; done
 
 
 # Check if the working tree is clean.


### PR DESCRIPTION
crates.io is async, so publishing will fail if we immediately publish a second crate after publishing the first. There are definitely more reliable ways to fix this, but this is "good enough" for a makefile. It's idempotent anyways...