### PR TITLE
Fix typo in paych unit test.

### DIFF
--- a/actors/paych/tests/paych_actor_test.rs
+++ b/actors/paych/tests/paych_actor_test.rs
@@ -244,7 +244,7 @@ mod create_lane_tests {
                         .to_string(),
                 )
                 .payment_channel(paych_non_id)
-                .exp_exit_code(ExitCode::Ok)
+                .exp_exit_code(ExitCode::OK)
                 .sig(sig.clone())
                 .build()
                 .unwrap(),


### PR DESCRIPTION
Not sure what happen here or why it wasn't caught by the CI.