### PR TITLE
fix: check actor build status in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -151,6 +151,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     j1.join().unwrap();
     j2.join().unwrap();
 
+    let result = child.wait().expect("failed to wait for build to finish");
+    if !result.success() {
+        return Err("actor build failed".into());
+    }
+
     let dst = Path::new(&out_dir).join("bundle.car");
     let mut bundler = Bundler::new(&dst);
     for (pkg, id) in ACTORS {


### PR DESCRIPTION
Otherwise, it can fail and we can end up using the cached version.