### PR TITLE
Revert "fil-actor" feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "anyhow",
  "cid",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "anyhow",
  "cid",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "anyhow",
  "cid",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "anyhow",
  "cid",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "anyhow",
  "cid",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "7.2.0"
+version = "7.2.2"
 dependencies = [
  "cid",
  "fil_actor_account",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "7.2.1"
+version = "7.2.0"
 dependencies = [
  "cid",
  "fil_actor_account",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_builtin_actors_bundle"
 description = "Bundle of FVM-compatible Wasm bytecode for Filecoin builtin actors"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -10,18 +10,18 @@ keywords = ["filecoin", "web3", "wasm"]
 exclude = ["examples", ".github"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fil_actor_account = { version = "7.2.1", path = "./actors/account", features = ["fil-actor"] }
-fil_actor_verifreg = { version = "7.2.1", path = "./actors/verifreg", features = ["fil-actor"] }
-fil_actor_cron = { version = "7.2.1", path = "./actors/cron", features = ["fil-actor"] }
-fil_actor_market = { version = "7.2.1", path = "./actors/market", features = ["fil-actor"] }
-fil_actor_multisig = { version = "7.2.1", path = "./actors/multisig", features = ["fil-actor"] }
-fil_actor_paych = { version = "7.2.1", path = "./actors/paych", features = ["fil-actor"] }
-fil_actor_power = { version = "7.2.1", path = "./actors/power", features = ["fil-actor"] }
-fil_actor_miner = { version = "7.2.1", path = "./actors/miner", features = ["fil-actor"] }
-fil_actor_reward = { version = "7.2.1", path = "./actors/reward", features = ["fil-actor"] }
-fil_actor_system = { version = "7.2.1", path = "./actors/system", features = ["fil-actor"] }
-fil_actor_init = { version = "7.2.1", path = "./actors/init", features = ["fil-actor"] }
-fil_actors_runtime = { version = "7.2.1", path = "./actors/runtime", features = ["fil-actor"] }
+fil_actor_account = { version = "7.2.0", path = "./actors/account", features = ["fil-actor"] }
+fil_actor_verifreg = { version = "7.2.0", path = "./actors/verifreg", features = ["fil-actor"] }
+fil_actor_cron = { version = "7.2.0", path = "./actors/cron", features = ["fil-actor"] }
+fil_actor_market = { version = "7.2.0", path = "./actors/market", features = ["fil-actor"] }
+fil_actor_multisig = { version = "7.2.0", path = "./actors/multisig", features = ["fil-actor"] }
+fil_actor_paych = { version = "7.2.0", path = "./actors/paych", features = ["fil-actor"] }
+fil_actor_power = { version = "7.2.0", path = "./actors/power", features = ["fil-actor"] }
+fil_actor_miner = { version = "7.2.0", path = "./actors/miner", features = ["fil-actor"] }
+fil_actor_reward = { version = "7.2.0", path = "./actors/reward", features = ["fil-actor"] }
+fil_actor_system = { version = "7.2.0", path = "./actors/system", features = ["fil-actor"] }
+fil_actor_init = { version = "7.2.0", path = "./actors/init", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "./actors/runtime", features = ["fil-actor"] }
 
 [build-dependencies]
 fil_actor_bundler = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_builtin_actors_bundle"
 description = "Bundle of FVM-compatible Wasm bytecode for Filecoin builtin actors"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -10,18 +10,18 @@ keywords = ["filecoin", "web3", "wasm"]
 exclude = ["examples", ".github"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fil_actor_account = { version = "7.2.0", path = "./actors/account" }
-fil_actor_verifreg = { version = "7.2.0", path = "./actors/verifreg" }
-fil_actor_cron = { version = "7.2.0", path = "./actors/cron" }
-fil_actor_market = { version = "7.2.0", path = "./actors/market" }
-fil_actor_multisig = { version = "7.2.0", path = "./actors/multisig" }
-fil_actor_paych = { version = "7.2.0", path = "./actors/paych" }
-fil_actor_power = { version = "7.2.0", path = "./actors/power" }
-fil_actor_miner = { version = "7.2.0", path = "./actors/miner" }
-fil_actor_reward = { version = "7.2.0", path = "./actors/reward" }
-fil_actor_system = { version = "7.2.0", path = "./actors/system" }
-fil_actor_init = { version = "7.2.0", path = "./actors/init" }
-fil_actors_runtime = { version = "7.2.0", path = "./actors/runtime" }
+fil_actor_account = { version = "7.2.2", path = "./actors/account" }
+fil_actor_verifreg = { version = "7.2.2", path = "./actors/verifreg" }
+fil_actor_cron = { version = "7.2.2", path = "./actors/cron" }
+fil_actor_market = { version = "7.2.2", path = "./actors/market" }
+fil_actor_multisig = { version = "7.2.2", path = "./actors/multisig" }
+fil_actor_paych = { version = "7.2.2", path = "./actors/paych" }
+fil_actor_power = { version = "7.2.2", path = "./actors/power" }
+fil_actor_miner = { version = "7.2.2", path = "./actors/miner" }
+fil_actor_reward = { version = "7.2.2", path = "./actors/reward" }
+fil_actor_system = { version = "7.2.2", path = "./actors/system" }
+fil_actor_init = { version = "7.2.2", path = "./actors/init" }
+fil_actors_runtime = { version = "7.2.2", path = "./actors/runtime" }
 
 [build-dependencies]
 fil_actor_bundler = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,18 @@ keywords = ["filecoin", "web3", "wasm"]
 exclude = ["examples", ".github"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fil_actor_account = { version = "7.2.0", path = "./actors/account", features = ["fil-actor"] }
-fil_actor_verifreg = { version = "7.2.0", path = "./actors/verifreg", features = ["fil-actor"] }
-fil_actor_cron = { version = "7.2.0", path = "./actors/cron", features = ["fil-actor"] }
-fil_actor_market = { version = "7.2.0", path = "./actors/market", features = ["fil-actor"] }
-fil_actor_multisig = { version = "7.2.0", path = "./actors/multisig", features = ["fil-actor"] }
-fil_actor_paych = { version = "7.2.0", path = "./actors/paych", features = ["fil-actor"] }
-fil_actor_power = { version = "7.2.0", path = "./actors/power", features = ["fil-actor"] }
-fil_actor_miner = { version = "7.2.0", path = "./actors/miner", features = ["fil-actor"] }
-fil_actor_reward = { version = "7.2.0", path = "./actors/reward", features = ["fil-actor"] }
-fil_actor_system = { version = "7.2.0", path = "./actors/system", features = ["fil-actor"] }
-fil_actor_init = { version = "7.2.0", path = "./actors/init", features = ["fil-actor"] }
-fil_actors_runtime = { version = "7.2.0", path = "./actors/runtime", features = ["fil-actor"] }
+fil_actor_account = { version = "7.2.0", path = "./actors/account" }
+fil_actor_verifreg = { version = "7.2.0", path = "./actors/verifreg" }
+fil_actor_cron = { version = "7.2.0", path = "./actors/cron" }
+fil_actor_market = { version = "7.2.0", path = "./actors/market" }
+fil_actor_multisig = { version = "7.2.0", path = "./actors/multisig" }
+fil_actor_paych = { version = "7.2.0", path = "./actors/paych" }
+fil_actor_power = { version = "7.2.0", path = "./actors/power" }
+fil_actor_miner = { version = "7.2.0", path = "./actors/miner" }
+fil_actor_reward = { version = "7.2.0", path = "./actors/reward" }
+fil_actor_system = { version = "7.2.0", path = "./actors/system" }
+fil_actor_init = { version = "7.2.0", path = "./actors/init" }
+fil_actors_runtime = { version = "7.2.0", path = "./actors/runtime" }
 
 [build-dependencies]
 fil_actor_bundler = "3.0.0"

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
 fvm_ipld_blockstore = { version = "0.1.0" }
 fvm_ipld_encoding = { version = "0.1.0" }
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -24,7 +24,4 @@ serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
-
-[features]
-fil-actor = []
 

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_account"
 description = "Builtin account actor for Filecoin"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -13,7 +13,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime" }
 fvm_ipld_blockstore = { version = "0.1.0" }
 fvm_ipld_encoding = { version = "0.1.0" }
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -23,5 +23,5 @@ num-derive = "0.3.3"
 serde_tuple = "0.5.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime", features = ["test_utils", "sector-default"] }
 

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_account"
 description = "Builtin account actor for Filecoin"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -13,7 +13,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = { version = "0.1.0" }
 fvm_ipld_encoding = { version = "0.1.0" }
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -23,7 +23,7 @@ num-derive = "0.3.3"
 serde_tuple = "0.5.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 
 [features]
 fil-actor = []

--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -15,8 +15,7 @@ pub use self::state::State;
 
 mod state;
 
-#[cfg(feature = "fil-actor")]
-fil_actors_runtime::wasm_trampoline!(Actor);
+wasm_trampoline!(Actor);
 
 // * Updated to specs-actors commit: 845089a6d2580e46055c24415a6c32ee688e5186 (v3.0.0)
 

--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -3,7 +3,7 @@
 
 use fil_actors_runtime::builtin::singletons::SYSTEM_ACTOR_ADDR;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_error, ActorError};
+use fil_actors_runtime::{actor_error, wasm_trampoline, ActorError};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::{Address, Protocol};

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_cron"
 description = "Builtin cron actor for Filecoin"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"]  }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"]  }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -25,6 +25,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"]  }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -26,5 +26,3 @@ serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
-[features]
-fil-actor = []

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_cron"
 description = "Builtin cron actor for Filecoin"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime" }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -25,4 +25,4 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_error, ActorError, SYSTEM_ACTOR_ADDR};
+use fil_actors_runtime::{actor_error, wasm_trampoline, ActorError, SYSTEM_ACTOR_ADDR};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
 use fvm_ipld_encoding::RawBytes;

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -15,8 +15,7 @@ pub use self::state::{Entry, State};
 
 mod state;
 
-#[cfg(feature = "fil-actor")]
-fil_actors_runtime::wasm_trampoline!(Actor);
+wasm_trampoline!(Actor);
 
 // * Updated to specs-actors commit: 845089a6d2580e46055c24415a6c32ee688e5186 (v3.0.0)
 

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_init"
 description = "Builtin init actor for Filecoin"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -28,6 +28,6 @@ anyhow = "1.0.56"
 log = "0.4.14"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_init"
 description = "Builtin init actor for Filecoin"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime" }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -28,4 +28,4 @@ anyhow = "1.0.56"
 log = "0.4.14"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -29,5 +29,3 @@ log = "0.4.14"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
-[features]
-fil-actor = []

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -21,8 +21,7 @@ pub use self::types::*;
 mod state;
 mod types;
 
-#[cfg(feature = "fil-actor")]
-fil_actors_runtime::wasm_trampoline!(Actor);
+wasm_trampoline!(Actor);
 
 // * Updated to specs-actors commit: 999e57a151cc7ada020ca2844b651499ab8c0dec (v3.0.1)
 

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -3,7 +3,9 @@
 
 use cid::Cid;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_error, ActorDowncast, ActorError, SYSTEM_ACTOR_ADDR};
