### PR TITLE
Miner tests (part 28)

### DIFF
--- a/actors/miner/tests/deadline_cron_defers_stops_restarts.rs
+++ b/actors/miner/tests/deadline_cron_defers_stops_restarts.rs
@@ -58,19 +58,8 @@ fn cron_enrolls_on_precommit_expires_on_pcd_expiration_re_enrolls_on_new_precomm
     let mut cron_ctrl = CronControl::default();
 
     let epoch = cron_ctrl.pre_commit_start_cron_expire_stop_cron(&h, &mut rt, epoch);
-    cron_ctrl.pre_commit_to_start_cron(epoch);
+    cron_ctrl.pre_commit_to_start_cron(&h, &mut rt, epoch);
 }
-// 	t.Run("cron enrolls on precommit, expires on pcd expiration, re-enrolls on new precommit immediately", func(t *testing.T) {
-// 		rt := builder.Build(t)
-// 		epoch := periodOffset + 1
-// 		rt.SetEpoch(epoch)
-// 		actor.constructAndVerify(rt)
-// 		cronCtrl := newCronControl(rt, actor)
-
-// 		epoch = cronCtrl.preCommitStartCronExpireStopCron(t, epoch)
-// 		cronCtrl.preCommitToStartCron(t, epoch)
-// 	})
-
 // 	t.Run("cron enrolls on precommit, expires on pcd expiration, re-enrolls on new precommit after falling out of date", func(t *testing.T) {
 // 		rt := builder.Build(t)
 // 		epoch := periodOffset + 1

