### PR TITLE
miner tests part 35

### DIFF
--- a/actors/miner/tests/change_peer_id_test.rs
+++ b/actors/miner/tests/change_peer_id_test.rs
@@ -1,0 +1,28 @@
+use fil_actors_runtime::test_utils::MockRuntime;
+use fvm_shared::econ::TokenAmount;
+
+mod util;
+use util::*;
+
+fn setup() -> (ActorHarness, MockRuntime) {
+    let big_balance = 20u128.pow(23);
+    let period_offset = 100;
+    let precommit_epoch = 1;
+
+    let h = ActorHarness::new(period_offset);
+    let mut rt = h.new_runtime();
+    h.construct_and_verify(&mut rt);
+    rt.balance.replace(TokenAmount::from(big_balance));
+    rt.set_epoch(precommit_epoch);
+
+    (h, rt)
+}
+
+#[test]
+fn successfully_change_peer_id() {
+    let (h, mut rt) = setup();
+    let new_pid = b"cthulhu".to_vec();
+    h.change_peer_id(&mut rt, new_pid);
+
+    check_state_invariants(&rt);
+}

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1670,6 +1670,22 @@ impl ActorHarness {
 
         (-sector_power, pledge_delta)
     }
+
+    pub fn change_peer_id(&self, rt: &mut MockRuntime, new_id: Vec<u8>) {
+        let params = ChangePeerIDParams { new_id: new_id.to_owned() };
+
+        rt.expect_validate_caller_addr(self.caller_addrs());
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
+
+        rt.call::<Actor>(Method::ChangePeerID as u64, &RawBytes::serialize(params).unwrap())
+            .unwrap();
+        rt.verify();
+
+        let state: State = rt.get_state();
+        let info = state.get_info(rt.store()).unwrap();
+
+        assert_eq!(new_id, info.peer_id);
+    }
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
Implemented test from [here](https://github.com/filecoin-project/specs-actors/blob/0afe155bfffa036057af5519afdead845e0780de/actors/builtin/miner/miner_test.go#L2331)
* `successfully_change_peer_id`