### PR TITLE
Reintroduce signing voucher secret hash limit

### DIFF
--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -133,6 +133,13 @@ impl Actor {
             ));
         }
 
+        if sv.secret_hash.len() > MAX_SECRET_HASH_SIXE {
+            return Err(actor_error!(
+                illegal_argument,
+                "secret hash cannot exceed 2 << 20 bytes long"
+            ));
+        }
+
         // Generate unsigned bytes
         let sv_bz = sv
             .signing_bytes()
@@ -170,9 +177,9 @@ impl Actor {
                     "voucher amount must be non-negative, was {}", sv.amount));
         }
 
-        if !sv.secret_pre_image.is_empty() {
+        if !sv.secret_hash.is_empty() {
             let hashed_secret: &[u8] = &rt.hash_blake2b(&params.secret);
-            if hashed_secret != sv.secret_pre_image.as_slice() {
+            if hashed_secret != sv.secret_hash.as_slice() {
                 return Err(actor_error!(USR_ILLEGAL_ARGUMENT; "incorrect secret"));
             }
         }

--- a/actors/paych/src/types.rs
+++ b/actors/paych/src/types.rs
@@ -20,6 +20,7 @@ pub const SETTLE_DELAY: ChainEpoch = EPOCHS_IN_HOUR * 12;
 
 // Maximum byte length of a secret that can be submitted with a payment channel update.
 pub const MAX_SECRET_SIZE: usize = 256;
+pub const MAX_SECRET_HASH_SIXE: usize = 2 << 20;
 
 pub const LANE_STATES_AMT_BITWIDTH: u32 = 3;
 /// Constructor parameters for payment channel actor
@@ -42,7 +43,7 @@ pub struct SignedVoucher {
     pub time_lock_max: ChainEpoch,
     /// (optional) Used by `to` to validate
     #[serde(with = "serde_bytes")]
-    pub secret_pre_image: Vec<u8>,
+    pub secret_hash: Vec<u8>,
     /// (optional) Specified by `from` to add a verification method to the voucher
     pub extra: Option<ModVerifyParams>,
     /// Specifies which lane the Voucher merges into (will be created if does not exist)
@@ -85,7 +86,7 @@ impl SignedVoucher {
             channel_addr: &self.channel_addr,
             time_lock_min: self.time_lock_min,
             time_lock_max: self.time_lock_max,
-            secret_pre_image: &self.secret_pre_image,
+            secret_pre_image: &self.secret_hash,
             extra: &self.extra,
             lane: self.lane,
             nonce: self.nonce,


### PR DESCRIPTION
This came up as a regression from go tests.  Not sure if we want to enforce this explicitly or let gas limit disincentivize it.  As far as I can tell there is still an overall breaking change to message execution because these params wouldn't serialize on v15 so this would fail with a system error.

If we want to do explicit actor code limiting like this then we should probably choose something much smaller