### PR TITLE
Switch to the new BitField version with better validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,13 +916,14 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_bitfield"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46227fefc63b479b4bdfbc1676897edbccb6c380809ebb4b91efc51b2bd0b0e"
+checksum = "e10b0c2784b4c434ccb2229bd14e95378572ef02f1caa6bda95cc475ad9a95ff"
 dependencies = [
  "cs_serde_bytes",
  "fvm_shared 0.3.1",
  "serde",
+ "thiserror",
  "unsigned-varint",
 ]
 

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "lib"]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
 fvm_ipld_hamt = "0.3.0"
 fvm_shared = { version = "0.3.1", default-features = false }
-fvm_ipld_bitfield = "0.3.0"
+fvm_ipld_bitfield = "0.4.0"
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 ahash = "0.7.6"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
 fvm_shared = { version = "0.3.1", default-features = false }
-fvm_ipld_bitfield = "0.3.0"
+fvm_ipld_bitfield = "0.4.0"
 fvm_ipld_amt = { version = "0.3.0", features = ["go-interop"] }
 fvm_ipld_hamt = "0.3.0"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/miner/src/bitfield_queue.rs
+++ b/actors/miner/src/bitfield_queue.rs
@@ -51,7 +51,7 @@ impl<'db, BS: Blockstore> BitFieldQueue<'db, BS> {
         epoch: ChainEpoch,
         values: impl IntoIterator<Item = u64>,
     ) -> anyhow::Result<()> {
-        self.add_to_queue(epoch, &values.into_iter().collect())
+        self.add_to_queue(epoch, &BitField::try_from_bits(values)?)
     }
 
     /// Cut cuts the elements from the bits in the given bitfield out of the queue,

