### PR TITLE
Use new ExitCode type and values, change ActorError to make bad exit codes less likely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.4.0"
+source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -942,6 +943,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.0"
+source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
 dependencies = [
  "cs_serde_bytes",
  "fvm_ipld_encoding",
@@ -953,6 +955,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.0"
+source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
 dependencies = [
  "anyhow",
  "cid",
@@ -975,6 +978,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.1.0"
+source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
 dependencies = [
  "anyhow",
  "cid",
@@ -990,6 +994,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.4.0"
+source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1009,6 +1014,7 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "0.4.0"
+source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -1052,6 +1058,7 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "0.4.1"
+source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
 dependencies = [
  "anyhow",
  "bimap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "num-derive",
  "num-traits",
  "serde",
@@ -581,7 +581,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "log",
  "num-derive",
  "num-traits",
@@ -598,7 +598,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "log",
  "num-derive",
  "num-traits",
@@ -618,7 +618,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "libipld-core",
  "log",
  "num-derive",
@@ -643,7 +643,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "itertools",
  "lazy_static",
  "log",
@@ -664,7 +664,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "indexmap",
  "integer-encoding",
  "num-derive",
@@ -683,7 +683,7 @@ dependencies = [
  "fvm_ipld_amt",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "num-derive",
  "num-traits",
  "serde",
@@ -699,7 +699,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -716,7 +716,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "lazy_static",
  "log",
  "num-derive",
@@ -732,7 +732,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "num-derive",
  "num-traits",
  "serde",
@@ -748,7 +748,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "lazy_static",
  "num-derive",
  "num-traits",
@@ -770,7 +770,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_sdk",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "getrandom",
  "hex",
  "indexmap",
@@ -927,7 +927,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.4.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3394e5f9c2adb4d586519bc24bbfd659366e01e7ffa6cda676be94a62bab474"
 dependencies = [
  "ahash",
  "anyhow",
@@ -943,7 +944,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9011349297962982b8ab2663c220034525ec0f95f408c2b561d3d98867f1a803"
 dependencies = [
  "cs_serde_bytes",
  "fvm_ipld_encoding",
@@ -955,7 +957,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1985eae58ec2fbf54535ce115c72a2141459fb7fb4ff7379e17bffae0e302578"
 dependencies = [
  "anyhow",
  "cid",
@@ -978,7 +981,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.1.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bd635987aac46a753ec81767713af35cb50f182c7cc49d3a429643ede0e709"
 dependencies = [
  "anyhow",
  "cid",
@@ -994,7 +998,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.4.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a03c6ae361a882360bc0c0f47265b294429f096baa8d9467247bbd62c6a6683c"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1013,12 +1018,13 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "0.4.0"
-source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1da3325e5885d985e9066d65d030ac2ea4cef9f173cf0bbd04c2caa366562700"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "lazy_static",
  "log",
  "num-traits",
@@ -1057,8 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "0.4.1"
-source = "git+https://github.com/filecoin-project/ref-fvm#78530c8156332a7ab44d21ffdf42dd407b0ed2c7"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "295109128cf0ae81063f1e033e56e3aab858b93eeabe446f80beb34709955de2"
 dependencies = [
  "anyhow",
  "bimap",
@@ -1683,7 +1690,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "indexmap",
  "log",
  "num-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "num-derive",
  "num-traits",
  "serde",
@@ -581,7 +581,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "log",
  "num-derive",
  "num-traits",
@@ -598,7 +598,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "log",
  "num-derive",
  "num-traits",
@@ -618,7 +618,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "libipld-core",
  "log",
  "num-derive",
@@ -643,7 +643,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "itertools",
  "lazy_static",
  "log",
@@ -664,7 +664,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "indexmap",
  "integer-encoding",
  "num-derive",
@@ -683,7 +683,7 @@ dependencies = [
  "fvm_ipld_amt",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "num-derive",
  "num-traits",
  "serde",
@@ -699,7 +699,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -716,7 +716,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "lazy_static",
  "log",
  "num-derive",
@@ -732,7 +732,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "num-derive",
  "num-traits",
  "serde",
@@ -748,7 +748,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "lazy_static",
  "num-derive",
  "num-traits",
@@ -770,7 +770,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_sdk",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "getrandom",
  "hex",
  "indexmap",
@@ -927,8 +927,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3394e5f9c2adb4d586519bc24bbfd659366e01e7ffa6cda676be94a62bab474"
 dependencies = [
  "ahash",
  "anyhow",
@@ -944,8 +942,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9011349297962982b8ab2663c220034525ec0f95f408c2b561d3d98867f1a803"
 dependencies = [
  "cs_serde_bytes",
  "fvm_ipld_encoding",
@@ -957,8 +953,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1985eae58ec2fbf54535ce115c72a2141459fb7fb4ff7379e17bffae0e302578"
 dependencies = [
  "anyhow",
  "cid",
@@ -981,8 +975,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bd635987aac46a753ec81767713af35cb50f182c7cc49d3a429643ede0e709"
 dependencies = [
  "anyhow",
  "cid",
@@ -998,8 +990,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03c6ae361a882360bc0c0f47265b294429f096baa8d9467247bbd62c6a6683c"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1019,12 +1009,10 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee9d472c4f0ad63f91a23b2ef72d9015935a3be040fa3a0ee3a0d6c4549e394"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "lazy_static",
  "log",
  "num-traits",
@@ -1063,9 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1f6ca4fb268d06287c26bc96d7f9e6ac161557b7d70cf557550a186d0714b5"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bimap",
@@ -1690,7 +1676,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 0.4.0",
+ "fvm_shared 0.4.1",
  "indexmap",
  "log",
  "num-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,15 +39,14 @@ members = [
      "test_vm",
 ]
 
-[patch.crates-io]
-# Needed until a new release is published
-fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm" }
+#[patch.crates-io]
+#fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm" }
 
 ## Uncomment when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,16 @@ members = [
      "test_vm",
 ]
 
+[patch.crates-io]
+# Needed until a new release is published
+fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm" }
+fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm" }
+fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm" }
+fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm" }
+fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm" }
+fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm" }
+fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm" }
+
 ## Uncomment when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
 ## (Valid while FVM modules aren't published to crates.io)
@@ -54,14 +64,14 @@ members = [
 ## Uncomment entries below when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
 ## (Valid once FVM modules are published to crates.io)
-[patch.crates-io]
-fvm_shared = { path = "../ref-fvm/shared" }
-fvm_sdk = { path = "../ref-fvm/sdk" }
-fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
-fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
-fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
-fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
-fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
+# [patch.crates-io]
+# fvm_shared = { path = "../ref-fvm/shared" }
+# fvm_sdk = { path = "../ref-fvm/sdk" }
+# fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
+# fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
+# fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
+# fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
+# fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
 
 [profile.wasm]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,14 +54,14 @@ members = [
 ## Uncomment entries below when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
 ## (Valid once FVM modules are published to crates.io)
-#[patch.crates-io]
-#fvm_shared = { path = "../ref-fvm/shared" }
-#fvm_sdk = { path = "../ref-fvm/sdk" }
-#fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
-#fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
-#fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
-#fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
-#fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
+[patch.crates-io]
+fvm_shared = { path = "../ref-fvm/shared" }
+fvm_sdk = { path = "../ref-fvm/sdk" }
+fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
+fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
+fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
+fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
+fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
 
 [profile.wasm]
 inherits = "release"

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -82,7 +82,7 @@ impl ActorCode for Actor {
                 let addr = Self::pubkey_address(rt)?;
                 Ok(RawBytes::serialize(addr)?)
             }
-            None => Err(actor_error!(SysErrInvalidMethod; "Invalid method")),
+            None => Err(actor_error!(ErrUnhandledMessage; "Invalid method")),
         }
     }
 }

--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -43,7 +43,7 @@ impl Actor {
         match address.protocol() {
             Protocol::Secp256k1 | Protocol::BLS => {}
             protocol => {
-                return Err(actor_error!(ErrIllegalArgument;
+                return Err(actor_error!(illegal_argument;
                     "address must use BLS or SECP protocol, got {}", protocol));
             }
         }
@@ -82,7 +82,7 @@ impl ActorCode for Actor {
                 let addr = Self::pubkey_address(rt)?;
                 Ok(RawBytes::serialize(addr)?)
             }
-            None => Err(actor_error!(ErrUnhandledMessage; "Invalid method")),
+            None => Err(actor_error!(unhandled_message; "Invalid method")),
         }
     }
 }

--- a/actors/account/tests/account_actor_test.rs
+++ b/actors/account/tests/account_actor_test.rs
@@ -51,18 +51,18 @@ macro_rules! account_tests {
 account_tests! {
     happy_construct_secp256k1_address: (
         Address::new_secp256k1(&[2; fvm_shared::address::SECP_PUB_LEN]).unwrap(),
-        ExitCode::Ok
+        ExitCode::OK
     ),
     happy_construct_bls_address: (
         Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap(),
-        ExitCode::Ok
+        ExitCode::OK
     ),
     fail_construct_id_address: (
         Address::new_id(1),
-        ExitCode::ErrIllegalArgument
+        ExitCode::USR_ILLEGAL_ARGUMENT
     ),
     fail_construct_actor_address: (
         Address::new_actor(&[1, 2, 3]),
-        ExitCode::ErrIllegalArgument
+        ExitCode::USR_ILLEGAL_ARGUMENT
     ),
 }

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -100,7 +100,7 @@ impl ActorCode for Actor {
                 Self::epoch_tick(rt)?;
                 Ok(RawBytes::default())
             }
-            None => Err(actor_error!(ErrUnhandledMessage; "Invalid method")),
+            None => Err(actor_error!(unhandled_message; "Invalid method")),
         }
     }
 }

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -100,7 +100,7 @@ impl ActorCode for Actor {
                 Self::epoch_tick(rt)?;
                 Ok(RawBytes::default())
             }
-            None => Err(actor_error!(SysErrInvalidMethod; "Invalid method")),
+            None => Err(actor_error!(ErrUnhandledMessage; "Invalid method")),
         }
     }
 }

--- a/actors/cron/tests/cron_actor_test.rs
+++ b/actors/cron/tests/cron_actor_test.rs
@@ -73,7 +73,7 @@ fn epoch_tick_with_entries() {
         RawBytes::default(),
         0u8.into(),
         RawBytes::default(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
     rt.expect_send(
         entry2.receiver,
@@ -81,7 +81,7 @@ fn epoch_tick_with_entries() {
         RawBytes::default(),
         0u8.into(),
         RawBytes::default(),
-        ExitCode::ErrIllegalArgument,
+        ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     rt.expect_send(
         entry3.receiver,
@@ -89,7 +89,7 @@ fn epoch_tick_with_entries() {
         RawBytes::default(),
         0u8.into(),
         RawBytes::default(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
     rt.expect_send(
         entry4.receiver,
@@ -97,7 +97,7 @@ fn epoch_tick_with_entries() {
         RawBytes::default(),
         0u8.into(),
         RawBytes::default(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
 
     epoch_tick_and_verify(&mut rt);

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 fvm_ipld_hamt = "0.4.0"
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 fvm_ipld_hamt = "0.4.0"
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -63,13 +63,13 @@ impl Actor {
         log::trace!("called exec; params.code_cid: {:?}", &params.code_cid);
 
         let caller_code = rt.get_actor_code_cid(&rt.message().caller()).ok_or_else(|| {
-            actor_error!(ErrIllegalState, "no code for caller as {}", rt.message().caller())
+            actor_error!(illegal_state, "no code for caller as {}", rt.message().caller())
         })?;
 
         log::trace!("caller code CID: {:?}", &caller_code);
 
         if !can_exec(rt, &caller_code, &params.code_cid) {
-            return Err(actor_error!(ErrForbidden;
+            return Err(actor_error!(forbidden;
                     "called type {} cannot exec actor type {}",
                     &caller_code, &params.code_cid
             ));
@@ -126,7 +126,7 @@ impl ActorCode for Actor {
                 let res = Self::exec(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::serialize(res)?)
             }
-            None => Err(actor_error!(ErrUnhandledMessage; "Invalid method")),
+            None => Err(actor_error!(unhandled_message; "Invalid method")),
         }
     }
 }

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -44,7 +44,7 @@ impl Actor {
         let sys_ref: &Address = &SYSTEM_ACTOR_ADDR;
         rt.validate_immediate_caller_is(std::iter::once(sys_ref))?;
         let state = State::new(rt.store(), params.network_name).map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to construct init actor state")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to construct init actor state")
         })?;
 
         rt.create(&state)?;
@@ -87,7 +87,7 @@ impl Actor {
         // Store mapping of pubkey or actor address to actor ID
         let id_address: ActorID = rt.transaction(|s: &mut State, rt| {
             s.map_address_to_new_id(rt.store(), &robust_address).map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to allocate ID address")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to allocate ID address")
             })
         })?;
 
@@ -126,7 +126,7 @@ impl ActorCode for Actor {
                 let res = Self::exec(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::serialize(res)?)
             }
-            None => Err(actor_error!(SysErrInvalidMethod; "Invalid method")),
+            None => Err(actor_error!(ErrUnhandledMessage; "Invalid method")),
         }
     }
 }

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -72,7 +72,7 @@ fn create_2_payment_channels() {
             RawBytes::serialize(&fake_params).unwrap(),
             balance,
             RawBytes::default(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
 
         let exec_ret = exec_and_verify(&mut rt, *PAYCH_ACTOR_CODE_ID, &fake_params).unwrap();
@@ -113,7 +113,7 @@ fn create_storage_miner() {
         RawBytes::serialize(&fake_params).unwrap(),
         0u8.into(),
         RawBytes::default(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
 
     let exec_ret = exec_and_verify(&mut rt, *MINER_ACTOR_CODE_ID, &fake_params).unwrap();
@@ -163,7 +163,7 @@ fn create_multisig_actor() {
         RawBytes::serialize(&fake_params).unwrap(),
         0u8.into(),
         RawBytes::default(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
 
     // Return should have been successful. Check the returned addresses
@@ -197,7 +197,7 @@ fn sending_constructor_failure() {
         RawBytes::serialize(&fake_params).unwrap(),
         0u8.into(),
         RawBytes::default(),
-        ExitCode::ErrIllegalState,
+        ExitCode::USR_ILLEGAL_STATE,
     );
 
     let error = exec_and_verify(&mut rt, *MINER_ACTOR_CODE_ID, &fake_params)
@@ -207,7 +207,7 @@ fn sending_constructor_failure() {
 
     assert_eq!(
         error_exit_code,
-        ExitCode::ErrIllegalState,
+        ExitCode::USR_ILLEGAL_STATE,
         "Exit Code that is returned is not ErrIllegalState"
     );
 

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -36,7 +36,7 @@ fn abort_cant_call_exec() {
 
     let err =
         exec_and_verify(&mut rt, *POWER_ACTOR_CODE_ID, &"").expect_err("Exec should have failed");
-    assert_eq!(err.exit_code(), ExitCode::ErrForbidden);
+    assert_eq!(err.exit_code(), ExitCode::USR_FORBIDDEN);
 }
 
 #[test]

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_hamt = "0.4.0"
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 fvm_ipld_bitfield = "0.5.0"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_hamt = "0.4.0"
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 fvm_ipld_bitfield = "0.5.0"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -408,7 +408,7 @@ where
             self.unlock_balance(&deal.client, &payment_remaining, Reason::ClientStorageFee)
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         "failed to unlock remaining client storage fee",
                     )
                 })?;
@@ -417,7 +417,7 @@ where
             self.unlock_balance(&deal.client, &deal.client_collateral, Reason::ClientCollateral)
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         "failed to unlock client collateral",
                     )
                 })?;
@@ -425,7 +425,7 @@ where
             // slash provider collateral
             let slashed = deal.provider_collateral.clone();
             self.slash_balance(&deal.provider, &slashed, Reason::ProviderCollateral)
-                .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "slashing balance"))?;
+                .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "slashing balance"))?;
 
             return Ok((slashed, EPOCH_UNDEFINED, true));
         }
@@ -453,14 +453,14 @@ where
         self.unlock_balance(&deal.client, &deal.total_storage_fee(), Reason::ClientStorageFee)
             .map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failure unlocking client storage fee",
                 )
             })?;
 
         self.unlock_balance(&deal.client, &deal.client_collateral, Reason::ClientCollateral)
             .map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failure unlocking client collateral")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failure unlocking client collateral")
             })?;
 
         let amount_slashed =
@@ -468,13 +468,13 @@ where
         let amount_remaining = deal.provider_balance_requirement() - &amount_slashed;
 
         self.slash_balance(&deal.provider, &amount_slashed, Reason::ProviderCollateral).map_err(
-            |e| e.downcast_default(ExitCode::ErrIllegalState, "failed to slash balance"),
+            |e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to slash balance"),
         )?;
 
         self.unlock_balance(&deal.provider, &amount_remaining, Reason::ProviderCollateral)
             .map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to unlock deal provider balance",
                 )
             })?;
@@ -498,7 +498,7 @@ where
         self.unlock_balance(&deal.provider, &deal.provider_collateral, Reason::ProviderCollateral)
             .map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed unlocking deal provider balance",
                 )
             })?;
@@ -506,7 +506,7 @@ where
         self.unlock_balance(&deal.client, &deal.client_collateral, Reason::ClientCollateral)
             .map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed unlocking deal client balance",
                 )
             })?;
@@ -527,10 +527,10 @@ where
         amount_to_lock: &TokenAmount,
     ) -> anyhow::Result<bool> {
         let prev_locked = self.locked_table.as_ref().unwrap().get(&addr).map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to get locked balance")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get locked balance")
         })?;
         let escrow_balance = self.escrow_table.as_ref().unwrap().get(&addr).map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to get escrow balance")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get escrow balance")
         })?;
         Ok((prev_locked + amount_to_lock) <= escrow_balance)
     }
@@ -545,11 +545,11 @@ where
         }
 
         let prev_locked = self.locked_table.as_ref().unwrap().get(addr).map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to get locked balance")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get locked balance")
         })?;
 
         let escrow_balance = self.escrow_table.as_ref().unwrap().get(addr).map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to get escrow balance")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get escrow balance")
         })?;
 
         if &prev_locked + amount > escrow_balance {
@@ -560,7 +560,7 @@ where
         }
 
         self.locked_table.as_mut().unwrap().add(addr, amount).map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to add locked balance")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to add locked balance")
         })?;
         Ok(())
     }
@@ -629,17 +629,17 @@ where
             .as_mut()
             .unwrap()
             .must_subtract(from_addr, amount)
-            .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "subtract from escrow"))?;
+            .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "subtract from escrow"))?;
 
         self.unlock_balance(from_addr, amount, Reason::ClientStorageFee)
