### PR TITLE
Implement last test in the UpdateChannelStateRedeem category for paych.

### DIFF
--- a/actors/paych/tests/paych_actor_test.rs
+++ b/actors/paych/tests/paych_actor_test.rs
@@ -244,7 +244,7 @@ mod create_lane_tests {
                         .to_string(),
                 )
                 .payment_channel(paych_non_id)
-                .exp_exit_code(ExitCode::Ok)
+                .exp_exit_code(ExitCode::OK)
                 .sig(sig.clone())
                 .build()
                 .unwrap(),

--- a/actors/paych/tests/paych_actor_test.rs
+++ b/actors/paych/tests/paych_actor_test.rs
@@ -479,7 +479,7 @@ mod update_channel_state_redeem {
         expect_error(
             &mut rt,
             Method::UpdateChannelState as u64,
-            &RawBytes::serialize(UpdateChannelStateParams::from(sv.clone())).unwrap(),
+            &RawBytes::serialize(UpdateChannelStateParams::from(sv)).unwrap(),
             ExitCode::USR_ILLEGAL_ARGUMENT,
         );
 

--- a/actors/paych/tests/paych_actor_test.rs
+++ b/actors/paych/tests/paych_actor_test.rs
@@ -454,6 +454,37 @@ mod update_channel_state_redeem {
         assert_eq!(sv.amount, ls_updated.redeemed);
         assert_eq!(sv.nonce, ls_updated.nonce);
     }
+
+    #[test]
+    fn redeem_voucher_nonce_reuse() {
+        let (mut rt, mut sv) = require_create_channel_with_lanes(3);
+        let state: PState = rt.get_state().unwrap();
+        let payee_addr = Address::new_id(PAYEE_ID);
+
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, payee_addr);
+        rt.expect_validate_caller_addr(vec![state.from, state.to]);
+
+        sv.amount = BigInt::from(9);
+        sv.nonce = 1;
+
+        let payer_addr = Address::new_id(PAYER_ID);
+
+        rt.expect_verify_signature(ExpectedVerifySig {
+            sig: sv.clone().signature.unwrap(),
+            signer: payer_addr,
+            plaintext: sv.signing_bytes().unwrap(),
+            result: Ok(()),
+        });
+
+        expect_error(
+            &mut rt,
+            Method::UpdateChannelState as u64,
+            &RawBytes::serialize(UpdateChannelStateParams::from(sv.clone())).unwrap(),
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+        );
+
+        rt.verify();
+    }
 }
 
 mod merge_tests {


### PR DESCRIPTION
- TestActor_UpdateChannelStateRedeem
  - [x] TestActor_UpdateChannelStateRedeem/redeeming_voucher_fails_on_nonce_reuse
