### PR TITLE
miner tests part 31

### DIFF
--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -1,0 +1,367 @@
+use fil_actor_miner::{
+    power_for_sector, seal_proof_sector_maximum_lifetime, ExpirationExtension,
+    ExtendSectorExpirationParams, PoStPartition, SectorOnChainInfo, State,
+};
+use fil_actors_runtime::{
+    runtime::{Policy, Runtime},
+    test_utils::{expect_abort_contains_message, MockRuntime},
+};
+use fvm_ipld_bitfield::{BitField, UnvalidatedBitField};
+use fvm_shared::{clock::ChainEpoch, econ::TokenAmount, error::ExitCode};
+
+mod util;
+use itertools::Itertools;
+use util::*;
+
+// an expriration ~10 days greater than effective min expiration taking into account 30 days max between pre and prove commit
+const DEFAULT_SECTOR_EXPIRATION: ChainEpoch = 220;
+
+fn setup() -> (ActorHarness, MockRuntime) {
+    let big_balance = 10u128.pow(24);
+    let period_offset = 100;
+    let precommit_epoch = 1;
+
+    let h = ActorHarness::new(period_offset);
+    let mut rt = h.new_runtime();
+    rt.balance.replace(TokenAmount::from(big_balance));
+    rt.set_epoch(precommit_epoch);
+
+    (h, rt)
+}
+
+fn commit_sector(h: &mut ActorHarness, rt: &mut MockRuntime) -> SectorOnChainInfo {
+    h.construct_and_verify(rt);
+
+    h.commit_and_prove_sectors(rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, Vec::new(), true)[0]
+        .to_owned()
+}
+
+#[test]
+fn rejects_negative_extensions() {
+    let (mut h, mut rt) = setup();
+    let sector = commit_sector(&mut h, &mut rt);
+    let policy = Policy::default();
+
+    // attempt to shorten epoch
+    let new_expiration = sector.expiration - policy.wpost_proving_period;
+
+    // find deadline and partition
+    let state: State = rt.get_state();
+    let (deadline_index, partition_index) =
+        state.find_sector(&policy, rt.store(), sector.sector_number).unwrap();
+
+    let params = ExtendSectorExpirationParams {
+        extensions: vec![ExpirationExtension {
+            deadline: deadline_index,
+            partition: partition_index,
+            sectors: make_bitfield(&[sector.sector_number]),
+            new_expiration,
+        }],
+    };
+
+    let res = h.extend_sectors(&mut rt, params);
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        &format!("cannot reduce sector {} expiration", sector.sector_number),
+        res,
+    );
+    check_state_invariants(&rt);
+}
+
+#[test]
+fn rejects_extension_too_far_in_future() {
+    let (mut h, mut rt) = setup();
+    let sector = commit_sector(&mut h, &mut rt);
+    let policy = Policy::default();
+
+    // extend by even proving period after max
+    rt.set_epoch(sector.expiration);
+    let extension = policy.wpost_proving_period
+        * (policy.max_sector_expiration_extension / policy.wpost_proving_period + 1);
+    let new_expiration = rt.epoch + extension;
+
+    // find deadline and partition
+    let state: State = rt.get_state();
+    let (deadline_index, partition_index) =
+        state.find_sector(&policy, rt.store(), sector.sector_number).unwrap();
+
+    let params = ExtendSectorExpirationParams {
+        extensions: vec![ExpirationExtension {
+            deadline: deadline_index,
+            partition: partition_index,
+            sectors: make_bitfield(&[sector.sector_number]),
+            new_expiration,
+        }],
+    };
+
+    let res = h.extend_sectors(&mut rt, params);
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        &format!(
+            "cannot be more than {} past current epoch",
+            policy.max_sector_expiration_extension
+        ),
+        res,
+    );
+    check_state_invariants(&rt);
+}
+
+#[test]
+fn rejects_extension_past_max_for_seal_proof() {
+    let (mut h, mut rt) = setup();
+    let mut sector = commit_sector(&mut h, &mut rt);
+    // and prove it once to activate it.
+    h.advance_and_submit_posts(&mut rt, &vec![sector.clone()]);
+
+    let policy = Policy::default();
+    let max_lifetime = seal_proof_sector_maximum_lifetime(sector.seal_proof).unwrap();
+
+    let state: State = rt.get_state();
+    let (deadline_index, partition_index) =
+        state.find_sector(&policy, rt.store(), sector.sector_number).unwrap();
+
+    // extend sector until just below threshold
+    rt.set_epoch(sector.expiration);
+    let extension = policy.min_sector_expiration;
+
+    let mut expiration = sector.expiration + extension;
+    while expiration - sector.activation < max_lifetime {
+        let params = ExtendSectorExpirationParams {
+            extensions: vec![ExpirationExtension {
+                deadline: deadline_index,
+                partition: partition_index,
+                sectors: make_bitfield(&[sector.sector_number]),
+                new_expiration: expiration,
+            }],
+        };
+        h.extend_sectors(&mut rt, params).unwrap();
+        sector.expiration = expiration;
+
+        expiration += extension;
+    }
+
+    // next extension fails because it extends sector past max lifetime
+    let params = ExtendSectorExpirationParams {
+        extensions: vec![ExpirationExtension {
+            deadline: deadline_index,
+            partition: partition_index,
+            sectors: make_bitfield(&[sector.sector_number]),
+            new_expiration: expiration,
+        }],
+    };
+
+    let res = h.extend_sectors(&mut rt, params);
+    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "total sector lifetime", res);
+    check_state_invariants(&rt);
+}
+
+#[test]
+fn updates_expiration_with_valid_params() {
+    let (mut h, mut rt) = setup();
+    let old_sector = commit_sector(&mut h, &mut rt);
+    h.advance_and_submit_posts(&mut rt, &vec![old_sector.clone()]);
+
+    let policy = Policy::default();
+    let state: State = rt.get_state();
+
+    let (deadline_index, partition_index) =
+        state.find_sector(&policy, rt.store(), old_sector.sector_number).unwrap();
+
+    let extension = 42 * policy.wpost_proving_period;
+    let new_expiration = old_sector.expiration + extension;
+
+    let params = ExtendSectorExpirationParams {
+        extensions: vec![ExpirationExtension {
+            deadline: deadline_index,
+            partition: partition_index,
+            sectors: make_bitfield(&[old_sector.sector_number]),
+            new_expiration,
+        }],
+    };
+
+    h.extend_sectors(&mut rt, params).unwrap();
+
+    // assert sector expiration is set to the new value
+    let new_sector = h.get_sector(&rt, old_sector.sector_number);
+    assert_eq!(new_expiration, new_sector.expiration);
+
+    let quant = state.quant_spec_for_deadline(&policy, deadline_index);
+
+    // assert that new expiration exists
+    let (_, mut partition) = h.get_deadline_and_partition(&rt, deadline_index, partition_index);
+    let expiration_set =
+        partition.pop_expired_sectors(rt.store(), new_expiration - 1, quant).unwrap();
+    assert!(expiration_set.is_empty());
+
+    let expiration_set = partition
+        .pop_expired_sectors(rt.store(), quant.quantize_up(new_expiration), quant)
+        .unwrap();
+    assert!(!expiration_set.is_empty());
+
+    check_state_invariants(&rt);
+}
+
+#[test]
+fn updates_many_sectors() {
+    let (mut h, mut rt) = setup();
+    h.construct_and_verify(&mut rt);
+
+    let sector_count = 4_000u64;
+
+    // commit a bunch of sectors to ensure that we get multiple partitions
+    let sector_infos = h.commit_and_prove_sectors(
+        &mut rt,
+        sector_count as usize,
+        DEFAULT_SECTOR_EXPIRATION as u64,
+        Vec::new(),
+        true,
+    );
+    h.advance_and_submit_posts(&mut rt, &sector_infos);
+
+    let policy = Policy::default();
+    let new_expiration = sector_infos[0].expiration + 42 * policy.wpost_proving_period;
+    let mut extensions: Vec<ExpirationExtension> = Vec::new();
+
+    let state: State = rt.get_state();
+    let deadlines = state.load_deadlines(rt.store()).unwrap();
+    deadlines
+        .for_each(&policy, rt.store(), |deadline_index, deadline| {
+            let partitions = deadline.partitions_amt(rt.store()).unwrap();
+            partitions
+                .for_each(|partition_index, partition| {
+                    // filter out even-numbered sectors
+                    let sectors = partition
+                        .sectors
+                        .bounded_iter(policy.addressed_sectors_max)
+                        .unwrap()
+                        .filter(|n| n % 2 != 0)
+                        .collect_vec();
+
+                    extensions.push(ExpirationExtension {
+                        deadline: deadline_index,
+                        partition: partition_index,
+                        sectors: make_bitfield(&sectors),
+                        new_expiration,
+                    });
+
+                    Ok(())
+                })
+                .unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+    // make sure we're touching at least two sectors
+    assert!(extensions.len() >= 2, "test error: this test should touch more than one partition");
+    let params = ExtendSectorExpirationParams { extensions };
+
+    h.extend_sectors(&mut rt, params).unwrap();
+    let state: State = rt.get_state();
+    let deadlines = state.load_deadlines(rt.store()).unwrap();
+
+    // half of the sectors should expire on-time
+    let mut on_time_total = 0;
+    deadlines
+        .for_each(&policy, rt.store(), |deadline_index, mut deadline| {
+            let expiration_set = deadline
+                .pop_expired_sectors(
+                    rt.store(),
+                    new_expiration - 1,
+                    state.quant_spec_for_deadline(&policy, deadline_index),
+                )
+                .unwrap();
+            on_time_total += expiration_set.len();
+            Ok(())
+        })
+        .unwrap();
+    assert_eq!(sector_count / 2, on_time_total);
+
+    // half of the sectors should expire late
+    let mut extended_total = 0;
+    deadlines
+        .for_each(&policy, rt.store(), |deadline_index, mut deadline| {
+            let expiration_set = deadline
+                .pop_expired_sectors(
+                    rt.store(),
+                    new_expiration - 1,
+                    state.quant_spec_for_deadline(&policy, deadline_index),
+                )
+                .unwrap();
+            extended_total += expiration_set.len();
+            Ok(())
+        })
+        .unwrap();
+    assert_eq!(sector_count / 2, extended_total);
+
+    check_state_invariants(&rt);
+}
+
+#[test]
+fn supports_extensions_off_deadline_boundary() {
+    let (mut h, mut rt) = setup();
+    let old_sector = commit_sector(&mut h, &mut rt);
+    h.advance_and_submit_posts(&mut rt, &vec![old_sector.clone()]);
+
+    let state: State = rt.get_state();
+    let policy = Policy::default();
+    let (deadline_index, partition_index) =
+        state.find_sector(&policy, rt.store(), old_sector.sector_number).unwrap();
+
+    let extension = 42 * policy.wpost_proving_period + policy.wpost_proving_period / 3;
+    let new_expiration = old_sector.expiration + extension;
+
+    let params = ExtendSectorExpirationParams {
+        extensions: vec![ExpirationExtension {
+            deadline: deadline_index,
+            partition: partition_index,
+            sectors: make_bitfield(&[old_sector.sector_number]),
+            new_expiration,
+        }],
+    };
+
+    h.extend_sectors(&mut rt, params).unwrap();
+
+    // assert sector expiration is set to the new value
+    let mut state: State = rt.get_state();
+    let new_sector = h.get_sector(&rt, old_sector.sector_number);
+    assert_eq!(new_expiration, new_sector.expiration);
+
+    // advance clock to expiration
+    rt.set_epoch(new_sector.expiration);
+    state.proving_period_start += policy.wpost_proving_period
+        * ((rt.epoch - state.proving_period_start) / policy.wpost_proving_period + 1);
+    rt.replace_state(&state);
+
+    // confirm it is not in sector's deadline
+    let deadline_info = h.deadline(&rt);
+    assert_ne!(deadline_index, deadline_info.index);
+
+    // advance to deadline and submit one last PoSt
+    let deadline_info = h.advance_to_deadline(&mut rt, deadline_index);
+
+    let partitions = vec![PoStPartition {
+        index: partition_index,
+        skipped: UnvalidatedBitField::Validated(BitField::default()),
+    }];
+    h.submit_window_post(
+        &mut rt,
+        &deadline_info,
+        partitions,
+        vec![new_sector.clone()],
+        PoStConfig::empty(),
+    );
+
+    // advance one more time. No missed PoSt fees are charged. Total power and pledge are lowered.
+    let power = -power_for_sector(h.sector_size, &new_sector);
+    let mut cron_config = CronConfig::empty();
+    cron_config.no_enrollment = true;
+    cron_config.expired_sectors_power_delta = Some(power);
+    cron_config.expired_sectors_pledge_delta = -new_sector.initial_pledge;
+
+    h.advance_deadline(&mut rt, cron_config);
+
+    let state: State = rt.get_state();
+    assert!(!state.deadline_cron_active);
+
+    check_state_invariants(&rt);
+}

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1889,7 +1889,7 @@ impl ActorHarness {
         &self,
         rt: &mut MockRuntime,
         mut params: ExtendSectorExpirationParams,
-    ) -> Result<(), ActorError> {
+    ) -> Result<RawBytes, ActorError> {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
         rt.expect_validate_caller_addr(self.caller_addrs());
 
@@ -1919,13 +1919,13 @@ impl ActorHarness {
             );
         }
 
-        rt.call::<Actor>(
+        let ret = rt.call::<Actor>(
             Method::ExtendSectorExpiration as u64,
             &RawBytes::serialize(params).unwrap(),
         )?;
 
         rt.verify();
-        Ok(())
+        Ok(ret)
     }
 }
 

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -10,8 +10,8 @@ use fil_actor_miner::ext::market::ON_MINER_SECTORS_TERMINATE_METHOD;
 use fil_actor_miner::ext::power::{UPDATE_CLAIMED_POWER_METHOD, UPDATE_PLEDGE_TOTAL_METHOD};
 use fil_actor_miner::max_prove_commit_duration;
 use fil_actor_miner::{
-    aggregate_pre_commit_network_fee, ChangeWorkerAddressParams, CheckSectorProvenParams,
-    TerminateSectorsParams, TerminationDeclaration,
+    aggregate_pre_commit_network_fee, qa_power_for_sector, ChangeWorkerAddressParams,
+    ExtendSectorExpirationParams,
 };
 use fil_actor_miner::{
     initial_pledge_for_power, locked_reward_from_reward, new_deadline_info_from_offset_and_epoch,
@@ -26,6 +26,7 @@ use fil_actor_miner::{
     Sectors, State, SubmitWindowedPoStParams, VestingFunds, WindowedPoSt, WithdrawBalanceParams,
     WithdrawBalanceReturn, CRON_EVENT_PROVING_DEADLINE,
 };
+use fil_actor_miner::{CheckSectorProvenParams, TerminateSectorsParams, TerminationDeclaration};
 use fil_actor_power::{
     CurrentTotalPowerReturn, EnrollCronEventParams, Method as PowerMethod, UpdateClaimedPowerParams,
 };
@@ -39,7 +40,7 @@ use fil_actors_runtime::{
 };
 use fvm_shared::bigint::Zero;
 
-use fvm_ipld_bitfield::{BitField, UnvalidatedBitField};
+use fvm_ipld_bitfield::{BitField, UnvalidatedBitField, Validate};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::de::Deserialize;
 use fvm_ipld_encoding::ser::Serialize;
@@ -852,7 +853,7 @@ impl ActorHarness {
         }
     }
 
-    fn get_sector(&self, rt: &MockRuntime, sector_number: SectorNumber) -> SectorOnChainInfo {
+    pub fn get_sector(&self, rt: &MockRuntime, sector_number: SectorNumber) -> SectorOnChainInfo {
         let state = self.get_state(rt);
         state.get_sector(&rt.store, sector_number).unwrap().unwrap()
     }
@@ -1881,6 +1882,49 @@ impl ActorHarness {
         rt.call::<Actor>(Method::ConfirmUpdateWorkerKey as u64, &RawBytes::default())?;
         rt.verify();
 
+        Ok(())
+    }
+
+    pub fn extend_sectors(
+        &self,
+        rt: &mut MockRuntime,
+        mut params: ExtendSectorExpirationParams,
+    ) -> Result<(), ActorError> {
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
+        rt.expect_validate_caller_addr(self.caller_addrs());
+
+        let mut qa_delta = BigInt::zero();
+        for extension in params.extensions.iter_mut() {
+            for sector_nr in extension.sectors.validate().unwrap().iter() {
+                let sector = self.get_sector(&rt, sector_nr);
+                let mut new_sector = sector.clone();
+                new_sector.expiration = extension.new_expiration;
+                qa_delta += qa_power_for_sector(self.sector_size, &new_sector)
+                    - qa_power_for_sector(self.sector_size, &sector);
+            }
+        }
+
+        if !qa_delta.is_zero() {
+            let params = UpdateClaimedPowerParams {
+                raw_byte_delta: BigInt::zero(),
+                quality_adjusted_delta: qa_delta,
+            };
+            rt.expect_send(
+                *STORAGE_POWER_ACTOR_ADDR,
+                UPDATE_CLAIMED_POWER_METHOD,
+                RawBytes::serialize(params).unwrap(),
+                TokenAmount::zero(),
+                RawBytes::default(),
+                ExitCode::OK,
+            );
+        }
+
+        rt.call::<Actor>(
+            Method::ExtendSectorExpiration as u64,
+            &RawBytes::serialize(params).unwrap(),
+        )?;
+
+        rt.verify();
         Ok(())
     }
 }


### PR DESCRIPTION
Implemented tests from [here](https://github.com/filecoin-project/specs-actors/blob/0afe155bfffa036057af5519afdead845e0780de/actors/builtin/miner/miner_test.go#L1802)

* `rejects_negative_extensions`
* `rejects_extension_too_far_in_future`
* `rejects_extension_past_max_for_seal_proof`
* `updates_expiration_with_valid_params`
* `updates_many_sectors`
* `supports_extensions_off_deadline_boundary`

~~Long test warning :warning:~~