-            .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "subtract from locked"))?;
+            .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "subtract from locked"))?;
 
         // Add subtracted amount to the recipient
         self.escrow_table
             .as_mut()
             .unwrap()
             .add(to_addr, amount)
-            .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "add to escrow"))?;
+            .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "add to escrow"))?;
 
         Ok(())
     }

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -298,7 +298,7 @@ fn withdraw_provider_to_owner() {
         RawBytes::default(),
         withdraw_amount.clone(),
         RawBytes::default(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
 
     let params =
@@ -337,7 +337,7 @@ fn withdraw_non_provider() {
         RawBytes::default(),
         withdraw_amount.clone(),
         RawBytes::default(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
 
     let params = WithdrawBalanceParams { provider_or_client: client_addr, amount: withdraw_amount };
@@ -372,7 +372,7 @@ fn client_withdraw_more_than_available() {
         RawBytes::default(),
         amount,
         RawBytes::default(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
 
     let params = WithdrawBalanceParams { provider_or_client: client_addr, amount: withdraw_amount };
@@ -411,7 +411,7 @@ fn worker_withdraw_more_than_available() {
         RawBytes::default(),
         amount,
         RawBytes::default(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
 
     let params =
@@ -446,7 +446,7 @@ fn expect_provider_control_address(
         RawBytes::default(),
         TokenAmount::from(0u8),
         RawBytes::serialize(return_value).unwrap(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
 }
 

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -225,7 +225,7 @@ fn account_actor_check() {
     rt.set_caller(*MINER_ACTOR_CODE_ID, provider_addr);
 
     assert_eq!(
-        ExitCode::ErrForbidden,
+        ExitCode::USR_FORBIDDEN,
         rt.call::<MarketActor>(
             Method::AddBalance as u64,
             &RawBytes::serialize(provider_addr).unwrap(),

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 fvm_ipld_bitfield = "0.5.0"
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
 fvm_ipld_hamt = "0.4.0"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 fvm_ipld_bitfield = "0.5.0"
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
 fvm_ipld_hamt = "0.4.0"

--- a/actors/miner/src/deadline_state.rs
+++ b/actors/miner/src/deadline_state.rs
@@ -253,7 +253,7 @@ impl Deadline {
             .get(partition_idx)
             .map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("failed to lookup partition {}", partition_idx),
                 )
             })?
@@ -273,7 +273,7 @@ impl Deadline {
             .get(partition_idx)
             .map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("failed to lookup partition snapshot {}", partition_idx),
                 )
             })?
@@ -760,7 +760,7 @@ impl Deadline {
                 .get(partition_idx)
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         format!("failed to load partition {}", partition_idx),
                     )
                 })?
@@ -791,14 +791,14 @@ impl Deadline {
 
             partitions.set(partition_idx, partition).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("failed to store partition {}", partition_idx),
                 )
             })?;
         }
 
         self.partitions = partitions.flush().map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to store partitions root")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to store partitions root")
         })?;
 
         self.add_expiration_partitions(
@@ -809,7 +809,7 @@ impl Deadline {
         )
         .map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 "failed to update expirations for partitions with faults",
             )
         })?;
@@ -831,7 +831,7 @@ impl Deadline {
                 .get(partition_idx)
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         format!("failed to load partition {}", partition_idx),
                     )
                 })?
@@ -844,7 +844,7 @@ impl Deadline {
 
             partitions.set(partition_idx, partition).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("failed to update partition {}", partition_idx),
                 )
             })?;
@@ -853,7 +853,7 @@ impl Deadline {
         // Power is not regained until the deadline end, when the recovery is confirmed.
 
         self.partitions = partitions.flush().map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to store partitions root")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to store partitions root")
         })?;
 
         Ok(())
@@ -870,7 +870,7 @@ impl Deadline {
         sectors: Cid,
     ) -> Result<(PowerPair, PowerPair), ActorError> {
         let mut partitions = self.partitions_amt(store).map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to load partitions")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load partitions")
         })?;
 
         let mut detected_any = false;
@@ -888,7 +888,7 @@ impl Deadline {
                 .get(partition_idx)
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         format!("failed to load partition {}", partition_idx),
                     )
                 })?
@@ -910,7 +910,7 @@ impl Deadline {
                 .record_missed_post(store, fault_expiration_epoch, quant)
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         format!("failed to record missed PoSt for partition {}", partition_idx),
                     )
                 })?;
@@ -925,7 +925,7 @@ impl Deadline {
             // Save new partition state.
             partitions.set(partition_idx, partition).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("failed to update partition {}", partition_idx),
                 )
             })?;
@@ -939,7 +939,7 @@ impl Deadline {
         // Save modified deadline state.
         if detected_any {
             self.partitions = partitions.flush().map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to store partitions")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to store partitions")
             })?;
         }
 
@@ -951,7 +951,7 @@ impl Deadline {
         )
         .map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 "failed to update deadline expiration queue",
             )
         })?;
@@ -966,7 +966,7 @@ impl Deadline {
         )
         .flush()
         .map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to clear pending proofs array")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to clear pending proofs array")
         })?;
 
         // only snapshot sectors if there's a proof that might be disputed (this is equivalent to asking if the OptimisticPoStSubmissionsSnapshot is empty)
@@ -977,7 +977,7 @@ impl Deadline {
                 Array::<(), BS>::new_with_bit_width(store, SECTORS_AMT_BITWIDTH).flush().map_err(
                     |e| {
                         e.downcast_default(
-                            ExitCode::ErrIllegalState,
+                            ExitCode::USR_ILLEGAL_STATE,
                             "failed to clear sectors snapshot array",
                         )
                     },
@@ -1201,7 +1201,7 @@ impl Deadline {
             // This will be rolled back if the method aborts with a failed proof.
             partitions.set(post.index, partition).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("failed to update partition {}", post.index),
                 )
             })?;
@@ -1219,7 +1219,7 @@ impl Deadline {
         self.add_expiration_partitions(store, fault_expiration, &rescheduled_partitions, quant)
             .map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to update expirations for partitions with faults",
                 )
             })?;
@@ -1229,7 +1229,7 @@ impl Deadline {
         self.faulty_power += &new_faulty_power_total;
 
         self.partitions = partitions.flush().map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to persist partitions")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to persist partitions")
         })?;
 
         // Collect all sectors, faults, and recoveries for proof verification.

--- a/actors/miner/src/partition_state.rs
+++ b/actors/miner/src/partition_state.rs
@@ -761,7 +761,7 @@ impl Partition {
                 quant,
             )
             .map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to add skipped faults")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to add skipped faults")
             })?;
 
         // Remove faulty recoveries

--- a/actors/miner/src/partition_state.rs
+++ b/actors/miner/src/partition_state.rs
@@ -219,7 +219,7 @@ impl Partition {
         quant: QuantSpec,
     ) -> anyhow::Result<(BitField, PowerPair, PowerPair)> {
         validate_partition_contains_sectors(self, sector_numbers)
-            .map_err(|e| actor_error!(ErrIllegalArgument; "failed fault declaration: {}", e))?;
+            .map_err(|e| actor_error!(illegal_argument; "failed fault declaration: {}", e))?;
 
         let sector_numbers = sector_numbers
             .validate()
@@ -316,7 +316,7 @@ impl Partition {
     ) -> anyhow::Result<()> {
         // Check that the declared sectors are actually assigned to the partition.
         validate_partition_contains_sectors(self, sector_numbers)
-            .map_err(|e| actor_error!(ErrIllegalArgument; "failed fault declaration: {}", e))?;
+            .map_err(|e| actor_error!(illegal_argument; "failed fault declaration: {}", e))?;
 
         let sector_numbers = sector_numbers
             .validate()
@@ -377,7 +377,7 @@ impl Partition {
         quant: QuantSpec,
     ) -> anyhow::Result<Vec<SectorOnChainInfo>> {
         let sector_numbers = sector_numbers.validate().map_err(|e| {
-            actor_error!(ErrIllegalArgument, "failed to validate rescheduled sectors: {}", e)
+            actor_error!(illegal_argument, "failed to validate rescheduled sectors: {}", e)
         })?;
 
         // Ensure these sectors actually belong to this partition.
@@ -490,11 +490,11 @@ impl Partition {
     ) -> anyhow::Result<ExpirationSet> {
         let live_sectors = self.live_sectors();
         let sector_numbers = sector_numbers.validate().map_err(|e| {
-            actor_error!(ErrIllegalArgument, "failed to validate terminating sectors: {}", e)
+            actor_error!(illegal_argument, "failed to validate terminating sectors: {}", e)
         })?;
 
         if !live_sectors.contains_all(sector_numbers) {
-            return Err(actor_error!(ErrIllegalArgument, "can only terminate live sectors").into());
+            return Err(actor_error!(illegal_argument, "can only terminate live sectors").into());
         }
 
         let sector_infos = sectors.load_sector(sector_numbers)?;
@@ -722,7 +722,7 @@ impl Partition {
         skipped: &mut UnvalidatedBitField,
     ) -> anyhow::Result<(PowerPair, PowerPair, PowerPair, bool)> {
         let skipped = skipped.validate().map_err(|e| {
-            actor_error!(ErrIllegalArgument, "failed to validate skipped sectors: {}", e)
+            actor_error!(illegal_argument, "failed to validate skipped sectors: {}", e)
         })?;
 
         if skipped.is_empty() {
@@ -732,7 +732,7 @@ impl Partition {
         // Check that the declared sectors are actually in the partition.
         if !self.sectors.contains_all(skipped) {
             return Err(actor_error!(
-                ErrIllegalArgument,
+                illegal_argument,
                 "skipped faults contains sectors outside partition"
             )
             .into());

--- a/actors/miner/src/sectors.rs
+++ b/actors/miner/src/sectors.rs
@@ -29,9 +29,7 @@ impl<'db, BS: Blockstore> Sectors<'db, BS> {
     ) -> Result<Vec<SectorOnChainInfo>, ActorError> {
         let sector_numbers = match sector_numbers.validate() {
             Ok(sector_numbers) => sector_numbers,
-            Err(e) => {
-                return Err(actor_error!(ErrIllegalArgument, "failed to load sectors: {}", e))
-            }
+            Err(e) => return Err(actor_error!(illegal_argument, "failed to load sectors: {}", e)),
         };
 
         let mut sector_infos: Vec<SectorOnChainInfo> = Vec::new();
@@ -46,7 +44,7 @@ impl<'db, BS: Blockstore> Sectors<'db, BS> {
                     )
                 })?
                 .cloned()
-                .ok_or_else(|| actor_error!(ErrNotFound; "sector not found: {}", sector_number))?;
+                .ok_or_else(|| actor_error!(not_found; "sector not found: {}", sector_number))?;
             sector_infos.push(sector_on_chain);
         }
         Ok(sector_infos)

--- a/actors/miner/src/sectors.rs
+++ b/actors/miner/src/sectors.rs
@@ -41,7 +41,7 @@ impl<'db, BS: Blockstore> Sectors<'db, BS> {
                 .get(sector_number)
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         format!("failed to load sector {}", sector_number),
                     )
                 })?

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -132,7 +132,7 @@ impl State {
         let empty_precommit_map =
             make_empty_map::<_, ()>(store, HAMT_BIT_WIDTH).flush().map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to construct empty precommit map",
                 )
             })?;
@@ -141,7 +141,7 @@ impl State {
                 .flush()
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         "failed to construct empty precommits array",
                     )
                 })?;
@@ -150,27 +150,27 @@ impl State {
                 .flush()
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         "failed to construct sectors array",
                     )
                 })?;
         let empty_bitfield = store.put_cbor(&BitField::new(), Code::Blake2b256).map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to construct empty bitfield")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to construct empty bitfield")
         })?;
         let deadline = Deadline::new(store)?;
         let empty_deadline = store.put_cbor(&deadline, Code::Blake2b256).map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "failed to construct illegal state")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to construct illegal state")
         })?;
 
         let empty_deadlines = store
             .put_cbor(&Deadlines::new(policy, empty_deadline), Code::Blake2b256)
             .map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to construct illegal state")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to construct illegal state")
             })?;
 
         let empty_vesting_funds_cid =
             store.put_cbor(&VestingFunds::new(), Code::Blake2b256).map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to construct illegal state")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to construct illegal state")
             })?;
 
         Ok(Self {
@@ -255,7 +255,7 @@ impl State {
             .get_cbor(&self.allocated_sectors)
             .map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to load allocated sectors bitfield",
                 )
             })?
@@ -277,7 +277,7 @@ impl State {
         self.allocated_sectors =
             store.put_cbor(&new_allocation, Code::Blake2b256).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalArgument,
+                    ExitCode::USR_ILLEGAL_ARGUMENT,
                     format!(
                         "failed to store allocated sectors bitfield after adding {:?}",
                         sector_numbers,
@@ -723,7 +723,7 @@ impl State {
     pub fn load_deadlines<BS: Blockstore>(&self, store: &BS) -> Result<Deadlines, ActorError> {
         store
             .get_cbor::<Deadlines>(&self.deadlines)
-            .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "failed to load deadlines"))?
+            .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load deadlines"))?
             .ok_or_else(
                 || actor_error!(ErrIllegalState; "failed to load deadlines {}", self.deadlines),
             )

--- a/actors/miner/tests/miner_actor_test_construction.rs
+++ b/actors/miner/tests/miner_actor_test_construction.rs
@@ -74,7 +74,7 @@ fn simple_construction() {
         RawBytes::default(),
         TokenAmount::from(0),
         RawBytes::serialize(env.worker_key).unwrap(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
 
     let result = env
@@ -147,7 +147,7 @@ fn control_addresses_are_resolved_during_construction() {
         RawBytes::default(),
         TokenAmount::from(0),
         RawBytes::serialize(env.worker_key).unwrap(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
 
     let result = env
@@ -181,14 +181,14 @@ fn fails_if_control_address_is_not_an_account_actor() {
         RawBytes::default(),
         TokenAmount::from(0),
         RawBytes::serialize(env.worker_key).unwrap(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
 
     let result = env
         .rt
         .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
         .unwrap_err();
-    assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
+    assert_eq!(result.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
     env.rt.verify();
 }
 
@@ -204,7 +204,7 @@ fn test_construct_with_invalid_peer_id() {
         .rt
         .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
         .unwrap_err();
-    assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
+    assert_eq!(result.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
     env.rt.verify();
 }
 
@@ -223,7 +223,7 @@ fn fails_if_control_addresses_exceeds_maximum_length() {
         .rt
         .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
         .unwrap_err();
-    assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
+    assert_eq!(result.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
     env.rt.verify();
 }
 
@@ -242,7 +242,7 @@ fn test_construct_with_large_multiaddr() {
         .rt
         .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
         .unwrap_err();
-    assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
+    assert_eq!(result.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
     env.rt.verify();
 }
 
@@ -260,6 +260,6 @@ fn test_construct_with_empty_multiaddr() {
         .rt
         .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
         .unwrap_err();
-    assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
+    assert_eq!(result.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
     env.rt.verify();
 }

--- a/actors/miner/tests/miner_actor_test_wpost.rs
+++ b/actors/miner/tests/miner_actor_test_wpost.rs
@@ -131,7 +131,7 @@ fn invalid_submissions() {
             params,
             PoStConfig::empty(),
         );
-        expect_abort_contains_message(ExitCode::ErrIllegalArgument, "invalid deadline", result);
+        expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "invalid deadline", result);
         rt.reset();
     }
 
@@ -153,7 +153,7 @@ fn invalid_submissions() {
             PoStConfig::empty(),
         );
         expect_abort_contains_message(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             "expected proof to be smaller",
             result,
         );
@@ -180,7 +180,7 @@ fn invalid_submissions() {
             params,
             PoStConfig::empty(),
         );
-        expect_abort_contains_message(ExitCode::ErrIllegalArgument, "too many partitions", result);
+        expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "too many partitions", result);
         rt.reset();
     }
 
@@ -223,7 +223,7 @@ fn invalid_submissions() {
             PoStConfig::empty(),
         );
         expect_abort_contains_message(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             "skipped faults contains sectors outside partition",
             result,
         );
@@ -248,7 +248,7 @@ fn invalid_submissions() {
             PoStConfig::empty(),
         );
         expect_abort_contains_message(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             "expected exactly one proof",
             result,
         );
@@ -273,7 +273,7 @@ fn invalid_submissions() {
             PoStConfig::empty(),
         );
         expect_abort_contains_message(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             "proof type StackedDRGWindow8MiBV1 not allowed",
             result,
         );
@@ -298,7 +298,7 @@ fn invalid_submissions() {
             PoStConfig::empty(),
         );
         expect_abort_contains_message(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             "expected proof of type",
             result,
         );
@@ -325,7 +325,7 @@ fn invalid_submissions() {
             PoStConfig::empty(),
         );
         expect_abort_contains_message(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             "expected proof to be smaller",
             result,
         );
@@ -349,7 +349,7 @@ fn invalid_submissions() {
             params,
             PoStConfig::empty(),
         );
-        expect_abort_contains_message(ExitCode::ErrIllegalArgument, "bytes of randomness", result);
+        expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "bytes of randomness", result);
         rt.reset();
     }
 
@@ -377,7 +377,7 @@ fn invalid_submissions() {
         //      giving a starting deadline of 20.  Because committing a sector takes 2 deadlines the
         //      specs-actors test does sector assignment in an immutable deadline 0 forcing assignment to
         //      deadline 2.
-        expect_abort_contains_message(ExitCode::ErrIllegalArgument, "invalid deadline", result);
+        expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "invalid deadline", result);
         rt.epoch = dlinfo.current_epoch;
         rt.reset();
     }
@@ -400,7 +400,7 @@ fn invalid_submissions() {
             PoStConfig::empty(),
         );
         expect_abort_contains_message(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             "expected chain commit epoch",
             result,
         );
@@ -425,7 +425,7 @@ fn invalid_submissions() {
             PoStConfig::empty(),
         );
         expect_abort_contains_message(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             "must be less than the current epoch",
             result,
         );
@@ -450,7 +450,7 @@ fn invalid_submissions() {
             PoStConfig::with_randomness(Randomness(b"far".to_vec())),
         );
         expect_abort_contains_message(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             "randomness mismatched",
             result,
         );
@@ -549,7 +549,7 @@ fn duplicate_proof_rejected() {
         miner::Method::SubmitWindowedPoSt as u64,
         &RawBytes::serialize(params).unwrap(),
     );
-    expect_abort_contains_message(ExitCode::ErrIllegalArgument, "partition already proven", result);
+    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "partition already proven", result);
     rt.reset();
 
     // Advance to end-of-deadline cron to verify no penalties.
@@ -632,7 +632,7 @@ fn duplicate_proof_rejected_with_many_partitions() {
             PoStConfig::with_expected_power_delta(&pwr),
         );
         expect_abort_contains_message(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             "partition already proven",
             result,
         );

--- a/actors/miner/tests/miner_actor_test_wpost.rs
+++ b/actors/miner/tests/miner_actor_test_wpost.rs
@@ -180,7 +180,11 @@ fn invalid_submissions() {
             params,
             PoStConfig::empty(),
         );
-        expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "too many partitions", result);
+        expect_abort_contains_message(
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            "too many partitions",
+            result,
+        );
         rt.reset();
     }
 
@@ -349,7 +353,11 @@ fn invalid_submissions() {
             params,
             PoStConfig::empty(),
         );
-        expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "bytes of randomness", result);
+        expect_abort_contains_message(
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            "bytes of randomness",
+            result,
+        );
         rt.reset();
     }
 
