### PR TITLE
add workflow to upload bundle from CI to estuary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,17 @@ jobs:
       with:
         command: ${{ matrix.command }}
         args: ${{ matrix.args }}
-    - name: making bundle
+    - name: make bundle
       if: ${{ matrix.command == 'build' }}
       run: ./build-bundle.sh
-    - name: Publishing build artifacts
+    - name: upload bundle
+      if: ${{ matrix.command == 'build' }}
+      env:
+        ESTUARY_TOKEN: ${{ secrets.ESTUARY_TOKEN }}
+      run: ./upload-bundle.sh
+    - name: Publishing build artifacts to github
       if: ${{ matrix.command == 'build' }}
       uses: actions/upload-artifact@v2
       with:
         name: bundle
-        path: output/builtin-actors.car
+        path: output/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,4 +86,6 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: bundle
-        path: output/*
+        path: |
+         output/builtin-actors.car
+         output/upload.json

--- a/upload-bundle.sh
+++ b/upload-bundle.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+bundle=output/builtin-actors.car
+curl -k -X POST -F "data=@${bundle};type=application/octet-stream;filename=\"${bundle}\"" -H "Authorization: Bearer $ESTUARY_TOKEN" -H "Content-Type: multipart/form-data" https://shuttle-4.estuary.tech/content/add > output/upload.json
+cat output/upload.json


### PR DESCRIPTION
Notice the -k in the curl invocation; estuary's certificates have expired.
We'll have to fix that once the certs have been renewed.