### PR TITLE
Miner: Declare_faults_recovered: fix exitcode to match specs-actors

### DIFF
--- a/actors/miner/src/deadline_state.rs
+++ b/actors/miner/src/deadline_state.rs
@@ -853,7 +853,7 @@ impl Deadline {
 
             partition
                 .declare_faults_recovered(sectors, sector_size, sector_numbers)
-                .map_err(|e| e.downcast_wrap("failed to add recoveries"))?;
+                .map_err(|e| actor_error!(ErrIllegalState; "failed to add recoveries: {}", e));
 
             partitions.set(partition_idx, partition).map_err(|e| {
                 e.downcast_default(


### PR DESCRIPTION
See #167.

Fixes https://github.com/filecoin-project/lotus/issues/8263.