@@ -549,7 +557,11 @@ fn duplicate_proof_rejected() {
         miner::Method::SubmitWindowedPoSt as u64,
         &RawBytes::serialize(params).unwrap(),
     );
-    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "partition already proven", result);
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        "partition already proven",
+        result,
+    );
     rt.reset();
 
     // Advance to end-of-deadline cron to verify no penalties.

--- a/actors/miner/tests/miner_actor_test_wpost.rs
+++ b/actors/miner/tests/miner_actor_test_wpost.rs
@@ -205,7 +205,7 @@ fn invalid_submissions() {
             params,
             PoStConfig::empty(),
         );
-        expect_abort_contains_message(ExitCode::ErrNotFound, "no such partition", result);
+        expect_abort_contains_message(ExitCode::USR_NOT_FOUND, "no such partition", result);
         rt.reset();
     }
 

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -177,7 +177,7 @@ impl ActorHarness {
             RawBytes::default(),
             TokenAmount::from(0),
             RawBytes::serialize(self.worker_key).unwrap(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
 
         let result = rt
@@ -217,7 +217,7 @@ impl ActorHarness {
         let result = rt
             .call::<Actor>(Method::ChangePeerID as u64, &RawBytes::serialize(params).unwrap())
             .unwrap_err();
-        assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
+        assert_eq!(result.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
         rt.verify();
     }
 
@@ -247,7 +247,7 @@ impl ActorHarness {
         let result = rt
             .call::<Actor>(Method::ChangeMultiaddrs as u64, &RawBytes::serialize(params).unwrap())
             .unwrap_err();
-        assert_eq!(result.exit_code(), ExitCode::ErrIllegalArgument);
+        assert_eq!(result.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
         rt.verify();
     }
 
@@ -376,7 +376,7 @@ impl ActorHarness {
                 RawBytes::serialize(vdparams).unwrap(),
                 TokenAmount::from(0),
                 RawBytes::serialize(vdreturn).unwrap(),
-                ExitCode::Ok,
+                ExitCode::OK,
             );
         }
         // in the original test the else branch does some redundant checks which we can omit.
@@ -389,7 +389,7 @@ impl ActorHarness {
                 RawBytes::default(),
                 state.fee_debt.clone(),
                 RawBytes::default(),
-                ExitCode::Ok,
+                ExitCode::OK,
             );
         }
 
@@ -406,7 +406,7 @@ impl ActorHarness {
                 RawBytes::serialize(cron_params).unwrap(),
                 TokenAmount::from(0),
                 RawBytes::default(),
-                ExitCode::Ok,
+                ExitCode::OK,
             );
         }
 
@@ -448,7 +448,7 @@ impl ActorHarness {
             RawBytes::default(),
             TokenAmount::from(0),
             RawBytes::serialize(current_reward).unwrap(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
         rt.expect_send(
             *STORAGE_POWER_ACTOR_ADDR,
@@ -456,7 +456,7 @@ impl ActorHarness {
             RawBytes::default(),
             TokenAmount::from(0),
             RawBytes::serialize(current_power).unwrap(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
     }
 
@@ -496,7 +496,7 @@ impl ActorHarness {
             RawBytes::serialize(cdc_params).unwrap(),
             TokenAmount::from(0),
             RawBytes::serialize(cdc_ret).unwrap(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
 
         let entropy = RawBytes::serialize(self.receiver).unwrap();
@@ -530,7 +530,7 @@ impl ActorHarness {
             RawBytes::serialize(seal).unwrap(),
             TokenAmount::from(0),
             RawBytes::default(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
         rt.expect_validate_caller_any();
         let result = rt
@@ -584,7 +584,7 @@ impl ActorHarness {
                     sector_expiry: pc.info.expiration,
                 };
 
-                let mut exit = ExitCode::Ok;
+                let mut exit = ExitCode::OK;
                 match cfg.verify_deals_exit.get(&pc.info.sector_number) {
                     Some(exit_code) => {
                         exit = *exit_code;
@@ -654,7 +654,7 @@ impl ActorHarness {
                     RawBytes::serialize(BigIntSer(&expected_pledge)).unwrap(),
                     TokenAmount::from(0),
                     RawBytes::default(),
-                    ExitCode::Ok,
+                    ExitCode::OK,
                 );
             }
         }
@@ -726,7 +726,7 @@ impl ActorHarness {
                 RawBytes::serialize(params).unwrap(),
                 TokenAmount::from(0),
                 RawBytes::default(),
-                ExitCode::Ok,
+                ExitCode::OK,
             );
         }
 
@@ -744,7 +744,7 @@ impl ActorHarness {
                 RawBytes::default(),
                 penalty_total.clone(),
                 RawBytes::default(),
-                ExitCode::Ok,
+                ExitCode::OK,
             );
 
             let mut penalty_from_vesting = penalty_total.clone();
@@ -768,7 +768,7 @@ impl ActorHarness {
                 RawBytes::serialize(BigIntSer(&pledge_delta)).unwrap(),
                 TokenAmount::from(0),
                 RawBytes::default(),
-                ExitCode::Ok,
+                ExitCode::OK,
             );
         }
 
@@ -781,7 +781,7 @@ impl ActorHarness {
                 RawBytes::serialize(params).unwrap(),
                 TokenAmount::from(0),
                 RawBytes::default(),
-                ExitCode::Ok,
+                ExitCode::OK,
             );
         }
 
@@ -881,7 +881,7 @@ impl ActorHarness {
                 );
                 let exit_code = match cfg.verification_exit {
                     Some(exit_code) => exit_code,
-                    None => ExitCode::Ok,
+                    None => ExitCode::OK,
                 };
                 rt.expect_verify_post(vi, exit_code);
             }
@@ -899,7 +899,7 @@ impl ActorHarness {
                 RawBytes::serialize(claim).unwrap(),
                 TokenAmount::from(0),
                 RawBytes::default(),
-                ExitCode::Ok,
+                ExitCode::OK,
             );
         }
 
@@ -986,8 +986,8 @@ impl ActorHarness {
             post.proofs,
         );
         let verify_result = match expect_success {
-            Some(_) => ExitCode::ErrIllegalArgument,
-            None => ExitCode::Ok,
+            Some(_) => ExitCode::USR_ILLEGAL_ARGUMENT,
+            None => ExitCode::OK,
         };
         rt.expect_verify_post(vi, verify_result);
 
@@ -1006,7 +1006,7 @@ impl ActorHarness {
                     RawBytes::serialize(claim).unwrap(),
                     TokenAmount::from(0),
                     RawBytes::default(),
-                    ExitCode::Ok,
+                    ExitCode::OK,
                 );
             }
 
@@ -1018,7 +1018,7 @@ impl ActorHarness {
                     RawBytes::default(),
                     expected_reward,
                     RawBytes::default(),
-                    ExitCode::Ok,
+                    ExitCode::OK,
                 );
             }
 
@@ -1030,7 +1030,7 @@ impl ActorHarness {
                     RawBytes::default(),
                     expected_penalty,
                     RawBytes::default(),
-                    ExitCode::Ok,
+                    ExitCode::OK,
                 );
             }
 
@@ -1042,7 +1042,7 @@ impl ActorHarness {
                     RawBytes::serialize(BigIntSer(&expected_pledge_delta)).unwrap(),
                     TokenAmount::from(0),
                     RawBytes::default(),
-                    ExitCode::Ok,
+                    ExitCode::OK,
                 );
             }
         }
@@ -1058,7 +1058,7 @@ impl ActorHarness {
             result.unwrap();
         } else {
             expect_abort_contains_message(
-                ExitCode::ErrIllegalArgument,
+                ExitCode::USR_ILLEGAL_ARGUMENT,
                 "failed to dispute valid post",
                 result,
             );

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 fvm_ipld_hamt = "0.4.0"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 fvm_ipld_hamt = "0.4.0"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -58,12 +58,12 @@ impl Actor {
         rt.validate_immediate_caller_is(std::iter::once(&*INIT_ACTOR_ADDR))?;
 
         if params.signers.is_empty() {
-            return Err(actor_error!(ErrIllegalArgument; "Must have at least one signer"));
+            return Err(actor_error!(illegal_argument; "Must have at least one signer"));
         }
 
         if params.signers.len() > SIGNERS_MAX {
             return Err(actor_error!(
-                ErrIllegalArgument,
+                illegal_argument,
                 "cannot add more than {} signers",
                 SIGNERS_MAX
             ));
@@ -81,7 +81,7 @@ impl Actor {
             })?;
             if !dedup_signers.insert(resolved.id().expect("address should be resolved")) {
                 return Err(
-                    actor_error!(ErrIllegalArgument; "duplicate signer not allowed: {}", signer),
+                    actor_error!(illegal_argument; "duplicate signer not allowed: {}", signer),
                 );
             }
             resolved_signers.push(resolved);
@@ -89,16 +89,16 @@ impl Actor {
 
         if params.num_approvals_threshold > params.signers.len() as u64 {
             return Err(
-                actor_error!(ErrIllegalArgument; "must not require more approvals than signers"),
+                actor_error!(illegal_argument; "must not require more approvals than signers"),
             );
         }
 
         if params.num_approvals_threshold < 1 {
-            return Err(actor_error!(ErrIllegalArgument; "must require at least one approval"));
+            return Err(actor_error!(illegal_argument; "must require at least one approval"));
         }
 
         if params.unlock_duration < 0 {
-            return Err(actor_error!(ErrIllegalArgument; "negative unlock duration disallowed"));
+            return Err(actor_error!(illegal_argument; "negative unlock duration disallowed"));
         }
 
         let empty_root =
@@ -139,7 +139,7 @@ impl Actor {
 
         if params.value.sign() == Sign::Minus {
             return Err(actor_error!(
-                ErrIllegalArgument,
+                illegal_argument,
                 "proposed value must be non-negative, was {}",
                 params.value
             ));
@@ -147,11 +147,14 @@ impl Actor {
 
         let (txn_id, txn) = rt.transaction(|st: &mut State, rt| {
             if !st.is_signer(&proposer) {
-                return Err(actor_error!(ErrForbidden, "{} is not a signer", proposer));
+                return Err(actor_error!(forbidden, "{} is not a signer", proposer));
             }
 
             let mut ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(|e| {
-                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load pending transactions")
+                e.downcast_default(
+                    ExitCode::USR_ILLEGAL_STATE,
+                    "failed to load pending transactions",
+                )
             })?;
 
             let t_id = st.next_tx_id;
@@ -199,11 +202,14 @@ impl Actor {
         let id = params.id;
         let (st, txn) = rt.transaction(|st: &mut State, rt| {
             if !st.is_signer(&approver) {
-                return Err(actor_error!(ErrForbidden; "{} is not a signer", approver));
+                return Err(actor_error!(forbidden; "{} is not a signer", approver));
             }
 
             let ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(|e| {
-                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load pending transactions")
+                e.downcast_default(
+                    ExitCode::USR_ILLEGAL_STATE,
+                    "failed to load pending transactions",
+                )
             })?;
 
             let txn = get_transaction(rt, &ptx, params.id, params.proposal_hash)?;
@@ -235,7 +241,7 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             if !st.is_signer(&caller_addr) {
-                return Err(actor_error!(ErrForbidden; "{} is not a signer", caller_addr));
+                return Err(actor_error!(forbidden; "{} is not a signer", caller_addr));
             }
 
             let mut ptx = make_map_with_root::<_, Transaction>(&st.pending_txs, rt.store())
@@ -255,14 +261,12 @@ impl Actor {
                     )
                 })?
                 .ok_or_else(|| {
-                    actor_error!(ErrNotFound, "no such transaction {:?} to cancel", params.id)
+                    actor_error!(not_found, "no such transaction {:?} to cancel", params.id)
                 })?;
 
             // Check to make sure transaction proposer is caller address
             if tx.approved.get(0) != Some(&caller_addr) {
-                return Err(
-                    actor_error!(ErrForbidden; "Cannot cancel another signers transaction"),
-                );
+                return Err(actor_error!(forbidden; "Cannot cancel another signers transaction"));
             }
 
             let calculated_hash = compute_proposal_hash(&tx, rt).map_err(|e| {
@@ -273,7 +277,7 @@ impl Actor {
             })?;
 
             if !params.proposal_hash.is_empty() && params.proposal_hash != calculated_hash {
-                return Err(actor_error!(ErrIllegalState, "hash does not match proposal params"));
+                return Err(actor_error!(illegal_state, "hash does not match proposal params"));
             }
 
             st.pending_txs = ptx.flush().map_err(|e| {
@@ -305,17 +309,13 @@ impl Actor {
         rt.transaction(|st: &mut State, _| {
             if st.signers.len() >= SIGNERS_MAX {
                 return Err(actor_error!(
-                    ErrForbidden,
+                    forbidden,
                     "cannot add more than {} signers",
                     SIGNERS_MAX
                 ));
             }
             if st.is_signer(&resolved_new_signer) {
-                return Err(actor_error!(
-                    ErrForbidden,
-                    "{} is already a signer",
-                    resolved_new_signer
-                ));
+                return Err(actor_error!(forbidden, "{} is already a signer", resolved_new_signer));
             }
 
             // Add signer and increase threshold if set
@@ -345,16 +345,16 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             if !st.is_signer(&resolved_old_signer) {
-                return Err(actor_error!(ErrForbidden, "{} is not a signer", resolved_old_signer));
+                return Err(actor_error!(forbidden, "{} is not a signer", resolved_old_signer));
             }
 
             if st.signers.len() == 1 {
-                return Err(actor_error!(ErrForbidden; "Cannot remove only signer"));
+                return Err(actor_error!(forbidden; "Cannot remove only signer"));
             }
 
             if !params.decrease && ((st.signers.len() - 1) as u64) < st.num_approvals_threshold {
                 return Err(actor_error!(
-                    ErrIllegalArgument,
+                    illegal_argument,
                     "can't reduce signers to {} below threshold {} with decrease=false",
                     st.signers.len(),
                     st.num_approvals_threshold
@@ -364,7 +364,7 @@ impl Actor {
             if params.decrease {
                 if st.num_approvals_threshold < 2 {
                     return Err(actor_error!(
-                        ErrIllegalArgument,
+                        illegal_argument,
                         "can't decrease approvals from {} to {}",
                         st.num_approvals_threshold,
                         st.num_approvals_threshold - 1
@@ -411,13 +411,11 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             if !st.is_signer(&from_resolved) {
-                return Err(actor_error!(ErrForbidden; "{} is not a signer", from_resolved));
+                return Err(actor_error!(forbidden; "{} is not a signer", from_resolved));
             }
 
             if st.is_signer(&to_resolved) {
-                return Err(
-                    actor_error!(ErrIllegalArgument; "{} is already a signer", to_resolved),
-                );
+                return Err(actor_error!(illegal_argument; "{} is already a signer", to_resolved));
             }
 
             // Remove signer from state (retain preserves order of elements)
@@ -453,7 +451,7 @@ impl Actor {
         rt.transaction(|st: &mut State, _| {
             // Check if valid threshold value
             if params.new_threshold == 0 || params.new_threshold > st.signers.len() as u64 {
-                return Err(actor_error!(ErrIllegalArgument; "New threshold value not supported"));
+                return Err(actor_error!(illegal_argument; "New threshold value not supported"));
             }
 
             // Update threshold on state
@@ -474,16 +472,16 @@ impl Actor {
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
 
         if params.unlock_duration <= 0 {
-            return Err(actor_error!(ErrIllegalArgument, "unlock duration must be positive"));
+            return Err(actor_error!(illegal_argument, "unlock duration must be positive"));
         }
 
         if params.amount.is_negative() {
-            return Err(actor_error!(ErrIllegalArgument, "amount to lock must be positive"));
+            return Err(actor_error!(illegal_argument, "amount to lock must be positive"));
         }
 
         rt.transaction(|st: &mut State, _| {
             if st.unlock_duration != 0 {
-                return Err(actor_error!(ErrForbidden, "modification of unlock disallowed"));
+                return Err(actor_error!(forbidden, "modification of unlock disallowed"));
             }
             st.set_locked(params.start_epoch, params.unlock_duration, params.amount);
             Ok(())
@@ -504,7 +502,7 @@ impl Actor {
         for previous_approver in &txn.approved {
             if *previous_approver == rt.message().caller() {
                 return Err(actor_error!(
-                    ErrForbidden,
+                    forbidden,
                     "{} already approved this message",
                     previous_approver
                 ));
@@ -513,7 +511,10 @@ impl Actor {
 
         let st = rt.transaction(|st: &mut State, rt| {
             let mut ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(|e| {
-                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load pending transactions")
+                e.downcast_default(
+                    ExitCode::USR_ILLEGAL_STATE,
+                    "failed to load pending transactions",
+                )
             })?;
 
             // update approved on the transaction
@@ -557,9 +558,8 @@ where
     let mut applied = false;
     let threshold_met = txn.approved.len() as u64 >= st.num_approvals_threshold;
     if threshold_met {
-        st.check_available(rt.current_balance(), &txn.value, rt.curr_epoch()).map_err(|e| {
-            actor_error!(ErrInsufficientFunds, "insufficient funds unlocked: {}", e)
-        })?;
+        st.check_available(rt.current_balance(), &txn.value, rt.curr_epoch())
+            .map_err(|e| actor_error!(insufficient_funds, "insufficient funds unlocked: {}", e))?;
 
         match rt.send(txn.to, txn.method, txn.params.clone(), txn.value.clone()) {
             Ok(ser) => {
@@ -618,9 +618,7 @@ where
                 format!("failed to load transaction {:?} for approval", txn_id),
             )
         })?
-        .ok_or_else(|| {
-            actor_error!(ErrNotFound, "no such transaction {:?} for approval", txn_id)
-        })?;
+        .ok_or_else(|| actor_error!(not_found, "no such transaction {:?} for approval", txn_id))?;
 
     if !proposal_hash.is_empty() {
         let calculated_hash = compute_proposal_hash(txn, rt).map_err(|e| {
@@ -632,7 +630,7 @@ where
 
         if proposal_hash != calculated_hash {
             return Err(actor_error!(
-                ErrIllegalArgument,
+                illegal_argument,
                 "hash does not match proposal params (ensure requester is an ID address)"
             ));
         }
@@ -702,7 +700,7 @@ impl ActorCode for Actor {
                 Self::lock_balance(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            None => Err(actor_error!(ErrUnhandledMessage, "Invalid method")),
+            None => Err(actor_error!(unhandled_message, "Invalid method")),
         }
     }
 }

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -75,7 +75,7 @@ impl Actor {
         for signer in &params.signers {
             let resolved = resolve_to_id_addr(rt, signer).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("failed to resolve addr {} to ID addr", signer),
                 )
             })?;
@@ -103,7 +103,7 @@ impl Actor {
 
         let empty_root =
             make_empty_map::<_, ()>(rt.store(), HAMT_BIT_WIDTH).flush().map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "Failed to create empty map")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "Failed to create empty map")
             })?;
 
         let mut st: State = State {
@@ -151,7 +151,7 @@ impl Actor {
             }
 
             let mut ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to load pending transactions")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load pending transactions")
             })?;
 
             let t_id = st.next_tx_id;
@@ -167,14 +167,14 @@ impl Actor {
 
             ptx.set(t_id.key(), txn.clone()).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to put transaction for propose",
                 )
             })?;
 
             st.pending_txs = ptx.flush().map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to flush pending transactions",
                 )
             })?;
@@ -203,7 +203,7 @@ impl Actor {
             }
 
             let ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to load pending transactions")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load pending transactions")
             })?;
 
             let txn = get_transaction(rt, &ptx, params.id, params.proposal_hash)?;
@@ -241,7 +241,7 @@ impl Actor {
             let mut ptx = make_map_with_root::<_, Transaction>(&st.pending_txs, rt.store())
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         "failed to load pending transactions",
                     )
                 })?;
@@ -250,7 +250,7 @@ impl Actor {
                 .delete(&params.id.key())
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         format!("failed to pop transaction {:?} for cancel", params.id),
                     )
                 })?
@@ -267,7 +267,7 @@ impl Actor {
 
             let calculated_hash = compute_proposal_hash(&tx, rt).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("failed to compute proposal hash for (tx: {:?})", params.id),
                 )
             })?;
@@ -278,7 +278,7 @@ impl Actor {
 
             st.pending_txs = ptx.flush().map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to flush pending transactions",
                 )
             })?;
@@ -297,7 +297,7 @@ impl Actor {
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let resolved_new_signer = resolve_to_id_addr(rt, &params.signer).map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 format!("failed to resolve address {}", params.signer),
             )
         })?;
@@ -338,7 +338,7 @@ impl Actor {
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let resolved_old_signer = resolve_to_id_addr(rt, &params.signer).map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 format!("failed to resolve address {}", params.signer),
             )
         })?;
@@ -376,7 +376,7 @@ impl Actor {
             // Remove approvals from removed signer
             st.purge_approvals(rt.store(), &resolved_old_signer).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to purge approvals of removed signer",
                 )
             })?;
@@ -398,13 +398,13 @@ impl Actor {
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let from_resolved = resolve_to_id_addr(rt, &params.from).map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 format!("failed to resolve address {}", params.from),
             )
         })?;
         let to_resolved = resolve_to_id_addr(rt, &params.to).map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 format!("failed to resolve address {}", params.to),
             )
         })?;
@@ -428,7 +428,7 @@ impl Actor {
 
             st.purge_approvals(rt.store(), &from_resolved).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to purge approvals of removed signer",
                 )
             })?;
@@ -513,7 +513,7 @@ impl Actor {
 
         let st = rt.transaction(|st: &mut State, rt| {
             let mut ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to load pending transactions")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load pending transactions")
             })?;
 
             // update approved on the transaction
@@ -521,14 +521,14 @@ impl Actor {
 
             ptx.set(tx_id.key(), txn.clone()).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("failed to put transaction {} for approval", tx_id.0),
                 )
             })?;
 
             st.pending_txs = ptx.flush().map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to flush pending transactions",
                 )
             })?;
