### PR TITLE
chore: strip debug info in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,4 @@ panic = "unwind"
 overflow-checks = true
 lto = "thin"
 opt-level = "z"
+strip = true


### PR DESCRIPTION
This brings the uncompressed bundle size down to 5.23MiB uncompressed, or 640KiB compressed (zstd, level 18).