--- a/actors/miner/src/expiration_queue.rs
+++ b/actors/miner/src/expiration_queue.rs
@@ -4,7 +4,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryInto;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use cid::Cid;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{ActorDowncast, Array};
@@ -179,7 +179,7 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
         let mut total_sectors = Vec::<BitField>::new();
 
         for group in group_new_sectors_by_declared_expiration(sector_size, sectors, self.quant) {
-            let sector_numbers: BitField = group.sectors.iter().copied().collect();
+            let sector_numbers = BitField::try_from_bits(group.sectors)?;
 
             self.add(
                 group.epoch,
@@ -258,8 +258,8 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
                 expiring_power += &group.sector_epoch_set.power;
             } else {
                 // Remove sectors from on-time expiry and active power.
-                let sectors_bitfield: BitField =
-                    group.sector_epoch_set.sectors.iter().copied().collect();
+                let sectors_bitfield =
+                    BitField::try_from_bits(group.sector_epoch_set.sectors.iter().copied())?;
                 group.expiration_set.on_time_sectors -= &sectors_bitfield;
                 group.expiration_set.on_time_pledge -= &group.sector_epoch_set.pledge;
                 group.expiration_set.active_power -= &group.sector_epoch_set.power;
@@ -276,7 +276,7 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
 
         if !sectors_total.is_empty() {
             // Add sectors to new expiration as early-terminating and faulty.
-            let early_sectors: BitField = sectors_total.iter().copied().collect();
+            let early_sectors = BitField::try_from_bits(sectors_total)?;
             self.add(
                 new_expiration,
                 &BitField::new(),
@@ -375,14 +375,14 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
             let on_time_sectors: BTreeSet<SectorNumber> = expiration_set
                 .on_time_sectors
                 .bounded_iter(ENTRY_SECTORS_MAX)
-                .map_err(|e| anyhow!(e))?
+                .context("too many sectors to reschedule")?
                 .map(|i| i as SectorNumber)
                 .collect();
 
             let early_sectors: BTreeSet<SectorNumber> = expiration_set
                 .early_sectors
                 .bounded_iter(ENTRY_SECTORS_MAX)
-                .map_err(|e| anyhow!(e))?
+                .context("too many sectors to reschedule")?
                 .map(|i| i as SectorNumber)
                 .collect();
 
@@ -476,13 +476,13 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
         // ADDRESSED_SECTORS_MAX is defined as 25000, so this will not error.
         let faults_map: BTreeSet<_> = faults
             .bounded_iter(policy.addressed_sectors_max)
-            .map_err(|e| anyhow!("failed to expand faults: {}", e))?
+            .context("too many faults to expand")?
             .map(|i| i as SectorNumber)
             .collect();
 
         let recovering_map: BTreeSet<_> = recovering
             .bounded_iter(policy.addressed_sectors_max)
-            .map_err(|e| anyhow!("failed to expand recoveries: {}", e))?
+            .context("too many recoveries to expand")?
             .map(|i| i as SectorNumber)
             .collect();
 
@@ -524,14 +524,14 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
             let on_time_sectors: BTreeSet<SectorNumber> = expiration_set
                 .on_time_sectors
                 .bounded_iter(ENTRY_SECTORS_MAX)
-                .map_err(|e| anyhow!(e))?
+                .context("too many on-time sectors to expand")?
                 .map(|i| i as SectorNumber)
                 .collect();
 
             let early_sectors: BTreeSet<SectorNumber> = expiration_set
                 .early_sectors
                 .bounded_iter(ENTRY_SECTORS_MAX)
-                .map_err(|e| anyhow!(e))?
+                .context("too many early sectors to expand")?
                 .map(|i| i as SectorNumber)
                 .collect();
 
@@ -672,15 +672,15 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
         sectors: &[SectorOnChainInfo],
         sector_size: SectorSize,
     ) -> anyhow::Result<(BitField, PowerPair, TokenAmount)> {
-        let mut removed_sector_numbers = BitField::new();
+        let mut removed_sector_numbers = Vec::<u64>::new();
         let mut removed_power = PowerPair::zero();
         let mut removed_pledge = TokenAmount::zero();
 
         // Group sectors by their expiration, then remove from existing queue entries according to those groups.
         let groups = self.find_sectors_by_expiration(sector_size, sectors)?;
         for group in groups {
-            let sectors_bitfield: BitField =
-                group.sector_epoch_set.sectors.iter().copied().collect();
+            let sectors_bitfield =
+                BitField::try_from_bits(group.sector_epoch_set.sectors.iter().copied())?;
             self.remove(
                 group.sector_epoch_set.epoch,
                 &sectors_bitfield,
@@ -690,15 +690,13 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
                 &group.sector_epoch_set.pledge,
             )?;
 
-            for n in group.sector_epoch_set.sectors {
-                removed_sector_numbers.set(n);
-            }
+            removed_sector_numbers.extend(&group.sector_epoch_set.sectors);
 
             removed_power += &group.sector_epoch_set.power;
             removed_pledge += &group.sector_epoch_set.pledge;
         }
 
-        Ok((removed_sector_numbers, removed_power, removed_pledge))
+        Ok((BitField::try_from_bits(removed_sector_numbers)?, removed_power, removed_pledge))
     }
 
     /// Traverses the entire queue with a callback function that may mutate entries.

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -901,7 +901,10 @@ impl Actor {
                 continue;
             }
 
-            sector_numbers.set(update.sector_number);
+            if sector_numbers.try_set(update.sector_number).is_err() {
+                info!("invalid sector number, skipping");
+                continue;
+            }
 
             if update.replica_proof.len() > 4096 {
                 info!(
@@ -1071,7 +1074,7 @@ impl Actor {
         let pow = request_current_total_power(rt)?;
 
         let succeeded_sectors = rt.transaction(|state: &mut State, rt| {
-            let mut bf = BitField::new();
+            let mut succeeded = Vec::new();
             let mut deadlines = state
                 .load_deadlines(rt.store())?;
 
@@ -1243,7 +1246,7 @@ impl Actor {
                             )
                         })?;
 
-                    bf.set(new_sector_info.sector_number);
+                    succeeded.push(new_sector_info.sector_number);
                     new_sectors[i] = new_sector_info;
                 }
 
@@ -1264,8 +1267,8 @@ impl Actor {
                     })?;
             }
 
-            let success_len = bf.len();
-            if success_len != validated_updates.len() as u64 {
+            let success_len = succeeded.len();
+            if success_len != validated_updates.len() {
                 return Err(actor_error!(
                     ErrIllegalState,
                     "unexpected success_len {} != {}",
@@ -1289,7 +1292,9 @@ impl Actor {
                 e.downcast_default(ExitCode::ErrIllegalState, "failed to save deadlines")
             })?;
 
-            Ok(bf)
+            BitField::try_from_bits(succeeded).map_err(|_|{
+                actor_error!(ErrIllegalArgument; "invalid sector number")
+            })
         })?;
 
         notify_pledge_changed(rt, &pledge_delta)?;
@@ -1571,19 +1576,19 @@ impl Actor {
                     precommit.sector_number
                 ));
             }
+            if precommit.sector_number > MAX_SECTOR_NUMBER {
+                return Err(actor_error!(
+                    ErrIllegalArgument,
+                    "sector number {} out of range 0..(2^63-1)",
+                    precommit.sector_number
+                ));
+            }
             sector_numbers.set(precommit.sector_number);
             if !can_pre_commit_seal_proof(rt.policy(), precommit.seal_proof) {
                 return Err(actor_error!(
                     ErrIllegalArgument,
                     "unsupported seal proof type {}",
                     i64::from(precommit.seal_proof)
-                ));
-            }
-            if precommit.sector_number > MAX_SECTOR_NUMBER {
-                return Err(actor_error!(
-                    ErrIllegalArgument,
-                    "sector number {} out of range 0..(2^63-1)",
-                    precommit.sector_number
                 ));
             }
             // Skip checking if CID is defined because it cannot be so in Rust

--- a/actors/miner/src/partition_state.rs
+++ b/actors/miner/src/partition_state.rs
@@ -4,7 +4,7 @@
 use std::convert::TryInto;
 use std::ops::{self, Neg};
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use cid::Cid;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{actor_error, ActorDowncast, Array};
@@ -663,9 +663,8 @@ impl Partition {
                 let limit = max_sectors - result.sectors_processed;
 
                 let to_process = if limit < count {
-                    let to_process = sectors
-                        .slice(0, limit)
-                        .map_err(|e| anyhow!("failed to slice early terminations: {}", e))?;
+                    let to_process =
+                        sectors.slice(0, limit).context("expected more sectors in bitfield")?;
                     let rest = sectors - &to_process;
                     remaining = Some((rest, epoch));
                     result.sectors_processed += limit;

--- a/actors/miner/src/sector_map.rs
+++ b/actors/miner/src/sector_map.rs
@@ -80,7 +80,7 @@ impl DeadlineSectorMap {
             policy,
             deadline_idx,
             partition_idx,
-            sector_numbers.iter().copied().collect::<BitField>().into(),
+            BitField::try_from_bits(sector_numbers.iter().copied())?.into(),
         )
     }
 
@@ -106,7 +106,7 @@ impl PartitionSectorMap {
         partition_idx: u64,
         sector_numbers: Vec<u64>,
     ) -> anyhow::Result<()> {
-        self.add(partition_idx, sector_numbers.into_iter().collect::<BitField>().into())
+        self.add(partition_idx, BitField::try_from_bits(sector_numbers)?.into())
     }
     /// Records the given sector bitfield at the given partition index, merging
     /// it with any existing bitfields if necessary.

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1205,7 +1205,7 @@ pub fn make_empty_bitfield() -> UnvalidatedBitField {
 
 #[allow(dead_code)]
 pub fn make_bitfield(bits: &[u64]) -> UnvalidatedBitField {
-    UnvalidatedBitField::Validated(bits.iter().copied().collect())
+    UnvalidatedBitField::Validated(BitField::try_from_bits(bits.iter().copied()).unwrap())
 }
 
 fn get_bitfield(ubf: &UnvalidatedBitField) -> BitField {


### PR DESCRIPTION
1. Validates that we can't try to "set" the u64::MAX bit.
2. Validates that input bitfields are "minimally encoded".