### PR TITLE
Replace Runtime.deserialize_params with static helper function

### DIFF
--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -1,15 +1,17 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fil_actors_runtime::builtin::singletons::SYSTEM_ACTOR_ADDR;
-use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_error, wasm_trampoline, ActorError};
 use fvm_shared::address::{Address, Protocol};
 use fvm_shared::blockstore::Blockstore;
 use fvm_shared::encoding::RawBytes;
 use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
+
+use fil_actors_runtime::builtin::singletons::SYSTEM_ACTOR_ADDR;
+use fil_actors_runtime::cbor;
+use fil_actors_runtime::runtime::{ActorCode, Runtime};
+use fil_actors_runtime::{actor_error, wasm_trampoline, ActorError};
 
 pub use self::state::State;
 
@@ -72,7 +74,7 @@ impl ActorCode for Actor {
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {
-                Self::constructor(rt, rt.deserialize_params(params)?)?;
+                Self::constructor(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::PubkeyAddress) => {

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_error, wasm_trampoline, ActorError, SYSTEM_ACTOR_ADDR};
+use fil_actors_runtime::{actor_error, cbor, wasm_trampoline, ActorError, SYSTEM_ACTOR_ADDR};
 use fvm_shared::blockstore::Blockstore;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::tuple::*;
@@ -91,7 +91,7 @@ impl ActorCode for Actor {
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {
-                Self::constructor(rt, rt.deserialize_params(params)?)?;
+                Self::constructor(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::EpochTick) => {

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -4,7 +4,7 @@
 use cid::Cid;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, wasm_trampoline, ActorDowncast, ActorError, SYSTEM_ACTOR_ADDR,
+    actor_error, cbor, wasm_trampoline, ActorDowncast, ActorError, SYSTEM_ACTOR_ADDR,
 };
 use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
@@ -120,11 +120,11 @@ impl ActorCode for Actor {
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {
-                Self::constructor(rt, rt.deserialize_params(params)?)?;
+                Self::constructor(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::Exec) => {
-                let res = Self::exec(rt, rt.deserialize_params(params)?)?;
+                let res = Self::exec(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::serialize(res)?)
             }
             None => Err(actor_error!(SysErrInvalidMethod; "Invalid method")),

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -133,7 +133,7 @@ impl Actor {
         let sv_bz = sv.signing_bytes().map_err(|e| {
             ActorError::new(
                 ExitCode::ErrSerialization,
-                format!("failed to serialized SignedVoucher: {}", e.to_string()),
+                format!("failed to serialized SignedVoucher: {}", e),
             )
         })?;
 

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -8,7 +8,7 @@ use anyhow::anyhow;
 use ext::init;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, make_map_with_root_and_bitwidth, wasm_trampoline, ActorDowncast, ActorError,
+    actor_error, cbor, make_map_with_root_and_bitwidth, wasm_trampoline, ActorDowncast, ActorError,
     Multimap, CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fvm_shared::actor::builtin::{Type, CALLER_TYPES_SIGNABLE};
@@ -657,15 +657,15 @@ impl ActorCode for Actor {
                 Ok(RawBytes::default())
             }
             Some(Method::CreateMiner) => {
-                let res = Self::create_miner(rt, rt.deserialize_params(params)?)?;
+                let res = Self::create_miner(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::serialize(res)?)
             }
             Some(Method::UpdateClaimedPower) => {
-                Self::update_claimed_power(rt, rt.deserialize_params(params)?)?;
+                Self::update_claimed_power(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::EnrollCronEvent) => {
-                Self::enroll_cron_event(rt, rt.deserialize_params(params)?)?;
+                Self::enroll_cron_event(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::OnEpochTickEnd) => {
@@ -673,12 +673,12 @@ impl ActorCode for Actor {
                 Ok(RawBytes::default())
             }
             Some(Method::UpdatePledgeTotal) => {
-                let BigIntDe(param) = rt.deserialize_params(params)?;
+                let BigIntDe(param) = cbor::deserialize_params(params)?;
                 Self::update_pledge_total(rt, param)?;
                 Ok(RawBytes::default())
             }
             Some(Method::SubmitPoRepForBulkVerify) => {
-                Self::submit_porep_for_bulk_verify(rt, rt.deserialize_params(params)?)?;
+                Self::submit_porep_for_bulk_verify(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::CurrentTotalPower) => {

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -3,8 +3,8 @@
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, wasm_trampoline, ActorError, BURNT_FUNDS_ACTOR_ADDR, EXPECTED_LEADERS_PER_EPOCH,
-    STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    actor_error, cbor, wasm_trampoline, ActorError, BURNT_FUNDS_ACTOR_ADDR,
+    EXPECTED_LEADERS_PER_EPOCH, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fvm_shared::bigint::bigint_ser::BigIntDe;
 use fvm_shared::bigint::{Integer, Sign};
@@ -240,12 +240,12 @@ impl ActorCode for Actor {
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {
-                let param: Option<BigIntDe> = rt.deserialize_params(params)?;
+                let param: Option<BigIntDe> = cbor::deserialize_params(params)?;
                 Self::constructor(rt, param.map(|v| v.0))?;
                 Ok(RawBytes::default())
             }
             Some(Method::AwardBlockReward) => {
-                Self::award_block_reward(rt, rt.deserialize_params(params)?)?;
+                Self::award_block_reward(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::ThisEpochReward) => {
@@ -253,7 +253,7 @@ impl ActorCode for Actor {
                 Ok(RawBytes::serialize(&res)?)
             }
             Some(Method::UpdateNetworkKPI) => {
-                let param: Option<BigIntDe> = rt.deserialize_params(params)?;
+                let param: Option<BigIntDe> = cbor::deserialize_params(params)?;
                 Self::update_network_kpi(rt, param.map(|v| v.0))?;
                 Ok(RawBytes::default())
             }

--- a/actors/runtime/src/actor_error.rs
+++ b/actors/runtime/src/actor_error.rs
@@ -39,7 +39,7 @@ impl ActorError {
     }
 }
 
-// TODO former EncodingError
+/// Converts a raw encoding error into an ErrSerialization.
 impl From<fvm_shared::encoding::Error> for ActorError {
     fn from(e: fvm_shared::encoding::Error) -> Self {
         Self { exit_code: ExitCode::ErrSerialization, msg: e.to_string() }

--- a/actors/runtime/src/runtime/mod.rs
+++ b/actors/runtime/src/runtime/mod.rs
@@ -10,7 +10,7 @@ use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::randomness::DomainSeparationTag;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::encoding::{de, Cbor, RawBytes};
+use fvm_shared::encoding::{Cbor, RawBytes};
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::Randomness;
 use fvm_shared::sector::{
@@ -20,8 +20,10 @@ use fvm_shared::sector::{
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum};
 
-pub use self::actor_code::*;
 use crate::ActorError;
+
+pub use self::actor_code::*;
+pub use self::policy::*;
 
 mod actor_code;
 
@@ -32,7 +34,6 @@ pub mod fvm;
 mod actor_blockstore;
 
 mod policy;
-pub use self::policy::*;
 
 /// Runtime is the VM's internal runtime object.
 /// this is everything that is accessible to actors, beyond parameters.
@@ -159,14 +160,6 @@ pub trait Runtime<BS: Blockstore>: Syscalls + RuntimePolicy {
     /// ChargeGas charges specified amount of `gas` for execution.
     /// `name` provides information about gas charging point
     fn charge_gas(&mut self, name: &'static str, compute: i64);
-
-    /// This should be removed from runtime now that it doesn't depend on network version.
-    fn deserialize_params<O: de::DeserializeOwned>(
-        &self,
-        params: &RawBytes,
-    ) -> Result<O, ActorError> {
-        params.deserialize().map_err(|e| ActorError::from(e).wrap("failed to decode parameters"))
-    }
 
     fn base_fee(&self) -> TokenAmount;
 }

--- a/actors/runtime/src/util/cbor.rs
+++ b/actors/runtime/src/util/cbor.rs
@@ -1,0 +1,44 @@
+use fvm_shared::encoding::{to_vec, RawBytes};
+use fvm_shared::error::ExitCode;
+use serde::{de, ser};
+
+use crate::ActorError;
+
+/// Serializes a structure as a CBOR vector of bytes, returning a serialization error on failure.
+/// `desc` is a noun phrase for the object being serialized, included in any error message.
+pub fn serialize_vec<T>(value: &T, desc: &str) -> Result<Vec<u8>, ActorError>
+where
+    T: ser::Serialize + ?Sized,
+{
+    to_vec(value).map_err(|e| {
+        ActorError::new(
+            ExitCode::ErrSerialization,
+            format!("failed to serialize {}: {}", desc, e.to_string()),
+        )
+    })
+}
+
+/// Serializes a structure as CBOR bytes, returning a serialization error on failure.
+/// `desc` is a noun phrase for the object being serialized, included in any error message.
+pub fn serialize<T>(value: &T, desc: &str) -> Result<RawBytes, ActorError>
+where
+    T: ser::Serialize + ?Sized,
+{
+    Ok(RawBytes::new(serialize_vec(value, desc)?))
+}
+
+/// Deserialises CBOR-encoded bytes as a structure, returning a serialization error on failure.
+/// `desc` is a noun phrase for the object being deserialized, included in any error message.
+pub fn deserialize<O: de::DeserializeOwned>(v: &RawBytes, desc: &str) -> Result<O, ActorError> {
+    v.deserialize().map_err(|e| {
+        ActorError::new(
+            ExitCode::ErrSerialization,
+            format!("failed to deserialize {}: {}", desc, e.to_string()),
+        )
+    })
+}
+
+/// Deserialises CBOR-encoded bytes as a method parameters object.
+pub fn deserialize_params<O: de::DeserializeOwned>(params: &RawBytes) -> Result<O, ActorError> {
+    deserialize(params, "method parameters")
+}

--- a/actors/runtime/src/util/cbor.rs
+++ b/actors/runtime/src/util/cbor.rs
@@ -11,10 +11,7 @@ where
     T: ser::Serialize + ?Sized,
 {
     to_vec(value).map_err(|e| {
-        ActorError::new(
-            ExitCode::ErrSerialization,
-            format!("failed to serialize {}: {}", desc, e.to_string()),
-        )
+        ActorError::new(ExitCode::ErrSerialization, format!("failed to serialize {}: {}", desc, e))
     })
 }
 
@@ -33,7 +30,7 @@ pub fn deserialize<O: de::DeserializeOwned>(v: &RawBytes, desc: &str) -> Result<
     v.deserialize().map_err(|e| {
         ActorError::new(
             ExitCode::ErrSerialization,
-            format!("failed to deserialize {}: {}", desc, e.to_string()),
+            format!("failed to deserialize {}: {}", desc, e),
         )
     })
 }

--- a/actors/runtime/src/util/chaos/mod.rs
+++ b/actors/runtime/src/util/chaos/mod.rs
@@ -14,7 +14,7 @@ pub use state::*;
 pub use types::*;
 
 use crate::runtime::{ActorCode, Runtime};
-use crate::{actor_error, ActorError};
+use crate::{actor_error, cbor, ActorError};
 
 mod state;
 mod types;
@@ -208,36 +208,36 @@ impl ActorCode for Actor {
                 Ok(RawBytes::default())
             }
             Some(Method::CallerValidation) => {
-                Self::caller_validation(rt, rt.deserialize_params(params)?)?;
+                Self::caller_validation(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
 
             Some(Method::CreateActor) => {
-                Self::create_actor(rt, rt.deserialize_params(params)?)?;
+                Self::create_actor(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::ResolveAddress) => {
-                let res = Self::resolve_address(rt, rt.deserialize_params(params)?)?;
+                let res = Self::resolve_address(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::serialize(res)?)
             }
 
             Some(Method::Send) => {
-                let res: SendReturn = Self::send(rt, rt.deserialize_params(params)?)?;
+                let res: SendReturn = Self::send(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::serialize(res)?)
             }
 
             Some(Method::DeleteActor) => {
-                Self::delete_actor(rt, rt.deserialize_params(params)?)?;
+                Self::delete_actor(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
 
             Some(Method::MutateState) => {
-                Self::mutate_state(rt, rt.deserialize_params(params)?)?;
+                Self::mutate_state(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
 
             Some(Method::AbortWith) => {
-                Self::abort_with(rt.deserialize_params(params)?)?;
+                Self::abort_with(cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
 

--- a/actors/runtime/src/util/mod.rs
+++ b/actors/runtime/src/util/mod.rs
@@ -6,6 +6,7 @@ pub use self::multimap::*;
 pub use self::set::Set;
 pub use self::set_multimap::SetMultimap;
 
+pub mod cbor;
 pub mod chaos;
 mod downcast;
 mod multimap;

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -3,7 +3,7 @@
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, make_map_with_root_and_bitwidth, resolve_to_id_addr, wasm_trampoline,
+    actor_error, cbor, make_map_with_root_and_bitwidth, resolve_to_id_addr, wasm_trampoline,
     ActorDowncast, ActorError, Map, STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fvm_ipld_hamt::BytesKey;
@@ -760,31 +760,31 @@ impl ActorCode for Actor {
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {
-                Self::constructor(rt, rt.deserialize_params(params)?)?;
+                Self::constructor(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::AddVerifier) => {
-                Self::add_verifier(rt, rt.deserialize_params(params)?)?;
+                Self::add_verifier(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::RemoveVerifier) => {
-                Self::remove_verifier(rt, rt.deserialize_params(params)?)?;
+                Self::remove_verifier(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::AddVerifiedClient) => {
-                Self::add_verified_client(rt, rt.deserialize_params(params)?)?;
+                Self::add_verified_client(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::UseBytes) => {
-                Self::use_bytes(rt, rt.deserialize_params(params)?)?;
+                Self::use_bytes(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::RestoreBytes) => {
-                Self::restore_bytes(rt, rt.deserialize_params(params)?)?;
+                Self::restore_bytes(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             Some(Method::RemoveVerifiedClientDataCap) => {
-                Self::remove_verified_client_data_cap(rt, rt.deserialize_params(params)?)?;
+                Self::remove_verified_client_data_cap(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
             None => Err(actor_error!(SysErrInvalidMethod; "Invalid method")),


### PR DESCRIPTION
Also added a mirroring serialization function. Note that there are still many paths which go through `ActorError::from(e: fvm_shared::encoding::Error)` via the `?` operator, which thus don't have the opportunity to describe the object that failed to de/serialize.

- [x] Rebase on master after #162 is merged