### PR TITLE
power actor tests part 9, 10 & 12

### DIFF
--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -42,7 +42,9 @@ mod types;
 
 /// GasOnSubmitVerifySeal is amount of gas charged for SubmitPoRepForBulkVerify
 /// This number is empirically determined
-const GAS_ON_SUBMIT_VERIFY_SEAL: i64 = 34721049;
+pub mod detail {
+    pub const GAS_ON_SUBMIT_VERIFY_SEAL: i64 = 34721049;
+}
 
 /// Storage power actor methods available
 #[derive(FromPrimitive)]
@@ -363,7 +365,7 @@ impl Actor {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to flush proofs batch map")
             })?;
 
-            rt.charge_gas("OnSubmitVerifySeal", GAS_ON_SUBMIT_VERIFY_SEAL);
+            rt.charge_gas("OnSubmitVerifySeal", detail::GAS_ON_SUBMIT_VERIFY_SEAL);
             st.proof_validation_batch = Some(mmrc);
             Ok(())
         })?;

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -230,7 +230,7 @@ impl Harness {
         epoch: ChainEpoch,
         miner_address: &Address,
         payload: &RawBytes,
-    ) {
+    ) -> Result<(), ActorError> {
         rt.set_caller(*MINER_ACTOR_CODE_ID, miner_address.to_owned());
         rt.expect_validate_caller_type(vec![*MINER_ACTOR_CODE_ID]);
         let params = RawBytes::serialize(EnrollCronEventParams {
@@ -238,8 +238,9 @@ impl Harness {
             payload: payload.clone(),
         })
         .unwrap();
-        rt.call::<PowerActor>(Method::EnrollCronEvent as u64, &params).unwrap();
+        rt.call::<PowerActor>(Method::EnrollCronEvent as u64, &params)?;
         rt.verify();
+        Ok(())
     }
 
     pub fn get_enrolled_cron_ticks(&self, rt: &MockRuntime, epoch: ChainEpoch) -> Vec<CronEvent> {

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -1,4 +1,5 @@
 use cid::Cid;
+use fil_actor_power::detail::GAS_ON_SUBMIT_VERIFY_SEAL;
 use fil_actor_power::epoch_key;
 use fil_actor_power::ext::miner::ConfirmSectorProofsParams;
 use fil_actor_power::ext::miner::CONFIRM_SECTOR_PROOFS_VALID_METHOD;
@@ -431,11 +432,28 @@ impl Harness {
         let state: State = rt.get_state();
         assert!(state.proof_validation_batch.is_none());
     }
+
+    pub fn submit_porep_for_bulk_verify(
+        &self,
+        rt: &mut MockRuntime,
+        miner_address: Address,
+        seal_info: SealVerifyInfo,
+    ) -> Result<(), ActorError> {
+        rt.expect_gas_charge(GAS_ON_SUBMIT_VERIFY_SEAL);
+        rt.expect_validate_caller_type(vec![*MINER_ACTOR_CODE_ID]);
+        rt.set_caller(*MINER_ACTOR_CODE_ID, miner_address);
+        rt.call::<PowerActor>(
+            Method::SubmitPoRepForBulkVerify as u64,
+            &RawBytes::serialize(seal_info).unwrap(),
+        )?;
+        rt.verify();
+        Ok(())
+    }
 }
 
 pub struct ConfirmedSectorSend {
-    miner: Address,
-    sector_nums: Vec<SectorNumber>,
+    pub miner: Address,
+    pub sector_nums: Vec<SectorNumber>,
 }
 
 pub fn batch_verify_default_output(infos: &[SealVerifyInfo]) -> Vec<bool> {

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -205,6 +205,11 @@ impl Harness {
         keys.iter().map(|k| Address::from_bytes(k).unwrap()).collect::<Vec<_>>()
     }
 
+    pub fn miner_count(&self, rt: &MockRuntime) -> i64 {
+        let st: State = rt.get_state();
+        st.miner_count
+    }
+
     pub fn get_claim(&self, rt: &MockRuntime, miner: &Address) -> Option<Claim> {
         let st: State = rt.get_state();
         let claims =


### PR DESCRIPTION
Implemented tests from [here](https://github.com/filecoin-project/specs-actors/blob/0afe155bfffa036057af5519afdead845e0780de/actors/builtin/power/power_test.go#L643).

* `event_scheduled_in_past_called_next_round`
* `fails_to_enroll_if_epoch_negative`
* `skips_invocation_if_miner_has_no_claim`
* `handles_failed_call`
* `success_with_one_miner_and_one_confirmed_sector`
* `success_with_one_miner_and_multiple_confirmed_sectors`
* `duplicate_sector_numbers_are_ignored_for_a_miner`

I omitted verify log checks, doesn't seem we are exposing those and it's not done in other tests? If we still want it, I can spend some time trying to catch those "somehow". :)

Sorry for so many tests in one PR, I wanted to avoid having conflicts with myself. 