### PR TITLE
policy: fix minimum consensus power for caterpillarnet

### DIFF
--- a/actors/runtime/build.rs
+++ b/actors/runtime/build.rs
@@ -8,7 +8,7 @@ static NETWORKS: &[(&str, &[&str])] = &[
             "sector-64g",
             "small-deals",
             "short-precommit",
-            "min-power-2g",
+            "min-power-2k",
         ],
     ),
     ("butterflynet", &["sector-512m", "sector-32g", "sector-64g", "min-power-2g"]),


### PR DESCRIPTION
This was wrongly set to 2GiB; it should be 2KiB.