### PR TITLE
chore: release v7.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "cid",
  "fil_actor_account",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_builtin_actors_bundle"
 description = "Bundle of FVM-compatible Wasm bytecode for Filecoin builtin actors"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -10,18 +10,18 @@ keywords = ["filecoin", "web3", "wasm"]
 exclude = ["examples", ".github"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fil_actor_account = { version = "7.2.0", path = "./actors/account", features = ["fil-actor"] }
-fil_actor_verifreg = { version = "7.2.0", path = "./actors/verifreg", features = ["fil-actor"] }
-fil_actor_cron = { version = "7.2.0", path = "./actors/cron", features = ["fil-actor"] }
-fil_actor_market = { version = "7.2.0", path = "./actors/market", features = ["fil-actor"] }
-fil_actor_multisig = { version = "7.2.0", path = "./actors/multisig", features = ["fil-actor"] }
-fil_actor_paych = { version = "7.2.0", path = "./actors/paych", features = ["fil-actor"] }
-fil_actor_power = { version = "7.2.0", path = "./actors/power", features = ["fil-actor"] }
-fil_actor_miner = { version = "7.2.0", path = "./actors/miner", features = ["fil-actor"] }
-fil_actor_reward = { version = "7.2.0", path = "./actors/reward", features = ["fil-actor"] }
-fil_actor_system = { version = "7.2.0", path = "./actors/system", features = ["fil-actor"] }
-fil_actor_init = { version = "7.2.0", path = "./actors/init", features = ["fil-actor"] }
-fil_actors_runtime = { version = "7.2.0", path = "./actors/runtime", features = ["fil-actor"] }
+fil_actor_account = { version = "7.2.1", path = "./actors/account", features = ["fil-actor"] }
+fil_actor_verifreg = { version = "7.2.1", path = "./actors/verifreg", features = ["fil-actor"] }
+fil_actor_cron = { version = "7.2.1", path = "./actors/cron", features = ["fil-actor"] }
+fil_actor_market = { version = "7.2.1", path = "./actors/market", features = ["fil-actor"] }
+fil_actor_multisig = { version = "7.2.1", path = "./actors/multisig", features = ["fil-actor"] }
+fil_actor_paych = { version = "7.2.1", path = "./actors/paych", features = ["fil-actor"] }
+fil_actor_power = { version = "7.2.1", path = "./actors/power", features = ["fil-actor"] }
+fil_actor_miner = { version = "7.2.1", path = "./actors/miner", features = ["fil-actor"] }
+fil_actor_reward = { version = "7.2.1", path = "./actors/reward", features = ["fil-actor"] }
+fil_actor_system = { version = "7.2.1", path = "./actors/system", features = ["fil-actor"] }
+fil_actor_init = { version = "7.2.1", path = "./actors/init", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.1", path = "./actors/runtime", features = ["fil-actor"] }
 
 [build-dependencies]
 fil_actor_bundler = "3.0.0"

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_account"
 description = "Builtin account actor for Filecoin"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -13,7 +13,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = { version = "0.1.0" }
 fvm_ipld_encoding = { version = "0.1.0" }
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -23,7 +23,7 @@ num-derive = "0.3.3"
 serde_tuple = "0.5.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
 
 [features]
 fil-actor = []

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_cron"
 description = "Builtin cron actor for Filecoin"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"]  }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"]  }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -25,6 +25,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_init"
 description = "Builtin init actor for Filecoin"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -28,6 +28,6 @@ anyhow = "1.0.56"
 log = "0.4.14"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_market"
 description = "Builtin market actor for Filecoin"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_ipld_hamt = "0.4.0"
@@ -30,7 +30,7 @@ log = "0.4.14"
 anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
 [features]
 fil-actor = []

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_miner"
 description = "Builtin miner actor for Filecoin"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.6.0", default-features = false }
 bitfield = { version = "0.5.0", package = "fvm_ipld_bitfield" }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
@@ -33,8 +33,8 @@ anyhow = "1.0.56"
 itertools = "0.10.3"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
-fil_actor_account = { version = "7.2.0", path = "../account" }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actor_account = { version = "7.2.1", path = "../account" }
 rand = "0.8.5"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 blake2b_simd = "1.0.0"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_multisig"
 description = "Builtin multisig actor for Filecoin"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -29,6 +29,6 @@ serde_tuple = "0.5.0"
 anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_paych"
 description = "Builtin paych actor for Filecoin"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -26,7 +26,7 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
 derive_builder = "0.10.2"
 [features]

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_power"
 description = "Builtin power actor for Filecoin"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -31,6 +31,6 @@ serde_tuple = "0.5.0"
 anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_reward"
 description = "Builtin reward actor for Filecoin"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -26,6 +26,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actors_runtime"
 description = "System actors for the Filecoin protocol"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_system"
 description = "Builtin system actor for Filecoin"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -23,6 +23,6 @@ num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_verifreg"
 description = "Builtin verifreg actor for Filecoin"
-version = "7.2.0"
+version = "7.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -28,6 +28,6 @@ anyhow = "1.0.56"
 fvm_ipld_hamt = "0.4.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []


### PR DESCRIPTION
Adds the `fil-actor` feature so users can import these actors as libraries.