### PR TITLE
fake-proofs: match lotus verify post behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_repr",
+ "sha2",
  "thiserror",
  "unsigned-varint",
 ]

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -35,6 +35,9 @@ multihash = { version = "0.16.1", default-features = false }
 rand = "0.8.5"
 serde_repr = "0.1.8"
 
+[dependencies.sha2]
+version = "0.10"
+
 [dev-dependencies]
 derive_builder = "0.10.2"
 hex = "0.4.3"


### PR DESCRIPTION
This matches Lotus fake proofs behaviour and makes one of our tests pass. I assume it's okay for all other clients (but if not we can change things as needed).

Also, I'm not sure whether or not the distinction between `testing` and `testing-fake-proofs` introduced in https://github.com/filecoin-project/builtin-actors/pull/261 is actually needed. I think we might be able to get rid of one of them, but that requires some investigation on my part.