@@ -553,7 +553,7 @@ where
     RT: Runtime<BS>,
 {
     let mut out = RawBytes::default();
-    let mut code = ExitCode::Ok;
+    let mut code = ExitCode::OK;
     let mut applied = false;
     let threshold_met = txn.approved.len() as u64 >= st.num_approvals_threshold;
     if threshold_met {
@@ -575,21 +575,21 @@ where
             let mut ptx = make_map_with_root::<_, Transaction>(&st.pending_txs, rt.store())
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         "failed to load pending transactions",
                     )
                 })?;
 
             ptx.delete(&txn_id.key()).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to delete transaction for cleanup",
                 )
             })?;
 
             st.pending_txs = ptx.flush().map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to flush pending transactions",
                 )
             })?;
@@ -614,7 +614,7 @@ where
         .get(&txn_id.key())
         .map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 format!("failed to load transaction {:?} for approval", txn_id),
             )
         })?
@@ -625,7 +625,7 @@ where
     if !proposal_hash.is_empty() {
         let calculated_hash = compute_proposal_hash(txn, rt).map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 format!("failed to compute proposal hash for (tx: {:?})", txn_id),
             )
         })?;
@@ -702,7 +702,7 @@ impl ActorCode for Actor {
                 Self::lock_balance(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            None => Err(actor_error!(SysErrInvalidMethod, "Invalid method")),
+            None => Err(actor_error!(ErrUnhandledMessage, "Invalid method")),
         }
     }
 }

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -160,7 +160,7 @@ fn test_add_signer() {
             increase: false,
             expect_signers: vec![anne, bob, chuck],
             expect_approvals: 3,
-            code: ExitCode::ErrForbidden,
+            code: ExitCode::USR_FORBIDDEN,
         },
         TestCase{
             desc: "fail to add signer with ID address that already exists even thugh we only have non ID address as approver",
@@ -171,7 +171,7 @@ fn test_add_signer() {
             increase:false,
             expect_signers: vec![anne, bob, chuck],
             expect_approvals: 3,
-            code: ExitCode::ErrForbidden,
+            code: ExitCode::USR_FORBIDDEN,
         },
         TestCase{
             desc: "fail to add signer with ID address that already exists even thugh we only have non ID address as approver",
@@ -182,7 +182,7 @@ fn test_add_signer() {
             increase:false,
             expect_signers: vec![anne, bob, chuck],
             expect_approvals: 3,
-            code: ExitCode::ErrForbidden,
+            code: ExitCode::USR_FORBIDDEN,
         }
     ];
 

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -36,7 +36,7 @@ fn test_construction_fail_to_construct_multisig_actor_with_0_signers() {
     rt.set_caller(*INIT_ACTOR_CODE_ID, *INIT_ACTOR_ADDR);
 
     expect_abort(
-        ExitCode::ErrIllegalArgument,
+        ExitCode::USR_ILLEGAL_ARGUMENT,
         rt.call::<MultisigActor>(
             Method::Constructor as u64,
             &RawBytes::serialize(&zero_signer_params).unwrap(),
@@ -64,7 +64,7 @@ fn test_construction_fail_to_construct_multisig_with_more_than_max_signers() {
     rt.expect_validate_caller_addr(vec![*INIT_ACTOR_ADDR]);
     rt.set_caller(*INIT_ACTOR_CODE_ID, *INIT_ACTOR_ADDR);
     expect_abort(
-        ExitCode::ErrIllegalArgument,
+        ExitCode::USR_ILLEGAL_ARGUMENT,
         rt.call::<MultisigActor>(
             Method::Constructor as u64,
             &RawBytes::serialize(&over_max_signers_params).unwrap(),
@@ -138,7 +138,7 @@ fn test_add_signer() {
             increase: false,
             expect_signers: vec![anne, bob, chuck],
             expect_approvals: 2,
-            code: ExitCode::Ok,
+            code: ExitCode::OK,
         },
         TestCase{
             desc: "add signer and increase threshold",
@@ -149,7 +149,7 @@ fn test_add_signer() {
             increase: true,
             expect_signers: vec![anne, bob, chuck],
             expect_approvals: 3,
-            code: ExitCode::Ok,
+            code: ExitCode::OK,
         },
         TestCase{
             desc: "fail to add signer that already exists",
@@ -197,7 +197,7 @@ fn test_add_signer() {
 
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
         match tc.code {
-            ExitCode::Ok => {
+            ExitCode::OK => {
                 let ret = h.add_signer(&mut rt, tc.add_signer, tc.increase).unwrap();
                 assert_eq!(RawBytes::default(), ret);
                 let st = rt.get_state::<State>().unwrap();
@@ -302,7 +302,7 @@ fn test_approve_simple_propose_and_approval() {
     // approval
     rt.set_balance(send_value.clone());
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
-    rt.expect_send(chuck, fake_method, fake_params, send_value, fake_ret, ExitCode::Ok);
+    rt.expect_send(chuck, fake_method, fake_params, send_value, fake_ret, ExitCode::OK);
     h.approve_ok(&mut rt, TxnID(0), proposal_hash);
     h.assert_transactions(&rt, vec![]);
 }
@@ -354,13 +354,13 @@ fn test_lock_balance_checks_preconditions() {
     // Disallow negative duration but allow negative start epoch
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
     expect_abort(
-        ExitCode::ErrIllegalArgument,
+        ExitCode::USR_ILLEGAL_ARGUMENT,
         h.lock_balance(&mut rt, vest_start, -1_i64, lock_amount),
     );
 
     // Disallow negative amount
     expect_abort(
-        ExitCode::ErrIllegalArgument,
+        ExitCode::USR_ILLEGAL_ARGUMENT,
         h.lock_balance(&mut rt, vest_start, vest_duration, TokenAmount::from(-1i32)),
     );
 }

--- a/actors/multisig/tests/util.rs
+++ b/actors/multisig/tests/util.rs
@@ -116,7 +116,7 @@ impl ActorHarness {
     ) -> RawBytes {
         let ret = self.approve(rt, txn_id, proposal_hash).unwrap();
         let approve_ret = ret.deserialize::<ApproveReturn>().unwrap();
-        assert_eq!(ExitCode::Ok, approve_ret.code);
+        assert_eq!(ExitCode::OK, approve_ret.code);
         approve_ret.ret
     }
 

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/paych/tests/paych_actor_test.rs
+++ b/actors/paych/tests/paych_actor_test.rs
@@ -128,7 +128,7 @@ mod paych_constructor {
             caller_code: *INIT_ACTOR_CODE_ID,
             new_actor_code: *MULTISIG_ACTOR_CODE_ID,
             payer_code: *ACCOUNT_ACTOR_CODE_ID,
-            expected_exit_code: ExitCode::ErrForbidden,
+            expected_exit_code: ExitCode::USR_FORBIDDEN,
         }];
 
         for test_case in test_cases {
@@ -637,12 +637,12 @@ mod update_channel_state_extra {
     #[test]
     #[ignore = "old functionality -- test framework needs to be updated"]
     fn extra_call_fail() {
-        let (mut rt, sv) = construct_runtime(ExitCode::ErrPlaceholder);
+        let (mut rt, sv) = construct_runtime(ExitCode::USR_UNSPECIFIED);
         expect_error(
             &mut rt,
             Method::UpdateChannelState as u64,
             &RawBytes::serialize(UpdateChannelStateParams::from(sv)).unwrap(),
-            ExitCode::ErrPlaceholder,
+            ExitCode::USR_UNSPECIFIED,
         );
         rt.verify();
     }
@@ -876,13 +876,13 @@ mod actor_collect {
             TestCase {
                 dont_settle: true,
                 exp_send_to: ExitCode::OK,
-                exp_collect_exit: ExitCode::ErrForbidden,
+                exp_collect_exit: ExitCode::USR_FORBIDDEN,
             },
             // fails if Failed to send funds to `To`
             TestCase {
                 dont_settle: false,
-                exp_send_to: ExitCode::ErrPlaceholder,
-                exp_collect_exit: ExitCode::ErrPlaceholder,
+                exp_send_to: ExitCode::USR_UNSPECIFIED,
+                exp_collect_exit: ExitCode::USR_UNSPECIFIED,
             },
         ];
 

--- a/actors/paych/tests/paych_actor_test.rs
+++ b/actors/paych/tests/paych_actor_test.rs
@@ -105,7 +105,7 @@ mod paych_constructor {
             &mut rt,
             METHOD_CONSTRUCTOR,
             &RawBytes::serialize(params).unwrap(),
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
         );
     }
 
@@ -198,7 +198,7 @@ mod create_lane_tests {
         sig: Option<Signature>,
         #[builder(default = "true")]
         verify_sig: bool,
-        #[builder(default = "ExitCode::ErrIllegalArgument")]
+        #[builder(default = "ExitCode::USR_ILLEGAL_ARGUMENT")]
         exp_exit_code: ExitCode,
     }
     impl TestCase {
@@ -220,7 +220,7 @@ mod create_lane_tests {
             TestCase::builder()
                 .desc("succeeds".to_string())
                 .sig(sig.clone())
-                .exp_exit_code(ExitCode::Ok)
+                .exp_exit_code(ExitCode::OK)
                 .build()
                 .unwrap(),
             TestCase::builder()
@@ -316,7 +316,7 @@ mod create_lane_tests {
                 });
             }
 
-            if test_case.exp_exit_code == ExitCode::Ok {
+            if test_case.exp_exit_code == ExitCode::OK {
                 call(
                     &mut rt,
                     Method::UpdateChannelState as u64,
@@ -513,28 +513,28 @@ mod merge_tests {
                 voucher: 10,
                 balance: 0,
                 merge: 1,
-                exit: ExitCode::ErrIllegalArgument,
+                exit: ExitCode::USR_ILLEGAL_ARGUMENT,
             },
             TestCase {
                 lane: 1,
                 voucher: 0,
                 balance: 0,
                 merge: 10,
-                exit: ExitCode::ErrIllegalArgument,
+                exit: ExitCode::USR_ILLEGAL_ARGUMENT,
             },
             TestCase {
                 lane: 1,
                 voucher: 10,
                 balance: 1,
                 merge: 10,
-                exit: ExitCode::ErrIllegalArgument,
+                exit: ExitCode::USR_ILLEGAL_ARGUMENT,
             },
             TestCase {
                 lane: 0,
                 voucher: 10,
                 balance: 0,
                 merge: 10,
-                exit: ExitCode::ErrIllegalArgument,
+                exit: ExitCode::USR_ILLEGAL_ARGUMENT,
             },
         ];
 
@@ -569,7 +569,7 @@ mod merge_tests {
             signer: Address::new_id(PAYEE_ID),
             result: Ok(()),
         });
-        failure_end(&mut rt, sv, ExitCode::ErrIllegalArgument);
+        failure_end(&mut rt, sv, ExitCode::USR_ILLEGAL_ARGUMENT);
     }
 
     #[test]
@@ -579,7 +579,7 @@ mod merge_tests {
         sv.lane = MAX_LANE + 1;
         sv.nonce += 1;
         sv.amount = BigInt::from(100);
-        failure_end(&mut rt, sv, ExitCode::ErrIllegalArgument);
+        failure_end(&mut rt, sv, ExitCode::USR_ILLEGAL_ARGUMENT);
     }
 }
 
@@ -625,7 +625,7 @@ mod update_channel_state_extra {
     #[test]
     #[ignore = "old functionality -- test framework needs to be updated"]
     fn extra_call_succeed() {
-        let (mut rt, sv) = construct_runtime(ExitCode::Ok);
+        let (mut rt, sv) = construct_runtime(ExitCode::OK);
         call(
             &mut rt,
             Method::UpdateChannelState as u64,
@@ -745,7 +745,7 @@ mod secret_preimage {
             &mut rt,
             Method::UpdateChannelState as u64,
             &RawBytes::serialize(ucp).unwrap(),
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
         );
 
         rt.verify();
@@ -786,7 +786,7 @@ mod actor_settle {
             &mut rt,
             Method::Settle as u64,
             &RawBytes::default(),
-            ExitCode::ErrIllegalState,
+            ExitCode::USR_ILLEGAL_STATE,
         );
     }
 
@@ -852,7 +852,7 @@ mod actor_collect {
             Default::default(),
             st.to_send.clone(),
             Default::default(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
 
         // Collect.
@@ -875,7 +875,7 @@ mod actor_collect {
             // fails if not settling with: payment channel not settling or settled
             TestCase {
                 dont_settle: true,
-                exp_send_to: ExitCode::Ok,
+                exp_send_to: ExitCode::OK,
                 exp_collect_exit: ExitCode::ErrForbidden,
             },
             // fails if Failed to send funds to `To`

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 fvm_ipld_hamt = "0.4.0"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 fvm_ipld_hamt = "0.4.0"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -140,7 +140,7 @@ impl Actor {
 
             st.update_stats_for_new_miner(window_post_proof_type).map_err(|e| {
                 actor_error!(
-                    ErrIllegalState,
+                    illegal_state,
                     "failed to update power stats for new miner {}: {}",
                     &id_address,
                     e
@@ -214,7 +214,7 @@ impl Actor {
         // Ensure it is not possible to enter a large negative number which would cause
         // problems in cron processing.
         if params.event_epoch < 0 {
-            return Err(actor_error!(ErrIllegalArgument;
+            return Err(actor_error!(illegal_argument;
                 "cron event epoch {} cannot be less than zero", params.event_epoch));
         }
 
@@ -297,7 +297,7 @@ impl Actor {
             st.add_pledge_total(pledge_delta);
             if st.total_pledge_collateral.is_negative() {
                 return Err(actor_error!(
-                    ErrIllegalState,
+                    illegal_state,
                     "negative total pledge collateral {}",
                     st.total_pledge_collateral
                 ));
@@ -345,7 +345,7 @@ impl Actor {
             })?;
             if let Some(arr) = arr {
                 if arr.count() >= MAX_MINER_PROVE_COMMITS_PER_EPOCH {
-                    return Err(ActorError::new_unchecked(
+                    return Err(ActorError::unchecked(
                         ERR_TOO_MANY_PROVE_COMMITS,
                         format!(
                             "miner {} attempting to prove commit over {} sectors in epoch",
@@ -695,7 +695,7 @@ impl ActorCode for Actor {
                 let res = Self::current_total_power(rt)?;
                 Ok(RawBytes::serialize(res)?)
             }
-            None => Err(actor_error!(ErrUnhandledMessage; "Invalid method")),
+            None => Err(actor_error!(unhandled_message; "Invalid method")),
         }
     }
 }

--- a/actors/power/src/state.rs
+++ b/actors/power/src/state.rs
@@ -82,7 +82,7 @@ impl State {
         let empty_mmap = Multimap::new(store, CRON_QUEUE_HAMT_BITWIDTH, CRON_QUEUE_AMT_BITWIDTH)
             .root()
             .map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "Failed to get empty multimap cid")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "Failed to get empty multimap cid")
             })?;
         Ok(State {
             cron_event_queue: empty_mmap,
@@ -267,11 +267,11 @@ impl State {
         BS: Blockstore,
     {
         let claims = make_map_with_root::<_, Claim>(&self.claims, store)
-            .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "failed to load claims"))?;
+            .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load claims"))?;
 
         if !claims
             .contains_key(&miner_addr.to_bytes())
-            .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "failed to look up claim"))?
+            .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to look up claim"))?
         {
             return Err(actor_error!(
                 ErrForbidden,
@@ -290,7 +290,7 @@ impl State {
         let claims =
             make_map_with_root_and_bitwidth::<_, Claim>(&self.claims, store, HAMT_BIT_WIDTH)
                 .map_err(|e| {
-                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load claims")
+                    e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load claims")
                 })?;
 
         let claim = get_claim(&claims, miner)?;

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -137,7 +137,7 @@ impl Harness {
             RawBytes::serialize(expected_init_params).unwrap(),
             value.clone(),
             RawBytes::serialize(create_miner_ret).unwrap(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
         let params = CreateMinerParams {
             owner: *owner,

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -258,7 +258,7 @@ impl ActorCode for Actor {
                 Self::update_network_kpi(rt, param.map(|v| v.0))?;
                 Ok(RawBytes::default())
             }
-            None => Err(actor_error!(SysErrInvalidMethod, "Invalid method")),
+            None => Err(actor_error!(ErrUnhandledMessage, "Invalid method")),
         }
     }
 }

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -66,7 +66,7 @@ impl Actor {
             rt.create(&State::new(power))?;
             Ok(())
         } else {
-            Err(actor_error!(ErrIllegalArgument, "argument should not be nil"))
+            Err(actor_error!(illegal_argument, "argument should not be nil"))
         }
     }
 
@@ -91,30 +91,30 @@ impl Actor {
         rt.validate_immediate_caller_is(std::iter::once(&*SYSTEM_ACTOR_ADDR))?;
         let prior_balance = rt.current_balance();
         if params.penalty.sign() == Sign::Minus {
-            return Err(actor_error!(ErrIllegalArgument, "negative penalty {}", params.penalty));
+            return Err(actor_error!(illegal_argument, "negative penalty {}", params.penalty));
         }
         if params.gas_reward.sign() == Sign::Minus {
             return Err(actor_error!(
-                ErrIllegalArgument,
+                illegal_argument,
                 "negative gas reward {}",
                 params.gas_reward
             ));
         }
         if prior_balance < params.gas_reward {
             return Err(actor_error!(
-                ErrIllegalState,
+                illegal_state,
                 "actor current balance {} insufficient to pay gas reward {}",
                 prior_balance,
                 params.gas_reward
             ));
         }
         if params.win_count <= 0 {
-            return Err(actor_error!(ErrIllegalArgument, "invalid win count {}", params.win_count));
+            return Err(actor_error!(illegal_argument, "invalid win count {}", params.win_count));
         }
 
         let miner_addr = rt
             .resolve_address(&params.miner)
-            .ok_or_else(|| actor_error!(ErrNotFound, "failed to resolve given owner address"))?;
+            .ok_or_else(|| actor_error!(not_found, "failed to resolve given owner address"))?;
 
         let penalty: TokenAmount = &params.penalty * PENALTY_MULTIPLIER;
 
@@ -133,7 +133,7 @@ impl Actor {
                 block_reward = &total_reward - &params.gas_reward;
                 if block_reward.is_negative() {
                     return Err(actor_error!(
-                        ErrIllegalState,
+                        illegal_state,
                         "programming error, block reward {} below zero",
                         block_reward
                     ));
@@ -147,7 +147,7 @@ impl Actor {
         // * as they treat panics as an exit code. Revisit this.
         if total_reward > prior_balance {
             return Err(actor_error!(
-                ErrIllegalState,
+                illegal_state,
                 "reward {} exceeds balance {}",
                 total_reward,
                 prior_balance
@@ -210,7 +210,7 @@ impl Actor {
     {
         rt.validate_immediate_caller_is(std::iter::once(&*STORAGE_POWER_ACTOR_ADDR))?;
         let curr_realized_power = curr_realized_power
-            .ok_or_else(|| actor_error!(ErrIllegalArgument, "argument cannot be None"))?;
+            .ok_or_else(|| actor_error!(illegal_argument, "argument cannot be None"))?;
 
         rt.transaction(|st: &mut State, rt| {
             let prev = st.epoch;
@@ -258,7 +258,7 @@ impl ActorCode for Actor {
                 Self::update_network_kpi(rt, param.map(|v| v.0))?;
                 Ok(RawBytes::default())
             }
-            None => Err(actor_error!(ErrUnhandledMessage, "Invalid method")),
+            None => Err(actor_error!(unhandled_message, "Invalid method")),
         }
     }
 }

--- a/actors/reward/tests/reward_actor_test.rs
+++ b/actors/reward/tests/reward_actor_test.rs
@@ -254,7 +254,7 @@ mod test_award_block_reward {
             RawBytes::serialize(BigIntSer(&expected_reward)).unwrap(),
             expected_reward.clone(),
             RawBytes::default(),
-            ExitCode::ErrForbidden,
+            ExitCode::USR_FORBIDDEN,
         );
         rt.expect_send(
             *BURNT_FUNDS_ACTOR_ADDR,

--- a/actors/reward/tests/reward_actor_test.rs
+++ b/actors/reward/tests/reward_actor_test.rs
@@ -87,7 +87,7 @@ mod test_award_block_reward {
         rt.set_balance(TokenAmount::from(9));
         rt.expect_validate_caller_addr(vec![*SYSTEM_ACTOR_ADDR]);
         assert_eq!(
-            ExitCode::ErrIllegalState,
+            ExitCode::USR_ILLEGAL_STATE,
             award_block_reward(
                 &mut rt,
                 *WINNER,
@@ -111,7 +111,7 @@ mod test_award_block_reward {
 
         for (reward, penalty) in &reward_penalty_pairs {
             assert_eq!(
-                ExitCode::ErrIllegalArgument,
+                ExitCode::USR_ILLEGAL_ARGUMENT,
                 award_block_reward(
                     &mut rt,
                     *WINNER,
@@ -179,7 +179,7 @@ mod test_award_block_reward {
             RawBytes::serialize(BigIntSer(&expected_reward)).unwrap(),
             expected_reward,
             RawBytes::default(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
         rt.expect_send(
             *BURNT_FUNDS_ACTOR_ADDR,
@@ -187,7 +187,7 @@ mod test_award_block_reward {
             RawBytes::default(),
             penalty.clone(),
             RawBytes::default(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
 
         let params = AwardBlockRewardParams {
@@ -262,7 +262,7 @@ mod test_award_block_reward {
             RawBytes::default(),
             expected_reward,
             RawBytes::default(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
 
         let params = AwardBlockRewardParams {
@@ -350,7 +350,7 @@ fn award_block_reward(
         .unwrap(),
         expected_payment.clone(),
         RawBytes::default(),
-        ExitCode::Ok,
+        ExitCode::OK,
     );
 
     if penalty > TokenAmount::from(0) {
@@ -360,7 +360,7 @@ fn award_block_reward(
             RawBytes::default(),
             expected_payment,
             RawBytes::default(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
     }
 

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 [dependencies]
 fvm_ipld_hamt = "0.4.0"
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -27,7 +27,7 @@ thiserror = "1.0.30"
 getrandom = { version = "0.2.5", features = ["js"] }
 hex = { version = "0.4.3", optional = true }
 anyhow = "1.0.56"
-fvm_sdk = { version = "0.4.0", optional = true }
+fvm_sdk = { version = "0.5.0", optional = true }
 blake2b_simd = "1.0"
 fvm_ipld_blockstore = { version = "0.1" }
 fvm_ipld_encoding = "0.1.0"

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 [dependencies]
 fvm_ipld_hamt = "0.4.0"
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/runtime/src/actor_error.rs
+++ b/actors/runtime/src/actor_error.rs
@@ -12,9 +12,6 @@ pub struct ActorError {
     msg: String,
 }
 
-// TODO: use symbolic constant for ErrAssertionFailed when it's defined.
-pub const EXIT_CODE_ERR_ASSERTION_FAILED: ExitCode = ExitCode::new(24);
-
 impl ActorError {
     /// Creates a new ActorError. This method does not check that the code is in the
     /// range of valid actor abort codes.
@@ -47,7 +44,7 @@ impl ActorError {
         Self { exit_code: ExitCode::USR_UNSPECIFIED, msg }
     }
     pub fn user_assertion_failed(msg: String) -> Self {
-        Self { exit_code: EXIT_CODE_ERR_ASSERTION_FAILED, msg }
+        Self { exit_code: ExitCode::USR_ASSERTION_FAILED, msg }
     }
 
     /// Returns the exit code of the error.

--- a/actors/runtime/src/actor_error.rs
+++ b/actors/runtime/src/actor_error.rs
@@ -12,6 +12,9 @@ pub struct ActorError {
     msg: String,
 }
 
+// TODO: use symbolic constant for ErrAssertionFailed when it's defined.
+pub const EXIT_CODE_ERR_ASSERTION_FAILED: ExitCode = ExitCode::new(24);
+
 impl ActorError {
     /// Creates a new ActorError. This method does not check that the code is in the
     /// range of valid actor abort codes.
@@ -44,8 +47,7 @@ impl ActorError {
         Self { exit_code: ExitCode::USR_UNSPECIFIED, msg }
     }
     pub fn user_assertion_failed(msg: String) -> Self {
-        // TODO: use symbolic constant for ErrAssertionFailed when it's defined.
-        Self { exit_code: ExitCode::from(24), msg }
+        Self { exit_code: EXIT_CODE_ERR_ASSERTION_FAILED, msg }
     }
 
     /// Returns the exit code of the error.

--- a/actors/runtime/src/actor_error.rs
+++ b/actors/runtime/src/actor_error.rs
@@ -1,30 +1,55 @@
 use fvm_shared::error::ExitCode;
 use thiserror::Error;
 
-/// TODO fix error system; actor errors should be transparent to the VM.
-/// The error type that gets returned by actor method calls.
+/// The error type returned by actor method calls.
 #[derive(Error, Debug, Clone, PartialEq)]
 #[error("ActorError(exit_code: {exit_code:?}, msg: {msg})")]
 pub struct ActorError {
-    /// The exit code for this invocation, must not be `0`.
+    /// The exit code for this invocation.
+    /// Codes less than `FIRST_ACTOR_EXIT_CODE` are prohibited and will be overwritten by the VM.
     exit_code: ExitCode,
     /// Message for debugging purposes,
     msg: String,
 }
 
 impl ActorError {
-    pub fn new(exit_code: ExitCode, msg: String) -> Self {
-        Self { exit_code, msg }
+    /// Creates a new ActorError. This method does not check that the code is in the
+    /// range of valid actor abort codes.
+    pub fn new_unchecked(code: ExitCode, msg: String) -> Self {
+        Self { exit_code: code, msg }
+    }
+
+    pub fn ErrIllegalArgument(msg: String) -> Self {
+        Self { exit_code: ExitCode::USR_ILLEGAL_ARGUMENT, msg }
+    }
+    pub fn ErrNotFound(msg: String) -> Self {
+        Self { exit_code: ExitCode::USR_NOT_FOUND, msg }
+    }
+    pub fn ErrForbidden(msg: String) -> Self {
+        Self { exit_code: ExitCode::USR_FORBIDDEN, msg }
+    }
+    pub fn ErrInsufficientFunds(msg: String) -> Self {
+        Self { exit_code: ExitCode::USR_INSUFFICIENT_FUNDS, msg }
+    }
+    pub fn ErrIllegalState(msg: String) -> Self {
+        Self { exit_code: ExitCode::USR_ILLEGAL_STATE, msg }
+    }
+    pub fn ErrSerialization(msg: String) -> Self {
+        Self { exit_code: ExitCode::USR_SERIALIZATION, msg }
+    }
+    pub fn ErrUnhandledMessage(msg: String) -> Self {
+        Self { exit_code: ExitCode::USR_UNHANDLED_MESSAGE, msg }
+    }
+    pub fn ErrUnspecified(msg: String) -> Self {
+        Self { exit_code: ExitCode::USR_UNSPECIFIED, msg }
+    }
+    pub fn ErrInternalSendAborted(msg: String) -> Self {
+        Self { exit_code: ExitCode::from(24), msg } // TODO use symbolic constant when it's defined.
     }
 
     /// Returns the exit code of the error.
     pub fn exit_code(&self) -> ExitCode {
         self.exit_code
-    }
-
-    /// Returns true when the exit code is `Ok`.
-    pub fn is_ok(&self) -> bool {
-        self.exit_code == ExitCode::Ok
     }
 
     /// Error message of the actor error.
@@ -42,7 +67,7 @@ impl ActorError {
 /// Converts a raw encoding error into an ErrSerialization.
 impl From<fvm_ipld_encoding::Error> for ActorError {
     fn from(e: fvm_ipld_encoding::Error) -> Self {
-        Self { exit_code: ExitCode::ErrSerialization, msg: e.to_string() }
+        Self { exit_code: ExitCode::USR_SERIALIZATION, msg: e.to_string() }
     }
 }
 
@@ -51,16 +76,7 @@ impl From<fvm_ipld_encoding::Error> for ActorError {
 #[cfg(feature = "fil-actor")]
 impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
     fn from(e: fvm_sdk::error::ActorDeleteError) -> Self {
-        use fvm_sdk::error::ActorDeleteError::*;
-        Self {
-            // FIXME: These shouldn't be "system" errors, but we're trying to match existing
-            // behavior here.
-            exit_code: match e {
-                BeneficiaryIsSelf => ExitCode::SysErrIllegalActor,
-                BeneficiaryDoesNotExist => ExitCode::SysErrIllegalArgument,
-            },
-            msg: e.to_string(),
-        }
+        Self { exit_code: ExitCode::USR_ILLEGAL_ARGUMENT, msg: e.to_string() }
     }
 }
 
@@ -69,32 +85,27 @@ impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
 #[cfg(feature = "fil-actor")]
 impl From<fvm_sdk::error::NoStateError> for ActorError {
     fn from(e: fvm_sdk::error::NoStateError) -> Self {
-        Self {
-            // FIXME: These shouldn't be "system" errors, but we're trying to match existing
-            // behavior here.
-            exit_code: ExitCode::SysErrIllegalActor,
-            msg: e.to_string(),
-        }
+        Self { exit_code: ExitCode::USR_ILLEGAL_STATE, msg: e.to_string() }
     }
 }
 
 /// Performs conversions from SyscallResult, whose error type is ExitCode,
 /// to ActorErrors. This facilitates propagation.
-impl From<ExitCode> for ActorError {
-    fn from(e: ExitCode) -> Self {
-        ActorError { exit_code: e, msg: "".to_string() }
-    }
-}
+// impl From<ExitCode> for ActorError {
+//     fn from(e: ExitCode) -> Self {
+//         ActorError { exit_code: e, msg: "".to_string() }
+//     }
+// }
 
 /// Convenience macro for generating Actor Errors
 #[macro_export]
 macro_rules! actor_error {
     // Error with only one stringable expression
-    ( $code:ident; $msg:expr ) => { $crate::ActorError::new(fvm_shared::error::ExitCode::$code, $msg.to_string()) };
+    ( $code:ident; $msg:expr ) => { $crate::ActorError::$code($msg.to_string()) };
 
     // String with positional arguments
     ( $code:ident; $msg:literal $(, $ex:expr)+ ) => {
-        $crate::ActorError::new(fvm_shared::error::ExitCode::$code, format!($msg, $($ex,)*))
+        $crate::ActorError::$code(format!($msg, $($ex,)*))
     };
 
     // Error with only one stringable expression, with comma separator

--- a/actors/runtime/src/actor_error.rs
+++ b/actors/runtime/src/actor_error.rs
@@ -15,36 +15,37 @@ pub struct ActorError {
 impl ActorError {
     /// Creates a new ActorError. This method does not check that the code is in the
     /// range of valid actor abort codes.
-    pub fn new_unchecked(code: ExitCode, msg: String) -> Self {
+    pub fn unchecked(code: ExitCode, msg: String) -> Self {
         Self { exit_code: code, msg }
     }
 
-    pub fn ErrIllegalArgument(msg: String) -> Self {
+    pub fn illegal_argument(msg: String) -> Self {
         Self { exit_code: ExitCode::USR_ILLEGAL_ARGUMENT, msg }
     }
-    pub fn ErrNotFound(msg: String) -> Self {
+    pub fn not_found(msg: String) -> Self {
         Self { exit_code: ExitCode::USR_NOT_FOUND, msg }
     }
-    pub fn ErrForbidden(msg: String) -> Self {
+    pub fn forbidden(msg: String) -> Self {
         Self { exit_code: ExitCode::USR_FORBIDDEN, msg }
     }
-    pub fn ErrInsufficientFunds(msg: String) -> Self {
+    pub fn insufficient_funds(msg: String) -> Self {
         Self { exit_code: ExitCode::USR_INSUFFICIENT_FUNDS, msg }
     }
-    pub fn ErrIllegalState(msg: String) -> Self {
+    pub fn illegal_state(msg: String) -> Self {
         Self { exit_code: ExitCode::USR_ILLEGAL_STATE, msg }
     }
-    pub fn ErrSerialization(msg: String) -> Self {
+    pub fn serialization(msg: String) -> Self {
         Self { exit_code: ExitCode::USR_SERIALIZATION, msg }
     }
-    pub fn ErrUnhandledMessage(msg: String) -> Self {
+    pub fn unhandled_message(msg: String) -> Self {
         Self { exit_code: ExitCode::USR_UNHANDLED_MESSAGE, msg }
     }
-    pub fn ErrUnspecified(msg: String) -> Self {
+    pub fn unspecified(msg: String) -> Self {
         Self { exit_code: ExitCode::USR_UNSPECIFIED, msg }
     }
-    pub fn ErrInternalSendAborted(msg: String) -> Self {
-        Self { exit_code: ExitCode::from(24), msg } // TODO use symbolic constant when it's defined.
+    pub fn internal_send_aborted(msg: String) -> Self {
+        // TODO use symbolic constant for USR_SEND_ABORTED when it's defined.
+        Self { exit_code: ExitCode::from(24), msg }
     }
 
     /// Returns the exit code of the error.
@@ -88,14 +89,6 @@ impl From<fvm_sdk::error::NoStateError> for ActorError {
         Self { exit_code: ExitCode::USR_ILLEGAL_STATE, msg: e.to_string() }
     }
 }
-
-/// Performs conversions from SyscallResult, whose error type is ExitCode,
-/// to ActorErrors. This facilitates propagation.
-// impl From<ExitCode> for ActorError {
-//     fn from(e: ExitCode) -> Self {
-//         ActorError { exit_code: e, msg: "".to_string() }
-//     }
-// }
 
 /// Convenience macro for generating Actor Errors
 #[macro_export]

--- a/actors/runtime/src/actor_error.rs
+++ b/actors/runtime/src/actor_error.rs
@@ -43,8 +43,8 @@ impl ActorError {
     pub fn unspecified(msg: String) -> Self {
         Self { exit_code: ExitCode::USR_UNSPECIFIED, msg }
     }
-    pub fn internal_send_aborted(msg: String) -> Self {
-        // TODO use symbolic constant for USR_SEND_ABORTED when it's defined.
+    pub fn user_assertion_failed(msg: String) -> Self {
+        // TODO: use symbolic constant for ErrAssertionFailed when it's defined.
         Self { exit_code: ExitCode::from(24), msg }
     }
 

--- a/actors/runtime/src/runtime/actor_blockstore.rs
+++ b/actors/runtime/src/runtime/actor_blockstore.rs
@@ -19,17 +19,16 @@ impl fvm_ipld_blockstore::Blockstore for ActorBlockstore {
     fn get(&self, cid: &Cid) -> Result<Option<Vec<u8>>> {
         // If this fails, the _CID_ is invalid. I.e., we have a bug.
         fvm::ipld::get(cid).map(Some).map_err(|c| {
-            actor_error!(ErrIllegalState; "get failed with {:?} on CID '{}'", c, cid).into()
+            actor_error!(illegal_state; "get failed with {:?} on CID '{}'", c, cid).into()
         })
     }
 
     fn put_keyed(&self, k: &Cid, block: &[u8]) -> Result<()> {
         let code = Code::try_from(k.hash().code())
-            .map_err(|e| actor_error!(ErrSerialization, e.to_string()))?;
+            .map_err(|e| actor_error!(serialization, e.to_string()))?;
         let k2 = self.put(code, &Block::new(k.codec(), block))?;
         if k != &k2 {
-            Err(actor_error!(ErrSerialization; "put block with cid {} but has cid {}", k, k2)
-                .into())
+            Err(actor_error!(serialization; "put block with cid {} but has cid {}", k, k2).into())
         } else {
             Ok(())
         }
@@ -43,7 +42,7 @@ impl fvm_ipld_blockstore::Blockstore for ActorBlockstore {
         //  codec at the moment.
         const SIZE: u32 = 32;
         let k = fvm::ipld::put(code.into(), SIZE, block.codec, block.data.as_ref())
-            .map_err(|c| actor_error!(ErrIllegalState; "put failed with {:?}", c))?;
+            .map_err(|c| actor_error!(illegal_state; "put failed with {:?}", c))?;
         Ok(k)
     }
 }

--- a/actors/runtime/src/runtime/fvm.rs
+++ b/actors/runtime/src/runtime/fvm.rs
@@ -271,12 +271,23 @@ where
                     // The returned code can't be simply propagated as it may be a system exit code.
                     // TODO: improve propagation once we return a RuntimeError.
                     // Ref https://github.com/filecoin-project/builtin-actors/issues/144
-                    Err(actor_error!(
-                        user_assertion_failed,
+                    let exit_code = match ret.exit_code {
+                        // This means the called actor did something wrong. We can't "make up" a
+                        // reasonable exit code.
+                        ExitCode::SYS_MISSING_RETURN
+                        | ExitCode::SYS_ILLEGAL_INSTRUCTION
+                        | ExitCode::SYS_ILLEGAL_EXIT_CODE => ExitCode::USR_UNSPECIFIED,
+                        // We don't expect any other system errors.
+                        code if code.is_system_error() => ExitCode::USR_ASSERTION_FAILED,
+                        // Otherwise, pass it through.
+                        code => code,
+                    };
+                    Err(ActorError::unchecked(
+                        exit_code,
                         format!(
                             "send to {} method {} aborted with code {}",
                             to, method, ret.exit_code
-                        )
+                        ),
                     ))
                 }
             }

--- a/actors/runtime/src/runtime/fvm.rs
+++ b/actors/runtime/src/runtime/fvm.rs
@@ -11,7 +11,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::randomness::DomainSeparationTag;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::error::ErrorNumber;
+use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::Randomness;
 use fvm_shared::sector::{
@@ -23,7 +23,7 @@ use fvm_shared::{ActorID, MethodNum};
 
 use crate::runtime::actor_blockstore::ActorBlockstore;
 use crate::runtime::{ActorCode, ConsensusFault, MessageInfo, Policy, RuntimePolicy, Syscalls};
-use crate::{actor_error, ActorError, Runtime, EXIT_CODE_ERR_ASSERTION_FAILED};
+use crate::{actor_error, ActorError, Runtime};
 
 lazy_static! {
     /// Cid of the empty array Cbor bytes (`EMPTY_ARR_BYTES`).
@@ -449,7 +449,7 @@ pub fn trampoline<C: ActorCode>(params: u32) -> u32 {
     // We do this after handling the error, because the actor may have encountered an error before
     // it even could validate the caller.
     if !rt.caller_validated {
-        fvm::vm::abort(EXIT_CODE_ERR_ASSERTION_FAILED.value(), Some("failed to validate caller"))
+        fvm::vm::abort(ExitCode::USR_ASSERTION_FAILED.value(), Some("failed to validate caller"))
     }
 
     // Then handle the return value.

--- a/actors/runtime/src/runtime/fvm.rs
+++ b/actors/runtime/src/runtime/fvm.rs
@@ -60,7 +60,7 @@ impl<B> FvmRuntime<B> {
     fn assert_not_validated(&mut self) -> Result<(), ActorError> {
         if self.caller_validated {
             return Err(actor_error!(
-                ErrUnspecified, // FIXME is this the right one?
+                unspecified, // FIXME is this the right one?
                 "Method must validate caller identity exactly once"
             ));
         }
@@ -121,7 +121,7 @@ where
         if addresses.into_iter().any(|a| *a == caller_addr) {
             Ok(())
         } else {
-            return Err(actor_error!(ErrForbidden;
+            return Err(actor_error!(forbidden;
                 "caller {} is not one of supported", caller_addr
             ));
         }
@@ -140,7 +140,7 @@ where
 
         match self.resolve_builtin_actor_type(&caller_cid) {
             Some(typ) if types.into_iter().any(|t| *t == typ) => Ok(()),
-            _ => Err(actor_error!(ErrForbidden;
+            _ => Err(actor_error!(forbidden;
                     "caller cid type {} not one of supported", caller_cid)),
         }
     }
@@ -179,7 +179,7 @@ where
         // unexpected bad value to the syscall).
         fvm::rand::get_chain_randomness(personalization, rand_epoch, entropy).map_err(|e| match e {
             ErrorNumber::LimitExceeded => {
-                actor_error!(ErrIllegalArgument; "randomness lookback exceeded: {}", e)
+                actor_error!(illegal_argument; "randomness lookback exceeded: {}", e)
             }
             e => panic!("get chain randomness failed with an unexpected error: {}", e),
         })
@@ -195,7 +195,7 @@ where
         fvm::rand::get_beacon_randomness(personalization, rand_epoch, entropy).map_err(
             |e| match e {
                 ErrorNumber::LimitExceeded => {
-                    actor_error!(ErrIllegalArgument; "randomness lookback exceeded: {}", e)
+                    actor_error!(illegal_argument; "randomness lookback exceeded: {}", e)
                 }
                 e => panic!("get chain randomness failed with an unexpected error: {}", e),
             },
@@ -206,11 +206,11 @@ where
         let root = fvm::sself::root()?;
         if root != *EMPTY_ARR_CID {
             return Err(
-                actor_error!(ErrIllegalState; "failed to create state; expected empty array CID, got: {}", root),
+                actor_error!(illegal_state; "failed to create state; expected empty array CID, got: {}", root),
             );
         }
         let new_root = ActorBlockstore.put_cbor(obj, Code::Blake2b256)
-            .map_err(|e| actor_error!(ErrIllegalArgument; "failed to write actor state during creation: {}", e.to_string()))?;
+            .map_err(|e| actor_error!(illegal_argument; "failed to write actor state during creation: {}", e.to_string()))?;
         fvm::sself::set_root(&new_root)?;
         Ok(())
     }
@@ -219,9 +219,7 @@ where
         let root = fvm::sself::root()?;
         Ok(ActorBlockstore
             .get_cbor(&root)
-            .map_err(
-                |_| actor_error!(ErrIllegalArgument; "failed to get actor for Readonly state"),
-            )?
+            .map_err(|_| actor_error!(illegal_argument; "failed to get actor for Readonly state"))?
             .expect("State does not exist for actor state root"))
     }
 
@@ -231,13 +229,13 @@ where
         F: FnOnce(&mut C, &mut Self) -> Result<RT, ActorError>,
     {
         let state_cid = fvm::sself::root()
-            .map_err(|_| actor_error!(ErrIllegalArgument; "failed to get actor root state CID"))?;
+            .map_err(|_| actor_error!(illegal_argument; "failed to get actor root state CID"))?;
 
         log::debug!("getting cid: {}", state_cid);
 
         let mut state = ActorBlockstore
             .get_cbor::<C>(&state_cid)
-            .map_err(|_| actor_error!(ErrIllegalArgument; "failed to get actor state"))?
+            .map_err(|_| actor_error!(illegal_argument; "failed to get actor state"))?
             .expect("State does not exist for actor state root");
 
         self.in_transaction = true;
@@ -246,7 +244,7 @@ where
 
         let ret = result?;
         let new_root = ActorBlockstore.put_cbor(&state, Code::Blake2b256)
-            .map_err(|e| actor_error!(ErrIllegalArgument; "failed to write actor state in transaction: {}", e.to_string()))?;
+            .map_err(|e| actor_error!(illegal_argument; "failed to write actor state in transaction: {}", e.to_string()))?;
         fvm::sself::set_root(&new_root)?;
         Ok(ret)
     }
@@ -263,7 +261,7 @@ where
         value: TokenAmount,
     ) -> Result<RawBytes, ActorError> {
         if self.in_transaction {
-            return Err(actor_error!(ErrUnspecified; "runtime.send() is not allowed"));
+            return Err(actor_error!(unspecified; "runtime.send() is not allowed"));
         }
         match fvm::send::send(&to, method, params, value) {
             Ok(ret) => {
@@ -271,7 +269,7 @@ where
                     Ok(ret.return_data)
                 } else {
                     // The returned code can't be simply propagated as it may be a system exit code.
-                    Err(ActorError::ErrInternalSendAborted(format!(
+                    Err(ActorError::internal_send_aborted(format!(
                         "send to {} method {} aborted with code {}",
                         to, method, ret.exit_code
                     )))
@@ -284,7 +282,7 @@ where
                     // How do we know the receiver is what triggered this?
                     // An error number doesn't carry enough information at this level
                     // above the raw syscall (and even then).
-                    actor_error!(ErrNotFound; "receiver not found")
+                    actor_error!(not_found; "receiver not found")
                 }
                 ErrorNumber::InsufficientFunds => {
                     // Actually this is more like an illegal argument where the caller attempted
@@ -292,10 +290,10 @@ where
                     // token amount type. Yes, the caller doesn't have that amount, but if they'd
                     // attempted to transfer a representable amount it would fail with
                     // SYS_INSUFFICIENT_FUNDS instead, so this difference is wierd.
-                    actor_error!(ErrInsufficientFunds; "not enough funds")
+                    actor_error!(insufficient_funds; "not enough funds")
                 }
                 err => {
-                    actor_error!(ErrUnspecified; "unexpected error: {}", err)
+                    actor_error!(unspecified; "unexpected error: {}", err)
                 }
             }),
         }
@@ -308,7 +306,7 @@ where
     fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {
         fvm::actor::create_actor(actor_id, &code_id).map_err(|e| match e {
             ErrorNumber::IllegalArgument => {
-                ActorError::ErrIllegalArgument("failed to create actor".into())
+                ActorError::illegal_argument("failed to create actor".into())
             }
             _ => panic!("create failed with unknown error: {}", e),
         })

--- a/actors/runtime/src/runtime/mod.rs
+++ b/actors/runtime/src/runtime/mod.rs
@@ -20,9 +20,8 @@ use fvm_shared::sector::{
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum};
 
-use crate::ActorError;
-
 pub use self::actor_code::*;
+use crate::{ActorError};
 pub use self::policy::*;
 
 mod actor_code;

--- a/actors/runtime/src/runtime/mod.rs
+++ b/actors/runtime/src/runtime/mod.rs
@@ -21,8 +21,8 @@ use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum};
 
 pub use self::actor_code::*;
-use crate::{ActorError};
 pub use self::policy::*;
+use crate::ActorError;
 
 mod actor_code;
 

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -785,7 +785,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
         F: FnOnce(&mut C, &mut Self) -> Result<RT, ActorError>,
     {
         if self.in_transaction {
-            return Err(actor_error!(unspecified; "nested transaction"));
+            return Err(actor_error!(user_assertion_failed; "nested transaction"));
         }
         let mut read_only = self.state()?;
         self.in_transaction = true;
@@ -810,7 +810,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
     ) -> Result<RawBytes, ActorError> {
         self.require_in_call();
         if self.in_transaction {
-            return Err(actor_error!(unspecified; "side-effect within transaction"));
+            return Err(actor_error!(user_assertion_failed; "side-effect within transaction"));
         }
 
         assert!(
@@ -855,7 +855,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
     fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {
         self.require_in_call();
         if self.in_transaction {
-            return Err(actor_error!(unspecified; "side-effect within transaction"));
+            return Err(actor_error!(user_assertion_failed; "side-effect within transaction"));
         }
         let expect_create_actor = self
             .expectations
@@ -871,7 +871,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
     fn delete_actor(&mut self, addr: &Address) -> Result<(), ActorError> {
         self.require_in_call();
         if self.in_transaction {
-            return Err(actor_error!(unspecified; "side-effect within transaction"));
+            return Err(actor_error!(user_assertion_failed; "side-effect within transaction"));
         }
         let exp_act = self.expectations.borrow_mut().expect_delete_actor.take();
         if exp_act.is_none() {

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -841,7 +841,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
 
         match expected_msg.exit_code {
             ExitCode::OK => Ok(expected_msg.send_return),
-            x => Err(ActorError::new_unchecked(x, "Expected message Fail".to_string())),
+            x => Err(ActorError::unchecked(x, "Expected message Fail".to_string())),
         }
     }
 
@@ -965,51 +965,64 @@ impl Syscalls for MockRuntime {
     ) -> anyhow::Result<Cid> {
         let exp =
             self.expectations.borrow_mut().expect_compute_unsealed_sector_cid.take().ok_or_else(
-                || actor_error!(ErrIllegalState; "Unexpected syscall to ComputeUnsealedSectorCID"),
+                || actor_error!(illegal_state; "Unexpected syscall to ComputeUnsealedSectorCID"),
             )?;
 
         if exp.reg != reg {
-            return Err(anyhow!(actor_error!(ErrIllegalState;
+            return Err(anyhow!(actor_error!(illegal_state;
                 "Unexpected compute_unsealed_sector_cid : reg mismatch"
             )));
         }
 
         if exp.pieces[..].eq(pieces) {
-            return Err(anyhow!(actor_error!(ErrIllegalState;
+            return Err(anyhow!(actor_error!(illegal_state;
                 "Unexpected compute_unsealed_sector_cid : pieces mismatch"
             )));
         }
 
         if exp.exit_code != ExitCode::OK {
-            return Err(anyhow!(ActorError::new_unchecked(exp.exit_code, "Expected Failure".to_string(),)));
+            return Err(anyhow!(ActorError::unchecked(
+                exp.exit_code,
+                "Expected Failure".to_string(),
+            )));
         }
         Ok(exp.cid)
     }
     fn verify_seal(&self, seal: &SealVerifyInfo) -> anyhow::Result<()> {
-        let exp =
-            self.expectations.borrow_mut().expect_verify_seal.take().ok_or_else(
-                || actor_error!(ErrIllegalState; "Unexpected syscall to verify seal"),
-            )?;
+        let exp = self
+            .expectations
+            .borrow_mut()
+            .expect_verify_seal
+            .take()
+            .ok_or_else(|| actor_error!(illegal_state; "Unexpected syscall to verify seal"))?;
 
         if exp.seal != *seal {
-            return Err(anyhow!(actor_error!(ErrIllegalState; "Unexpected seal verification"),));
+            return Err(anyhow!(actor_error!(illegal_state; "Unexpected seal verification"),));
         }
         if exp.exit_code != ExitCode::OK {
-            return Err(anyhow!(ActorError::new_unchecked(exp.exit_code, "Expected Failure".to_string(),)));
+            return Err(anyhow!(ActorError::unchecked(
+                exp.exit_code,
+                "Expected Failure".to_string(),
+            )));
         }
         Ok(())
     }
     fn verify_post(&self, post: &WindowPoStVerifyInfo) -> anyhow::Result<()> {
-        let exp =
-            self.expectations.borrow_mut().expect_verify_post.take().ok_or_else(
-                || actor_error!(ErrIllegalState; "Unexpected syscall to verify PoSt"),
-            )?;
+        let exp = self
+            .expectations
+            .borrow_mut()
+            .expect_verify_post
+            .take()
+            .ok_or_else(|| actor_error!(illegal_state; "Unexpected syscall to verify PoSt"))?;
 
         if exp.post != *post {
-            return Err(anyhow!(actor_error!(ErrIllegalState; "Unexpected PoSt verification"),));
+            return Err(anyhow!(actor_error!(illegal_state; "Unexpected PoSt verification"),));
         }
         if exp.exit_code != ExitCode::OK {
-            return Err(anyhow!(ActorError::new_unchecked(exp.exit_code, "Expected Failure".to_string(),)));
+            return Err(anyhow!(ActorError::unchecked(
+                exp.exit_code,
+                "Expected Failure".to_string(),
+            )));
         }
         Ok(())
     }
@@ -1020,21 +1033,24 @@ impl Syscalls for MockRuntime {
         extra: &[u8],
     ) -> anyhow::Result<Option<ConsensusFault>> {
         let exp = self.expectations.borrow_mut().expect_verify_consensus_fault.take().ok_or_else(
-            || actor_error!(ErrIllegalState; "Unexpected syscall to verify_consensus_fault"),
+            || actor_error!(illegal_state; "Unexpected syscall to verify_consensus_fault"),
         )?;
         if exp.require_correct_input {
             if exp.block_header_1 != h1 {
-                return Err(anyhow!(actor_error!(ErrIllegalState; "Header 1 mismatch")));
+                return Err(anyhow!(actor_error!(illegal_state; "Header 1 mismatch")));
             }
             if exp.block_header_2 != h2 {
-                return Err(anyhow!(actor_error!(ErrIllegalState; "Header 2 mismatch")));
+                return Err(anyhow!(actor_error!(illegal_state; "Header 2 mismatch")));
             }
             if exp.block_header_extra != extra {
-                return Err(anyhow!(actor_error!(ErrIllegalState; "Header extra mismatch"),));
+                return Err(anyhow!(actor_error!(illegal_state; "Header extra mismatch"),));
             }
         }
         if exp.exit_code != ExitCode::OK {
-            return Err(anyhow!(ActorError::new_unchecked(exp.exit_code, "Expected Failure".to_string(),)));
+            return Err(anyhow!(ActorError::unchecked(
+                exp.exit_code,
+                "Expected Failure".to_string(),
+            )));
         }
         Ok(exp.fault)
     }

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -840,8 +840,8 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
         }
 
         match expected_msg.exit_code {
-            ExitCode::Ok => Ok(expected_msg.send_return),
-            x => Err(ActorError::new(x, "Expected message Fail".to_string())),
+            ExitCode::OK => Ok(expected_msg.send_return),
+            x => Err(ActorError::new_unchecked(x, "Expected message Fail".to_string())),
         }
     }
 
@@ -980,8 +980,8 @@ impl Syscalls for MockRuntime {
             )));
         }
 
-        if exp.exit_code != ExitCode::Ok {
-            return Err(anyhow!(ActorError::new(exp.exit_code, "Expected Failure".to_string(),)));
+        if exp.exit_code != ExitCode::OK {
+            return Err(anyhow!(ActorError::new_unchecked(exp.exit_code, "Expected Failure".to_string(),)));
         }
         Ok(exp.cid)
     }
@@ -994,8 +994,8 @@ impl Syscalls for MockRuntime {
         if exp.seal != *seal {
             return Err(anyhow!(actor_error!(ErrIllegalState; "Unexpected seal verification"),));
         }
-        if exp.exit_code != ExitCode::Ok {
-            return Err(anyhow!(ActorError::new(exp.exit_code, "Expected Failure".to_string(),)));
+        if exp.exit_code != ExitCode::OK {
+            return Err(anyhow!(ActorError::new_unchecked(exp.exit_code, "Expected Failure".to_string(),)));
         }
         Ok(())
     }
@@ -1008,8 +1008,8 @@ impl Syscalls for MockRuntime {
         if exp.post != *post {
             return Err(anyhow!(actor_error!(ErrIllegalState; "Unexpected PoSt verification"),));
         }
-        if exp.exit_code != ExitCode::Ok {
-            return Err(anyhow!(ActorError::new(exp.exit_code, "Expected Failure".to_string(),)));
+        if exp.exit_code != ExitCode::OK {
+            return Err(anyhow!(ActorError::new_unchecked(exp.exit_code, "Expected Failure".to_string(),)));
         }
         Ok(())
     }
@@ -1033,8 +1033,8 @@ impl Syscalls for MockRuntime {
                 return Err(anyhow!(actor_error!(ErrIllegalState; "Header extra mismatch"),));
             }
         }
-        if exp.exit_code != ExitCode::Ok {
-            return Err(anyhow!(ActorError::new(exp.exit_code, "Expected Failure".to_string(),)));
+        if exp.exit_code != ExitCode::OK {
+            return Err(anyhow!(ActorError::new_unchecked(exp.exit_code, "Expected Failure".to_string(),)));
         }
         Ok(exp.fault)
     }

--- a/actors/runtime/src/util/cbor.rs
+++ b/actors/runtime/src/util/cbor.rs
@@ -1,7 +1,7 @@
 use fvm_ipld_encoding::{to_vec, RawBytes};
 use serde::{de, ser};
 
-use crate::{ActorError};
+use crate::ActorError;
 
 /// Serializes a structure as a CBOR vector of bytes, returning a serialization error on failure.
 /// `desc` is a noun phrase for the object being serialized, included in any error message.
@@ -9,9 +9,8 @@ pub fn serialize_vec<T>(value: &T, desc: &str) -> Result<Vec<u8>, ActorError>
 where
     T: ser::Serialize + ?Sized,
 {
-    to_vec(value).map_err(|e| {
-        ActorError::ErrSerialization(format!("failed to serialize {}: {}", desc, e))
-    })
+    to_vec(value)
+        .map_err(|e| ActorError::serialization(format!("failed to serialize {}: {}", desc, e)))
 }
 
 /// Serializes a structure as CBOR bytes, returning a serialization error on failure.
@@ -26,9 +25,8 @@ where
 /// Deserialises CBOR-encoded bytes as a structure, returning a serialization error on failure.
 /// `desc` is a noun phrase for the object being deserialized, included in any error message.
 pub fn deserialize<O: de::DeserializeOwned>(v: &RawBytes, desc: &str) -> Result<O, ActorError> {
-    v.deserialize().map_err(|e| {
-        ActorError::ErrSerialization(format!("failed to deserialize {}: {}", desc, e))
-    })
+    v.deserialize()
+        .map_err(|e| ActorError::serialization(format!("failed to deserialize {}: {}", desc, e)))
 }
 
 /// Deserialises CBOR-encoded bytes as a method parameters object.

--- a/actors/runtime/src/util/cbor.rs
+++ b/actors/runtime/src/util/cbor.rs
@@ -1,8 +1,7 @@
 use fvm_ipld_encoding::{to_vec, RawBytes};
-use fvm_shared::error::ExitCode;
 use serde::{de, ser};
 
-use crate::ActorError;
+use crate::{ActorError};
 
 /// Serializes a structure as a CBOR vector of bytes, returning a serialization error on failure.
 /// `desc` is a noun phrase for the object being serialized, included in any error message.
@@ -11,7 +10,7 @@ where
     T: ser::Serialize + ?Sized,
 {
     to_vec(value).map_err(|e| {
-        ActorError::new(ExitCode::ErrSerialization, format!("failed to serialize {}: {}", desc, e))
+        ActorError::ErrSerialization(format!("failed to serialize {}: {}", desc, e))
     })
 }
 
@@ -28,10 +27,7 @@ where
 /// `desc` is a noun phrase for the object being deserialized, included in any error message.
 pub fn deserialize<O: de::DeserializeOwned>(v: &RawBytes, desc: &str) -> Result<O, ActorError> {
     v.deserialize().map_err(|e| {
-        ActorError::new(
-            ExitCode::ErrSerialization,
-            format!("failed to deserialize {}: {}", desc, e),
-        )
+        ActorError::ErrSerialization(format!("failed to deserialize {}: {}", desc, e))
     })
 }
 

--- a/actors/runtime/src/util/chaos/mod.rs
+++ b/actors/runtime/src/util/chaos/mod.rs
@@ -60,7 +60,7 @@ impl Actor {
         if let Err(e) = result {
             Ok(SendReturn { return_value: RawBytes::default(), code: e.exit_code() })
         } else {
-            Ok(SendReturn { return_value: result.unwrap(), code: ExitCode::Ok })
+            Ok(SendReturn { return_value: result.unwrap(), code: ExitCode::OK })
         }
     }
 
@@ -172,7 +172,7 @@ impl Actor {
         if arg.uncontrolled {
             panic!("Uncontrolled abort/error");
         }
-        Err(ActorError::new(arg.code, arg.message))
+        Err(ActorError::new_unchecked(arg.code, arg.message))
     }
 
     pub fn inspect_runtime<BS, RT>(rt: &mut RT) -> Result<InspectRuntimeReturn, ActorError>
@@ -246,7 +246,7 @@ impl ActorCode for Actor {
                 Ok(RawBytes::serialize(inspect)?)
             }
 
-            None => Err(actor_error!(SysErrInvalidMethod; "Invalid method")),
+            None => Err(actor_error!(ErrUnhandledMessage; "Invalid method")),
         }
     }
 }

--- a/actors/runtime/src/util/chaos/mod.rs
+++ b/actors/runtime/src/util/chaos/mod.rs
@@ -164,7 +164,7 @@ impl Actor {
                 Ok(())
             }),
 
-            _ => Err(actor_error!(ErrIllegalArgument; "Invalid mutate state command given" )),
+            _ => Err(actor_error!(illegal_argument; "Invalid mutate state command given" )),
         }
     }
 
@@ -172,7 +172,7 @@ impl Actor {
         if arg.uncontrolled {
             panic!("Uncontrolled abort/error");
         }
-        Err(ActorError::new_unchecked(arg.code, arg.message))
+        Err(ActorError::unchecked(arg.code, arg.message))
     }
 
     pub fn inspect_runtime<BS, RT>(rt: &mut RT) -> Result<InspectRuntimeReturn, ActorError>
@@ -246,7 +246,7 @@ impl ActorCode for Actor {
                 Ok(RawBytes::serialize(inspect)?)
             }
 
-            None => Err(actor_error!(ErrUnhandledMessage; "Invalid method")),
+            None => Err(actor_error!(unhandled_message; "Invalid method")),
         }
     }
 }

--- a/actors/runtime/src/util/downcast.rs
+++ b/actors/runtime/src/util/downcast.rs
@@ -7,7 +7,7 @@ use fvm_ipld_encoding::Error as EncodingError;
 use fvm_ipld_hamt::Error as HamtError;
 use fvm_shared::error::ExitCode;
 
-use crate::{ActorError};
+use crate::ActorError;
 
 /// Trait to allow multiple error types to be able to be downcasted into an `ActorError`.
 pub trait ActorDowncast {
@@ -24,7 +24,7 @@ impl ActorDowncast for anyhow::Error {
         match downcast_util(self) {
             Ok(actor_error) => actor_error.wrap(msg),
             Err(other) => {
-                ActorError::new_unchecked(default_exit_code, format!("{}: {}", msg.as_ref(), other))
+                ActorError::unchecked(default_exit_code, format!("{}: {}", msg.as_ref(), other))
             }
         }
     }
@@ -40,7 +40,9 @@ impl ActorDowncast for AmtError {
     fn downcast_default(self, default_exit_code: ExitCode, msg: impl AsRef<str>) -> ActorError {
         match self {
             AmtError::Dynamic(e) => e.downcast_default(default_exit_code, msg),
-            other => ActorError::new_unchecked(default_exit_code, format!("{}: {}", msg.as_ref(), other)),
+            other => {
+                ActorError::unchecked(default_exit_code, format!("{}: {}", msg.as_ref(), other))
+            }
         }
     }
     fn downcast_wrap(self, msg: impl AsRef<str>) -> anyhow::Error {
@@ -55,7 +57,9 @@ impl ActorDowncast for HamtError {
     fn downcast_default(self, default_exit_code: ExitCode, msg: impl AsRef<str>) -> ActorError {
         match self {
             HamtError::Dynamic(e) => e.downcast_default(default_exit_code, msg),
-            other => ActorError::new_unchecked(default_exit_code, format!("{}: {}", msg.as_ref(), other)),
+            other => {
+                ActorError::unchecked(default_exit_code, format!("{}: {}", msg.as_ref(), other))
+            }
         }
     }
     fn downcast_wrap(self, msg: impl AsRef<str>) -> anyhow::Error {
@@ -79,7 +83,7 @@ fn downcast_util(error: anyhow::Error) -> anyhow::Result<ActorError> {
     // Check if error is Encoding error, if so return `ErrSerialization`
     let error = match error.downcast::<EncodingError>() {
         Ok(enc_error) => {
-            return Ok(ActorError::new_unchecked(ExitCode::USR_SERIALIZATION, enc_error.to_string()))
+            return Ok(ActorError::unchecked(ExitCode::USR_SERIALIZATION, enc_error.to_string()))
         }
         Err(other) => other,
     };

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 fvm_ipld_encoding = "0.1.0"
 fvm_ipld_blockstore = { version = "0.1.0" }
 num-traits = "0.2.14"

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 fvm_ipld_encoding = "0.1.0"
 fvm_ipld_blockstore = { version = "0.1.0" }
 num-traits = "0.2.14"

--- a/actors/system/src/lib.rs
+++ b/actors/system/src/lib.rs
@@ -61,7 +61,7 @@ impl Actor {
             .store()
             .put_cbor(&Vec::<(String, Cid)>::new(), multihash::Code::Blake2b256)
             .map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to construct state")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to construct state")
             })?;
 
         rt.create(&State { builtin_actors: c })?;
@@ -84,7 +84,7 @@ impl ActorCode for Actor {
                 Self::constructor(rt)?;
                 Ok(RawBytes::default())
             }
-            None => Err(actor_error!(SysErrInvalidMethod; "Invalid method")),
+            None => Err(actor_error!(ErrUnhandledMessage; "Invalid method")),
         }
     }
 }

--- a/actors/system/src/lib.rs
+++ b/actors/system/src/lib.rs
@@ -84,7 +84,7 @@ impl ActorCode for Actor {
                 Self::constructor(rt)?;
                 Ok(RawBytes::default())
             }
-            None => Err(actor_error!(ErrUnhandledMessage; "Invalid method")),
+            None => Err(actor_error!(unhandled_message; "Invalid method")),
         }
     }
 }

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -56,7 +56,7 @@ impl Actor {
             .ok_or_else(|| actor_error!(ErrIllegalArgument, "root should be an ID address"))?;
 
         let st = State::new(rt.store(), id_addr).map_err(|e| {
-            e.downcast_default(ExitCode::ErrIllegalState, "Failed to create verifreg state")
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "Failed to create verifreg state")
         })?;
 
         rt.create(&st)?;
@@ -79,7 +79,7 @@ impl Actor {
 
         let verifier = resolve_to_id_addr(rt, &params.address).map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 format!("failed to resolve addr {} to ID addr", params.address),
             )
         })?;
@@ -96,7 +96,7 @@ impl Actor {
                 make_map_with_root_and_bitwidth(&st.verifiers, rt.store(), HAMT_BIT_WIDTH)
                     .map_err(|e| {
                         e.downcast_default(
-                            ExitCode::ErrIllegalState,
+                            ExitCode::USR_ILLEGAL_STATE,
                             "failed to load verified clients",
                         )
                     })?;
@@ -106,12 +106,12 @@ impl Actor {
                 HAMT_BIT_WIDTH,
             )
             .map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load verified clients")
             })?;
 
             let found = verified_clients.contains_key(&verifier.to_bytes()).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("failed to get client state for {}", verifier),
                 )
             })?;
@@ -124,10 +124,10 @@ impl Actor {
             }
 
             verifiers.set(verifier.to_bytes().into(), BigIntDe(params.allowance.clone())).map_err(
-                |e| e.downcast_default(ExitCode::ErrIllegalState, "failed to add verifier"),
+                |e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to add verifier"),
             )?;
             st.verifiers = verifiers.flush().map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verifiers")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to flush verifiers")
             })?;
 
             Ok(())
@@ -143,7 +143,7 @@ impl Actor {
     {
         let verifier = resolve_to_id_addr(rt, &verifier_addr).map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 format!("failed to resolve addr {} to ID addr", verifier_addr),
             )
         })?;
@@ -158,19 +158,19 @@ impl Actor {
                 HAMT_BIT_WIDTH,
             )
             .map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load verified clients")
             })?;
             verifiers
                 .delete(&verifier.to_bytes())
                 .map_err(|e| {
-                    e.downcast_default(ExitCode::ErrIllegalState, "failed to remove verifier")
+                    e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to remove verifier")
                 })?
                 .ok_or_else(|| {
                     actor_error!(ErrIllegalArgument, "failed to remove verifier: not found")
                 })?;
 
             st.verifiers = verifiers.flush().map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verifiers")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to flush verifiers")
             })?;
             Ok(())
         })?;
@@ -200,7 +200,7 @@ impl Actor {
 
         let client = resolve_to_id_addr(rt, &params.address).map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 format!("failed to resolve addr {} to ID addr", params.address),
             )
         })?;
@@ -215,14 +215,14 @@ impl Actor {
                 make_map_with_root_and_bitwidth(&st.verifiers, rt.store(), HAMT_BIT_WIDTH)
                     .map_err(|e| {
                         e.downcast_default(
-                            ExitCode::ErrIllegalState,
+                            ExitCode::USR_ILLEGAL_STATE,
                             "failed to load verified clients",
                         )
                     })?;
             let mut verified_clients =
                 make_map_with_root_and_bitwidth(&st.verified_clients, rt.store(), HAMT_BIT_WIDTH)
                     .map_err(|e| {
-                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+                    e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load verified clients")
                 })?;
 
             // Validate caller is one of the verifiers.
@@ -231,7 +231,7 @@ impl Actor {
                 .get(&verifier.to_bytes())
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         format!("failed to get Verifier {}", verifier),
                     )
                 })?
@@ -241,7 +241,7 @@ impl Actor {
 
             // Validate client to be added isn't a verifier
             let found = verifiers.contains_key(&client.to_bytes()).map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to get verifier")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get verifier")
             })?;
             if found {
                 return Err(actor_error!(
@@ -264,14 +264,14 @@ impl Actor {
 
             verifiers.set(verifier.to_bytes().into(), BigIntDe(new_verifier_cap)).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("Failed to update new verifier cap for {}", verifier),
                 )
             })?;
 
             let client_cap = verified_clients.get(&client.to_bytes()).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("Failed to get verified client {}", client),
                 )
             })?;
@@ -286,7 +286,7 @@ impl Actor {
             verified_clients.set(client.to_bytes().into(), BigIntDe(client_cap.clone())).map_err(
                 |e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         format!(
                             "Failed to add verified client {} with cap {}",
                             client, client_cap,
@@ -296,10 +296,10 @@ impl Actor {
             )?;
 
             st.verifiers = verifiers.flush().map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verifiers")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to flush verifiers")
             })?;
             st.verified_clients = verified_clients.flush().map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verified clients")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to flush verified clients")
             })?;
 
             Ok(())
@@ -320,7 +320,7 @@ impl Actor {
 
         let client = resolve_to_id_addr(rt, &params.address).map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 format!("failed to resolve addr {} to ID addr", params.address),
             )
         })?;
@@ -337,14 +337,14 @@ impl Actor {
             let mut verified_clients =
                 make_map_with_root_and_bitwidth(&st.verified_clients, rt.store(), HAMT_BIT_WIDTH)
                     .map_err(|e| {
-                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+                    e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load verified clients")
                 })?;
 
             let BigIntDe(vc_cap) = verified_clients
                 .get(&client.to_bytes())
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         format!("failed to get verified client {}", &client),
                     )
                 })?
@@ -376,7 +376,7 @@ impl Actor {
                     .delete(&client.to_bytes())
                     .map_err(|e| {
                         e.downcast_default(
-                            ExitCode::ErrIllegalState,
+                            ExitCode::USR_ILLEGAL_STATE,
                             format!("Failed to delete verified client {}", client),
                         )
                     })?
@@ -391,7 +391,7 @@ impl Actor {
                 verified_clients.set(client.to_bytes().into(), BigIntDe(new_vc_cap)).map_err(
                     |e| {
                         e.downcast_default(
-                            ExitCode::ErrIllegalState,
+                            ExitCode::USR_ILLEGAL_STATE,
                             format!("Failed to update verified client {}", client),
                         )
                     },
@@ -399,7 +399,7 @@ impl Actor {
             }
 
             st.verified_clients = verified_clients.flush().map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verified clients")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to flush verified clients")
             })?;
             Ok(())
         })?;
@@ -425,7 +425,7 @@ impl Actor {
 
         let client = resolve_to_id_addr(rt, &params.address).map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalState,
+                ExitCode::USR_ILLEGAL_STATE,
                 format!("failed to resolve addr {} to ID addr", params.address),
             )
         })?;
@@ -439,7 +439,7 @@ impl Actor {
             let mut verified_clients =
                 make_map_with_root_and_bitwidth(&st.verified_clients, rt.store(), HAMT_BIT_WIDTH)
                     .map_err(|e| {
-                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+                    e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load verified clients")
                 })?;
             let verifiers = make_map_with_root_and_bitwidth::<_, BigIntDe>(
                 &st.verifiers,
@@ -447,12 +447,12 @@ impl Actor {
                 HAMT_BIT_WIDTH,
             )
             .map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to load verifiers")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load verifiers")
             })?;
 
             // validate we are NOT attempting to do this for a verifier
             let found = verifiers.contains_key(&client.to_bytes()).map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to get verifier")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get verifier")
             })?;
             if found {
                 return Err(actor_error!(
@@ -467,7 +467,7 @@ impl Actor {
                 .get(&client.to_bytes())
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         format!("failed to get verified client {}", &client),
                     )
                 })?
@@ -478,13 +478,13 @@ impl Actor {
             let new_vc_cap = vc_cap + &params.deal_size;
             verified_clients.set(client.to_bytes().into(), BigIntDe(new_vc_cap)).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     format!("Failed to put verified client {}", client),
                 )
             })?;
 
             st.verified_clients = verified_clients.flush().map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verified clients")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to flush verified clients")
             })?;
             Ok(())
         })?;
@@ -503,7 +503,7 @@ impl Actor {
     {
         let client = resolve_to_id_addr(rt, &params.verified_client_to_remove).map_err(|e| {
             e.downcast_default(
-                ExitCode::ErrIllegalArgument,
+                ExitCode::USR_ILLEGAL_ARGUMENT,
                 format!(
                     "failed to resolve client addr {} to ID addr",
                     params.verified_client_to_remove
@@ -514,7 +514,7 @@ impl Actor {
         let verifier_1 =
             resolve_to_id_addr(rt, &params.verifier_request_1.verifier).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalArgument,
+                    ExitCode::USR_ILLEGAL_ARGUMENT,
                     format!(
                         "failed to resolve verifier addr {} to ID addr",
                         params.verifier_request_1.verifier
@@ -525,7 +525,7 @@ impl Actor {
         let verifier_2 =
             resolve_to_id_addr(rt, &params.verifier_request_2.verifier).map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalArgument,
+                    ExitCode::USR_ILLEGAL_ARGUMENT,
                     format!(
                         "failed to resolve verifier addr {} to ID addr",
                         params.verifier_request_2.verifier
@@ -551,7 +551,7 @@ impl Actor {
                 HAMT_BIT_WIDTH,
             )
             .map_err(|e| {
-                e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load verified clients")
             })?;
 
             // check that `client` is currently a verified client
@@ -564,7 +564,7 @@ impl Actor {
                 .get(&client.to_bytes())
                 .map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         format!("failed to get verified client {}", &client),
                     )
                 })?
@@ -589,7 +589,7 @@ impl Actor {
             )
             .map_err(|e| {
                 e.downcast_default(
-                    ExitCode::ErrIllegalState,
+                    ExitCode::USR_ILLEGAL_STATE,
                     "failed to load datacap removal proposal ids",
                 )
             })?;
@@ -617,7 +617,7 @@ impl Actor {
                 // no DataCap remaining, delete verified client
                 verified_clients.delete(&client.to_bytes()).map_err(|e| {
                     e.downcast_default(
-                        ExitCode::ErrIllegalState,
+                        ExitCode::USR_ILLEGAL_STATE,
                         format!("failed to delete verified client {}", &client),
                     )
                 })?;
@@ -628,7 +628,7 @@ impl Actor {
                     .set(BytesKey::from(client.to_bytes()), BigIntDe(new_data_cap))
                     .map_err(|e| {
                         e.downcast_default(
-                            ExitCode::ErrIllegalState,
+                            ExitCode::USR_ILLEGAL_STATE,
                             format!("failed to update datacap for verified client {}", &client),
                         )
                     })?;
@@ -670,13 +670,13 @@ where
         HAMT_BIT_WIDTH,
     )
     .map_err(|e| {
-        e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+        e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load verified clients")
     })?;
 
     // check that the `address` is currently a verified client
     let found = verified_clients
         .contains_key(&address.to_bytes())
-        .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "failed to get verifier"))?;
+        .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get verifier"))?;
 
     Ok(found)
 }
@@ -788,7 +788,7 @@ impl ActorCode for Actor {
                 Self::remove_verified_client_data_cap(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            None => Err(actor_error!(SysErrInvalidMethod; "Invalid method")),
+            None => Err(actor_error!(ErrUnhandledMessage; "Invalid method")),
         }
     }
 }

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -54,7 +54,7 @@ mod construction {
 
         rt.expect_validate_caller_addr(vec![*SYSTEM_ACTOR_ADDR]);
         expect_abort(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             rt.call::<VerifregActor>(
                 Method::Constructor as MethodNum,
                 &RawBytes::serialize(root_pubkey).unwrap(),
@@ -101,7 +101,7 @@ mod verifiers {
     fn add_verifier_enforces_min_size() {
         let (h, mut rt) = new_harness();
         let allowance = MINIMUM_VERIFIED_DEAL_SIZE.clone() - 1;
-        expect_abort(ExitCode::ErrIllegalArgument, h.add_verifier(&mut rt, &VERIFIER, &allowance));
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.add_verifier(&mut rt, &VERIFIER, &allowance));
         h.check_state();
     }
 
@@ -109,7 +109,7 @@ mod verifiers {
     fn add_verifier_rejects_root() {
         let (h, mut rt) = new_harness();
         expect_abort(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_verifier(&mut rt, &ROOT_ADDR, &VERIFIER_ALLOWANCE),
         );
         h.check_state();
@@ -126,7 +126,7 @@ mod verifiers {
             &VERIFIER_ALLOWANCE,
         );
         expect_abort(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_verifier(&mut rt, &CLIENT, &VERIFIER_ALLOWANCE),
         );
         h.check_state();
@@ -144,10 +144,10 @@ mod verifiers {
             RawBytes::default(),
             TokenAmount::default(),
             RawBytes::default(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
         expect_abort(
-            ExitCode::ErrIllegalState,
+            ExitCode::USR_ILLEGAL_STATE,
             h.add_verifier(&mut rt, &verifier_key_address, &VERIFIER_ALLOWANCE),
         );
         h.check_state();
@@ -192,7 +192,7 @@ mod verifiers {
     #[test]
     fn remove_requires_verifier_exists() {
         let (h, mut rt) = new_harness();
-        expect_abort(ExitCode::ErrIllegalArgument, h.remove_verifier(&mut rt, &VERIFIER));
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.remove_verifier(&mut rt, &VERIFIER));
         h.check_state();
     }
 
@@ -265,7 +265,7 @@ mod clients {
 
         h.add_client(&mut rt, &VERIFIER, &CLIENT, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE).unwrap();
         expect_abort(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&mut rt, &VERIFIER, &CLIENT2, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE),
         );
 
@@ -318,11 +318,11 @@ mod clients {
             RawBytes::default(),
             TokenAmount::default(),
             RawBytes::default(),
-            ExitCode::Ok,
+            ExitCode::OK,
         );
 
         expect_abort(
-            ExitCode::ErrIllegalState,
+            ExitCode::USR_ILLEGAL_STATE,
             h.add_client(&mut rt, &VERIFIER, &client, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE),
         );
         h.check_state();
@@ -335,7 +335,7 @@ mod clients {
 
         let allowance = MINIMUM_VERIFIED_DEAL_SIZE.clone() - 1;
         expect_abort(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&mut rt, &VERIFIER, &CLIENT, &allowance, &allowance),
         );
         h.check_state();
@@ -368,7 +368,7 @@ mod clients {
 
         let allowance = VERIFIER_ALLOWANCE.clone() + 1;
         expect_abort(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&mut rt, &VERIFIER, &h.root, &allowance, &allowance),
         );
         h.check_state();
@@ -379,7 +379,7 @@ mod clients {
         let (h, mut rt) = new_harness();
         h.add_verifier(&mut rt, &VERIFIER, &VERIFIER_ALLOWANCE).unwrap();
         expect_abort(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&mut rt, &VERIFIER, &h.root, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE),
         );
         h.check_state();
@@ -390,13 +390,13 @@ mod clients {
         let (h, mut rt) = new_harness();
         h.add_verifier(&mut rt, &VERIFIER, &VERIFIER_ALLOWANCE).unwrap();
         expect_abort(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&mut rt, &VERIFIER, &VERIFIER, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE),
         );
 
         h.add_verifier(&mut rt, &VERIFIER2, &VERIFIER_ALLOWANCE).unwrap();
         expect_abort(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&mut rt, &VERIFIER, &VERIFIER2, &CLIENT_ALLOWANCE, &CLIENT_ALLOWANCE),
         );
 
@@ -466,7 +466,7 @@ mod datacap {
 
         // Attempt to use more than remaining.
         let deal_size = MINIMUM_VERIFIED_DEAL_SIZE.clone() + 2;
-        expect_abort(ExitCode::ErrIllegalArgument, h.use_bytes(&mut rt, &CLIENT, &deal_size));
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.use_bytes(&mut rt, &CLIENT, &deal_size));
         h.check_state()
     }
 
@@ -525,7 +525,7 @@ mod datacap {
         );
 
         let deal_size = MINIMUM_VERIFIED_DEAL_SIZE.clone() - 1;
-        expect_abort(ExitCode::ErrIllegalArgument, h.use_bytes(&mut rt, &CLIENT, &deal_size));
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.use_bytes(&mut rt, &CLIENT, &deal_size));
         h.check_state()
     }
 
@@ -551,7 +551,7 @@ mod datacap {
         );
 
         let deal_size = CLIENT_ALLOWANCE.clone() + 1;
-        expect_abort(ExitCode::ErrIllegalArgument, h.use_bytes(&mut rt, &CLIENT, &deal_size));
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.use_bytes(&mut rt, &CLIENT, &deal_size));
         h.check_state()
     }
 
@@ -679,7 +679,7 @@ mod datacap {
         );
 
         let deal_size = MINIMUM_VERIFIED_DEAL_SIZE.clone() - 1;
-        expect_abort(ExitCode::ErrIllegalArgument, h.restore_bytes(&mut rt, &CLIENT, &deal_size));
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.restore_bytes(&mut rt, &CLIENT, &deal_size));
         h.check_state()
     }
 
@@ -688,7 +688,7 @@ mod datacap {
         let (h, mut rt) = new_harness();
         let deal_size = MINIMUM_VERIFIED_DEAL_SIZE.clone();
         expect_abort(
-            ExitCode::ErrIllegalArgument,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
             h.restore_bytes(&mut rt, &ROOT_ADDR, &deal_size),
         );
         h.check_state()
@@ -699,7 +699,7 @@ mod datacap {
         let (h, mut rt) = new_harness();
         h.add_verifier(&mut rt, &VERIFIER, &VERIFIER_ALLOWANCE).unwrap();
         let deal_size = MINIMUM_VERIFIED_DEAL_SIZE.clone();
-        expect_abort(ExitCode::ErrIllegalArgument, h.restore_bytes(&mut rt, &VERIFIER, &deal_size));
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.restore_bytes(&mut rt, &VERIFIER, &deal_size));
         h.check_state()
     }
 }

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -88,7 +88,7 @@ mod verifiers {
             allowance: VERIFIER_ALLOWANCE.clone(),
         };
         expect_abort(
-            ExitCode::SysErrForbidden,
+            ExitCode::USR_FORBIDDEN,
             rt.call::<VerifregActor>(
                 Method::AddVerifier as MethodNum,
                 &RawBytes::serialize(params).unwrap(),
@@ -183,7 +183,7 @@ mod verifiers {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, caller);
         assert_ne!(h.root, caller);
         expect_abort(
-            ExitCode::SysErrForbidden,
+            ExitCode::USR_FORBIDDEN,
             rt.call::<VerifregActor>(
                 Method::RemoveVerifier as MethodNum,
                 &RawBytes::serialize(*VERIFIER).unwrap(),
@@ -355,7 +355,7 @@ mod clients {
         let params =
             AddVerifierClientParams { address: *CLIENT, allowance: CLIENT_ALLOWANCE.clone() };
         expect_abort(
-            ExitCode::ErrNotFound,
+            ExitCode::USR_NOT_FOUND,
             rt.call::<VerifregActor>(
                 Method::AddVerifiedClient as MethodNum,
                 &RawBytes::serialize(params).unwrap(),
@@ -495,7 +495,7 @@ mod datacap {
         // Use full allowance.
         h.use_bytes(&mut rt, &CLIENT, &allowance).unwrap();
         // Fail to use any more because client was removed.
-        expect_abort(ExitCode::ErrNotFound, h.use_bytes(&mut rt, &CLIENT, &allowance));
+        expect_abort(ExitCode::USR_NOT_FOUND, h.use_bytes(&mut rt, &CLIENT, &allowance));
         h.check_state()
     }
 
@@ -507,7 +507,7 @@ mod datacap {
         let params =
             UseBytesParams { address: *CLIENT, deal_size: MINIMUM_VERIFIED_DEAL_SIZE.clone() };
         expect_abort(
-            ExitCode::SysErrForbidden,
+            ExitCode::USR_FORBIDDEN,
             rt.call::<VerifregActor>(
                 Method::UseBytes as MethodNum,
                 &RawBytes::serialize(params).unwrap(),
@@ -536,7 +536,7 @@ mod datacap {
     fn consume_requires_client_exists() {
         let (h, mut rt) = new_harness();
         expect_abort(
-            ExitCode::ErrNotFound,
+            ExitCode::USR_NOT_FOUND,
             h.use_bytes(&mut rt, &CLIENT, &MINIMUM_VERIFIED_DEAL_SIZE),
         );
         h.check_state()
@@ -661,7 +661,7 @@ mod datacap {
         let params =
             RestoreBytesParams { address: *CLIENT, deal_size: MINIMUM_VERIFIED_DEAL_SIZE.clone() };
         expect_abort(
-            ExitCode::SysErrForbidden,
+            ExitCode::USR_FORBIDDEN,
             rt.call::<VerifregActor>(
                 Method::RestoreBytes as MethodNum,
                 &RawBytes::serialize(params).unwrap(),

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -101,7 +101,10 @@ mod verifiers {
     fn add_verifier_enforces_min_size() {
         let (h, mut rt) = new_harness();
         let allowance = MINIMUM_VERIFIED_DEAL_SIZE.clone() - 1;
-        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.add_verifier(&mut rt, &VERIFIER, &allowance));
+        expect_abort(
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            h.add_verifier(&mut rt, &VERIFIER, &allowance),
+        );
         h.check_state();
     }
 
@@ -699,7 +702,10 @@ mod datacap {
         let (h, mut rt) = new_harness();
         h.add_verifier(&mut rt, &VERIFIER, &VERIFIER_ALLOWANCE).unwrap();
         let deal_size = MINIMUM_VERIFIED_DEAL_SIZE.clone();
-        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.restore_bytes(&mut rt, &VERIFIER, &deal_size));
+        expect_abort(
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            h.restore_bytes(&mut rt, &VERIFIER, &deal_size),
+        );
         h.check_state()
     }
 }

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["filecoin", "web3", "wasm"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../actors/runtime" }
-fvm_shared = { version = "0.4.0", default-features = false }
+fvm_shared = { version = "0.4.1", default-features = false }
 fvm_ipld_encoding = { version = "0.1.0", default-features = false }
 fvm_ipld_blockstore = { version = "0.1.0", default-features = false }
 fvm_ipld_hamt = "0.4.0"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["filecoin", "web3", "wasm"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../actors/runtime" }
-fvm_shared = { version = "0.4.1", default-features = false }
+fvm_shared = { version = "0.5.1", default-features = false }
 fvm_ipld_encoding = { version = "0.1.0", default-features = false }
 fvm_ipld_blockstore = { version = "0.1.0", default-features = false }
 fvm_ipld_hamt = "0.4.0"


### PR DESCRIPTION
Updates all uses of the FVM's `ExitCode` type to the new one that will be released in the next crates. Updates to use the codes defined in the [spec](https://github.com/filecoin-project/fvm-specs/blob/main/07-errors.md).

Changes `ActorError`, the type used to propagate abort codes to the trampoline, to make it easier to construct common ones and a bit harder to accidentally attempt to exit with a system exit code. As part of this, introduces exit code 24 for "internal send failed", because the exit code of the internal send may be a system exit code and can't be propagated by the caller.

It's going to be painful, but please do review each change in exit code (or at least those that used to be `SysErrXxx`). There are many places where I've now had to replace a system exit code with a user exit code. The tests all pass locally, but I am somewhat surprised at that.

- [ ] Depend on new `fvm_shared` crates before merging.

FYI @dignifiedquire 