### PR TITLE
ActorBlockstore: assert that blake2-256 is used as multihash.

### DIFF
--- a/actors/runtime/src/runtime/actor_blockstore.rs
+++ b/actors/runtime/src/runtime/actor_blockstore.rs
@@ -39,8 +39,8 @@ impl fvm_ipld_blockstore::Blockstore for ActorBlockstore {
     where
         D: AsRef<[u8]>,
     {
-        // TODO: Don't hard-code the size. Unfortunately, there's no good way to get it from the
-        //  codec at the moment.
+        // See https://github.com/filecoin-project/builtin-actors/issues/207.
+        assert_eq!(code, Code::Blake2b256);
         const SIZE: u32 = 32;
         let k = fvm::ipld::put(code.into(), SIZE, block.codec, block.data.as_ref())
             .map_err(|c| actor_error!(ErrIllegalState; "put failed with {:?}", c))?;


### PR DESCRIPTION
We use blake2-256 with 32-byte hashes (i.e. full size hashes) in builtin-actors code. Due to API limitations (see #207) we cannot reliably get the full digest size from the multihash code. So we use a pass a 32 bytes as a constant over the syscall, but this only works because we use blake2-256 and nothing else. This PR adds an assertion here for extra safety.