### PR TITLE
feat: use a fil-actor feature instead of relying on the wasm target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,18 @@ keywords = ["filecoin", "web3", "wasm"]
 exclude = ["examples", ".github"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fil_actor_account = { version = "8.0.0-alpha.1", path = "./actors/account" }
-fil_actor_verifreg = { version = "8.0.0-alpha.1", path = "./actors/verifreg" }
-fil_actor_cron = { version = "8.0.0-alpha.1", path = "./actors/cron" }
-fil_actor_market = { version = "8.0.0-alpha.1", path = "./actors/market" }
-fil_actor_multisig = { version = "8.0.0-alpha.1", path = "./actors/multisig" }
-fil_actor_paych = { version = "8.0.0-alpha.1", path = "./actors/paych" }
-fil_actor_power = { version = "8.0.0-alpha.1", path = "./actors/power" }
-fil_actor_miner = { version = "8.0.0-alpha.1", path = "./actors/miner" }
-fil_actor_reward = { version = "8.0.0-alpha.1", path = "./actors/reward" }
-fil_actor_system = { version = "8.0.0-alpha.1", path = "./actors/system" }
-fil_actor_init = { version = "8.0.0-alpha.1", path = "./actors/init" }
-fil_actors_runtime = { version = "8.0.0-alpha.1", path = "./actors/runtime" }
+fil_actor_account = { version = "8.0.0-alpha.1", path = "./actors/account", features = ["fil-actor"] }
+fil_actor_verifreg = { version = "8.0.0-alpha.1", path = "./actors/verifreg", features = ["fil-actor"] }
+fil_actor_cron = { version = "8.0.0-alpha.1", path = "./actors/cron", features = ["fil-actor"] }
+fil_actor_market = { version = "8.0.0-alpha.1", path = "./actors/market", features = ["fil-actor"] }
+fil_actor_multisig = { version = "8.0.0-alpha.1", path = "./actors/multisig", features = ["fil-actor"] }
+fil_actor_paych = { version = "8.0.0-alpha.1", path = "./actors/paych", features = ["fil-actor"] }
+fil_actor_power = { version = "8.0.0-alpha.1", path = "./actors/power", features = ["fil-actor"] }
+fil_actor_miner = { version = "8.0.0-alpha.1", path = "./actors/miner", features = ["fil-actor"] }
+fil_actor_reward = { version = "8.0.0-alpha.1", path = "./actors/reward", features = ["fil-actor"] }
+fil_actor_system = { version = "8.0.0-alpha.1", path = "./actors/system", features = ["fil-actor"] }
+fil_actor_init = { version = "8.0.0-alpha.1", path = "./actors/init", features = ["fil-actor"] }
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "./actors/runtime", features = ["fil-actor"] }
 
 [build-dependencies]
 fil_actor_bundler = { version = "2.0.0" }

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.3.1", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
@@ -21,4 +21,7 @@ num-derive = "0.3.3"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+
+[features]
+fil-actor = []
 

--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -11,13 +11,14 @@ use num_traits::FromPrimitive;
 use fil_actors_runtime::builtin::singletons::SYSTEM_ACTOR_ADDR;
 use fil_actors_runtime::cbor;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_error, wasm_trampoline, ActorError};
+use fil_actors_runtime::{actor_error, ActorError};
 
 pub use self::state::State;
 
 mod state;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 // * Updated to specs-actors commit: 845089a6d2580e46055c24415a6c32ee688e5186 (v3.0.0)
 

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.3.1", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -23,3 +23,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []
+

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_error, cbor, wasm_trampoline, ActorError, SYSTEM_ACTOR_ADDR};
+use fil_actors_runtime::{actor_error, cbor, ActorError, SYSTEM_ACTOR_ADDR};
 use fvm_shared::blockstore::Blockstore;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::encoding::tuple::*;
@@ -15,7 +15,8 @@ pub use self::state::{Entry, State};
 
 mod state;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 // * Updated to specs-actors commit: 845089a6d2580e46055c24415a6c32ee688e5186 (v3.0.0)
 

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.3.1", default-features = false }
 fvm_ipld_hamt = "0.3.0"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -26,3 +26,6 @@ log = "0.4.14"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []
+

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -3,9 +3,7 @@
 
 use cid::Cid;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{
-    actor_error, cbor, wasm_trampoline, ActorDowncast, ActorError, SYSTEM_ACTOR_ADDR,
-};
+use fil_actors_runtime::{actor_error, cbor, ActorDowncast, ActorError, SYSTEM_ACTOR_ADDR};
 use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::blockstore::Blockstore;
