### PR TITLE
enable all-targets for clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       uses: ./.github/actions/rust-cargo-run
       with:
         command: clippy
-        args: --all
+        args: --all --all-targets -- -D warnings
         components: clippy
         github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/actors/miner/src/internal_tests.rs
+++ b/actors/miner/src/internal_tests.rs
@@ -178,7 +178,7 @@ fn declared_and_undeclared_fault_penalties_are_linear_over_sector_qa_power_term(
     // Construct plausible reward and qa power filtered estimates
     let epoch_reward = TokenAmount::from(100_u64 << 53);
     // not too much growth over ~3000 epoch projection in BR
-    let reward_estimate = FilterEstimate::new(epoch_reward.clone(), Zero::zero());
+    let reward_estimate = FilterEstimate::new(epoch_reward, Zero::zero());
 
     let network_power = StoragePower::from(100_u64 << 50);
     let power_estimate = FilterEstimate::new(network_power, Zero::zero());

--- a/actors/miner/tests/expiration_queue.rs
+++ b/actors/miner/tests/expiration_queue.rs
@@ -719,16 +719,16 @@ fn require_no_expiration_groups_before(
     assert!(set.is_empty());
 }
 
-fn empty_expiration_queue_with_quantizing<'a>(
-    rt: &'a MockRuntime,
+fn empty_expiration_queue_with_quantizing(
+    rt: &MockRuntime,
     quant: QuantSpec,
-) -> ExpirationQueue<'a, MemoryBlockstore> {
+) -> ExpirationQueue<MemoryBlockstore> {
     let empty_array =
         Amt::<(), _>::new_with_bit_width(&rt.store, TEST_AMT_BITWIDTH).flush().unwrap();
 
     ExpirationQueue::new(&rt.store, &empty_array, quant).unwrap()
 }
 
-fn empty_expiration_queue<'a>(rt: &'a MockRuntime) -> ExpirationQueue<'a, MemoryBlockstore> {
+fn empty_expiration_queue(rt: &MockRuntime) -> ExpirationQueue<MemoryBlockstore> {
     empty_expiration_queue_with_quantizing(rt, NO_QUANTIZATION)
 }

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -693,7 +693,7 @@ fn test_fail_propose_with_threshold_met_and_insufficient_balance() {
         h.propose(&mut rt, chuck, send_value, METHOD_SEND, fake_params),
     );
     rt.reset();
-    h.assert_transactions(&mut rt, vec![]);
+    h.assert_transactions(&rt, vec![]);
 }
 
 #[test]
@@ -725,7 +725,7 @@ fn test_fail_propose_from_non_signer() {
     );
 
     rt.reset();
-    h.assert_transactions(&mut rt, vec![]);
+    h.assert_transactions(&rt, vec![]);
 }
 
 // AddSigner
@@ -1125,7 +1125,7 @@ fn test_swap_signer_removes_approvals() {
 
     // Anne's approval is removed from each tx
     h.assert_transactions(
-        &mut rt,
+        &rt,
         vec![
             (
                 TxnID(0),
@@ -1209,7 +1209,7 @@ fn test_remove_signer_removes_approvals() {
 
     // Anne's approval is removed from each tx
     h.assert_transactions(
-        &mut rt,
+        &rt,
         vec![
             (
                 TxnID(0),
@@ -1406,9 +1406,9 @@ mod approval_tests {
                 TxnID(0),
                 Transaction {
                     to: chuck,
-                    value: send_value.clone(),
+                    value: send_value,
                     method: fake_method,
-                    params: fake_params.clone(),
+                    params: fake_params,
                     approved: vec![anne],
                 },
             )],
@@ -1441,9 +1441,9 @@ mod approval_tests {
                 TxnID(0),
                 Transaction {
                     to: chuck,
-                    value: send_value.clone(),
+                    value: send_value,
                     method: fake_method,
-                    params: fake_params.clone(),
+                    params: fake_params,
                     approved: vec![anne],
                 },
             )],
@@ -1474,9 +1474,9 @@ mod approval_tests {
         let bad_hash = compute_proposal_hash(
             &Transaction {
                 to: chuck,
-                value: send_value.clone(),
+                value: send_value,
                 method: fake_method,
-                params: fake_params.clone(),
+                params: fake_params,
                 approved: vec![bob], //mismatch
             },
             &rt,
@@ -1569,7 +1569,7 @@ mod approval_tests {
         let mut rt = construct_runtime(msig);
         let send_value = TokenAmount::from(10u8);
         let h = util::ActorHarness::new();
-        rt.set_balance(send_value.clone());
+        rt.set_balance(send_value);
         rt.set_received(TokenAmount::zero());
         h.construct_and_verify(&mut rt, 1, 0, 0, signers);
 
@@ -1800,13 +1800,13 @@ mod cancel_tests {
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, RawBytes::default());
+            h.propose_ok(&mut rt, chuck, send_value, fake_method, RawBytes::default());
 
         // anne cancels their tx
         h.cancel(&mut rt, TxnID(0), proposal_hash).unwrap();
 
         // tx should be removed from actor state after cancel
-        h.assert_transactions(&mut rt, vec![]);
+        h.assert_transactions(&rt, vec![]);
     }
 
     #[test]
@@ -2162,7 +2162,7 @@ mod lock_balance_tests {
         h.propose_ok(&mut rt, bob, vested.clone(), METHOD_SEND, RawBytes::default());
 
         // can't spend more
-        rt.set_balance(lock_amount.clone() - vested.clone());
+        rt.set_balance(lock_amount - vested);
         expect_abort(
             ExitCode::USR_INSUFFICIENT_FUNDS,
             h.propose(&mut rt, bob, TokenAmount::from(1), METHOD_SEND, RawBytes::default()),

--- a/actors/multisig/tests/util.rs
+++ b/actors/multisig/tests/util.rs
@@ -126,8 +126,7 @@ impl ActorHarness {
         params: RawBytes,
     ) -> Result<RawBytes, ActorError> {
         rt.expect_validate_caller_type(vec![*ACCOUNT_ACTOR_CODE_ID, *MULTISIG_ACTOR_CODE_ID]);
-        let propose_params =
-            ProposeParams { to, value: value.clone(), method, params: params.clone() };
+        let propose_params = ProposeParams { to, value, method, params };
         let ret =
             rt.call::<Actor>(Method::Propose as u64, &RawBytes::serialize(propose_params).unwrap());
         rt.verify();


### PR DESCRIPTION
So it can bash you also when you are doing redundant clones in your tests!