### PR TITLE
[v8] Clean up and simplify gas functionality 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.3.0",
  "fvm_shared 0.3.1",
  "log",
  "num-derive",
@@ -609,7 +609,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.3.0",
  "fvm_shared 0.3.1",
  "log",
  "num-derive",
@@ -631,7 +631,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.3.0",
  "fvm_shared 0.3.1",
  "itertools",
  "lazy_static",
@@ -650,7 +650,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.3.0",
  "fvm_shared 0.3.1",
  "indexmap",
  "integer-encoding",
@@ -681,7 +681,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.3.0",
  "fvm_shared 0.3.1",
  "indexmap",
  "integer-encoding",
@@ -724,7 +724,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.3.0",
  "fvm_shared 0.3.1",
  "lazy_static",
  "num-derive",
@@ -742,7 +742,7 @@ dependencies = [
  "cid",
  "derive_builder",
  "fvm_ipld_amt",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.3.0",
  "fvm_sdk",
  "fvm_shared 0.3.1",
  "getrandom",
@@ -938,6 +938,25 @@ dependencies = [
  "fvm_shared 0.2.2",
  "integer-encoding",
  "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_ipld_hamt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4f07857e1978ce116716012ea6a675803fea00fb36504c307656f935f32578"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "cid",
+ "cs_serde_bytes",
+ "forest_hash_utils",
+ "fvm_shared 0.2.2",
+ "libipld-core",
+ "once_cell",
+ "serde",
+ "sha2",
  "thiserror",
 ]
 
@@ -1621,6 +1640,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test_vm"
+version = "8.0.0-alpha.1"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_runtime",
+ "fvm_ipld_hamt 0.2.0",
+ "fvm_shared 0.2.2",
+ "indexmap",
+ "log",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/actors/runtime/src/runtime/fvm.rs
+++ b/actors/runtime/src/runtime/fvm.rs
@@ -353,13 +353,6 @@ where
             .map_err(|e| anyhow!("failed to compute unsealed sector CID; exit code: {}", e))
     }
 
-    fn verify_seal(&self, vi: &SealVerifyInfo) -> Result<(), Error> {
-        match fvm::crypto::verify_seal(vi) {
-            Ok(true) => Ok(()),
-            Ok(false) | Err(_) => Err(Error::msg("invalid seal")),
-        }
-    }
-
     fn verify_post(&self, verify_info: &WindowPoStVerifyInfo) -> Result<(), Error> {
         match fvm::crypto::verify_post(verify_info) {
             Ok(true) => Ok(()),

--- a/actors/runtime/src/runtime/mod.rs
+++ b/actors/runtime/src/runtime/mod.rs
@@ -197,9 +197,6 @@ pub trait Syscalls {
         pieces: &[PieceInfo],
     ) -> Result<Cid, anyhow::Error>;
 
-    /// Verifies a sector seal proof.
-    fn verify_seal(&self, vi: &SealVerifyInfo) -> Result<(), anyhow::Error>;
-
     /// Verifies a window proof of spacetime.
     fn verify_post(&self, verify_info: &WindowPoStVerifyInfo) -> Result<(), anyhow::Error>;
 


### PR DESCRIPTION
- Remove verify_seal, pretty sure this has been unused since pre-mainnet

Pairs with https://github.com/filecoin-project/ref-fvm/pull/442