### PR TITLE
Implement remaining market actor ComputeDataCommitment tests

### DIFF
--- a/actors/market/tests/compute_data_commitment.rs
+++ b/actors/market/tests/compute_data_commitment.rs
@@ -117,7 +117,6 @@ mod compute_data_commitment {
         check_state(&rt);
     }
 
-    #[ignore]
     #[test]
     fn success_with_multiple_sector_commitments() {
         let start_epoch = 10;
@@ -146,11 +145,11 @@ mod compute_data_commitment {
             inputs: vec![
                 SectorDataSpec {
                     deal_ids: vec![],
-                    sector_type: RegisteredSealProof::StackedDRG8MiBV1,
+                    sector_type: RegisteredSealProof::StackedDRG512MiBV1,
                 },
                 SectorDataSpec {
                     deal_ids: vec![deal_id1, deal_id2],
-                    sector_type: RegisteredSealProof::StackedDRG8MiBV1,
+                    sector_type: RegisteredSealProof::StackedDRG512MiBV1,
                 },
             ],
         };
@@ -162,13 +161,13 @@ mod compute_data_commitment {
         let c2 = make_piece_cid("UnsealedSector2".as_bytes());
 
         rt.expect_compute_unsealed_sector_cid(
-            RegisteredSealProof::StackedDRG8MiBV1,
+            RegisteredSealProof::StackedDRG512MiBV1,
             vec![],
             c1,
             ExitCode::OK,
         );
         rt.expect_compute_unsealed_sector_cid(
-            RegisteredSealProof::StackedDRG8MiBV1,
+            RegisteredSealProof::StackedDRG512MiBV1,
             vec![p1, p2],
             c2,
             ExitCode::OK,

--- a/actors/market/tests/compute_data_commitment.rs
+++ b/actors/market/tests/compute_data_commitment.rs
@@ -47,7 +47,7 @@ mod compute_data_commitment {
 
         let input = SectorDataSpec {
             deal_ids: vec![deal_id1, deal_id2],
-            sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+            sector_type: RegisteredSealProof::StackedDRG8MiBV1,
         };
 
         let param = ComputeDataCommitmentParams { inputs: vec![input] };
@@ -58,7 +58,7 @@ mod compute_data_commitment {
         let c = make_piece_cid("100".as_bytes());
 
         rt.expect_compute_unsealed_sector_cid(
-            RegisteredSealProof::StackedDRG2KiBV1P1,
+            RegisteredSealProof::StackedDRG8MiBV1,
             vec![p1, p2],
             c,
             ExitCode::OK,
@@ -86,13 +86,13 @@ mod compute_data_commitment {
         let mut rt = setup();
         let input = SectorDataSpec {
             deal_ids: vec![],
-            sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+            sector_type: RegisteredSealProof::StackedDRG8MiBV1,
         };
         let param = ComputeDataCommitmentParams { inputs: vec![input] };
 
         let c = make_piece_cid("UnsealedEmpty".as_bytes());
         rt.expect_compute_unsealed_sector_cid(
-            RegisteredSealProof::StackedDRG2KiBV1P1,
+            RegisteredSealProof::StackedDRG8MiBV1,
             vec![],
             c,
             ExitCode::OK,
@@ -144,11 +144,11 @@ mod compute_data_commitment {
             inputs: vec![
                 SectorDataSpec {
                     deal_ids: vec![],
-                    sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+                    sector_type: RegisteredSealProof::StackedDRG8MiBV1,
                 },
                 SectorDataSpec {
                     deal_ids: vec![deal_id1, deal_id2],
-                    sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+                    sector_type: RegisteredSealProof::StackedDRG8MiBV1,
                 },
             ],
         };
@@ -160,13 +160,13 @@ mod compute_data_commitment {
         let c2 = make_piece_cid("UnsealedSector2".as_bytes());
 
         rt.expect_compute_unsealed_sector_cid(
-            RegisteredSealProof::StackedDRG2KiBV1P1,
+            RegisteredSealProof::StackedDRG8MiBV1,
             vec![],
             c1,
             ExitCode::OK,
         );
         rt.expect_compute_unsealed_sector_cid(
-            RegisteredSealProof::StackedDRG2KiBV1P1,
+            RegisteredSealProof::StackedDRG8MiBV1,
             vec![p1, p2],
             c2,
             ExitCode::OK,
@@ -194,7 +194,7 @@ mod compute_data_commitment {
         let mut rt = setup();
         let input = SectorDataSpec {
             deal_ids: vec![1],
-            sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+            sector_type: RegisteredSealProof::StackedDRG8MiBV1,
         };
         let param = ComputeDataCommitmentParams { inputs: vec![input] };
         rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
@@ -225,14 +225,14 @@ mod compute_data_commitment {
         let d = get_deal_proposal(&mut rt, deal_id);
         let input = SectorDataSpec {
             deal_ids: vec![deal_id],
-            sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+            sector_type: RegisteredSealProof::StackedDRG8MiBV1,
         };
         let param = ComputeDataCommitmentParams { inputs: vec![input] };
 
         let pi = PieceInfo { size: d.piece_size, cid: d.piece_cid };
 
         rt.expect_compute_unsealed_sector_cid(
-            RegisteredSealProof::StackedDRG2KiBV1P1,
+            RegisteredSealProof::StackedDRG8MiBV1,
             vec![pi],
             Cid::default(),
             ExitCode::USR_ILLEGAL_ARGUMENT,
@@ -268,17 +268,17 @@ mod compute_data_commitment {
             inputs: vec![
                 SectorDataSpec {
                     deal_ids: vec![],
-                    sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+                    sector_type: RegisteredSealProof::StackedDRG8MiBV1,
                 },
                 SectorDataSpec {
                     deal_ids: vec![deal_id1, deal_id2],
-                    sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+                    sector_type: RegisteredSealProof::StackedDRG8MiBV1,
                 },
             ],
         };
         let c1 = make_piece_cid("UnsealedSector1".as_bytes());
         rt.expect_compute_unsealed_sector_cid(
-            RegisteredSealProof::StackedDRG2KiBV1P1,
+            RegisteredSealProof::StackedDRG8MiBV1,
             vec![],
             c1,
             ExitCode::OK,
@@ -320,16 +320,16 @@ mod compute_data_commitment {
             inputs: vec![
                 SectorDataSpec {
                     deal_ids: vec![],
-                    sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+                    sector_type: RegisteredSealProof::StackedDRG8MiBV1,
                 },
                 SectorDataSpec {
                     deal_ids: vec![deal_id1, deal_id2],
-                    sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+                    sector_type: RegisteredSealProof::StackedDRG8MiBV1,
                 },
             ],
         };
         rt.expect_compute_unsealed_sector_cid(
-            RegisteredSealProof::StackedDRG2KiBV1P1,
+            RegisteredSealProof::StackedDRG8MiBV1,
             vec![],
             Cid::default(),
             ExitCode::USR_ILLEGAL_ARGUMENT,

--- a/actors/market/tests/compute_data_commitment.rs
+++ b/actors/market/tests/compute_data_commitment.rs
@@ -75,6 +75,7 @@ mod compute_data_commitment {
             .deserialize()
             .unwrap();
 
+        assert_eq!(ret.commds.len(), 1);
         assert_eq!(c, ret.commds[0]);
 
         rt.verify();
@@ -109,6 +110,7 @@ mod compute_data_commitment {
             .deserialize()
             .unwrap();
 
+        assert_eq!(ret.commds.len(), 1);
         assert_eq!(c, ret.commds[0]);
 
         rt.verify();
@@ -182,6 +184,8 @@ mod compute_data_commitment {
             .unwrap()
             .deserialize()
             .unwrap();
+
+        assert_eq!(ret.commds.len(), 2);
         assert_eq!(c1, ret.commds[0]);
         assert_eq!(c2, ret.commds[1]);
 

--- a/actors/market/tests/compute_data_commitment.rs
+++ b/actors/market/tests/compute_data_commitment.rs
@@ -85,10 +85,8 @@ mod compute_data_commitment {
     #[test]
     fn success_on_empty_piece_info() {
         let mut rt = setup();
-        let input = SectorDataSpec {
-            deal_ids: vec![],
-            sector_type: RegisteredSealProof::StackedDRG8MiBV1,
-        };
+        let input =
+            SectorDataSpec { deal_ids: vec![], sector_type: RegisteredSealProof::StackedDRG8MiBV1 };
         let param = ComputeDataCommitmentParams { inputs: vec![input] };
 
         let c = make_piece_cid("UnsealedEmpty".as_bytes());

--- a/actors/market/tests/compute_data_commitment.rs
+++ b/actors/market/tests/compute_data_commitment.rs
@@ -1,0 +1,367 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fil_actor_market::policy::deal_provider_collateral_bounds;
+use fil_actor_market::{
+    Actor as MarketActor, ClientDealProposal, ComputeDataCommitmentParams,
+    ComputeDataCommitmentReturn, DealProposal, Method, PublishStorageDealsParams,
+    PublishStorageDealsReturn, SectorDataSpec,
+};
+use fil_actors_runtime::network::EPOCHS_IN_DAY;
+use fil_actors_runtime::runtime::Policy;
+use fil_actors_runtime::test_utils::*;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::Address;
+use fvm_shared::bigint::BigInt;
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::crypto::signature::Signature;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
+use fvm_shared::piece::PaddedPieceSize;
+use fvm_shared::piece::PieceInfo;
+use fvm_shared::sector::RegisteredSealProof;
+use fvm_shared::sector::StoragePower;
+use fvm_shared::TOTAL_FILECOIN;
+
+use anyhow::anyhow;
+use cid::Cid;
+use num_traits::FromPrimitive;
+
+mod harness;
+use harness::*;
+
+#[cfg(test)]
+mod compute_data_commitment {
+    use super::*;
+
+    #[test]
+    fn successfully_compute_cid() {
+        let start_epoch = 10;
+        let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+
+        let mut rt = setup();
+        let deal_id1 = generate_and_publish_deal(
+            &mut rt,
+            CLIENT_ADDR,
+            &MinerAddresses::default(),
+            start_epoch,
+            end_epoch,
+        );
+        let d1 = get_deal_proposal(&mut rt, deal_id1);
+
+        let deal_id2 = generate_and_publish_deal(
+            &mut rt,
+            CLIENT_ADDR,
+            &MinerAddresses::default(),
+            start_epoch,
+            end_epoch + 1,
+        );
+        let d2 = get_deal_proposal(&mut rt, deal_id2);
+
+        let input = SectorDataSpec {
+            deal_ids: vec![deal_id1, deal_id2],
+            sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+        };
+
+        let param = ComputeDataCommitmentParams { inputs: vec![input] };
+
+        let p1 = PieceInfo { size: d1.piece_size, cid: d1.piece_cid };
+        let p2 = PieceInfo { size: d2.piece_size, cid: d2.piece_cid };
+
+        let c = make_piece_cid("100".as_bytes());
+
+        rt.expect_compute_unsealed_sector_cid(
+            RegisteredSealProof::StackedDRG2KiBV1P1,
+            vec![p1, p2],
+            c,
+            ExitCode::OK,
+        );
+        rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
+        rt.expect_validate_caller_type(vec![*MINER_ACTOR_CODE_ID]);
+
+        let ret: ComputeDataCommitmentReturn = rt
+            .call::<MarketActor>(
+                Method::ComputeDataCommitment as u64,
+                &RawBytes::serialize(param).unwrap(),
+            )
+            .unwrap()
+            .deserialize()
+            .unwrap();
+
+        assert_eq!(c, ret.commds[0]);
+
+        rt.verify();
+        check_state(&rt);
+    }
+
+    #[test]
+    fn success_on_empty_piece_info() {
+        let start_epoch = 10;
+        let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+
+        let mut rt = setup();
+        let input = SectorDataSpec {
+            deal_ids: vec![],
+            sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+        };
+        let param = ComputeDataCommitmentParams { inputs: vec![input] };
+
+        let c = make_piece_cid("UnsealedEmpty".as_bytes());
+        rt.expect_compute_unsealed_sector_cid(
+            RegisteredSealProof::StackedDRG2KiBV1P1,
+            vec![],
+            c,
+            ExitCode::OK,
+        );
+        rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
+        rt.expect_validate_caller_type(vec![*MINER_ACTOR_CODE_ID]);
+
+        let ret: ComputeDataCommitmentReturn = rt
+            .call::<MarketActor>(
+                Method::ComputeDataCommitment as u64,
+                &RawBytes::serialize(param).unwrap(),
+            )
+            .unwrap()
+            .deserialize()
+            .unwrap();
+
+        assert_eq!(c, ret.commds[0]);
+
+        rt.verify();
+        check_state(&rt);
+    }
+
+    #[ignore]
+    #[test]
+    fn success_with_multiple_sector_commitments() {
+        let start_epoch = 10;
+        let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+
+        let mut rt = setup();
+        let deal_id1 = generate_and_publish_deal(
+            &mut rt,
+            CLIENT_ADDR,
+            &MinerAddresses::default(),
+            start_epoch,
+            end_epoch,
+        );
+        let d1 = get_deal_proposal(&mut rt, deal_id1);
+
+        let deal_id2 = generate_and_publish_deal(
+            &mut rt,
+            CLIENT_ADDR,
+            &MinerAddresses::default(),
+            start_epoch,
+            end_epoch + 1,
+        );
+        let d2 = get_deal_proposal(&mut rt, deal_id2);
+
+        let param = ComputeDataCommitmentParams {
+            inputs: vec![
+                SectorDataSpec {
+                    deal_ids: vec![],
+                    sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+                },
+                SectorDataSpec {
+                    deal_ids: vec![deal_id1, deal_id2],
+                    sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+                },
+            ],
+        };
+
+        let p1 = PieceInfo { size: d1.piece_size, cid: d1.piece_cid };
+        let p2 = PieceInfo { size: d2.piece_size, cid: d2.piece_cid };
+
+        let c1 = make_piece_cid("UnsealedSector1".as_bytes());
+        let c2 = make_piece_cid("UnsealedSector2".as_bytes());
+
+        rt.expect_compute_unsealed_sector_cid(
+            RegisteredSealProof::StackedDRG2KiBV1P1,
+            vec![],
+            c1,
+            ExitCode::OK,
+        );
+        rt.expect_compute_unsealed_sector_cid(
+            RegisteredSealProof::StackedDRG2KiBV1P1,
+            vec![p1, p2],
+            c2,
+            ExitCode::OK,
+        );
+        rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
+        rt.expect_validate_caller_type(vec![*MINER_ACTOR_CODE_ID]);
+
+        let ret: ComputeDataCommitmentReturn = rt
+            .call::<MarketActor>(
+                Method::ComputeDataCommitment as u64,
+                &RawBytes::serialize(param).unwrap(),
+            )
+            .unwrap()
+            .deserialize()
+            .unwrap();
+        assert_eq!(c1, ret.commds[0]);
+        assert_eq!(c2, ret.commds[1]);
+
+        rt.verify();
+        check_state(&rt);
+    }
+
+    #[test]
+    fn fail_when_deal_proposal_is_absent() {
+        let start_epoch = 10;
+        let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+
+        let mut rt = setup();
+        let input = SectorDataSpec {
+            deal_ids: vec![1],
+            sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+        };
+        let param = ComputeDataCommitmentParams { inputs: vec![input] };
+        rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
+        rt.expect_validate_caller_type(vec![*MINER_ACTOR_CODE_ID]);
+        expect_abort(
+            ExitCode::USR_NOT_FOUND,
+            rt.call::<MarketActor>(
+                Method::ComputeDataCommitment as u64,
+                &RawBytes::serialize(param).unwrap(),
+            ),
+        );
+        check_state(&rt);
+    }
+
+    #[test]
+    fn fail_when_syscall_returns_an_error() {
+        let start_epoch = 10;
+        let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+
+        let mut rt = setup();
+        let deal_id = generate_and_publish_deal(
+            &mut rt,
+            CLIENT_ADDR,
+            &MinerAddresses::default(),
+            start_epoch,
+            end_epoch,
+        );
+        let d = get_deal_proposal(&mut rt, deal_id);
+        let input = SectorDataSpec {
+            deal_ids: vec![deal_id],
+            sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+        };
+        let param = ComputeDataCommitmentParams { inputs: vec![input] };
+
+        let pi = PieceInfo { size: d.piece_size, cid: d.piece_cid };
+
+        rt.expect_compute_unsealed_sector_cid(
+            RegisteredSealProof::StackedDRG2KiBV1P1,
+            vec![pi],
+            Cid::default(),
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+        );
+        rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
+        rt.expect_validate_caller_type(vec![*MINER_ACTOR_CODE_ID]);
+        expect_abort(
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            rt.call::<MarketActor>(
+                Method::ComputeDataCommitment as u64,
+                &RawBytes::serialize(param).unwrap(),
+            ),
+        );
+        check_state(&rt);
+    }
+
+    #[test]
+    fn fail_whole_call_when_one_deal_proposal_of_one_sector_is_absent() {
+        let start_epoch = 10;
+        let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+
+        let mut rt = setup();
+        let deal_id1 = generate_and_publish_deal(
+            &mut rt,
+            CLIENT_ADDR,
+            &MinerAddresses::default(),
+            start_epoch,
+            end_epoch,
+        );
+        let deal_id2 = 2;
+
+        let param = ComputeDataCommitmentParams {
+            inputs: vec![
+                SectorDataSpec {
+                    deal_ids: vec![],
+                    sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+                },
+                SectorDataSpec {
+                    deal_ids: vec![deal_id1, deal_id2],
+                    sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+                },
+            ],
+        };
+        let c1 = make_piece_cid("UnsealedSector1".as_bytes());
+        rt.expect_compute_unsealed_sector_cid(
+            RegisteredSealProof::StackedDRG2KiBV1P1,
+            vec![],
+            c1,
+            ExitCode::OK,
+        ); // first sector is computed
+        rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
+        rt.expect_validate_caller_type(vec![*MINER_ACTOR_CODE_ID]);
+        expect_abort(
+            ExitCode::USR_NOT_FOUND,
+            rt.call::<MarketActor>(
+                Method::ComputeDataCommitment as u64,
+                &RawBytes::serialize(param).unwrap(),
+            ),
+        );
+        check_state(&rt);
+    }
+
+    #[test]
+    fn fail_whole_call_when_one_commitment_fails_syscall() {
+        let start_epoch = 10;
+        let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+
+        let mut rt = setup();
+        let deal_id1 = generate_and_publish_deal(
+            &mut rt,
+            CLIENT_ADDR,
+            &MinerAddresses::default(),
+            start_epoch,
+            end_epoch,
+        );
+        let deal_id2 = generate_and_publish_deal(
+            &mut rt,
+            CLIENT_ADDR,
+            &MinerAddresses::default(),
+            start_epoch,
+            end_epoch + 1,
+        );
+
+        let param = ComputeDataCommitmentParams {
+            inputs: vec![
+                SectorDataSpec {
+                    deal_ids: vec![],
+                    sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+                },
+                SectorDataSpec {
+                    deal_ids: vec![deal_id1, deal_id2],
+                    sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
+                },
+            ],
+        };
+        rt.expect_compute_unsealed_sector_cid(
+            RegisteredSealProof::StackedDRG2KiBV1P1,
+            vec![],
+            Cid::default(),
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+        );
+        rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
+        rt.expect_validate_caller_type(vec![*MINER_ACTOR_CODE_ID]);
+        expect_abort(
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            rt.call::<MarketActor>(
+                Method::ComputeDataCommitment as u64,
+                &RawBytes::serialize(param).unwrap(),
+            ),
+        );
+        check_state(&rt);
+    }
+}

--- a/actors/market/tests/compute_data_commitment.rs
+++ b/actors/market/tests/compute_data_commitment.rs
@@ -1,31 +1,18 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fil_actor_market::policy::deal_provider_collateral_bounds;
 use fil_actor_market::{
-    Actor as MarketActor, ClientDealProposal, ComputeDataCommitmentParams,
-    ComputeDataCommitmentReturn, DealProposal, Method, PublishStorageDealsParams,
-    PublishStorageDealsReturn, SectorDataSpec,
+    Actor as MarketActor, ComputeDataCommitmentParams, ComputeDataCommitmentReturn, Method,
+    SectorDataSpec,
 };
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
-use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::test_utils::*;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::address::Address;
-use fvm_shared::bigint::BigInt;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::crypto::signature::Signature;
-use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::RegisteredSealProof;
-use fvm_shared::sector::StoragePower;
-use fvm_shared::TOTAL_FILECOIN;
 
-use anyhow::anyhow;
 use cid::Cid;
-use num_traits::FromPrimitive;
 
 mod harness;
 use harness::*;

--- a/actors/market/tests/compute_data_commitment.rs
+++ b/actors/market/tests/compute_data_commitment.rs
@@ -83,9 +83,6 @@ mod compute_data_commitment {
 
     #[test]
     fn success_on_empty_piece_info() {
-        let start_epoch = 10;
-        let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
-
         let mut rt = setup();
         let input = SectorDataSpec {
             deal_ids: vec![],
@@ -194,9 +191,6 @@ mod compute_data_commitment {
 
     #[test]
     fn fail_when_deal_proposal_is_absent() {
-        let start_epoch = 10;
-        let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
-
         let mut rt = setup();
         let input = SectorDataSpec {
             deal_ids: vec![1],

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -146,7 +146,7 @@ pub struct Expectations {
     pub expect_verify_sigs: VecDeque<ExpectedVerifySig>,
     pub expect_verify_seal: Option<ExpectVerifySeal>,
     pub expect_verify_post: Option<ExpectVerifyPoSt>,
-    pub expect_compute_unsealed_sector_cid: Option<ExpectComputeUnsealedSectorCid>,
+    pub expect_compute_unsealed_sector_cid: VecDeque<ExpectComputeUnsealedSectorCid>,
     pub expect_verify_consensus_fault: Option<ExpectVerifyConsensusFault>,
     pub expect_get_randomness_tickets: Option<ExpectRandomness>,
     pub expect_get_randomness_beacon: Option<ExpectRandomness>,
@@ -204,8 +204,9 @@ impl Expectations {
             self.expect_verify_post
         );
         assert!(
-            self.expect_compute_unsealed_sector_cid.is_none(),
-            "expect_compute_unsealed_sector_cid not received",
+            self.expect_compute_unsealed_sector_cid.is_empty(),
+            "expect_compute_unsealed_sector_cid: {:?}, not received",
+            self.expect_compute_unsealed_sector_cid
         );
         assert!(
             self.expect_verify_consensus_fault.is_none(),
@@ -497,7 +498,7 @@ impl MockRuntime {
         exit_code: ExitCode,
     ) {
         let exp = ExpectComputeUnsealedSectorCid { reg, pieces, cid, exit_code };
-        self.expectations.borrow_mut().expect_compute_unsealed_sector_cid = Some(exp);
+        self.expectations.borrow_mut().expect_compute_unsealed_sector_cid.push_back(exp);
     }
 
     #[allow(dead_code)]
@@ -1045,7 +1046,7 @@ impl Primitives for MockRuntime {
             .expectations
             .borrow_mut()
             .expect_compute_unsealed_sector_cid
-            .take()
+            .pop_front()
             .expect("Unexpected syscall to ComputeUnsealedSectorCID");
 
         assert_eq!(exp.reg, reg, "Unexpected compute_unsealed_sector_cid : reg mismatch");

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -487,7 +487,19 @@ impl MockRuntime {
     }
 
     #[allow(dead_code)]
-    pub fn expect_compute_unsealed_sector_cid(&self, exp: ExpectComputeUnsealedSectorCid) {
+    pub fn expect_compute_unsealed_sector_cid(
+        &self,
+        reg: RegisteredSealProof,
+        pieces: Vec<PieceInfo>,
+        cid: Cid,
+        exit_code: ExitCode,
+    ) {
+        let exp = ExpectComputeUnsealedSectorCid {
+            reg,
+            pieces,
+            cid,
+            exit_code,
+        };
         self.expectations.borrow_mut().expect_compute_unsealed_sector_cid = Some(exp);
     }
 

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -494,12 +494,7 @@ impl MockRuntime {
         cid: Cid,
         exit_code: ExitCode,
     ) {
-        let exp = ExpectComputeUnsealedSectorCid {
-            reg,
-            pieces,
-            cid,
-            exit_code,
-        };
+        let exp = ExpectComputeUnsealedSectorCid { reg, pieces, cid, exit_code };
         self.expectations.borrow_mut().expect_compute_unsealed_sector_cid = Some(exp);
     }
 


### PR DESCRIPTION
 - TestComputeDataCommitment 
   - [x] successfully_compute_cid
   - [x] success_on_empty_piece_info
   - [x] success_with_multiple_sector_commitments
   - [x] fail_when_deal_proposal_is_absent
   - [x] fail_when_syscall_returns_an_error
   - [x] fail_whole_call_when_one_deal_proposal_of_one_sector_is_absent
   - [x] fail_whole_call_when_one_commitment_fails_syscall