### PR TITLE
Miner: Declare_faults_recovered: fix exitcode to match specs-actors

### DIFF
--- a/actors/miner/src/deadline_state.rs
+++ b/actors/miner/src/deadline_state.rs
@@ -841,7 +841,7 @@ impl Deadline {
 
             partition
                 .declare_faults_recovered(sectors, sector_size, sector_numbers)
-                .map_err(|e| e.downcast_wrap("failed to add recoveries"))?;
+                .map_err(|e| actor_error!(ErrIllegalState; "failed to add recoveries: {}", e));
 
             partitions.set(partition_idx, partition).map_err(|e| {
                 e.downcast_default(


### PR DESCRIPTION
Go code: https://github.com/filecoin-project/specs-actors/blob/3c87d38a4829460c92a084465521f649d7613796/actors/builtin/miner/miner_actor.go#L1702

This is needed to prevent the risk of FVM nodes falling out of sync on mainnet today. I'm not sure whether we _also_ want this in `master` (v8 actors), I'm inclined to say no.