+use fil_actors_runtime::{
+    actor_error, wasm_trampoline, ActorDowncast, ActorError, SYSTEM_ACTOR_ADDR,
+};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::actor::builtin::Type;

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_market"
 description = "Builtin market actor for Filecoin"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime" }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_ipld_hamt = "0.4.0"
@@ -30,5 +30,5 @@ log = "0.4.14"
 anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_ipld_hamt = "0.4.0"
@@ -32,5 +32,3 @@ anyhow = "1.0.56"
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
-[features]
-fil-actor = []

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_market"
 description = "Builtin market actor for Filecoin"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_ipld_hamt = "0.4.0"
@@ -30,7 +30,7 @@ log = "0.4.14"
 anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
 [features]
 fil-actor = []

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -41,8 +41,7 @@ mod policy;
 mod state;
 mod types;
 
-#[cfg(feature = "fil-actor")]
-fil_actors_runtime::wasm_trampoline!(Actor);
+wasm_trampoline!(Actor);
 
 fn request_miner_control_addrs<BS, RT>(
     rt: &mut RT,

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -6,8 +6,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use bitfield::BitField;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR,
-    REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+    actor_error, wasm_trampoline, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR,
+    CRON_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{to_vec, Cbor, RawBytes};

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_miner"
 description = "Builtin miner actor for Filecoin"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.6.0", default-features = false }
 bitfield = { version = "0.5.0", package = "fvm_ipld_bitfield" }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
@@ -33,8 +33,8 @@ anyhow = "1.0.56"
 itertools = "0.10.3"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
-fil_actor_account = { version = "7.2.1", path = "../account" }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actor_account = { version = "7.2.0", path = "../account" }
 rand = "0.8.5"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 blake2b_simd = "1.0.0"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_miner"
 description = "Builtin miner actor for Filecoin"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime" }
 fvm_shared = { version = "0.6.0", default-features = false }
 bitfield = { version = "0.5.0", package = "fvm_ipld_bitfield" }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
@@ -33,8 +33,8 @@ anyhow = "1.0.56"
 itertools = "0.10.3"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
-fil_actor_account = { version = "7.2.0", path = "../account" }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actor_account = { version = "7.2.2", path = "../account" }
 rand = "0.8.5"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 blake2b_simd = "1.0.0"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
 fvm_shared = { version = "0.6.0", default-features = false }
 bitfield = { version = "0.5.0", package = "fvm_ipld_bitfield" }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
@@ -38,5 +38,3 @@ fil_actor_account = { version = "7.2.0", path = "../account" }
 rand = "0.8.5"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 blake2b_simd = "1.0.0"
-[features]
-fil-actor = []

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -19,9 +19,9 @@ pub use deadlines::*;
 pub use expiration_queue::*;
 use fil_actors_runtime::runtime::{ActorCode, Policy, Runtime};
 use fil_actors_runtime::{
-    actor_error, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, INIT_ACTOR_ADDR,
-    REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYS_FORBIDDEN,
-    USR_PLACEHOLDER,
+    actor_error, wasm_trampoline, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR,
+    INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
+    SYS_FORBIDDEN, USR_PLACEHOLDER,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{from_slice, BytesDe, Cbor, CborStore, RawBytes};

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -58,8 +58,7 @@ pub use vesting_state::*;
 
 use crate::Code::Blake2b256;
 
-#[cfg(feature = "fil-actor")]
-fil_actors_runtime::wasm_trampoline!(Actor);
+wasm_trampoline!(Actor);
 
 mod bitfield_queue;
 mod deadline_assignment;

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_multisig"
 description = "Builtin multisig actor for Filecoin"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -29,6 +29,6 @@ serde_tuple = "0.5.0"
 anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -30,5 +30,3 @@ anyhow = "1.0.56"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
-[features]
-fil-actor = []

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_multisig"
 description = "Builtin multisig actor for Filecoin"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime" }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -29,4 +29,4 @@ serde_tuple = "0.5.0"
 anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -22,8 +22,7 @@ use num_traits::{FromPrimitive, Signed};
 pub use self::state::*;
 pub use self::types::*;
 
-#[cfg(feature = "fil-actor")]
-fil_actors_runtime::wasm_trampoline!(Actor);
+wasm_trampoline!(Actor);
 
 mod state;
 mod types;

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeSet;
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime, Syscalls};
 use fil_actors_runtime::{
-    actor_error, make_empty_map, make_map_with_root, resolve_to_id_addr, ActorDowncast, ActorError,
-    Map, INIT_ACTOR_ADDR,
+    actor_error, make_empty_map, make_map_with_root, resolve_to_id_addr, wasm_trampoline,
+    ActorDowncast, ActorError, Map, INIT_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{to_vec, RawBytes};

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_paych"
 description = "Builtin paych actor for Filecoin"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -26,7 +26,7 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
 derive_builder = "0.10.2"
 [features]

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_paych"
 description = "Builtin paych actor for Filecoin"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime" }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -26,6 +26,6 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
 derive_builder = "0.10.2"

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -29,6 +29,3 @@ anyhow = "1.0.56"
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.4.0", features = ["go-interop"] }
 derive_builder = "0.10.2"
-[features]
-fil-actor = []
-

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -19,8 +19,7 @@ use num_traits::FromPrimitive;
 pub use self::state::{LaneState, Merge, State};
 pub use self::types::*;
 
-#[cfg(feature = "fil-actor")]
-fil_actors_runtime::wasm_trampoline!(Actor);
+wasm_trampoline!(Actor);
 
 mod state;
 mod types;

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_error, resolve_to_id_addr, ActorDowncast, ActorError, Array};
+use fil_actors_runtime::{
+    actor_error, resolve_to_id_addr, wasm_trampoline, ActorDowncast, ActorError, Array,
+};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::actor::builtin::Type;

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -32,5 +32,3 @@ anyhow = "1.0.56"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
-[features]
-fil-actor = []

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_power"
 description = "Builtin power actor for Filecoin"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime" }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -31,4 +31,4 @@ serde_tuple = "0.5.0"
 anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_power"
 description = "Builtin power actor for Filecoin"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.6.0", default-features = false }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
@@ -31,6 +31,6 @@ serde_tuple = "0.5.0"
 anyhow = "1.0.56"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -29,8 +29,7 @@ pub use self::policy::*;
 pub use self::state::*;
 pub use self::types::*;
 
-#[cfg(feature = "fil-actor")]
-fil_actors_runtime::wasm_trampoline!(Actor);
+wasm_trampoline!(Actor);
 
 #[doc(hidden)]
 pub mod ext;

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -8,8 +8,8 @@ use anyhow::anyhow;
 use ext::init;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, make_map_with_root_and_bitwidth, ActorDowncast, ActorError, Multimap,
-    CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    actor_error, make_map_with_root_and_bitwidth, wasm_trampoline, ActorDowncast, ActorError,
+    Multimap, CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_reward"
 description = "Builtin reward actor for Filecoin"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -26,6 +26,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -27,5 +27,3 @@ serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
-[features]
-fil-actor = []

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_reward"
 description = "Builtin reward actor for Filecoin"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime" }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -26,4 +26,4 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -21,8 +21,7 @@ pub use self::logic::*;
 pub use self::state::{Reward, State, VestingFunction};
 pub use self::types::*;
 
-#[cfg(feature = "fil-actor")]
-fil_actors_runtime::wasm_trampoline!(Actor);
+wasm_trampoline!(Actor);
 
 pub(crate) mod expneg;
 mod logic;

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -3,7 +3,7 @@
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, ActorError, BURNT_FUNDS_ACTOR_ADDR, EXPECTED_LEADERS_PER_EPOCH,
+    actor_error, wasm_trampoline, ActorError, BURNT_FUNDS_ACTOR_ADDR, EXPECTED_LEADERS_PER_EPOCH,
     STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::Blockstore;

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -41,7 +41,6 @@ hex = "0.4.3"
 
 [features]
 default = []
-fil-actor = ["fvm_sdk"]
 
 # Enable 2k sectors
 sector-2k = []

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actors_runtime"
 description = "System actors for the Filecoin protocol"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -31,7 +31,9 @@ thiserror = "1.0.30"
 getrandom = { version = "0.2.5", features = ["js"] }
 hex = { version = "0.4.3", optional = true }
 anyhow = "1.0.56"
-fvm_sdk = { version = "0.6.0", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+fvm_sdk = "0.6.0"
 
 [dev-dependencies]
 derive_builder = "0.10.2"

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actors_runtime"
 description = "System actors for the Filecoin protocol"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"

--- a/actors/runtime/src/actor_error.rs
+++ b/actors/runtime/src/actor_error.rs
@@ -53,7 +53,7 @@ impl From<fvm_ipld_encoding::Error> for ActorError {
 
 /// Converts an actor deletion error into an actor error with the appropriate exit code. This
 /// facilitates propagation.
-#[cfg(feature = "fil-actor")]
+#[cfg(target_arch = "wasm32")]
 impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
     fn from(e: fvm_sdk::error::ActorDeleteError) -> Self {
         use fvm_sdk::error::ActorDeleteError::*;
@@ -71,7 +71,7 @@ impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
 
 /// Converts a no-state error into an an actor error with the appropriate exit code (illegal actor).
 /// This facilitates propagation.
-#[cfg(feature = "fil-actor")]
+#[cfg(target_arch = "wasm32")]
 impl From<fvm_sdk::error::NoStateError> for ActorError {
     fn from(e: fvm_sdk::error::NoStateError) -> Self {
         Self {

--- a/actors/runtime/src/lib.rs
+++ b/actors/runtime/src/lib.rs
@@ -37,6 +37,7 @@ pub mod test_utils;
 macro_rules! wasm_trampoline {
     ($target:ty) => {
         #[no_mangle]
+        #[cfg(target_arch = "wasm32")]
         pub extern "C" fn invoke(param: u32) -> u32 {
             $crate::runtime::fvm::trampoline::<$target>(param)
         }

--- a/actors/runtime/src/runtime/mod.rs
+++ b/actors/runtime/src/runtime/mod.rs
@@ -26,10 +26,10 @@ use crate::ActorError;
 
 mod actor_code;
 
-#[cfg(feature = "fil-actor")]
+#[cfg(target_arch = "wasm32")]
 pub mod fvm;
 
-#[cfg(feature = "fil-actor")]
+#[cfg(target_arch = "wasm32")]
 mod actor_blockstore;
 
 mod policy;

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -24,5 +24,3 @@ serde = { version = "1.0.136", features = ["derive"] }
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
-[features]
-fil-actor = []

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_system"
 description = "Builtin system actor for Filecoin"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -23,6 +23,6 @@ num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_system"
 description = "Builtin system actor for Filecoin"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime" }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -23,4 +23,4 @@ num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/system/src/lib.rs
+++ b/actors/system/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_error, ActorError, SYSTEM_ACTOR_ADDR};
+use fil_actors_runtime::{actor_error, wasm_trampoline, ActorError, SYSTEM_ACTOR_ADDR};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{Cbor, RawBytes};
 use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};

--- a/actors/system/src/lib.rs
+++ b/actors/system/src/lib.rs
@@ -10,8 +10,7 @@ use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "fil-actor")]
-fil_actors_runtime::wasm_trampoline!(Actor);
+wasm_trampoline!(Actor);
 
 // * Updated to specs-actors commit: 845089a6d2580e46055c24415a6c32ee688e5186 (v3.0.0)
 

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -29,5 +29,3 @@ fvm_ipld_hamt = "0.4.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
-[features]
-fil-actor = []

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_verifreg"
 description = "Builtin verifreg actor for Filecoin"
-version = "7.2.0"
+version = "7.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime" }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime" }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -28,4 +28,4 @@ anyhow = "1.0.56"
 fvm_ipld_hamt = "0.4.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.2", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_verifreg"
 description = "Builtin verifreg actor for Filecoin"
-version = "7.2.1"
+version = "7.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["fil-actor"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
 fvm_shared = { version = "0.6.0", default-features = false }
@@ -28,6 +28,6 @@ anyhow = "1.0.56"
 fvm_ipld_hamt = "0.4.0"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "7.2.1", path = "../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "7.2.0", path = "../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -3,8 +3,8 @@
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, make_map_with_root_and_bitwidth, resolve_to_id_addr, ActorDowncast, ActorError,
-    Map, STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    actor_error, make_map_with_root_and_bitwidth, resolve_to_id_addr, wasm_trampoline,
+    ActorDowncast, ActorError, Map, STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -19,8 +19,7 @@ use num_traits::{FromPrimitive, Signed, Zero};
 pub use self::state::State;
 pub use self::types::*;
 
-#[cfg(feature = "fil-actor")]
-fil_actors_runtime::wasm_trampoline!(Actor);
+wasm_trampoline!(Actor);
 
 mod state;
 mod types;

--- a/build.rs
+++ b/build.rs
@@ -97,7 +97,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         .arg("--target=wasm32-unknown-unknown")
         .arg("--profile=wasm")
         .arg("--locked")
-        .arg("--features=fil-actor")
         .arg("--manifest-path=".to_owned() + manifest_path.to_str().unwrap())
         .env("RUSTFLAGS", rustflags)
         .env(NETWORK_ENV, network_name)


### PR DESCRIPTION
Unfortunately, this feature breaks the bundler build script because it's not possible to specify features outside of the current workspace. It's theoretically possible to fix this by using environment variable hacks, but the correct solution is #263.

fixes #264