### PR TITLE
miner tests part 47

### DIFF
--- a/actors/miner/tests/expected_reward_for_power_clampted_at_atto_fil_test.rs
+++ b/actors/miner/tests/expected_reward_for_power_clampted_at_atto_fil_test.rs
@@ -1,0 +1,43 @@
+use std::ops::Neg;
+
+use fil_actor_miner::detail::expected_reward_for_power_clamped_at_atto_fil;
+use fvm_shared::bigint::{BigInt, Zero};
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::sector::StoragePower;
+use fvm_shared::smooth::FilterEstimate;
+
+#[test]
+fn expected_zero_valued_br_clamped_at_1_attofil() {
+    let epoch_target_reward = TokenAmount::from(1u64 << 50);
+    let zero_qa_power = StoragePower::zero();
+    let network_qa_power = StoragePower::from(1u64 << 10);
+    let power_rate_of_change = StoragePower::from(1 << 10);
+    let reward_estimate = FilterEstimate::new(epoch_target_reward, BigInt::zero());
+    let power_estimate = FilterEstimate::new(network_qa_power, power_rate_of_change);
+
+    let br_clamped = expected_reward_for_power_clamped_at_atto_fil(
+        &reward_estimate,
+        &power_estimate,
+        &zero_qa_power,
+        1,
+    );
+    assert_eq!(br_clamped, BigInt::from(1));
+}
+
+#[test]
+fn expected_negative_value_br_clamped_at_1_atto_fil() {
+    let epoch_target_reward = TokenAmount::from(1u64 << 50);
+    let qa_sector_power = StoragePower::from(1u64 << 36);
+    let network_qa_power = StoragePower::from(1u64 << 10);
+    let power_rate_of_change = StoragePower::from(1 << 10).neg();
+    let reward_estimate = FilterEstimate::new(epoch_target_reward, BigInt::zero());
+    let power_estimate = FilterEstimate::new(network_qa_power, power_rate_of_change);
+
+    let four_br_clamped = expected_reward_for_power_clamped_at_atto_fil(
+        &reward_estimate,
+        &power_estimate,
+        &qa_sector_power,
+        4,
+    );
+    assert_eq!(four_br_clamped, BigInt::from(1));
+}

--- a/actors/miner/tests/expected_reward_for_power_clampted_at_atto_fil_test.rs
+++ b/actors/miner/tests/expected_reward_for_power_clampted_at_atto_fil_test.rs
@@ -21,7 +21,7 @@ fn expected_zero_valued_br_clamped_at_1_attofil() {
         &zero_qa_power,
         1,
     );
-    assert_eq!(br_clamped, BigInt::from(1));
+    assert_eq!(BigInt::from(1), br_clamped);
 }
 
 #[test]
@@ -39,5 +39,5 @@ fn expected_negative_value_br_clamped_at_1_atto_fil() {
         &qa_sector_power,
         4,
     );
-    assert_eq!(four_br_clamped, BigInt::from(1));
+    assert_eq!(BigInt::from(1), four_br_clamped);
 }


### PR DESCRIPTION
Implemented tests from [here](https://github.com/filecoin-project/specs-actors/blob/0afe155bfffa036057af5519afdead845e0780de/actors/builtin/miner/monies_test.go#L172)
* `expected_zero_valued_br_clamped_at_1_attofil`
* `expected_negative_value_br_clamped_at_1_atto_fil`