### PR TITLE
refactor: use serde_tuple/serde_repr directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -606,6 +607,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -623,6 +625,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -648,6 +651,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -676,6 +680,7 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -694,6 +699,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -711,6 +717,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -731,6 +738,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -747,6 +755,8 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_repr",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -762,6 +772,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -779,6 +790,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -808,6 +820,7 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
+ "serde_tuple",
  "thiserror",
  "unsigned-varint",
 ]
@@ -1620,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
+checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1754,6 +1767,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
  "thiserror",
 ]
 

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -20,6 +20,7 @@ num-traits = "0.2.14"
 num-derive = "0.3.3"
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.2.0"
+serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/account/src/state.rs
+++ b/actors/account/src/state.rs
@@ -1,9 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 /// State includes the address for the actor
 #[derive(Serialize_tuple, Deserialize_tuple, Debug)]

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4.14"
 serde = { version = "1.0.136", features = ["derive"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.2.0"
+serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -4,9 +4,9 @@
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{actor_error, cbor, ActorError, SYSTEM_ACTOR_ADDR};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::econ::TokenAmount;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
 use num_derive::FromPrimitive;

--- a/actors/cron/src/state.rs
+++ b/actors/cron/src/state.rs
@@ -1,10 +1,10 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
 use fvm_shared::MethodNum;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 /// Cron actor state which holds entries to call during epoch tick
 #[derive(Default, Serialize_tuple, Deserialize_tuple)]

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = "1.0.56"
 log = "0.4.14"
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.2.0"
+serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/init/src/state.rs
+++ b/actors/init/src/state.rs
@@ -7,11 +7,11 @@ use fil_actors_runtime::{
     make_empty_map, make_map_with_root_and_bitwidth, FIRST_NON_SINGLETON_ADDR,
 };
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_ipld_hamt::Error as HamtError;
 use fvm_shared::address::{Address, Protocol};
 use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 /// State is reponsible for creating
 #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/init/src/types.rs
+++ b/actors/init/src/types.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{Cbor, RawBytes};
 use fvm_shared::address::Address;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 /// Init actor Constructor parameters
 #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -28,6 +28,7 @@ anyhow = "1.0.56"
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.2.0"
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
+serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/market/src/deal.rs
+++ b/actors/market/src/deal.rs
@@ -3,7 +3,6 @@
 
 use cid::{Cid, Version};
 use fil_actors_runtime::DealWeight;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{BytesSer, Cbor};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
@@ -14,6 +13,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PaddedPieceSize;
 use libipld_core::ipld::Ipld;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use std::convert::{TryFrom, TryInto};
 
 /// Cid prefix for piece Cids

--- a/actors/market/src/ext.rs
+++ b/actors/market/src/ext.rs
@@ -1,7 +1,7 @@
-use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::econ::TokenAmount;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use fvm_shared::sector::StoragePower;
 use fvm_shared::smooth::FilterEstimate;

--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -9,7 +9,6 @@ use fil_actors_runtime::{
     actor_error, make_empty_map, ActorDowncast, ActorError, Array, Set, SetMultimap,
 };
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
@@ -19,6 +18,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::HAMT_BIT_WIDTH;
 use num_traits::{Signed, Zero};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::policy::*;
 use super::types::*;

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -4,13 +4,13 @@
 use cid::Cid;
 use fil_actors_runtime::{Array, DealWeight};
 use fvm_ipld_bitfield::BitField;
-use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::RegisteredSealProof;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::deal::{ClientDealProposal, DealProposal, DealState};
 

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -30,6 +30,7 @@ anyhow = "1.0.56"
 itertools = "0.10.3"
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.2.0"
+serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/miner/src/deadline_state.rs
+++ b/actors/miner/src/deadline_state.rs
@@ -11,13 +11,13 @@ use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{actor_error, ActorDowncast, ActorError, Array};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::CborStore;
 use fvm_shared::clock::{ChainEpoch, QuantSpec};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::{PoStProof, SectorSize};
 use num_traits::{Signed, Zero};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::{
     BitFieldQueue, ExpirationSet, Partition, PartitionSectorMap, PoStPartition, PowerPair,

--- a/actors/miner/src/expiration_queue.rs
+++ b/actors/miner/src/expiration_queue.rs
@@ -11,12 +11,12 @@ use fil_actors_runtime::{ActorDowncast, Array};
 use fvm_ipld_amt::{Error as AmtError, ValueMut};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::tuple::*;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::{ChainEpoch, QuantSpec};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::{SectorNumber, SectorSize};
 use num_traits::{Signed, Zero};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::{power_for_sector, PowerPair, SectorOnChainInfo};
 

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -1,6 +1,5 @@
 use cid::Cid;
 use fil_actors_runtime::DealWeight;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
@@ -8,6 +7,7 @@ use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::{RegisteredSealProof, StoragePower};
 use fvm_shared::smooth::FilterEstimate;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 pub mod account {
     pub const PUBKEY_ADDRESS_METHOD: u64 = 2;

--- a/actors/miner/src/partition_state.rs
+++ b/actors/miner/src/partition_state.rs
@@ -10,13 +10,13 @@ use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{actor_error, ActorDowncast, Array};
 use fvm_ipld_bitfield::{BitField, UnvalidatedBitField, Validate};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::tuple::*;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::{ChainEpoch, QuantSpec, NO_QUANTIZATION};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::{SectorSize, StoragePower};
 use num_traits::{Signed, Zero};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::{
     power_for_sectors, select_sectors, validate_partition_contains_sectors, BitFieldQueue,

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -15,7 +15,6 @@ use fil_actors_runtime::{
 use fvm_ipld_amt::Error as AmtError;
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{serde_bytes, BytesDe, Cbor, CborStore};
 use fvm_ipld_hamt::Error as HamtError;
 use fvm_shared::address::Address;
@@ -26,6 +25,7 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, SectorSize, MAX_SECTOR_NUMBER};
 use fvm_shared::HAMT_BIT_WIDTH;
 use num_traits::{Signed, Zero};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::deadlines::new_deadline_info;
 use super::policy::*;

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -4,7 +4,6 @@
 use cid::Cid;
 use fil_actors_runtime::DealWeight;
 use fvm_ipld_bitfield::UnvalidatedBitField;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{serde_bytes, BytesDe};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
@@ -17,6 +16,7 @@ use fvm_shared::sector::{
     StoragePower,
 };
 use fvm_shared::smooth::FilterEstimate;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 pub type CronEvent = i64;
 

--- a/actors/miner/src/vesting_state.rs
+++ b/actors/miner/src/vesting_state.rs
@@ -3,12 +3,12 @@
 
 use std::{iter, mem};
 
-use fvm_ipld_encoding::tuple::*;
 use fvm_shared::bigint::{bigint_ser, Integer};
 use fvm_shared::clock::{ChainEpoch, QuantSpec};
 use fvm_shared::econ::TokenAmount;
 use itertools::{EitherOrBoth, Itertools};
 use num_traits::Zero;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::VestSpec;
 

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.56"
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.2.0"
+serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/multisig/src/state.rs
+++ b/actors/multisig/src/state.rs
@@ -4,7 +4,6 @@
 use anyhow::anyhow;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::{bigint_ser, Integer};
@@ -12,6 +11,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use indexmap::IndexMap;
 use num_traits::Zero;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::types::Transaction;
 use super::TxnID;

--- a/actors/multisig/src/types.rs
+++ b/actors/multisig/src/types.rs
@@ -1,7 +1,6 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{serde_bytes, RawBytes};
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
@@ -12,6 +11,7 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::MethodNum;
 use integer_encoding::VarInt;
 use serde::{Deserialize, Serialize};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 /// SignersMax is the maximum number of signers allowed in a multisig. If more
 /// are required, please use a combining tree of multisigs.

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -5,7 +5,6 @@ use fil_actor_multisig::{
 use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::test_utils::*;
 use fil_actors_runtime::{INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR};
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::{Address, BLS_PUB_LEN};
 use fvm_shared::bigint::bigint_ser;
@@ -14,6 +13,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::METHOD_SEND;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 mod util;
 

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -23,6 +23,7 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 anyhow = "1.0.56"
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.2.0"
+serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/paych/src/state.rs
+++ b/actors/paych/src/state.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::{bigint_ser, BigInt};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 /// A given payment channel actor is established by `from`
 /// to enable off-chain microtransactions to `to` address

--- a/actors/paych/src/types.rs
+++ b/actors/paych/src/types.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fil_actors_runtime::network::EPOCHS_IN_HOUR;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{serde_bytes, to_vec, Error, RawBytes};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::{bigint_ser, BigInt};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::MethodNum;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::Merge;
 

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.56"
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.2.0"
+serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/power/src/ext.rs
+++ b/actors/power/src/ext.rs
@@ -1,5 +1,4 @@
 use cid::Cid;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{serde_bytes, BytesDe, RawBytes};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
@@ -7,6 +6,7 @@ use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, StoragePower};
 use fvm_shared::smooth::FilterEstimate;
 use fvm_shared::METHOD_CONSTRUCTOR;
 use num_derive::FromPrimitive;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 pub mod init {
     use super::*;

--- a/actors/power/src/state.rs
+++ b/actors/power/src/state.rs
@@ -11,7 +11,6 @@ use fil_actors_runtime::{
     ActorDowncast, ActorError, Map, Multimap,
 };
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{Cbor, RawBytes};
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
@@ -25,6 +24,7 @@ use fvm_shared::HAMT_BIT_WIDTH;
 use integer_encoding::VarInt;
 use lazy_static::lazy_static;
 use num_traits::Signed;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::{CONSENSUS_MINER_MIN_MINERS, CRON_QUEUE_AMT_BITWIDTH, CRON_QUEUE_HAMT_BITWIDTH};
 

--- a/actors/power/src/types.rs
+++ b/actors/power/src/types.rs
@@ -1,7 +1,6 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{serde_bytes, BytesDe, Cbor, RawBytes};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
@@ -9,6 +8,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::{RegisteredPoStProof, StoragePower};
 use fvm_shared::smooth::FilterEstimate;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 pub type SectorTermination = i64;
 

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -23,6 +23,8 @@ lazy_static = "1.4.0"
 serde = { version = "1.0.136", features = ["derive"] }
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.2.0"
+serde_repr = "0.1.8"
+serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/reward/src/ext.rs
+++ b/actors/reward/src/ext.rs
@@ -1,6 +1,6 @@
-use fvm_ipld_encoding::tuple::*;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::econ::TokenAmount;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 pub mod miner {
     use super::*;

--- a/actors/reward/src/state.rs
+++ b/actors/reward/src/state.rs
@@ -1,12 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_encoding::repr::*;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::bigint::{bigint_ser, Integer};
 use fvm_shared::clock::{ChainEpoch, EPOCH_UNDEFINED};
 use fvm_shared::econ::TokenAmount;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use fvm_shared::sector::{Spacetime, StoragePower};
 use fvm_shared::smooth::{AlphaBetaFilter, FilterEstimate, DEFAULT_ALPHA, DEFAULT_BETA};

--- a/actors/reward/src/types.rs
+++ b/actors/reward/src/types.rs
@@ -1,10 +1,10 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::econ::TokenAmount;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 #[derive(Clone, Debug, PartialEq, Serialize_tuple, Deserialize_tuple)]
 pub struct AwardBlockRewardParams {

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -33,6 +33,7 @@ fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.2.0"
 multihash = { version = "0.16.1", default-features = false }
 rand = "0.8.5"
+serde_tuple = "0.5.0"
 
 [dev-dependencies]
 derive_builder = "0.10.2"

--- a/actors/runtime/src/util/chaos/state.rs
+++ b/actors/runtime/src/util/chaos/state.rs
@@ -1,8 +1,8 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use crate::util::chaos::unmarshallable::UnmarshallableCBOR;
 

--- a/actors/runtime/src/util/chaos/types.rs
+++ b/actors/runtime/src/util/chaos/types.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
@@ -10,6 +9,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::ActorID;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::state::State;
 

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = "1.0.56"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/system/src/lib.rs
+++ b/actors/system/src/lib.rs
@@ -3,13 +3,13 @@
 use anyhow::anyhow;
 use cid::{multihash, Cid};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::CborStore;
 use fvm_ipld_encoding::{Cbor, RawBytes};
 use fvm_shared::error::ExitCode;
 use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{actor_error, ActorDowncast, ActorError, SYSTEM_ACTOR_ADDR};

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = "1.0.56"
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.2.0"
+serde_tuple = "0.5.0"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/verifreg/src/state.rs
+++ b/actors/verifreg/src/state.rs
@@ -4,10 +4,10 @@
 use cid::Cid;
 use fil_actors_runtime::make_empty_map;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
 use fvm_shared::HAMT_BIT_WIDTH;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct State {

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -1,12 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::sector::StoragePower;
 use serde::{Deserialize, Serialize};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct VerifierParams {

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -36,5 +36,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 anyhow = "1.0.56"
 blake2b_simd = "1.0"
+serde_tuple = "0.5.0"
 
 

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -22,7 +22,6 @@ use fil_actors_runtime::{
     VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::MemoryBlockstore;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{Cbor, CborStore, RawBytes};
 use fvm_ipld_hamt::{BytesKey, Hamt, Sha256};
 use fvm_shared::actor::builtin::Type;
@@ -44,6 +43,7 @@ use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND};
 use num_traits::Signed;
 use serde::ser;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
 use std::error::Error;


### PR DESCRIPTION
There is an abstraction in fvm_ipld_encoding which has some flaws,
as those imports are macros. Hence it's cleaner to just use them
directly.

Given that a lot is happening on this repo, I don't know if such a PR is currently in scope to be merged or not. I just had it on my todo list, hence I thought I PR that one. Feel free to ignore if it's out of scope for now.