### PR TITLE
miner tests part 41

### DIFF
--- a/actors/miner/tests/change_owner_address_test.rs
+++ b/actors/miner/tests/change_owner_address_test.rs
@@ -1,0 +1,177 @@
+use fil_actors_runtime::test_utils::{
+    expect_abort, new_bls_addr, MockRuntime, ACCOUNT_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID,
+};
+use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode};
+
+mod util;
+use util::*;
+
+const NEW_ADDRESS: Address = Address::new_id(1001);
+const OTHER_ADDRESS: Address = Address::new_id(1002);
+
+fn setup() -> (ActorHarness, MockRuntime) {
+    let big_balance = 20u128.pow(23);
+    let period_offset = 100;
+
+    let h = ActorHarness::new(period_offset);
+    let mut rt = h.new_runtime();
+    h.construct_and_verify(&mut rt);
+    rt.balance.replace(TokenAmount::from(big_balance));
+
+    (h, rt)
+}
+
+#[test]
+fn successful_change() {
+    let (h, mut rt) = setup();
+
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
+    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+
+    let info = h.get_info(&rt);
+    assert_eq!(h.owner, info.owner);
+    assert_eq!(NEW_ADDRESS, info.pending_owner_address.unwrap());
+
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, NEW_ADDRESS);
+    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+
+    let info = h.get_info(&rt);
+    assert_eq!(NEW_ADDRESS, info.owner);
+    assert!(info.pending_owner_address.is_none());
+
+    check_state_invariants(&rt);
+}
+
+#[test]
+fn proposed_must_be_valid() {
+    let (h, mut rt) = setup();
+
+    let nominees = vec![
+        Address::new_actor(b"Cthulhu"),
+        new_bls_addr(42),
+        Address::new_secp256k1(&[42; 65]).unwrap(),
+    ];
+
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
+
+    for nominee in nominees {
+        let result = h.change_owner_address(&mut rt, nominee);
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
+    }
+
+    check_state_invariants(&rt);
+}
+
+#[test]
+fn withdraw_proposal() {
+    let (h, mut rt) = setup();
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
+    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+
+    // revert it
+    h.change_owner_address(&mut rt, h.owner).unwrap();
+
+    let info = h.get_info(&rt);
+    assert_eq!(h.owner, info.owner);
+    assert!(info.pending_owner_address.is_none());
+
+    // new address cannot confirm
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, NEW_ADDRESS);
+    let result = h.change_owner_address(&mut rt, NEW_ADDRESS);
+    expect_abort(ExitCode::USR_FORBIDDEN, result);
+
+    check_state_invariants(&rt);
+}
+
+#[test]
+fn only_owner_can_propose() {
+    let (h, mut rt) = setup();
+
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
+    let result = h.change_owner_address(&mut rt, NEW_ADDRESS);
+    expect_abort(ExitCode::USR_FORBIDDEN, result);
+
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, OTHER_ADDRESS);
+    let result = h.change_owner_address(&mut rt, NEW_ADDRESS);
+    expect_abort(ExitCode::USR_FORBIDDEN, result);
+
+    check_state_invariants(&rt);
+}
+
+#[test]
+fn only_owner_can_change_proposal() {
+    let (h, mut rt) = setup();
+
+    // make a proposal
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
+    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
+    let result = h.change_owner_address(&mut rt, OTHER_ADDRESS);
+    expect_abort(ExitCode::USR_FORBIDDEN, result);
+
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, OTHER_ADDRESS);
+    let result = h.change_owner_address(&mut rt, OTHER_ADDRESS);
+    expect_abort(ExitCode::USR_FORBIDDEN, result);
+
+    // owner can change it
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
+    h.change_owner_address(&mut rt, OTHER_ADDRESS).unwrap();
+
+    let info = h.get_info(&rt);
+    assert_eq!(h.owner, info.owner);
+    assert_eq!(OTHER_ADDRESS, info.pending_owner_address.unwrap());
+
+    check_state_invariants(&rt);
+}
+
+#[test]
+fn only_nominee_can_confirm() {
+    let (h, mut rt) = setup();
+
+    // make a proposal
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
+    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+
+    // owner re-proposing some address doesn't confirm it
+    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+    let info = h.get_info(&rt);
+    assert_eq!(h.owner, info.owner);
+    assert_eq!(NEW_ADDRESS, info.pending_owner_address.unwrap());
+
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
+    let result = h.change_owner_address(&mut rt, OTHER_ADDRESS);
+    expect_abort(ExitCode::USR_FORBIDDEN, result);
+
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, OTHER_ADDRESS);
+    let result = h.change_owner_address(&mut rt, OTHER_ADDRESS);
+    expect_abort(ExitCode::USR_FORBIDDEN, result);
+
+    // new address can confirm itself
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, NEW_ADDRESS);
+    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+
+    let info = h.get_info(&rt);
+    assert_eq!(NEW_ADDRESS, info.owner);
+    assert!(info.pending_owner_address.is_none());
+
+    check_state_invariants(&rt);
+}
+
+#[test]
+fn nominee_must_confirm_self_explicitly() {
+    let (h, mut rt) = setup();
+
+    // make a proposal
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
+    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+
+    // Not own address, should fail
+    rt.set_caller(*MULTISIG_ACTOR_CODE_ID, NEW_ADDRESS);
+    let result = h.change_owner_address(&mut rt, h.owner);
+    expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
+    let result = h.change_owner_address(&mut rt, OTHER_ADDRESS);
+    expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
+
+    check_state_invariants(&rt);
+}

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1968,9 +1968,14 @@ impl ActorHarness {
         let ret = rt.call::<Actor>(
             Method::ChangeOwnerAddress as u64,
             &RawBytes::serialize(new_address).unwrap(),
-        )?;
-        rt.verify();
-        Ok(ret)
+        );
+
+        if ret.is_ok() {
+            rt.verify();
+        } else {
+            rt.reset();
+        }
+        ret
     }
 }
 

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -10,7 +10,7 @@ use fil_actor_miner::ext::market::ON_MINER_SECTORS_TERMINATE_METHOD;
 use fil_actor_miner::ext::power::{UPDATE_CLAIMED_POWER_METHOD, UPDATE_PLEDGE_TOTAL_METHOD};
 use fil_actor_miner::{
     aggregate_pre_commit_network_fee, qa_power_for_sector, ChangeWorkerAddressParams,
-    ExtendSectorExpirationParams,
+    ExtendSectorExpirationParams, MinerInfo,
 };
 use fil_actor_miner::{
     initial_pledge_for_power, locked_reward_from_reward, new_deadline_info_from_offset_and_epoch,
@@ -1943,6 +1943,34 @@ impl ActorHarness {
         rt.call::<Actor>(Method::CompactPartitions as u64, &RawBytes::serialize(params).unwrap())?;
         rt.verify();
         Ok(())
+    }
+
+    pub fn get_info(&self, rt: &MockRuntime) -> MinerInfo {
+        let state: State = rt.get_state();
+        state.get_info(rt.store()).unwrap()
+    }
+
+    pub fn change_owner_address(
+        &self,
+        rt: &mut MockRuntime,
+        new_address: Address,
+    ) -> Result<RawBytes, ActorError> {
+        let expected = if rt.caller == self.owner {
+            self.owner
+        } else {
+            if let Some(pending_owner) = self.get_info(rt).pending_owner_address {
+                pending_owner
+            } else {
+                self.owner
+            }
+        };
+        rt.expect_validate_caller_addr(vec![expected]);
+        let ret = rt.call::<Actor>(
+            Method::ChangeOwnerAddress as u64,
+            &RawBytes::serialize(new_address).unwrap(),
+        )?;
+        rt.verify();
+        Ok(ret)
     }
 }
 


### PR DESCRIPTION
Implemented tests from [here](https://github.com/filecoin-project/specs-actors/blob/0afe155bfffa036057af5519afdead845e0780de/actors/builtin/miner/miner_test.go#L2954)

* `proposed_must_be_valid`
* `only_owner_can_propose`
* `withdraw_proposal`
* `nominee_must_confirm_self_explicitly`
* `only_owner_can_change_proposal`
* `successful_change`
* `only_nominee_can_confirm`

