### PR TITLE
remove duplicate `new_bls_addr` from miner utils

### DIFF
--- a/actors/miner/tests/miner_actor_test_construction.rs
+++ b/actors/miner/tests/miner_actor_test_construction.rs
@@ -33,7 +33,7 @@ fn prepare_env() -> TestEnv {
         receiver: Address::new_id(1000),
         owner: Address::new_id(100),
         worker: Address::new_id(101),
-        worker_key: util::new_bls_addr(0),
+        worker_key: new_bls_addr(0),
         control_addrs: vec![Address::new_id(999), Address::new_id(998)],
         peer_id: vec![1, 2, 3],
         multiaddrs: vec![BytesDe(vec![1, 2, 3])],
@@ -128,9 +128,9 @@ fn simple_construction() {
 fn control_addresses_are_resolved_during_construction() {
     let mut env = prepare_env();
 
-    let control1 = util::new_bls_addr(1);
+    let control1 = new_bls_addr(1);
     let control1id = Address::new_id(555);
-    let control2 = util::new_bls_addr(2);
+    let control2 = new_bls_addr(2);
     let control2id = Address::new_id(655);
 
     env.control_addrs = vec![control1, control2];

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -55,19 +55,9 @@ use cid::Cid;
 use multihash::derive::Multihash;
 use multihash::MultihashDigest;
 
-use rand::prelude::*;
-
 use std::collections::{BTreeMap, HashMap};
 
 const RECEIVER_ID: u64 = 1000;
-
-pub fn new_bls_addr(s: u8) -> Address {
-    let seed = [s; 32];
-    let mut rng: StdRng = SeedableRng::from_seed(seed);
-    let mut key = [0u8; 48];
-    rng.fill_bytes(&mut key);
-    Address::new_bls(&key).unwrap()
-}
 
 #[allow(dead_code)]
 pub fn setup() -> (ActorHarness, MockRuntime) {


### PR DESCRIPTION
It's a copy-paste from [here](https://github.com/filecoin-project/builtin-actors/blob/remove-duplicate/actors/runtime/src/test_utils.rs#L1226]. Or the other way around. Anyway, one duplicate less.