### PR TITLE
miner deadlines test p9

### DIFF
--- a/actors/miner/src/partition_state.rs
+++ b/actors/miner/src/partition_state.rs
@@ -251,6 +251,16 @@ impl Partition {
             Default::default()
         };
 
+        // remove faulty recoveries from state
+        let retracted_recovery_sectors = sectors
+            .load_sector(&retracted_recoveries)
+            .map_err(|e| e.wrap("failed to load recovery sectors"))?;
+        if !retracted_recovery_sectors.is_empty() {
+            let retracted_recovery_power =
+                power_for_sectors(sector_size, &retracted_recovery_sectors);
+            self.remove_recoveries(&retracted_recoveries, &retracted_recovery_power);
+        }
+
         // check invariants
         self.validate_state()?;
 

--- a/actors/miner/src/partition_state.rs
+++ b/actors/miner/src/partition_state.rs
@@ -223,7 +223,7 @@ impl Partition {
 
         let sector_numbers = sector_numbers
             .validate()
-            .map_err(|e| anyhow!("failed to intersect sectors with recoveries: {}", e))?;
+            .map_err(|e| anyhow!("failed to validate sector_numbers: {}", e))?;
 
         // Split declarations into declarations of new faults, and retraction of declared recoveries.
         let retracted_recoveries = &self.recoveries & sector_numbers;

--- a/actors/miner/tests/deadline_state_test.rs
+++ b/actors/miner/tests/deadline_state_test.rs
@@ -11,8 +11,7 @@ use fvm_ipld_bitfield::BitField;
 use fvm_ipld_bitfield::UnvalidatedBitField;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::clock::ChainEpoch;
-use fvm_shared::error::ExitCode;
-use fvm_shared::{clock::QuantSpec, sector::SectorSize};
+use fvm_shared::{clock::QuantSpec, error::ExitCode, sector::SectorSize};
 
 mod util;
 use crate::util::*;
@@ -656,6 +655,537 @@ fn cannot_pop_expired_sectors_before_proving() {
         .to_string()
         .to_lowercase()
         .contains("cannot pop expired sectors from a partition with unproven sectors"));
+}
+
+#[test]
+fn post_all_the_things() {
+    let (_, rt) = setup();
+    let mut deadline = Deadline::new(rt.store()).unwrap();
+    let fault_expiration_epoch = 13;
+
+    add_sectors(&rt, &mut deadline, true);
+
+    // add an inactive sector
+    let power = deadline
+        .add_sectors(rt.store(), PARTITION_SIZE, false, &extra_sectors(), SECTOR_SIZE, QUANT_SPEC)
+        .unwrap();
+    let expected_power = power_for_sectors(SECTOR_SIZE, &extra_sectors());
+    assert_eq!(expected_power, power);
+
+    let mut sectors_array = sectors_array(&rt, rt.store(), all_sectors());
+
+    let mut post_partitions = [
+        PoStPartition { index: 0, skipped: UnvalidatedBitField::Validated(BitField::default()) },
+        PoStPartition { index: 1, skipped: UnvalidatedBitField::Validated(BitField::default()) },
+    ];
+
+    let post_result1 = deadline
+        .record_proven_sectors(
+            rt.store(),
+            &sectors_array,
+            SECTOR_SIZE,
+            QUANT_SPEC,
+            fault_expiration_epoch,
+            &mut post_partitions,
+        )
+        .unwrap();
+    assert_bitfield_equals(&post_result1.sectors, &[1, 2, 3, 4, 5, 6, 7, 8]);
+    assert_eq!(post_result1.new_faulty_power, PowerPair::zero());
+    assert_eq!(post_result1.retracted_recovery_power, PowerPair::zero());
+    assert_eq!(post_result1.recovered_power, PowerPair::zero());
+
+    // first two partitions posted
+    deadline_state()
+        .with_posts(&[0, 1])
+        .with_unproven(&[10])
+        .with_partitions(vec![
+            make_bitfield(&[1, 2, 3, 4]),
+            make_bitfield(&[5, 6, 7, 8]),
+            make_bitfield(&[9, 10]),
+        ])
+        .assert(rt.store(), &all_sectors(), &deadline);
+
+    let mut post_partitions =
+        [PoStPartition { index: 2, skipped: UnvalidatedBitField::Validated(BitField::default()) }];
+    let post_result2 = deadline
+        .record_proven_sectors(
+            rt.store(),
+            &sectors_array,
+            SECTOR_SIZE,
+            QUANT_SPEC,
+            fault_expiration_epoch,
+            &mut post_partitions,
+        )
+        .unwrap();
+    assert_bitfield_equals(&post_result2.sectors, &[9, 10]);
+    assert!(post_result2.ignored_sectors.is_empty());
+    assert_eq!(post_result2.new_faulty_power, PowerPair::zero());
+    assert_eq!(post_result2.retracted_recovery_power, PowerPair::zero());
+    assert_eq!(post_result2.recovered_power, PowerPair::zero());
+
+    // activate sector 10
+    assert_eq!(post_result2.power_delta, sector_power(&[10]));
+
+    // all 3 partitions posted, unproven sector 10 proven and power activated
+    deadline_state()
+        .with_posts(&[0, 1, 2])
+        .with_partitions(vec![
+            make_bitfield(&[1, 2, 3, 4]),
+            make_bitfield(&[5, 6, 7, 8]),
+            make_bitfield(&[9, 10]),
+        ])
+        .assert(rt.store(), &all_sectors(), &deadline);
+    let sector_array_root = sectors_array.amt.flush().unwrap();
+
+    let (power_delta, penalized_power) = deadline
+        .process_deadline_end(rt.store(), QUANT_SPEC, fault_expiration_epoch, sector_array_root)
+        .unwrap();
+
+    // No power delta for successful post.
+    assert!(power_delta.is_zero());
+    assert!(penalized_power.is_zero());
+
+    // everything back to normal
+    deadline_state()
+        .with_partitions(vec![
+            make_bitfield(&[1, 2, 3, 4]),
+            make_bitfield(&[5, 6, 7, 8]),
+            make_bitfield(&[9, 10]),
+        ])
+        .assert(rt.store(), &all_sectors(), &deadline);
+}
+
+#[test]
+fn post_with_unproven_faults_recoveries_untracted_recoveries() {
+    let (_, rt) = setup();
+    let mut deadline = Deadline::new(rt.store()).unwrap();
+    let fault_expiration_epoch = 13;
+
+    // Marks sectors 1 (partition 0), 5 & 6 (partition 1) as faulty.
+    add_then_mark_faulty(&rt, &mut deadline, true);
+
+    // add an inactive sector
+    let power = deadline
+        .add_sectors(rt.store(), PARTITION_SIZE, false, &extra_sectors(), SECTOR_SIZE, QUANT_SPEC)
+        .unwrap();
+    let expected_power = power_for_sectors(SECTOR_SIZE, &extra_sectors());
+    assert_eq!(power, expected_power);
+
+    let mut sectors_array = sectors_array(&rt, rt.store(), all_sectors());
+
+    // declare sectors 1 & 6 recovered
+    let mut partition_sector_map = PartitionSectorMap::default();
+    partition_sector_map.add(0, UnvalidatedBitField::Validated(make_bitfield(&[1]))).unwrap();
+    partition_sector_map.add(1, UnvalidatedBitField::Validated(make_bitfield(&[6]))).unwrap();
+    deadline
+        .declare_faults_recovered(
+            rt.store(),
+            &sectors_array,
+            SECTOR_SIZE,
+            &mut partition_sector_map,
+        )
+        .unwrap();
+
+    // we are now recovering 1 & 6
+    deadline_state()
+        .with_recovering(&[1, 6])
+        .with_faults(&[1, 5, 6])
+        .with_unproven(&[10])
+        .with_partitions(vec![
+            make_bitfield(&[1, 2, 3, 4]),
+            make_bitfield(&[5, 6, 7, 8]),
+            make_bitfield(&[9, 10]),
+        ])
+        .assert(rt.store(), &all_sectors(), &deadline);
+
+    // prove partitions 0 & 1, skipping sectors 1 & 7
+    let mut post_partitions = [
+        PoStPartition { index: 0, skipped: UnvalidatedBitField::Validated(make_bitfield(&[1])) },
+        PoStPartition { index: 1, skipped: UnvalidatedBitField::Validated(make_bitfield(&[7])) },
+    ];
+    let post_result = deadline
+        .record_proven_sectors(
+            rt.store(),
+            &sectors_array,
+            SECTOR_SIZE,
+            QUANT_SPEC,
+            fault_expiration_epoch,
+            &mut post_partitions,
+        )
+        .unwrap();
+
+    // 1, 5, and 7 are expected to be faulty.
+    // - 1 should have recovered but didn't (retracted)
+    // - 5 was already marked faulty.
+    // - 7 is newly faulty.
+    // - 6 has recovered.
+    assert_bitfield_equals(&post_result.sectors, &[1, 2, 3, 4, 5, 6, 7, 8]);
+    assert_bitfield_equals(&post_result.ignored_sectors, &[1, 5, 7]);
+
+    // sector 7 is newly faulty
+    assert_eq!(post_result.new_faulty_power, sector_power(&[7]));
+    // we failed to recover 1 (retracted)
+    assert_eq!(post_result.retracted_recovery_power, sector_power(&[1]));
+    // we recovered 6
+    assert_eq!(post_result.recovered_power, sector_power(&[6]));
+    // no power delta from these deadlines
+    assert!(post_result.power_delta.is_zero());
+
+    // first two partitions should be posted
+    deadline_state()
+        .with_posts(&[0, 1])
+        .with_faults(&[1, 5, 7])
+        .with_unproven(&[10])
+        .with_partitions(vec![
+            make_bitfield(&[1, 2, 3, 4]),
+            make_bitfield(&[5, 6, 7, 8]),
+            make_bitfield(&[9, 10]),
+        ])
+        .assert(rt.store(), &all_sectors(), &deadline);
+
+    let sector_array_root = sectors_array.amt.flush().unwrap();
+    let (power_delta, penalized_power) = deadline
+        .process_deadline_end(rt.store(), QUANT_SPEC, fault_expiration_epoch, sector_array_root)
+        .unwrap();
+
+    let expected_fault_power = sector_power(&[9, 10]);
+    let expected_power_delta = -sector_power(&[9]);
+
+    // sector 9 wasn't proven
+    assert_eq!(power_delta, expected_power_delta);
+    // no new changes to recovering power
+    assert_eq!(penalized_power, expected_fault_power);
+
+    // posts taken care of
+    // unproven now faulty
+    deadline_state()
+        .with_faults(&[1, 5, 7, 9, 10])
+        .with_partitions(vec![
+            make_bitfield(&[1, 2, 3, 4]),
+            make_bitfield(&[5, 6, 7, 8]),
+            make_bitfield(&[9, 10]),
+        ])
+        .assert(rt.store(), &all_sectors(), &deadline);
+}
+
+#[test]
+fn post_with_skipped_unproven() {
+    let (_, rt) = setup();
+    let mut deadline = Deadline::new(rt.store()).unwrap();
+    let fault_expiration_epoch = 13;
+
+    add_sectors(&rt, &mut deadline, true);
+
+    // add an inactive sector
+    let power = deadline
+        .add_sectors(rt.store(), PARTITION_SIZE, false, &extra_sectors(), SECTOR_SIZE, QUANT_SPEC)
+        .unwrap();
+    let expected_power = power_for_sectors(SECTOR_SIZE, &extra_sectors());
+    assert_eq!(power, expected_power);
+
+    let mut sectors_array = sectors_array(&rt, rt.store(), all_sectors());
+    let mut post_partitions = [
+        PoStPartition { index: 0, skipped: UnvalidatedBitField::Validated(BitField::default()) },
+        PoStPartition { index: 1, skipped: UnvalidatedBitField::Validated(BitField::default()) },
+        PoStPartition { index: 2, skipped: UnvalidatedBitField::Validated(make_bitfield(&[10])) },
+    ];
+    let post_result = deadline
+        .record_proven_sectors(
+            rt.store(),
+            &sectors_array,
+            SECTOR_SIZE,
+            QUANT_SPEC,
+            fault_expiration_epoch,
+            &mut post_partitions,
+        )
+        .unwrap();
+
+    assert_bitfield_equals(&post_result.sectors, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    assert_bitfield_equals(&post_result.ignored_sectors, &[10]);
+    assert_eq!(post_result.new_faulty_power, sector_power(&[10]));
+    assert!(post_result.power_delta.is_zero());
+    assert!(post_result.retracted_recovery_power.is_zero());
+    assert!(post_result.recovered_power.is_zero());
+
+    // all posted
+    deadline_state()
+        .with_posts(&[0, 1, 2])
+        .with_faults(&[10])
+        .with_partitions(vec![
+            make_bitfield(&[1, 2, 3, 4]),
+            make_bitfield(&[5, 6, 7, 8]),
+            make_bitfield(&[9, 10]),
+        ])
+        .assert(rt.store(), &all_sectors(), &deadline);
+
+    let sector_array_root = sectors_array.amt.flush().unwrap();
+    let (power_delta, penalized_power) = deadline
+        .process_deadline_end(rt.store(), QUANT_SPEC, fault_expiration_epoch, sector_array_root)
+        .unwrap();
+
+    // all posts submitted, no power delta, no extra penalties
+    assert!(power_delta.is_zero());
+    assert!(penalized_power.is_zero());
+
+    // everything back to normal, except that we have a fault
+    deadline_state()
+        .with_faults(&[10])
+        .with_partitions(vec![
+            make_bitfield(&[1, 2, 3, 4]),
+            make_bitfield(&[5, 6, 7, 8]),
+            make_bitfield(&[9, 10]),
+        ])
+        .assert(rt.store(), &all_sectors(), &deadline);
+}
+
+#[test]
+fn post_missing_partition() {
+    let (_, rt) = setup();
+    let mut deadline = Deadline::new(rt.store()).unwrap();
+    let fault_expiration_epoch = 13;
+
+    add_sectors(&rt, &mut deadline, true);
+
+    // add an inactive sector
+    let power = deadline
+        .add_sectors(rt.store(), PARTITION_SIZE, false, &extra_sectors(), SECTOR_SIZE, QUANT_SPEC)
+        .unwrap();
+    let expected_power = power_for_sectors(SECTOR_SIZE, &extra_sectors());
+    assert_eq!(power, expected_power);
+
+    let sectors_array = sectors_array(&rt, rt.store(), all_sectors());
+    let mut post_partitions = [
+        PoStPartition { index: 0, skipped: UnvalidatedBitField::Validated(BitField::default()) },
+        PoStPartition { index: 3, skipped: UnvalidatedBitField::Validated(BitField::default()) },
+    ];
+    let post_result = deadline.record_proven_sectors(
+        rt.store(),
+        &sectors_array,
+        SECTOR_SIZE,
+        QUANT_SPEC,
+        fault_expiration_epoch,
+        &mut post_partitions,
+    );
+
+    let err = post_result
+        .err()
+        .expect("missing partition, should have failed")
+        .downcast::<ActorError>()
+        .expect("Invalid error");
+    assert_eq!(err.exit_code(), ExitCode::USR_NOT_FOUND);
+}
+
+#[test]
+fn post_partition_twice() {
+    let (_, rt) = setup();
+    let mut deadline = Deadline::new(rt.store()).unwrap();
+    let fault_expiration_epoch = 13;
+
+    add_sectors(&rt, &mut deadline, true);
+
+    // add an inactive sector
+    let power = deadline
+        .add_sectors(rt.store(), PARTITION_SIZE, false, &extra_sectors(), SECTOR_SIZE, QUANT_SPEC)
+        .unwrap();
+    let expected_power = power_for_sectors(SECTOR_SIZE, &extra_sectors());
+    assert_eq!(power, expected_power);
+
+    let sectors_array = sectors_array(&rt, rt.store(), all_sectors());
+    let mut post_partitions = [
+        PoStPartition { index: 0, skipped: UnvalidatedBitField::Validated(BitField::default()) },
+        PoStPartition { index: 0, skipped: UnvalidatedBitField::Validated(BitField::default()) },
+    ];
+    let post_result = deadline.record_proven_sectors(
+        rt.store(),
+        &sectors_array,
+        SECTOR_SIZE,
+        QUANT_SPEC,
+        fault_expiration_epoch,
+        &mut post_partitions,
+    );
+
+    let err = post_result
+        .err()
+        .expect("duplicate partition, should have failed")
+        .downcast::<ActorError>()
+        .expect("Invalid error");
+    assert_eq!(err.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
+}
+
+#[test]
+fn retract_recoveries() {
+    let (_, rt) = setup();
+    let mut deadline = Deadline::new(rt.store()).unwrap();
+    let fault_expiration_epoch = 13;
+
+    // Marks sectors 1 (partition 0), 5 & 6 (partition 1) as faulty.
+    let (_, sectors) = add_then_mark_faulty(&rt, &mut deadline, true);
+
+    let mut sectors_array = sectors_array(&rt, rt.store(), sectors.to_owned());
+
+    // declare sectors 1 & 6 recovered
+    let mut partition_sector_map = PartitionSectorMap::default();
+    partition_sector_map.add(0, UnvalidatedBitField::Validated(make_bitfield(&[1]))).unwrap();
+    partition_sector_map.add(1, UnvalidatedBitField::Validated(make_bitfield(&[6]))).unwrap();
+    deadline
+        .declare_faults_recovered(
+            rt.store(),
+            &sectors_array,
+            SECTOR_SIZE,
+            &mut partition_sector_map,
+        )
+        .unwrap();
+
+    // retract recovery for sector 1
+    let mut partition_sector_map = PartitionSectorMap::default();
+    partition_sector_map.add(0, UnvalidatedBitField::Validated(make_bitfield(&[1]))).unwrap();
+    let power_delta = deadline
+        .record_faults(
+            rt.store(),
+            &sectors_array,
+            SECTOR_SIZE,
+            QUANT_SPEC,
+            fault_expiration_epoch,
+            &mut partition_sector_map,
+        )
+        .unwrap();
+
+    // we're just retracting a recovery, this doesn't count as a new fault
+    assert!(power_delta.is_zero());
+
+    // we are now recovering 6
+    deadline_state()
+        .with_recovering(&[6])
+        .with_faults(&[1, 5, 6])
+        .with_partitions(vec![
+            make_bitfield(&[1, 2, 3, 4]),
+            make_bitfield(&[5, 6, 7, 8]),
+            make_bitfield(&[9]),
+        ])
+        .assert(rt.store(), &sectors, &deadline);
+
+    // prove all partitions
+    let post_result = deadline
+        .record_proven_sectors(
+            rt.store(),
+            &sectors_array,
+            SECTOR_SIZE,
+            QUANT_SPEC,
+            fault_expiration_epoch,
+            &mut [
+                PoStPartition {
+                    index: 0,
+                    skipped: UnvalidatedBitField::Validated(BitField::default()),
+                },
+                PoStPartition {
+                    index: 1,
+                    skipped: UnvalidatedBitField::Validated(BitField::default()),
+                },
+                PoStPartition {
+                    index: 2,
+                    skipped: UnvalidatedBitField::Validated(BitField::default()),
+                },
+            ],
+        )
+        .unwrap();
+
+    // 1 & 5 are still faulty
+    assert_bitfield_equals(&post_result.sectors, &[1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    assert_bitfield_equals(&post_result.ignored_sectors, &[1, 5]);
+
+    // all faults were declared
+    assert!(post_result.new_faulty_power.is_zero());
+    // we didn't fail to recover anything
+    assert!(post_result.retracted_recovery_power.is_zero());
+    // we recovered 6
+    assert_eq!(post_result.recovered_power, sector_power(&[6]));
+
+    // first two partitions should be posted
+    deadline_state()
+        .with_posts(&[0, 1, 2])
+        .with_faults(&[1, 5])
+        .with_partitions(vec![
+            make_bitfield(&[1, 2, 3, 4]),
+            make_bitfield(&[5, 6, 7, 8]),
+            make_bitfield(&[9]),
+        ])
+        .assert(rt.store(), &sectors, &deadline);
+
+    let sector_array_root = sectors_array.amt.flush().unwrap();
+    let (new_faulty_power, failed_recovery_power) = deadline
+        .process_deadline_end(rt.store(), QUANT_SPEC, fault_expiration_epoch, sector_array_root)
+        .unwrap();
+
+    // no power changes
+    assert!(new_faulty_power.is_zero());
+    assert!(failed_recovery_power.is_zero());
+
+    // posts taken care of
+    deadline_state()
+        .with_faults(&[1, 5])
+        .with_partitions(vec![
+            make_bitfield(&[1, 2, 3, 4]),
+            make_bitfield(&[5, 6, 7, 8]),
+            make_bitfield(&[9]),
+        ])
+        .assert(rt.store(), &all_sectors(), &deadline);
+}
+
+#[test]
+fn cannot_declare_faults_in_missing_partitions() {
+    let (_, rt) = setup();
+    let mut deadline = Deadline::new(rt.store()).unwrap();
+
+    let (_, sectors) = add_sectors(&rt, &mut deadline, true);
+    let sectors_array = sectors_array(&rt, rt.store(), sectors);
+
+    // declare sectors 1 & 6 faulty
+    let mut partition_sector_map = PartitionSectorMap::default();
+    partition_sector_map.add(0, UnvalidatedBitField::Validated(make_bitfield(&[1]))).unwrap();
+    partition_sector_map.add(4, UnvalidatedBitField::Validated(make_bitfield(&[6]))).unwrap();
+    let result = deadline.record_faults(
+        rt.store(),
+        &sectors_array,
+        SECTOR_SIZE,
+        QUANT_SPEC,
+        17,
+        &mut partition_sector_map,
+    );
+
+    let err = result
+        .err()
+        .expect("missing partition, should have failed")
+        .downcast::<ActorError>()
+        .expect("Invalid error");
+    assert_eq!(err.exit_code(), ExitCode::USR_NOT_FOUND);
+}
+
+#[test]
+fn cannot_declare_faults_recovered_in_missing_partitions() {
+    let (_, rt) = setup();
+    let mut deadline = Deadline::new(rt.store()).unwrap();
+
+    // Marks sectors 1 (partition 0), 5 & 6 (partition 1) as faulty.
+    let (_, sectors) = add_then_mark_faulty(&rt, &mut deadline, true);
+    let sectors_array = sectors_array(&rt, rt.store(), sectors);
+
+    // declare sectors 1 & 6 faulty
+    let mut partition_sector_map = PartitionSectorMap::default();
+    partition_sector_map.add(0, UnvalidatedBitField::Validated(make_bitfield(&[1]))).unwrap();
+    partition_sector_map.add(4, UnvalidatedBitField::Validated(make_bitfield(&[6]))).unwrap();
+    let result = deadline.declare_faults_recovered(
+        rt.store(),
+        &sectors_array,
+        SECTOR_SIZE,
+        &mut partition_sector_map,
+    );
+
+    let err = result
+        .err()
+        .expect("missing partition, should have failed")
+        .downcast::<ActorError>()
+        .expect("Invalid error");
+    assert_eq!(err.exit_code(), ExitCode::USR_NOT_FOUND);
 }
 
 fn deadline_state() -> ExpectedDeadlineState {

--- a/actors/miner/tests/deadline_state_test.rs
+++ b/actors/miner/tests/deadline_state_test.rs
@@ -690,6 +690,7 @@ fn post_all_the_things() {
         )
         .unwrap();
     assert_bitfield_equals(&post_result1.sectors, &[1, 2, 3, 4, 5, 6, 7, 8]);
+    assert!(post_result1.ignored_sectors.is_empty());
     assert_eq!(post_result1.new_faulty_power, PowerPair::zero());
     assert_eq!(post_result1.retracted_recovery_power, PowerPair::zero());
     assert_eq!(post_result1.recovered_power, PowerPair::zero());
@@ -761,7 +762,7 @@ fn post_with_unproven_faults_recoveries_untracted_recoveries() {
     let mut deadline = Deadline::new(rt.store()).unwrap();
     let fault_expiration_epoch = 13;
 
-    // Marks sectors 1 (partition 0), 5 & 6 (partition 1) as faulty.
+    // Adds sectors 1-9 then marks sectors 1 (partition 0), 5 & 6 (partition 1) as faulty
     add_then_mark_faulty(&rt, &mut deadline, true);
 
     // add an inactive sector
@@ -1018,7 +1019,7 @@ fn retract_recoveries() {
     let mut deadline = Deadline::new(rt.store()).unwrap();
     let fault_expiration_epoch = 13;
 
-    // Marks sectors 1 (partition 0), 5 & 6 (partition 1) as faulty.
+    // Adds sectors 1-9 then marks sectors 1 (partition 0), 5 & 6 (partition 1) as faulty
     let (_, sectors) = add_then_mark_faulty(&rt, &mut deadline, true);
 
     let mut sectors_array = sectors_array(&rt, rt.store(), sectors.to_owned());
@@ -1100,7 +1101,7 @@ fn retract_recoveries() {
     // we recovered 6
     assert_eq!(post_result.recovered_power, sector_power(&[6]));
 
-    // first two partitions should be posted
+    // first three partitions should be posted
     deadline_state()
         .with_posts(&[0, 1, 2])
         .with_faults(&[1, 5])
@@ -1169,7 +1170,7 @@ fn cannot_declare_faults_recovered_in_missing_partitions() {
     let (_, sectors) = add_then_mark_faulty(&rt, &mut deadline, true);
     let sectors_array = sectors_array(&rt, rt.store(), sectors);
 
-    // declare sectors 1 & 6 faulty
+    // declare sectors 1 & 6 recovered
     let mut partition_sector_map = PartitionSectorMap::default();
     partition_sector_map.add(0, UnvalidatedBitField::Validated(make_bitfield(&[1]))).unwrap();
     partition_sector_map.add(4, UnvalidatedBitField::Validated(make_bitfield(&[6]))).unwrap();


### PR DESCRIPTION
Implementing tests from [here](https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/miner/deadline_state_test.go).

* `post_all_the_things`
* `post_with_unproven_faults_recoveries_untracted_recoveries`
* `post_with_skipped_unproven`
* `post_missing_partition`
* `post_partition_twice`
* `retract_recoveries`
* `cannot_declare_faults_in_missing_partitions`
* `cannot_declare_faults_recovered_in_missing_partitions`

Fixed a particular fiasco in `Partition::record_faults` that was making `retract_recoveries` test fail.