### PR TITLE
power actor tests part 7

### DIFF
--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -174,6 +174,18 @@ impl Harness {
         claims.get(&miner.to_bytes()).unwrap().cloned()
     }
 
+    pub fn delete_claim(&mut self, rt: &mut MockRuntime, miner: &Address) {
+        let mut state: State = rt.get_state();
+
+        let mut claims =
+            make_map_with_root_and_bitwidth::<_, Claim>(&state.claims, rt.store(), HAMT_BIT_WIDTH)
+                .unwrap();
+        claims.delete(&miner.to_bytes()).expect("Failed to delete claim");
+        state.claims = claims.flush().unwrap();
+
+        rt.replace_state(&state);
+    }
+
     pub fn enroll_cron_event(
         &self,
         rt: &mut MockRuntime,

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -357,7 +357,7 @@ fn given_no_miner_claim_update_pledge_total_should_abort() {
     )
     .unwrap();
 
-    // explicitly delete miner clain
+    // explicitly delete miner claim
     h.delete_claim(&mut rt, &*MINER);
 
     rt.set_caller(*MINER_ACTOR_CODE_ID, *MINER);

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -1,12 +1,13 @@
 use fil_actor_power::ext::init::{ExecParams, EXEC_METHOD};
 use fil_actor_power::ext::miner::MinerConstructorParams;
 use fil_actors_runtime::test_utils::{
-    expect_abort, ACCOUNT_ACTOR_CODE_ID, CALLER_TYPES_SIGNABLE, MINER_ACTOR_CODE_ID,
-    SYSTEM_ACTOR_CODE_ID,
+    expect_abort, expect_abort_contains_message, ACCOUNT_ACTOR_CODE_ID, CALLER_TYPES_SIGNABLE,
+    MINER_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID,
 };
 use fil_actors_runtime::INIT_ACTOR_ADDR;
 use fvm_ipld_encoding::{BytesDe, RawBytes};
 use fvm_shared::address::Address;
+use fvm_shared::bigint::bigint_ser::BigIntSer;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -330,6 +331,43 @@ fn enroll_cron_epoch_given_negative_epoch_should_fail() {
         rt.call::<PowerActor>(
             Method::EnrollCronEvent as u64,
             &RawBytes::serialize(&params).unwrap(),
+        ),
+    );
+
+    rt.verify();
+    h.check_state();
+}
+
+#[test]
+fn given_no_miner_claim_update_pledge_total_should_abort() {
+    let (mut h, mut rt) = setup();
+
+    let peer = "miner".as_bytes().to_vec();
+    let multiaddrs = vec![BytesDe("multiaddr".as_bytes().to_vec())];
+    h.create_miner(
+        &mut rt,
+        &OWNER,
+        &OWNER,
+        &MINER,
+        &ACTOR,
+        peer,
+        multiaddrs,
+        RegisteredPoStProof::StackedDRGWindow32GiBV1,
+        &TokenAmount::zero(),
+    )
+    .unwrap();
+
+    // explicitly delete miner clain
+    h.delete_claim(&mut rt, &*MINER);
+
+    rt.set_caller(*MINER_ACTOR_CODE_ID, *MINER);
+    rt.expect_validate_caller_type(vec![*MINER_ACTOR_CODE_ID]);
+    expect_abort_contains_message(
+        ExitCode::USR_FORBIDDEN,
+        "unknown miner",
+        rt.call::<PowerActor>(
+            Method::UpdatePledgeTotal as u64,
+            &RawBytes::serialize(BigIntSer(&TokenAmount::from(1_000_000))).unwrap(),
         ),
     );
 


### PR DESCRIPTION
Implemented test from [here](https://github.com/filecoin-project/specs-actors/blob/0afe155bfffa036057af5519afdead845e0780de/actors/builtin/power/power_test.go#L518).

* `given_no_miner_claim_update_pledge_total_should_abort`
