### PR TITLE
feat: enable wasm optimizations using binaryen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "binaryen"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783bea139d75b6a565b13fab54d12ec4d58724a9458598ad7283d578f4f8777a"
+dependencies = [
+ "binaryen-sys",
+]
+
+[[package]]
+name = "binaryen-sys"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e9636d01b92f2df45dce29c35a9e3724687c1055bb4472fb4b829cc4a5a561"
+dependencies = [
+ "cc",
+ "cmake",
+ "heck 0.3.3",
+ "regex",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,7 +367,7 @@ version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -360,6 +381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -844,6 +874,7 @@ dependencies = [
 name = "fil_builtin_actors_bundle"
 version = "8.0.0-rc.1"
 dependencies = [
+ "binaryen",
  "cid",
  "clap",
  "fil_actor_account",
@@ -1162,6 +1193,15 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "heck"
@@ -1856,6 +1896,12 @@ name = "unicode-ident"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ fil_actor_state = { version = "8.0.0-alpha.1", path = "./actors/state", features
 [build-dependencies]
 fil_actor_bundler = "3.0.4"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+binaryen = "0.12.1"
 
 [dependencies]
 clap = { version = "3.1.8", features = ["derive"] }

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,10 @@
+use binaryen::CodegenConfig;
+
 use fil_actor_bundler::Bundler;
 use std::error::Error;
+use std::fs;
 use std::io::{BufRead, BufReader};
+use std::os::raw::c_char;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::thread;
@@ -28,6 +32,12 @@ const ACTORS: &[(&Package, &ID)] = &[
 const WASM_FEATURES: &[&str] = &["+bulk-memory", "+crt-static"];
 
 const NETWORK_ENV: &str = "BUILD_FIL_NETWORK";
+
+static CODEGEN_CONFIG: &CodegenConfig = &CodegenConfig {
+    shrink_level: 2,       // Oz
+    optimization_level: 3, // O3
+    debug_info: false,
+};
 
 /// Returns the configured network name, checking both the environment and feature flags.
 fn network_name() -> String {
@@ -167,7 +177,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         // content-addressed CIDs.
         let forced_cid = None;
 
-        let cid = bundler.add_from_file(id, forced_cid, &bytecode_path).unwrap_or_else(|err| {
+        let bytecode = fs::read(&bytecode_path).expect("failed to open wasm module");
+        let bytecode = optimize_module(&bytecode).expect("failed to optimize wasm");
+
+        let cid = bundler.add_from_bytes(id, forced_cid, &bytecode).unwrap_or_else(|err| {
             panic!("failed to add file {:?} to bundle for actor {}: {}", bytecode_path, id, err)
         });
         println!("cargo:warning=added actor {} to bundle with CID {}", id, cid);
@@ -177,4 +190,27 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:warning=bundle={}", dst.display());
 
     Ok(())
+}
+
+fn optimize_module(bytecode: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
+    // We have to do this manually to explicitly set the features.
+    let mut module = unsafe {
+        let raw = binaryen::ffi::BinaryenModuleSafeRead(
+            bytecode.as_ptr() as *const c_char,
+            bytecode.len(),
+        );
+        if raw.is_null() {
+            return Err("invalid module".to_string().into());
+        }
+
+        let wasm_features = binaryen::ffi::BinaryenFeatureMVP()
+            | binaryen::ffi::BinaryenFeatureSignExt()
+            | binaryen::ffi::BinaryenFeatureBulkMemory()
+            | binaryen::ffi::BinaryenFeatureMutableGlobals()
+            | binaryen::ffi::BinaryenFeatureNontrappingFPToInt();
+        binaryen::ffi::BinaryenModuleSetFeatures(raw, wasm_features);
+        binaryen::Module::from_raw(raw)
+    };
+    module.optimize(CODEGEN_CONFIG);
+    Ok(module.write())
 }


### PR DESCRIPTION
This enables both the speed (3) and size (z) optimizations, bringing the miner actor down to 1MiB.

~Draft because, while _this_ PR is correct, there's a bug in the FVM https://github.com/filecoin-project/ref-fvm/issues/602.~

---

This PR has two main parts:

1. It strips the binary, bringing, e.g., the miner actor down to 1.4MiB (ish).
2. It then uses binaryen to both optimize and further trim down the binary to 1.0MiB.

Motivation:

1. Reduce the block sizes (try to get them down below a megabyte).
2. Reduce the CAR size. With these changes (even without the binaryen optimization step), we can get the compressed CAR size down to about half a megabyte.
3. Optimize the WASM itself for better performance. Parity is doing this with substrate as well.

In terms of how much this helps.... we'll need more thorough testing, but it looks like it helps a bit...

The main downside of this change is that it would:

1. Add an additional compile-time dep on a non-rust project (binaryen).
2. Add a compile-time dependency on cmake (to build binaryen).

I'm happy to drop the binaryen part if we feel that it's too risky, too late. But I'd like to drop the debug info from the release builds so we can get the bundle size down. This would let us check-in the _main_ bundles into the lotus source, significantly simplifying the build process.