--- a/actors/miner/tests/deadline_cron_defers_stops_restarts.rs
+++ b/actors/miner/tests/deadline_cron_defers_stops_restarts.rs
@@ -14,7 +14,7 @@ fn cron_enrolls_on_precommit_prove_commits_and_continues_enrolling() {
     rt.set_balance(TokenAmount::from(BIG_BALANCE));
     h.construct_and_verify(&mut rt);
 
-    let cron_ctrl = CronControl { pre_commit_num: 0 };
+    let cron_ctrl = CronControl::default();
     let long_expiration = 500;
 
     cron_ctrl.require_cron_inactive(&h, &rt);

--- a/actors/miner/tests/deadline_cron_defers_stops_restarts.rs
+++ b/actors/miner/tests/deadline_cron_defers_stops_restarts.rs
@@ -1,0 +1,103 @@
+use fil_actor_miner::{
+    pledge_penalty_for_continued_fault, power_for_sectors, Deadline, PowerPair, SectorOnChainInfo,
+};
+use fil_actors_runtime::test_utils::MessageAccumulator;
+use fil_actors_runtime::test_utils::MockRuntime;
+use fvm_ipld_bitfield::BitField;
+use fvm_shared::bigint::Zero;
+use fvm_shared::clock::{ChainEpoch, QuantSpec};
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::sector::SectorSize;
+use std::ops::Neg;
+
+mod util;
+use crate::util::*;
+
+// an expriration ~10 days greater than effective min expiration taking into account 30 days max
+// between pre and prove commit
+const DEFAULT_SECTOR_EXPIRATION: ChainEpoch = 220;
+
+const PERIOD_OFFSET: ChainEpoch = 100;
+const BIG_BALANCE: u128 = 1_000_000_000_000_000_000_000_000u128;
+const BIG_REWARDS: u128 = 1_000 * 1e18 as u128;
+
+#[test]
+fn cron_enrolls_on_precommit_prove_commits_and_continues_enrolling() {
+    let h = ActorHarness::new(PERIOD_OFFSET);
+    let mut rt = h.new_runtime();
+    rt.set_balance(TokenAmount::from(BIG_BALANCE));
+    h.construct_and_verify(&mut rt);
+
+    let mut cron_ctrl = CronControl { rt, h, pre_commit_num: 0 };
+    let long_expiration = 500;
+
+    cron_ctrl.require_cron_inactive();
+    let sectors =
+        cron_ctrl.h.commit_and_prove_sectors(&mut cron_ctrl.rt, 1, long_expiration, vec![], true);
+}
+// func TestDeadlineCronDefersStopsRestarts(t *testing.T) {
+// 	periodOffset := abi.ChainEpoch(100)
+// 	actor := newHarness(t, periodOffset)
+// 	builder := builderForHarness(actor).
+// 		WithBalance(bigBalance, big.Zero())
+
+// 	t.Run("cron enrolls on precommit, prove commits and continues enrolling", func(t *testing.T) {
+// 		rt := builder.Build(t)
+// 		actor.constructAndVerify(rt)
+// 		cronCtrl := newCronControl(rt, actor)
+// 		longExpiration := uint64(500)
+
+// 		cronCtrl.requireCronInactive(t)
+// 		sectors := actor.commitAndProveSectors(rt, 1, longExpiration, nil, true)
+// 		cronCtrl.requireCronActive(t)
+
+// 		// advance cron to activate power.
+// 		advanceAndSubmitPoSts(rt, actor, sectors...)
+// 		// advance 499 days of deadline (1 before expiration occurrs)
+// 		// this asserts that cron continues to enroll within advanceAndSubmitPoSt
+// 		for i := 0; i < 499; i++ {
+// 			advanceAndSubmitPoSts(rt, actor, sectors...)
+// 		}
+// 		actor.checkState(rt)
+// 		st := getState(rt)
+// 		assert.True(t, st.DeadlineCronActive)
+// 	})
+
+// 	t.Run("cron enrolls on precommit, expires on pcd expiration, re-enrolls on new precommit immediately", func(t *testing.T) {
+// 		rt := builder.Build(t)
+// 		epoch := periodOffset + 1
+// 		rt.SetEpoch(epoch)
+// 		actor.constructAndVerify(rt)
+// 		cronCtrl := newCronControl(rt, actor)
+
+// 		epoch = cronCtrl.preCommitStartCronExpireStopCron(t, epoch)
+// 		cronCtrl.preCommitToStartCron(t, epoch)
+// 	})
+
+// 	t.Run("cron enrolls on precommit, expires on pcd expiration, re-enrolls on new precommit after falling out of date", func(t *testing.T) {
+// 		rt := builder.Build(t)
+// 		epoch := periodOffset + 1
+// 		rt.SetEpoch(epoch)
+// 		actor.constructAndVerify(rt)
+// 		cronCtrl := newCronControl(rt, actor)
+
+// 		epoch = cronCtrl.preCommitStartCronExpireStopCron(t, epoch)
+// 		// Advance some epochs to fall several pp out of date, then precommit again reenrolling cron
+// 		epoch = epoch + 200*miner.WPoStProvingPeriod
+// 		epoch = cronCtrl.preCommitStartCronExpireStopCron(t, epoch)
+// 		// Stay within the same deadline but advance an epoch
+// 		epoch = epoch + 1
+// 		cronCtrl.preCommitToStartCron(t, epoch)
+// 	})
+
+// 	t.Run("enroll, pcd expire, re-enroll x 3", func(t *testing.T) {
+// 		rt := builder.Build(t)
+// 		epoch := periodOffset + 1
+// 		rt.SetEpoch(epoch)
+// 		actor.constructAndVerify(rt)
+// 		cronCtrl := newCronControl(rt, actor)
+// 		for i := 0; i < 3; i++ {
+// 			epoch = cronCtrl.preCommitStartCronExpireStopCron(t, epoch) + 42
+// 		}
+// 	})
+// }

--- a/actors/miner/tests/deadline_cron_defers_stops_restarts.rs
+++ b/actors/miner/tests/deadline_cron_defers_stops_restarts.rs
@@ -47,6 +47,19 @@ fn cron_enrolls_on_precommit_prove_commits_and_continues_enrolling() {
     assert!(st.deadline_cron_active);
 }
 
+#[test]
+fn cron_enrolls_on_precommit_expires_on_pcd_expiration_re_enrolls_on_new_precommit_immediately() {
+    let mut h = ActorHarness::new(PERIOD_OFFSET);
+    let mut rt = h.new_runtime();
+    rt.set_balance(TokenAmount::from(BIG_BALANCE));
+    let epoch = PERIOD_OFFSET + 1;
+    rt.set_epoch(epoch);
+    h.construct_and_verify(&mut rt);
+    let mut cron_ctrl = CronControl::default();
+
+    let epoch = cron_ctrl.pre_commit_start_cron_expire_stop_cron(&h, &mut rt, epoch);
+    cron_ctrl.pre_commit_to_start_cron(epoch);
+}
 // 	t.Run("cron enrolls on precommit, expires on pcd expiration, re-enrolls on new precommit immediately", func(t *testing.T) {
 // 		rt := builder.Build(t)
 // 		epoch := periodOffset + 1

--- a/actors/miner/tests/deadline_cron_defers_stops_restarts.rs
+++ b/actors/miner/tests/deadline_cron_defers_stops_restarts.rs
@@ -60,10 +60,10 @@ fn cron_enrolls_on_precommit_expires_on_pcd_expiration_re_enrolls_on_new_precomm
 
     epoch = cron_ctrl.pre_commit_start_cron_expire_stop_cron(&h, &mut rt, epoch);
     // Advance some epochs to fall several pp out of date, then precommit again reenrolling cron
-    epoch = epoch + 200 * rt.policy.wpost_proving_period;
+    epoch += 200 * rt.policy.wpost_proving_period;
     epoch = cron_ctrl.pre_commit_start_cron_expire_stop_cron(&h, &mut rt, epoch);
     // Stay within the same deadline but advance an epoch
-    epoch = epoch + 1;
+    epoch += 1;
     cron_ctrl.pre_commit_to_start_cron(&h, &mut rt, epoch);
 }
 

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -6,7 +6,6 @@ use fil_actor_market::{
     Method as MarketMethod, OnMinerSectorsTerminateParams, SectorDataSpec, SectorDeals,
     SectorWeights, VerifyDealsForActivationParams, VerifyDealsForActivationReturn,
 };
