### PR TITLE
fix: propagate fault recovery error

### DIFF
--- a/actors/miner/src/deadline_state.rs
+++ b/actors/miner/src/deadline_state.rs
@@ -853,7 +853,7 @@ impl Deadline {
 
             partition
                 .declare_faults_recovered(sectors, sector_size, sector_numbers)
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to add recoveries: {}", e));
+                .map_err(|e| actor_error!(ErrIllegalState; "failed to add recoveries: {}", e))?;
 
             partitions.set(partition_idx, partition).map_err(|e| {
                 e.downcast_default(


### PR DESCRIPTION
This was a bug in state-mismatch fix. It doesn't affect master.