### PR TITLE
feat: call the abort syscall on panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,8 @@ members = [
 
 [profile.wasm]
 inherits = "release"
-panic = "abort"
+# This needs to be unwind, not abort, so that we can handle panics within our panic hook.
+panic = "unwind"
 overflow-checks = true
 lto = "thin"
 opt-level = "z"

--- a/actors/runtime/src/runtime/fvm.rs
+++ b/actors/runtime/src/runtime/fvm.rs
@@ -447,6 +447,10 @@ where
 pub fn trampoline<C: ActorCode>(params: u32) -> u32 {
     fvm::debug::init_logging();
 
+    std::panic::set_hook(Box::new(|info| {
+        fvm::vm::abort(ExitCode::USR_ASSERTION_FAILED.value(), Some(&format!("{}", info)))
+    }));
+
     let method = fvm::message::method_number();
     log::debug!("fetching parameters block: {}", params);
     let params = fvm::message::params_raw(params).expect("params block invalid").1;


### PR DESCRIPTION
Ideally, we'd be able to inject a full-on custom panic _handler_ instead of adding a hook (smaller build). But we can't do that and also use the standard library.