### PR TITLE
backport: `fil-actor` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,18 @@ keywords = ["filecoin", "web3", "wasm"]
 exclude = ["examples", ".github"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fil_actor_account = { version = "7.2.0", path = "./actors/account" }
-fil_actor_verifreg = { version = "7.2.0", path = "./actors/verifreg" }
-fil_actor_cron = { version = "7.2.0", path = "./actors/cron" }
-fil_actor_market = { version = "7.2.0", path = "./actors/market" }
-fil_actor_multisig = { version = "7.2.0", path = "./actors/multisig" }
-fil_actor_paych = { version = "7.2.0", path = "./actors/paych" }
-fil_actor_power = { version = "7.2.0", path = "./actors/power" }
-fil_actor_miner = { version = "7.2.0", path = "./actors/miner" }
-fil_actor_reward = { version = "7.2.0", path = "./actors/reward" }
-fil_actor_system = { version = "7.2.0", path = "./actors/system" }
-fil_actor_init = { version = "7.2.0", path = "./actors/init" }
-fil_actors_runtime = { version = "7.2.0", path = "./actors/runtime" }
+fil_actor_account = { version = "7.2.0", path = "./actors/account", features = ["fil-actor"] }
+fil_actor_verifreg = { version = "7.2.0", path = "./actors/verifreg", features = ["fil-actor"] }
+fil_actor_cron = { version = "7.2.0", path = "./actors/cron", features = ["fil-actor"] }
+fil_actor_market = { version = "7.2.0", path = "./actors/market", features = ["fil-actor"] }
+fil_actor_multisig = { version = "7.2.0", path = "./actors/multisig", features = ["fil-actor"] }
+fil_actor_paych = { version = "7.2.0", path = "./actors/paych", features = ["fil-actor"] }
+fil_actor_power = { version = "7.2.0", path = "./actors/power", features = ["fil-actor"] }
+fil_actor_miner = { version = "7.2.0", path = "./actors/miner", features = ["fil-actor"] }
+fil_actor_reward = { version = "7.2.0", path = "./actors/reward", features = ["fil-actor"] }
+fil_actor_system = { version = "7.2.0", path = "./actors/system", features = ["fil-actor"] }
+fil_actor_init = { version = "7.2.0", path = "./actors/init", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "./actors/runtime", features = ["fil-actor"] }
 
 [build-dependencies]
 fil_actor_bundler = "3.0.0"

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = { version = "0.1.0" }
 fvm_ipld_encoding = { version = "0.1.0" }
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -24,4 +24,7 @@ serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+
+[features]
+fil-actor = []
 

--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -15,7 +15,8 @@ pub use self::state::State;
 
 mod state;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 // * Updated to specs-actors commit: 845089a6d2580e46055c24415a6c32ee688e5186 (v3.0.0)
 

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"]  }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -26,3 +26,5 @@ serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -15,7 +15,8 @@ pub use self::state::{Entry, State};
 
 mod state;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 // * Updated to specs-actors commit: 845089a6d2580e46055c24415a6c32ee688e5186 (v3.0.0)
 

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -29,3 +29,5 @@ log = "0.4.14"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -21,7 +21,8 @@ pub use self::types::*;
 mod state;
 mod types;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 // * Updated to specs-actors commit: 999e57a151cc7ada020ca2844b651499ab8c0dec (v3.0.1)
 

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_ipld_hamt = "0.4.0"
@@ -32,3 +32,5 @@ anyhow = "1.0.56"
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
+[features]
+fil-actor = []

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -41,7 +41,8 @@ mod policy;
 mod state;
 mod types;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 fn request_miner_control_addrs<BS, RT>(
     rt: &mut RT,

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.6.0", default-features = false }
 bitfield = { version = "0.5.0", package = "fvm_ipld_bitfield" }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
@@ -38,3 +38,5 @@ fil_actor_account = { version = "7.2.0", path = "../account" }
 rand = "0.8.5"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 blake2b_simd = "1.0.0"
+[features]
+fil-actor = []

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -58,7 +58,8 @@ pub use vesting_state::*;
 
 use crate::Code::Blake2b256;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 mod bitfield_queue;
 mod deadline_assignment;

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -30,3 +30,5 @@ anyhow = "1.0.56"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -22,7 +22,8 @@ use num_traits::{FromPrimitive, Signed};
 pub use self::state::*;
 pub use self::types::*;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 mod state;
 mod types;

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -29,3 +29,6 @@ anyhow = "1.0.56"
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
 derive_builder = "0.10.2"
+[features]
+fil-actor = []
+

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -19,7 +19,8 @@ use num_traits::FromPrimitive;
 pub use self::state::{LaneState, Merge, State};
 pub use self::types::*;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 mod state;
 mod types;

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -32,3 +32,5 @@ anyhow = "1.0.56"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -29,7 +29,8 @@ pub use self::policy::*;
 pub use self::state::*;
 pub use self::types::*;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 #[doc(hidden)]
 pub mod ext;

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -27,3 +27,5 @@ serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -21,7 +21,8 @@ pub use self::logic::*;
 pub use self::state::{Reward, State, VestingFunction};
 pub use self::types::*;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 pub(crate) mod expneg;
 mod logic;

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -41,6 +41,7 @@ hex = "0.4.3"
 
 [features]
 default = []
+fil-actor = ["fvm_sdk"]
 
 # Enable 2k sectors
 sector-2k = []

--- a/actors/runtime/src/actor_error.rs
+++ b/actors/runtime/src/actor_error.rs
@@ -53,7 +53,7 @@ impl From<fvm_ipld_encoding::Error> for ActorError {
 
 /// Converts an actor deletion error into an actor error with the appropriate exit code. This
 /// facilitates propagation.
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "fil-actor")]
 impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
     fn from(e: fvm_sdk::error::ActorDeleteError) -> Self {
         use fvm_sdk::error::ActorDeleteError::*;
@@ -71,7 +71,7 @@ impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
 
 /// Converts a no-state error into an an actor error with the appropriate exit code (illegal actor).
 /// This facilitates propagation.
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "fil-actor")]
 impl From<fvm_sdk::error::NoStateError> for ActorError {
     fn from(e: fvm_sdk::error::NoStateError) -> Self {
         Self {

--- a/actors/runtime/src/lib.rs
+++ b/actors/runtime/src/lib.rs
@@ -37,7 +37,6 @@ pub mod test_utils;
 macro_rules! wasm_trampoline {
     ($target:ty) => {
         #[no_mangle]
-        #[cfg(target_arch = "wasm32")]
         pub extern "C" fn invoke(param: u32) -> u32 {
             $crate::runtime::fvm::trampoline::<$target>(param)
         }

--- a/actors/runtime/src/runtime/mod.rs
+++ b/actors/runtime/src/runtime/mod.rs
@@ -26,10 +26,10 @@ use crate::ActorError;
 
 mod actor_code;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "fil-actor")]
 pub mod fvm;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "fil-actor")]
 mod actor_blockstore;
 
 mod policy;

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -24,3 +24,5 @@ serde = { version = "1.0.136", features = ["derive"] }
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []

--- a/actors/system/src/lib.rs
+++ b/actors/system/src/lib.rs
@@ -10,7 +10,8 @@ use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 // * Updated to specs-actors commit: 845089a6d2580e46055c24415a6c32ee688e5186 (v3.0.0)
 

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -29,3 +29,5 @@ fvm_ipld_hamt = "0.4.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+[features]
+fil-actor = []

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -19,7 +19,8 @@ use num_traits::{FromPrimitive, Signed, Zero};
 pub use self::state::State;
 pub use self::types::*;
 
-wasm_trampoline!(Actor);
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(Actor);
 
 mod state;
 mod types;

--- a/build.rs
+++ b/build.rs
@@ -97,6 +97,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .arg("--target=wasm32-unknown-unknown")
         .arg("--profile=wasm")
         .arg("--locked")
+        .arg("--features=fil-actor")
         .arg("--manifest-path=".to_owned() + manifest_path.to_str().unwrap())
         .env("RUSTFLAGS", rustflags)
         .env(NETWORK_ENV, network_name)


### PR DESCRIPTION
feat: use a fil-actor feature instead of relying on the wasm target #175 

This way, the actors can be bundled with other wasm software as libraries.

fixes #109