-use fil_actor_miner::aggregate_pre_commit_network_fee;
 use fil_actor_miner::ext::market::ON_MINER_SECTORS_TERMINATE_METHOD;
 use fil_actor_miner::ext::power::{UPDATE_CLAIMED_POWER_METHOD, UPDATE_PLEDGE_TOTAL_METHOD};
 use fil_actor_miner::max_prove_commit_duration;
@@ -2739,7 +2738,7 @@ impl CronControl {
         let sector_no = self.pre_commit_num;
         self.pre_commit_num += 1;
         let expiration =
-            dlinfo.period_end() + DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period; // something on deadline boundary but > 180 days
+            dlinfo.period_end() + DEFAULT_SECTOR_EXPIRATION as i64 * rt.policy.wpost_proving_period; // something on deadline boundary but > 180 days
         let precommit_params =
             h.make_pre_commit_params(sector_no, pre_commit_epoch - 1, expiration, vec![]);
         h.pre_commit_sector(rt, precommit_params, PreCommitConfig::empty(), true);

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2602,8 +2602,8 @@ impl CronControl {
         h: &ActorHarness,
         rt: &mut MockRuntime,
         start_epoch: ChainEpoch,
-    ) {
+    ) -> ChainEpoch {
         let clean_up_epoch = self.pre_commit_to_start_cron(h, rt, start_epoch);
-        self.expire_pre_commit_stop_cron(h, rt, start_epoch, clean_up_epoch);
+        self.expire_pre_commit_stop_cron(h, rt, start_epoch, clean_up_epoch)
     }
 }

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -58,6 +58,7 @@ use cid::Cid;
 use multihash::derive::Multihash;
 use multihash::MultihashDigest;
 
+use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 const RECEIVER_ID: u64 = 1000;
@@ -2493,5 +2494,19 @@ pub fn check_deadline_state_invariants<BS: Blockstore>(
         live_power: all_live_power,
         active_power: all_active_power,
         faulty_power: all_faulty_power,
+    }
+}
+
+pub struct CronControl {
+    pub rt: RefCell<MockRuntime>,
+    pub h: RefCell<ActorHarness>,
+    pub pre_commit_num: u64,
+}
+
+impl CronControl {
+    pub fn require_cron_inactive(&self) {
+        let st = self.h.asref().get_state(&self.rt);
+        assert!(!st.deadline_cron_active); // No cron running now
+        assert!(!st.continue_deadline_cron()); // No reason to cron now, state inactive
     }
 }

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -6,14 +6,14 @@ use fil_actor_market::{
     Method as MarketMethod, OnMinerSectorsTerminateParams, SectorDataSpec, SectorDeals,
     SectorWeights, VerifyDealsForActivationParams, VerifyDealsForActivationReturn,
 };
+use fil_actor_miner::aggregate_pre_commit_network_fee;
 use fil_actor_miner::ext::market::ON_MINER_SECTORS_TERMINATE_METHOD;
 use fil_actor_miner::ext::power::{UPDATE_CLAIMED_POWER_METHOD, UPDATE_PLEDGE_TOTAL_METHOD};
+use fil_actor_miner::max_prove_commit_duration;
 use fil_actor_miner::{
     aggregate_pre_commit_network_fee, ChangeWorkerAddressParams, CheckSectorProvenParams,
     TerminateSectorsParams, TerminationDeclaration,
 };
-use fil_actor_miner::aggregate_pre_commit_network_fee;
-use fil_actor_miner::max_prove_commit_duration;
 use fil_actor_miner::{
     initial_pledge_for_power, locked_reward_from_reward, new_deadline_info_from_offset_and_epoch,
     pledge_penalty_for_continued_fault, power_for_sectors, qa_power_for_weight, Actor,


### PR DESCRIPTION
- [x] TestDeadlineCronDefersStopsRestarts
  - [x] cron_enrolls_on_precommit,_prove_commits_and_continues_enrolling
  - [x] cron_enrolls_on_precommit,_expires_on_pcd_expiration,_re-enrolls_on_new_precommit_immediately
  - [x] cron_enrolls_on_precommit,_expires_on_pcd_expiration,_re-enrolls_on_new_precommit_after_falling_out_of_date
  - [x] enroll,_pcd_expire,_re-enroll_x_3