@@ -21,7 +19,8 @@ pub use self::types::*;
 mod state;
 mod types;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 // * Updated to specs-actors commit: 999e57a151cc7ada020ca2844b651499ab8c0dec (v3.0.1)
 

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_hamt = "0.3.0"
 fvm_shared = { version = "0.3.1", default-features = false }
 fvm_ipld_bitfield = "0.4.0"
@@ -29,3 +29,6 @@ anyhow = "1.0.56"
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.3.0", features = ["go-interop"] }
+[features]
+fil-actor = []
+

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -24,9 +24,8 @@ use num_traits::{FromPrimitive, Signed, Zero};
 use fil_actors_runtime::cbor::serialize_vec;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, cbor, wasm_trampoline, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR,
-    CRON_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
-    VERIFIED_REGISTRY_ACTOR_ADDR,
+    actor_error, cbor, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR,
+    REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 
 use crate::ext::verifreg::UseBytesParams;
@@ -44,7 +43,8 @@ mod policy;
 mod state;
 mod types;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 fn request_miner_control_addrs<BS, RT>(
     rt: &mut RT,

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.3.1", default-features = false }
 fvm_ipld_bitfield = "0.4.0"
 fvm_ipld_amt = { version = "0.3.0", features = ["go-interop"] }
@@ -38,3 +38,6 @@ fil_actor_market = { version = "8.0.0-alpha.1", path = "../market" }
 rand = "0.8.5"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.1", default-features = false }
+[features]
+fil-actor = []
+

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -18,8 +18,8 @@ pub use deadlines::*;
 pub use expiration_queue::*;
 use fil_actors_runtime::runtime::{ActorCode, Policy, Runtime};
 use fil_actors_runtime::{
-    actor_error, cbor, wasm_trampoline, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR,
-    INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
+    actor_error, cbor, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, INIT_ACTOR_ADDR,
+    REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
 };
 use fvm_ipld_bitfield::{BitField, UnvalidatedBitField, Validate};
 use fvm_shared::address::{Address, Payload, Protocol};
@@ -59,7 +59,8 @@ pub use vesting_state::*;
 
 use crate::Code::Blake2b256;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 mod bitfield_queue;
 mod deadline_assignment;

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.3.1", default-features = false }
 fvm_ipld_hamt = "0.3.0"
 num-traits = "0.2.14"
@@ -27,3 +27,6 @@ anyhow = "1.0.56"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []
+

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -6,8 +6,8 @@ use std::collections::BTreeSet;
 use fil_actors_runtime::cbor::serialize_vec;
 use fil_actors_runtime::runtime::{ActorCode, Runtime, Syscalls};
 use fil_actors_runtime::{
-    actor_error, cbor, make_empty_map, make_map_with_root, resolve_to_id_addr, wasm_trampoline,
-    ActorDowncast, ActorError, Map, INIT_ACTOR_ADDR,
+    actor_error, cbor, make_empty_map, make_map_with_root, resolve_to_id_addr, ActorDowncast,
+    ActorError, Map, INIT_ACTOR_ADDR,
 };
 use fvm_shared::actor::builtin::CALLER_TYPES_SIGNABLE;
 use fvm_shared::address::Address;
@@ -23,7 +23,8 @@ use num_traits::{FromPrimitive, Signed};
 pub use self::state::*;
 pub use self::types::*;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 mod state;
 mod types;

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.3.1", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -26,3 +26,6 @@ anyhow = "1.0.56"
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.3.0", features = ["go-interop"] }
 derive_builder = "0.10.2"
+[features]
+fil-actor = []
+

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{
-    actor_error, cbor, resolve_to_id_addr, wasm_trampoline, ActorDowncast, ActorError, Array,
-};
+use fil_actors_runtime::{actor_error, cbor, resolve_to_id_addr, ActorDowncast, ActorError, Array};
 use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::{BigInt, Sign};
@@ -20,7 +18,8 @@ use num_traits::FromPrimitive;
 pub use self::state::{LaneState, Merge, State};
 pub use self::types::*;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 mod state;
 mod types;

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.3.1", default-features = false }
 fvm_ipld_hamt = "0.3.0"
 num-traits = "0.2.14"
@@ -29,3 +29,6 @@ anyhow = "1.0.56"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []
+

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -8,8 +8,8 @@ use anyhow::anyhow;
 use ext::init;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, cbor, make_map_with_root_and_bitwidth, wasm_trampoline, ActorDowncast, ActorError,
-    Multimap, CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    actor_error, cbor, make_map_with_root_and_bitwidth, ActorDowncast, ActorError, Multimap,
+    CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fvm_shared::actor::builtin::{Type, CALLER_TYPES_SIGNABLE};
 use fvm_shared::address::Address;
@@ -29,7 +29,8 @@ pub use self::policy::*;
 pub use self::state::*;
 pub use self::types::*;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 #[doc(hidden)]
 pub mod ext;

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.3.1", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -24,3 +24,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []
+

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -3,8 +3,8 @@
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, cbor, wasm_trampoline, ActorError, BURNT_FUNDS_ACTOR_ADDR,
-    EXPECTED_LEADERS_PER_EPOCH, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    actor_error, cbor, ActorError, BURNT_FUNDS_ACTOR_ADDR, EXPECTED_LEADERS_PER_EPOCH,
+    STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fvm_shared::bigint::bigint_ser::BigIntDe;
 use fvm_shared::bigint::{Integer, Sign};
@@ -21,7 +21,8 @@ pub use self::logic::*;
 pub use self::state::{Reward, State, VestingFunction};
 pub use self::types::*;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 pub(crate) mod expneg;
 mod logic;

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -27,9 +27,7 @@ thiserror = "1.0.30"
 getrandom = { version = "0.2.5", features = ["js"] }
 hex = { version = "0.4.3", optional = true }
 anyhow = "1.0.56"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = "0.3.0"
+fvm_sdk = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 derive_builder = "0.10.2"
@@ -37,6 +35,7 @@ hex = "0.4.3"
 
 [features]
 default = []
+fil-actor = ["fvm_sdk"]
 
 # Enable 2k sectors
 sector-2k = []

--- a/actors/runtime/src/actor_error.rs
+++ b/actors/runtime/src/actor_error.rs
@@ -48,7 +48,7 @@ impl From<fvm_shared::encoding::Error> for ActorError {
 
 /// Converts an actor deletion error into an actor error with the appropriate exit code. This
 /// facilitates propagation.
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "fil-actor")]
 impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
     fn from(e: fvm_sdk::error::ActorDeleteError) -> Self {
         use fvm_sdk::error::ActorDeleteError::*;
@@ -66,7 +66,7 @@ impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
 
 /// Converts a no-state error into an an actor error with the appropriate exit code (illegal actor).
 /// This facilitates propagation.
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "fil-actor")]
 impl From<fvm_sdk::error::NoStateError> for ActorError {
     fn from(e: fvm_sdk::error::NoStateError) -> Self {
         Self {

--- a/actors/runtime/src/lib.rs
+++ b/actors/runtime/src/lib.rs
@@ -37,7 +37,6 @@ pub mod test_utils;
 macro_rules! wasm_trampoline {
     ($target:ty) => {
         #[no_mangle]
-        #[cfg(target_arch = "wasm32")]
         pub extern "C" fn invoke(param: u32) -> u32 {
             $crate::runtime::fvm::trampoline::<$target>(param)
         }

--- a/actors/runtime/src/runtime/mod.rs
+++ b/actors/runtime/src/runtime/mod.rs
@@ -27,10 +27,10 @@ pub use self::policy::*;
 
 mod actor_code;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "fil-actor")]
 pub mod fvm;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "fil-actor")]
 mod actor_blockstore;
 
 mod policy;

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.3.1", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -23,3 +23,6 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []
+

--- a/actors/system/src/lib.rs
+++ b/actors/system/src/lib.rs
@@ -9,9 +9,10 @@ use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_error, wasm_trampoline, ActorError, SYSTEM_ACTOR_ADDR};
+use fil_actors_runtime::{actor_error, ActorError, SYSTEM_ACTOR_ADDR};
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 // * Updated to specs-actors commit: 845089a6d2580e46055c24415a6c32ee688e5186 (v3.0.0)
 

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime" }
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.3.1", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
@@ -26,3 +26,6 @@ fvm_ipld_hamt = "0.3.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []
+

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -3,8 +3,8 @@
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, cbor, make_map_with_root_and_bitwidth, resolve_to_id_addr, wasm_trampoline,
-    ActorDowncast, ActorError, Map, STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    actor_error, cbor, make_map_with_root_and_bitwidth, resolve_to_id_addr, ActorDowncast,
+    ActorError, Map, STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
@@ -19,7 +19,8 @@ use num_traits::{FromPrimitive, Signed, Zero};
 pub use self::state::State;
 pub use self::types::*;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 mod state;
 mod types;

--- a/build.rs
+++ b/build.rs
@@ -97,6 +97,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .arg("--target=wasm32-unknown-unknown")
         .arg("--profile=wasm")
         .arg("--locked")
+        .arg("--features=fil-actor")
         .arg("--manifest-path=".to_owned() + manifest_path.to_str().unwrap())
         .env("RUSTFLAGS", "-Ctarget-feature=+crt-static -Clink-arg=--export-table")
         .env(NETWORK_ENV, network_name)


### PR DESCRIPTION
This way, the actors can be bundled with other wasm software as libraries.

fixes #109