### PR TITLE
post commit happy path itest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,6 +1769,7 @@ dependencies = [
  "integer-encoding",
  "lazy_static",
  "log",
+ "multihash",
  "num-derive",
  "num-traits",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,7 @@ dependencies = [
  "fil_actor_system",
  "fil_actor_verifreg",
  "fil_actors_runtime",
+ "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3404,7 +3404,6 @@ where
                     "failed to expire pre-committed sectors",
                 )
             })?;
-
         state
             .apply_penalty(&deposit_to_burn)
             .map_err(|e| actor_error!(illegal_state, "failed to apply penalty: {}", e))?;
@@ -3422,6 +3421,11 @@ where
         let result = state.advance_deadline(policy, rt.store(), rt.curr_epoch()).map_err(|e| {
             e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to advance deadline")
         })?;
+        println!("previous faulty power: {}", result.previously_faulty_power.qa);
+        println!("reward {}", reward_smoothed.estimate());
+        println!("qap {}", quality_adj_power_smoothed.estimate());
+        println!("qap raw {:?}", quality_adj_power_smoothed);
+
 
         // Faults detected by this missed PoSt pay no penalty, but sectors that were already faulty
         // and remain faulty through this deadline pay the fault fee.
@@ -3430,6 +3434,7 @@ where
             quality_adj_power_smoothed,
             &result.previously_faulty_power.qa,
         );
+        println!("fault penalty {}", penalty_target);
 
         power_delta_total += &result.power_delta;
         pledge_delta_total += &result.pledge_delta;
@@ -3467,6 +3472,7 @@ where
 
     // Remove power for new faults, and burn penalties.
     request_update_power(rt, power_delta_total)?;
+    println!("burning {}", penalty_total);
     burn_funds(rt, penalty_total)?;
     notify_pledge_changed(rt, &pledge_delta_total)?;
 

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1552,6 +1552,7 @@ impl Actor {
         BS: Blockstore,
         RT: Runtime<BS>,
     {
+        println!("not crazy");
         let curr_epoch = rt.curr_epoch();
         {
             let policy = rt.policy();
@@ -1652,6 +1653,7 @@ impl Actor {
         rt.transaction(|state: &mut State, rt| {
             // Aggregate fee applies only when batching.
             if params.sectors.len() > 1 {
+                println!("trying to do aggregate fee with sector len {}", params.sectors.len());
                 let aggregate_fee = aggregate_pre_commit_network_fee(params.sectors.len() as i64, &rt.base_fee());
                 // AggregateFee applied to fee debt to consolidate burn with outstanding debts
                 state.apply_penalty(&aggregate_fee)
@@ -1675,6 +1677,7 @@ impl Actor {
                         e
                     )
                 })?;
+            println!("burn for some reason");
             fee_to_burn = repay_debts_or_abort(rt, state)?;
 
             let info = get_miner_info(rt.store(), state)?;
@@ -1748,6 +1751,7 @@ impl Actor {
             if available_balance < total_deposit_required {
                 return Err(actor_error!(insufficient_funds, "insufficient funds {} for pre-commit deposit: {}", available_balance, total_deposit_required));
             }
+            println!("PCD {}", total_deposit_required);
             state.add_pre_commit_deposit(&total_deposit_required)
                 .map_err(|e|
                     actor_error!(

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1552,7 +1552,6 @@ impl Actor {
         BS: Blockstore,
         RT: Runtime<BS>,
     {
-        println!("not crazy");
         let curr_epoch = rt.curr_epoch();
         {
             let policy = rt.policy();
@@ -1653,7 +1652,6 @@ impl Actor {
         rt.transaction(|state: &mut State, rt| {
             // Aggregate fee applies only when batching.
             if params.sectors.len() > 1 {
-                println!("trying to do aggregate fee with sector len {}", params.sectors.len());
                 let aggregate_fee = aggregate_pre_commit_network_fee(params.sectors.len() as i64, &rt.base_fee());
                 // AggregateFee applied to fee debt to consolidate burn with outstanding debts
                 state.apply_penalty(&aggregate_fee)
@@ -1677,7 +1675,6 @@ impl Actor {
                         e
                     )
                 })?;
-            println!("burn for some reason");
             fee_to_burn = repay_debts_or_abort(rt, state)?;
 
             let info = get_miner_info(rt.store(), state)?;
@@ -1751,7 +1748,6 @@ impl Actor {
             if available_balance < total_deposit_required {
                 return Err(actor_error!(insufficient_funds, "insufficient funds {} for pre-commit deposit: {}", available_balance, total_deposit_required));
             }
-            println!("PCD {}", total_deposit_required);
             state.add_pre_commit_deposit(&total_deposit_required)
                 .map_err(|e|
                     actor_error!(
@@ -3425,11 +3421,6 @@ where
         let result = state.advance_deadline(policy, rt.store(), rt.curr_epoch()).map_err(|e| {
             e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to advance deadline")
         })?;
-        println!("previous faulty power: {}", result.previously_faulty_power.qa);
-        println!("reward {}", reward_smoothed.estimate());
-        println!("qap {}", quality_adj_power_smoothed.estimate());
-        println!("qap raw {:?}", quality_adj_power_smoothed);
-
 
         // Faults detected by this missed PoSt pay no penalty, but sectors that were already faulty
         // and remain faulty through this deadline pay the fault fee.
@@ -3438,7 +3429,6 @@ where
             quality_adj_power_smoothed,
             &result.previously_faulty_power.qa,
         );
-        println!("fault penalty {}", penalty_target);
 
         power_delta_total += &result.power_delta;
         pledge_delta_total += &result.pledge_delta;
@@ -3476,7 +3466,6 @@ where
 
     // Remove power for new faults, and burn penalties.
     request_update_power(rt, power_delta_total)?;
-    println!("burning {}", penalty_total);
     burn_funds(rt, penalty_total)?;
     notify_pledge_changed(rt, &pledge_delta_total)?;
 

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -5,7 +5,7 @@ use cid::Cid;
 use fil_actors_runtime::DealWeight;
 use fvm_ipld_bitfield::UnvalidatedBitField;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::{serde_bytes, BytesDe};
+use fvm_ipld_encoding::{serde_bytes, BytesDe, Cbor};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
@@ -237,6 +237,9 @@ pub type PreCommitSectorParams = SectorPreCommitInfo;
 pub struct PreCommitSectorBatchParams {
     pub sectors: Vec<SectorPreCommitInfo>,
 }
+
+impl Cbor for PreCommitSectorBatchParams {}
+
 
 #[derive(Debug, Default, PartialEq, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct SectorPreCommitInfo {

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -113,6 +113,8 @@ pub struct SubmitWindowedPoStParams {
     pub chain_commit_rand: Randomness,
 }
 
+impl Cbor for SubmitWindowedPoStParams {}
+
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ProveCommitSectorParams {
     pub sector_number: SectorNumber,

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -120,6 +120,8 @@ pub struct ProveCommitSectorParams {
     pub proof: Vec<u8>,
 }
 
+impl Cbor for ProveCommitSectorParams {}
+
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct CheckSectorProvenParams {
     pub sector_number: SectorNumber,
@@ -239,7 +241,6 @@ pub struct PreCommitSectorBatchParams {
 }
 
 impl Cbor for PreCommitSectorBatchParams {}
-
 
 #[derive(Debug, Default, PartialEq, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct SectorPreCommitInfo {

--- a/actors/miner/tests/miner_actor_test_commitment.rs
+++ b/actors/miner/tests/miner_actor_test_commitment.rs
@@ -297,7 +297,7 @@ mod miner_actor_test_commitment {
         {
             let mut precommit_params =
                 h.make_pre_commit_params(102, challenge_epoch, deadline.period_end(), vec![]);
-            precommit_params.sealed_cid = make_cid("Random Data".as_bytes(), 0);
+            precommit_params.sealed_cid = make_cid_poseidon("Random Data".as_bytes(), 0);
             let ret = h.pre_commit_sector(
                 &mut rt,
                 precommit_params,

--- a/actors/power/src/state.rs
+++ b/actors/power/src/state.rs
@@ -15,7 +15,7 @@ use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{Cbor, RawBytes};
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
-use fvm_shared::bigint::{bigint_ser};
+use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;

--- a/actors/power/src/state.rs
+++ b/actors/power/src/state.rs
@@ -30,9 +30,9 @@ use super::{CONSENSUS_MINER_MIN_MINERS, CRON_QUEUE_AMT_BITWIDTH, CRON_QUEUE_HAMT
 
 lazy_static! {
     /// genesis power in bytes = 750,000 GiB
-    pub static ref INITIAL_QA_POWER_ESTIMATE_POSITION: StoragePower = StoragePower::from(750_000);// * (1 << 30);
+    pub static ref INITIAL_QA_POWER_ESTIMATE_POSITION: StoragePower = StoragePower::from(750_000) * (1 << 30);
     /// max chain throughput in bytes per epoch = 120 ProveCommits / epoch = 3,840 GiB
-    pub static ref INITIAL_QA_POWER_ESTIMATE_VELOCITY: StoragePower = StoragePower::from(3_840);// * (1 << 30);
+    pub static ref INITIAL_QA_POWER_ESTIMATE_VELOCITY: StoragePower = StoragePower::from(3_840) * (1 << 30);
 }
 
 /// Storage power actor state

--- a/actors/power/src/state.rs
+++ b/actors/power/src/state.rs
@@ -30,9 +30,9 @@ use super::{CONSENSUS_MINER_MIN_MINERS, CRON_QUEUE_AMT_BITWIDTH, CRON_QUEUE_HAMT
 
 lazy_static! {
     /// genesis power in bytes = 750,000 GiB
-    static ref INITIAL_QA_POWER_ESTIMATE_POSITION: BigInt = BigInt::from(750_000) * (1 << 30);
+    pub static ref INITIAL_QA_POWER_ESTIMATE_POSITION: StoragePower = StoragePower::from(750_000);// * (1 << 30);
     /// max chain throughput in bytes per epoch = 120 ProveCommits / epoch = 3,840 GiB
-    static ref INITIAL_QA_POWER_ESTIMATE_VELOCITY: BigInt = BigInt::from(3_840) * (1 << 30);
+    pub static ref INITIAL_QA_POWER_ESTIMATE_VELOCITY: StoragePower = StoragePower::from(3_840);// * (1 << 30);
 }
 
 /// Storage power actor state
@@ -88,10 +88,10 @@ impl State {
         Ok(State {
             cron_event_queue: empty_mmap,
             claims: empty_map,
-            this_epoch_qa_power_smoothed: FilterEstimate {
-                position: INITIAL_QA_POWER_ESTIMATE_POSITION.clone(),
-                velocity: INITIAL_QA_POWER_ESTIMATE_VELOCITY.clone(),
-            },
+            this_epoch_qa_power_smoothed: FilterEstimate::new(
+                INITIAL_QA_POWER_ESTIMATE_POSITION.clone(),
+                INITIAL_QA_POWER_ESTIMATE_VELOCITY.clone(),
+            ),
             ..Default::default()
         })
     }

--- a/actors/power/src/state.rs
+++ b/actors/power/src/state.rs
@@ -15,7 +15,7 @@ use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{Cbor, RawBytes};
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
-use fvm_shared::bigint::{bigint_ser, BigInt};
+use fvm_shared::bigint::{bigint_ser};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;

--- a/actors/runtime/src/test_utils.rs
+++ b/actors/runtime/src/test_utils.rs
@@ -1227,17 +1227,25 @@ enum MhCode {
     Sha256TruncPaddedFake,
 }
 
-pub fn make_cid(input: &[u8], prefix: u64) -> Cid {
-    let hash = MhCode::Sha256TruncPaddedFake.digest(input);
+fn make_cid(input: &[u8], prefix: u64, hash: MhCode) -> Cid {
+    let hash = hash.digest(input);
     Cid::new_v1(prefix, hash)
 }
 
+pub fn make_cid_sha(input: &[u8], prefix: u64) -> Cid {
+    make_cid(input, prefix, MhCode::Sha256TruncPaddedFake)
+}
+
+pub fn make_cid_poseidon(input: &[u8], prefix: u64) -> Cid {
+    make_cid(input, prefix, MhCode::PoseidonFake)
+}
+
 pub fn make_piece_cid(input: &[u8]) -> Cid {
-    make_cid(input, FIL_COMMITMENT_UNSEALED)
+    make_cid_sha(input, FIL_COMMITMENT_UNSEALED)
 }
 
 pub fn make_sealed_cid(input: &[u8]) -> Cid {
-    make_cid(input, FIL_COMMITMENT_SEALED)
+    make_cid_poseidon(input, FIL_COMMITMENT_SEALED)
 }
 
 pub fn new_bls_addr(s: u8) -> Address {

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -26,6 +26,7 @@ lazy_static = "1.4.0"
 fvm_shared = { version = "0.7.1", default-features = false }
 fvm_ipld_encoding = { version = "0.2.0", default-features = false }
 fvm_ipld_blockstore = { version = "0.1.1", default-features = false }
+fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -39,6 +39,9 @@ thiserror = "1.0.30"
 anyhow = "1.0.56"
 blake2b_simd = "1.0"
 integer-encoding = { version = "3.0.3", default-features = false }
+[dev-dependencies]
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+multihash = { version = "0.16.1", default-features = false }
 
 
 

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -18,9 +18,9 @@ use fil_actors_runtime::runtime::{
 };
 use fil_actors_runtime::test_utils::*;
 use fil_actors_runtime::{
-    ActorError, BURNT_FUNDS_ACTOR_ADDR, FIRST_NON_SINGLETON_ADDR, INIT_ACTOR_ADDR,
+    ActorError, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR, FIRST_NON_SINGLETON_ADDR, INIT_ACTOR_ADDR,
     REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
-    VERIFIED_REGISTRY_ACTOR_ADDR, CRON_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
@@ -477,15 +477,10 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
         };
         let mut msg = self.msg.clone();
         msg.to = match self.resolve_target(&self.msg.to) {
-            Ok((_, addr)) => addr, // use normalized address in trace 
+            Ok((_, addr)) => addr, // use normalized address in trace
             _ => self.msg.to, // if target resolution fails don't fail whole invoke, just use non normalized
         };
-        InvocationTrace {
-            msg,
-            code,
-            ret,
-            subinvocations: self.subinvocations.take(),
-        }
+        InvocationTrace { msg, code, ret, subinvocations: self.subinvocations.take() }
     }
 
     fn to(&'invocation self) -> Address {

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -425,7 +425,7 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
             Protocol::Actor | Protocol::ID => {
                 return Err(ActorError::unchecked(
                     ExitCode::SYS_INVALID_RECEIVER,
-                    "cannot create account for address {target} type {protocol}".to_string(),
+                    format!("cannot create account for address {} type {}", target, protocol),
                 ))
             }
             _ => (),
@@ -479,7 +479,7 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
         InvocationTrace { msg, code, ret, subinvocations: self.subinvocations.take() }
     }
 
-    fn to(&'invocation self) -> Address {
+    fn to(&'_ self) -> Address {
         self.resolve_target(&self.msg.to).unwrap().1
     }
 

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -215,10 +215,6 @@ impl<'bs> VM<'bs> {
         .unwrap();
 
         v.checkpoint();
-        let st = v.get_state::<PowerState>(*STORAGE_POWER_ACTOR_ADDR).unwrap();
-        println!("initial qap {:?}", st.this_epoch_qa_power_smoothed);
-        println!("initial qap estimate {}", st.this_epoch_qa_power_smoothed.estimate());
-
         v
     }
 

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -20,7 +20,7 @@ use fil_actors_runtime::test_utils::*;
 use fil_actors_runtime::{
     ActorError, BURNT_FUNDS_ACTOR_ADDR, FIRST_NON_SINGLETON_ADDR, INIT_ACTOR_ADDR,
     REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
-    VERIFIED_REGISTRY_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR, CRON_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
@@ -133,8 +133,8 @@ impl<'bs> VM<'bs> {
         ];
         let cron_head = v.put_store(&CronState { entries: builtin_entries });
         v.set_actor(
-            *STORAGE_MARKET_ACTOR_ADDR,
-            actor(*MARKET_ACTOR_CODE_ID, cron_head, 0, TokenAmount::zero()),
+            *CRON_ACTOR_ADDR,
+            actor(*CRON_ACTOR_CODE_ID, cron_head, 0, TokenAmount::zero()),
         );
 
         // power
@@ -426,11 +426,12 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
             }
         };
         // Address does not yet exist, create it
-        match target.protocol() {
+        let protocol = target.protocol();
+        match protocol {
             Protocol::Actor | Protocol::ID => {
                 return Err(ActorError::unchecked(
                     ExitCode::SYS_INVALID_RECEIVER,
-                    "cannot create account for address type".to_string(),
+                    "cannot create account for address {target} type {protocol}".to_string(),
                 ))
             }
             _ => (),

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -12,11 +12,12 @@ use fil_actor_multisig::{
 use fil_actor_market::{Method as MarketMethod};
 use fil_actor_power::{CreateMinerParams, CreateMinerReturn, Method as PowerMethod};
 use fil_actor_reward::Method as RewardMethod;
+use fil_actor_cron::Method as CronMethod;
 use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::runtime::{DomainSeparationTag, Policy, Runtime, RuntimePolicy};
 use fil_actors_runtime::{
     make_map_with_root, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
-    SYSTEM_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
+    SYSTEM_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, CRON_ACTOR_ADDR,
 };
 use fil_actors_runtime::{test_utils::*, BURNT_FUNDS_ACTOR_ADDR};
 use fvm_ipld_blockstore::MemoryBlockstore;
@@ -85,6 +86,9 @@ fn commit_post_flow_happy_path() {
         subinvocs: Some(vec![ExpectInvocation{to: *STORAGE_MARKET_ACTOR_ADDR, method: MarketMethod::ComputeDataCommitment as u64, ..Default::default()},ExpectInvocation{to: *STORAGE_POWER_ACTOR_ADDR, method: PowerMethod::SubmitPoRepForBulkVerify as u64, ..Default::default()}]),
         ..Default::default()
     }.matches(v.take_invocations().last().unwrap());
+    let res = v.apply_message(*SYSTEM_ACTOR_ADDR, *CRON_ACTOR_ADDR, TokenAmount::zero(), CronMethod::EpochTick as u64, RawBytes::default()).unwrap();
+    assert_eq!(ExitCode::OK, res.code);
+
 }
 
 fn create_miner(

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -1,33 +1,39 @@
-use fil_actor_miner::{
-    aggregate_pre_commit_network_fee, max_prove_commit_duration, Method as MinerMethod,
-    PreCommitSectorBatchParams, ProveCommitSectorParams,
-    SectorPreCommitInfo, SectorPreCommitOnChainInfo, State as MinerState, DeadlineInfo, new_deadline_info_from_offset_and_epoch,
-    PoStPartition, power_for_sector, PowerPair, SubmitWindowedPoStParams,
-};
-use fil_actor_market::{Method as MarketMethod};
-use fil_actor_power::{CreateMinerParams, CreateMinerReturn, Method as PowerMethod, State as PowerState};
-use fil_actor_reward::Method as RewardMethod;
 use fil_actor_cron::Method as CronMethod;
-use fil_actors_runtime::cbor::serialize;
-use fil_actors_runtime::runtime::{Policy};
-use fil_actors_runtime::{
-    REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
-    SYSTEM_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, CRON_ACTOR_ADDR,
+use fil_actor_market::Method as MarketMethod;
+use fil_actor_miner::{
+    aggregate_pre_commit_network_fee, max_prove_commit_duration,
+    new_deadline_info_from_offset_and_epoch, power_for_sector, DeadlineInfo, Method as MinerMethod,
+    PoStPartition, PowerPair, PreCommitSectorBatchParams, ProveCommitSectorParams,
+    SectorPreCommitInfo, SectorPreCommitOnChainInfo, State as MinerState, SubmitWindowedPoStParams,
 };
+use fil_actor_power::{
+    CreateMinerParams, CreateMinerReturn, Method as PowerMethod, State as PowerState,
+    UpdateClaimedPowerParams,
+};
+use fil_actor_reward::Method as RewardMethod;
+use fil_actors_runtime::cbor::serialize;
+use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{test_utils::*, BURNT_FUNDS_ACTOR_ADDR};
+use fil_actors_runtime::{
+    CRON_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
+    SYSTEM_ACTOR_ADDR,
+};
+use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::{BytesDe, RawBytes};
-use fvm_ipld_bitfield::{BitField};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
-use fvm_shared::clock::{ChainEpoch};
+use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof, SectorNumber, StoragePower, PoStProof};
+use fvm_shared::randomness::Randomness;
+use fvm_shared::sector::{
+    PoStProof, RegisteredPoStProof, RegisteredSealProof, SectorNumber, StoragePower,
+};
 use fvm_shared::METHOD_SEND;
 use num_traits::sign::Signed;
 use test_vm::util::{apply_ok, create_accounts};
-use test_vm::{ExpectInvocation, VM};
+use test_vm::{ExpectInvocation, TEST_VM_RAND_STRING, VM};
 
 #[test]
 fn commit_post_flow_happy_path() {
@@ -71,45 +77,71 @@ fn commit_post_flow_happy_path() {
         to: id_addr,
         method: MinerMethod::ProveCommitSector as u64,
         params: Some(prove_params_ser),
-        subinvocs: Some(vec![ExpectInvocation{to: *STORAGE_MARKET_ACTOR_ADDR, method: MarketMethod::ComputeDataCommitment as u64, ..Default::default()},ExpectInvocation{to: *STORAGE_POWER_ACTOR_ADDR, method: PowerMethod::SubmitPoRepForBulkVerify as u64, ..Default::default()}]),
+        subinvocs: Some(vec![
+            ExpectInvocation {
+                to: *STORAGE_MARKET_ACTOR_ADDR,
+                method: MarketMethod::ComputeDataCommitment as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: *STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::SubmitPoRepForBulkVerify as u64,
+                ..Default::default()
+            },
+        ]),
         ..Default::default()
-    }.matches(v.take_invocations().last().unwrap());
-    let res = v.apply_message(*SYSTEM_ACTOR_ADDR, *CRON_ACTOR_ADDR, TokenAmount::zero(), CronMethod::EpochTick as u64, RawBytes::default()).unwrap();
+    }
+    .matches(v.take_invocations().last().unwrap());
+    let res = v
+        .apply_message(
+            *SYSTEM_ACTOR_ADDR,
+            *CRON_ACTOR_ADDR,
+            TokenAmount::zero(),
+            CronMethod::EpochTick as u64,
+            RawBytes::default(),
+        )
+        .unwrap();
     assert_eq!(ExitCode::OK, res.code);
     ExpectInvocation {
         to: *CRON_ACTOR_ADDR,
         method: CronMethod::EpochTick as u64,
-        subinvocs: Some(vec![ExpectInvocation{
-            to: *STORAGE_POWER_ACTOR_ADDR,
-            method: PowerMethod::OnEpochTickEnd as u64,
-            subinvocs: Some(vec![
-                ExpectInvocation{
-                    to: *REWARD_ACTOR_ADDR,
-                    method: RewardMethod::ThisEpochReward as u64,
-                    ..Default::default()
-                },
-                ExpectInvocation{
-                    to: id_addr,
-                    method:MinerMethod::ConfirmSectorProofsValid as u64, 
-                    subinvocs: Some(vec![ExpectInvocation{to: *STORAGE_POWER_ACTOR_ADDR, method: PowerMethod::UpdatePledgeTotal as u64, ..Default::default()}]),
-                    ..Default::default()
-                },
-                ExpectInvocation{
-                    to: *REWARD_ACTOR_ADDR, 
-                    method: RewardMethod::UpdateNetworkKPI as u64,
-                    ..Default::default()
-                },
-            ]),
-            ..Default::default()
+        subinvocs: Some(vec![
+            ExpectInvocation {
+                to: *STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::OnEpochTickEnd as u64,
+                subinvocs: Some(vec![
+                    ExpectInvocation {
+                        to: *REWARD_ACTOR_ADDR,
+                        method: RewardMethod::ThisEpochReward as u64,
+                        ..Default::default()
+                    },
+                    ExpectInvocation {
+                        to: id_addr,
+                        method: MinerMethod::ConfirmSectorProofsValid as u64,
+                        subinvocs: Some(vec![ExpectInvocation {
+                            to: *STORAGE_POWER_ACTOR_ADDR,
+                            method: PowerMethod::UpdatePledgeTotal as u64,
+                            ..Default::default()
+                        }]),
+                        ..Default::default()
+                    },
+                    ExpectInvocation {
+                        to: *REWARD_ACTOR_ADDR,
+                        method: RewardMethod::UpdateNetworkKPI as u64,
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
             },
-            ExpectInvocation{
+            ExpectInvocation {
                 to: *STORAGE_MARKET_ACTOR_ADDR,
                 method: MarketMethod::CronTick as u64,
                 ..Default::default()
-            }
+            },
         ]),
         ..Default::default()
-    }.matches(v.take_invocations().last().unwrap());
+    }
+    .matches(v.take_invocations().last().unwrap());
     // pcd is released ip is added
     let balances = v.get_miner_balance(id_addr);
     assert!(balances.initial_pledge > TokenAmount::zero());
@@ -124,14 +156,19 @@ fn commit_post_flow_happy_path() {
     // submit post
     let st = v.get_state::<MinerState>(id_addr).unwrap();
     let sector = st.get_sector(v.store, sector_number).unwrap().unwrap();
-    let partitions = vec![PoStPartition{index: p_idx, skipped: fvm_ipld_bitfield::UnvalidatedBitField::Validated(BitField::new())}];
+    let partitions = vec![PoStPartition {
+        index: p_idx,
+        skipped: fvm_ipld_bitfield::UnvalidatedBitField::Validated(BitField::new()),
+    }];
     let sector_power = power_for_sector(seal_proof.sector_size().unwrap(), &sector);
     submit_windowed_post(&v, worker, id_addr, dline_info, partitions, sector_power);
     let balances = v.get_miner_balance(id_addr);
     assert!(balances.initial_pledge > TokenAmount::zero());
     let p_st = v.get_state::<PowerState>(*STORAGE_POWER_ACTOR_ADDR).unwrap();
-    assert_eq!(StoragePower::from(seal_proof.sector_size().unwrap() as u64), p_st.total_bytes_committed);
-
+    assert_eq!(
+        StoragePower::from(seal_proof.sector_size().unwrap() as u64),
+        p_st.total_bytes_committed
+    );
 }
 
 fn create_miner(
@@ -275,40 +312,66 @@ fn precommit_sectors(
         .collect()
 }
 
-fn advance_by_deadline_to_epoch<'bs>(v: VM<'bs>, maddr: Address, e: ChainEpoch) -> (VM<'bs>, DeadlineInfo) {
-    advance_by_deadline(v, maddr, |dline_info| {dline_info.close <= e})
+fn advance_by_deadline_to_epoch<'bs>(
+    v: VM<'bs>,
+    maddr: Address,
+    e: ChainEpoch,
+) -> (VM<'bs>, DeadlineInfo) {
+    advance_by_deadline(v, maddr, |dline_info| dline_info.close <= e)
 }
 
-fn advance_by_deadline_to_index<'bs>(v: VM<'bs>, maddr: Address, i: u64) -> (VM<'bs>, DeadlineInfo) {
-    advance_by_deadline(v, maddr, |dline_info| {dline_info.index != i})
+fn advance_by_deadline_to_index<'bs>(
+    v: VM<'bs>,
+    maddr: Address,
+    i: u64,
+) -> (VM<'bs>, DeadlineInfo) {
+    advance_by_deadline(v, maddr, |dline_info| dline_info.index != i)
 }
 
-fn advance_to_proving_deadline<'bs>(v: VM<'bs>, maddr: Address, s: SectorNumber) -> (DeadlineInfo, u64, VM<'bs>) {
+fn advance_to_proving_deadline<'bs>(
+    v: VM<'bs>,
+    maddr: Address,
+    s: SectorNumber,
+) -> (DeadlineInfo, u64, VM<'bs>) {
     let (d, p) = sector_deadline(&v, maddr, s);
     let (v, dline_info) = advance_by_deadline_to_index(v, maddr, d);
     let v = v.with_epoch(dline_info.open);
     (dline_info, p, v)
 }
 
-fn advance_by_deadline<'bs, F>(mut v: VM<'bs>, maddr: Address, more: F) -> (VM<'bs>, DeadlineInfo) where
-    F: Fn(DeadlineInfo) -> bool {
+fn advance_by_deadline<'bs, F>(mut v: VM<'bs>, maddr: Address, more: F) -> (VM<'bs>, DeadlineInfo)
+where
+    F: Fn(DeadlineInfo) -> bool,
+{
     loop {
         let dline_info = miner_dline_info(&v, maddr);
         if !more(dline_info) {
-            return (v, dline_info)
+            return (v, dline_info);
         }
         v = v.with_epoch(dline_info.last());
 
-        let res = v.apply_message(*SYSTEM_ACTOR_ADDR, *CRON_ACTOR_ADDR, TokenAmount::zero(), CronMethod::EpochTick as u64, RawBytes::default()).unwrap();
+        let res = v
+            .apply_message(
+                *SYSTEM_ACTOR_ADDR,
+                *CRON_ACTOR_ADDR,
+                TokenAmount::zero(),
+                CronMethod::EpochTick as u64,
+                RawBytes::default(),
+            )
+            .unwrap();
         assert_eq!(ExitCode::OK, res.code);
         let next = v.get_epoch() + 1;
         v = v.with_epoch(next);
-    };
+    }
 }
 
 fn miner_dline_info(v: &VM, m: Address) -> DeadlineInfo {
     let st = v.get_state::<MinerState>(m).unwrap();
-    new_deadline_info_from_offset_and_epoch(&Policy::default(), st.proving_period_start, v.get_epoch())
+    new_deadline_info_from_offset_and_epoch(
+        &Policy::default(),
+        st.proving_period_start,
+        v.get_epoch(),
+    )
 }
 
 fn sector_deadline(v: &VM, m: Address, s: SectorNumber) -> (u64, u64) {
@@ -316,10 +379,48 @@ fn sector_deadline(v: &VM, m: Address, s: SectorNumber) -> (u64, u64) {
     st.find_sector(&Policy::default(), v.store, s).unwrap()
 }
 
-fn submit_windowed_post(v: &VM, worker: Address, maddr: Address, dline_info: DeadlineInfo, partitions: Vec<PoStPartition>, sector: PowerPair) {
-    let params = SubmitWindowedPoStParams{
+fn submit_windowed_post(
+    v: &VM,
+    worker: Address,
+    maddr: Address,
+    dline_info: DeadlineInfo,
+    partitions: Vec<PoStPartition>,
+    sector: PowerPair,
+) {
+    let params = SubmitWindowedPoStParams {
         deadline: dline_info.index,
         partitions,
-        proofs: vec![RegisteredP]
+        proofs: vec![PoStProof {
+            post_proof: RegisteredPoStProof::StackedDRGWindow32GiBV1,
+            proof_bytes: vec![],
+        }],
+        chain_commit_epoch: dline_info.challenge,
+        chain_commit_rand: Randomness(TEST_VM_RAND_STRING.to_owned().into_bytes()),
+    };
+    apply_ok(
+        &v,
+        worker,
+        maddr,
+        TokenAmount::zero(),
+        MinerMethod::SubmitWindowedPoSt as u64,
+        params,
+    );
+
+    let update_power_params = serialize(
+        &UpdateClaimedPowerParams { raw_byte_delta: sector.raw, quality_adjusted_delta: sector.qa },
+        "update claim params",
+    )
+    .unwrap();
+    ExpectInvocation {
+        to: maddr,
+        method: MinerMethod::SubmitWindowedPoSt as u64,
+        subinvocs: Some(vec![ExpectInvocation {
+            to: *STORAGE_POWER_ACTOR_ADDR,
+            method: PowerMethod::UpdateClaimedPower as u64,
+            params: Some(update_power_params),
+            ..Default::default()
+        }]),
+        ..Default::default()
     }
+    .matches(v.take_invocations().last().unwrap());
 }

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -27,9 +27,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::randomness::Randomness;
-use fvm_shared::sector::{
-    PoStProof, RegisteredPoStProof, RegisteredSealProof, SectorNumber,
-};
+use fvm_shared::sector::{PoStProof, RegisteredPoStProof, RegisteredSealProof, SectorNumber};
 use fvm_shared::METHOD_SEND;
 use num_traits::sign::Signed;
 use test_vm::util::{apply_ok, create_accounts};
@@ -182,7 +180,7 @@ fn create_miner(
         worker,
         window_post_proof_type: post_proof_type,
         peer: peer_id,
-        multiaddrs: multiaddrs,
+        multiaddrs,
     };
 
     let res: CreateMinerReturn = v
@@ -310,27 +308,15 @@ fn precommit_sectors(
         .collect()
 }
 
-fn advance_by_deadline_to_epoch(
-    v: VM,
-    maddr: Address,
-    e: ChainEpoch,
-) -> (VM, DeadlineInfo) {
+fn advance_by_deadline_to_epoch(v: VM, maddr: Address, e: ChainEpoch) -> (VM, DeadlineInfo) {
     advance_by_deadline(v, maddr, |dline_info| dline_info.close <= e)
 }
 
-fn advance_by_deadline_to_index(
-    v: VM,
-    maddr: Address,
-    i: u64,
-) -> (VM, DeadlineInfo) {
+fn advance_by_deadline_to_index(v: VM, maddr: Address, i: u64) -> (VM, DeadlineInfo) {
     advance_by_deadline(v, maddr, |dline_info| dline_info.index != i)
 }
 
-fn advance_to_proving_deadline(
-    v: VM,
-    maddr: Address,
-    s: SectorNumber,
-) -> (DeadlineInfo, u64, VM) {
+fn advance_to_proving_deadline(v: VM, maddr: Address, s: SectorNumber) -> (DeadlineInfo, u64, VM) {
     let (d, p) = sector_deadline(&v, maddr, s);
     let (v, dline_info) = advance_by_deadline_to_index(v, maddr, d);
     let v = v.with_epoch(dline_info.open);
@@ -395,14 +381,7 @@ fn submit_windowed_post(
         chain_commit_epoch: dline_info.challenge,
         chain_commit_rand: Randomness(TEST_VM_RAND_STRING.to_owned().into_bytes()),
     };
-    apply_ok(
-        v,
-        worker,
-        maddr,
-        TokenAmount::zero(),
-        MinerMethod::SubmitWindowedPoSt as u64,
-        params,
-    );
+    apply_ok(v, worker, maddr, TokenAmount::zero(), MinerMethod::SubmitWindowedPoSt as u64, params);
 
     let update_power_params = serialize(
         &UpdateClaimedPowerParams { raw_byte_delta: sector.raw, quality_adjusted_delta: sector.qa },

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -144,13 +144,13 @@ fn commit_post_flow_happy_path() {
     .matches(v.take_invocations().last().unwrap());
     // pcd is released ip is added
     let balances = v.get_miner_balance(id_addr);
-    assert!(balances.initial_pledge > TokenAmount::zero());
+    assert!(balances.initial_pledge.is_positive());
     assert!(balances.pre_commit_deposit.is_zero());
 
     // power unproven so network stats are the same
     let p_st = v.get_state::<PowerState>(*STORAGE_POWER_ACTOR_ADDR).unwrap();
     assert!(p_st.total_bytes_committed.is_zero());
-    assert!(p_st.total_pledge_collateral > TokenAmount::zero());
+    assert!(p_st.total_pledge_collateral.is_positive());
     let (dline_info, p_idx, v) = advance_to_proving_deadline(v, id_addr, sector_number);
 
     // submit post
@@ -163,7 +163,7 @@ fn commit_post_flow_happy_path() {
     let sector_power = power_for_sector(seal_proof.sector_size().unwrap(), &sector);
     submit_windowed_post(&v, worker, id_addr, dline_info, partitions, sector_power.clone());
     let balances = v.get_miner_balance(id_addr);
-    assert!(balances.initial_pledge > TokenAmount::zero());
+    assert!(balances.initial_pledge.is_positive());
     let p_st = v.get_state::<PowerState>(*STORAGE_POWER_ACTOR_ADDR).unwrap();
     assert_eq!(
         sector_power.raw,
@@ -194,7 +194,7 @@ fn create_miner(
             *STORAGE_POWER_ACTOR_ADDR,
             balance,
             PowerMethod::CreateMiner as u64,
-            params.clone(),
+            params,
         )
         .unwrap()
         .ret

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -1,0 +1,206 @@
+use cid::Cid;
+use fil_actor_init::ExecReturn;
+use fil_actor_miner::{
+    aggregate_pre_commit_network_fee, max_prove_commit_duration, Method as MinerMethod,
+    PreCommitSectorBatchParams, SectorPreCommitInfo, SectorPreCommitOnChainInfo,
+    State as MinerState,
+};
+use fil_actor_multisig::{
+    compute_proposal_hash, Method as MsigMethod, ProposeParams, RemoveSignerParams,
+    State as MsigState, SwapSignerParams, Transaction, TxnID, TxnIDParams,
+};
+use fil_actor_power::{CreateMinerParams, CreateMinerReturn, Method as PowerMethod};
+use fil_actor_reward::Method as RewardMethod;
+use fil_actors_runtime::cbor::serialize;
+use fil_actors_runtime::runtime::{DomainSeparationTag, Policy, Runtime, RuntimePolicy};
+use fil_actors_runtime::{
+    make_map_with_root, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
+    SYSTEM_ACTOR_ADDR,
+};
+use fil_actors_runtime::{test_utils::*, BURNT_FUNDS_ACTOR_ADDR};
+use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_encoding::{BytesDe, RawBytes};
+use fvm_shared::address::Address;
+use fvm_shared::bigint::Zero;
+use fvm_shared::clock::{ChainEpoch, QuantSpec, NO_QUANTIZATION};
+use fvm_shared::commcid::{FIL_COMMITMENT_SEALED, FIL_COMMITMENT_UNSEALED};
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
+use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof, SectorNumber};
+use fvm_shared::METHOD_SEND;
+use integer_encoding::VarInt;
+use multihash::derive::Multihash;
+use multihash::MultihashDigest;
+use num_traits::sign::Signed;
+use std::collections::HashSet;
+use std::iter::FromIterator;
+use test_vm::util::{apply_code, apply_ok, create_accounts};
+use test_vm::{ExpectInvocation, TEST_FAUCET_ADDR, VM};
+
+#[test]
+fn commit_post_flow_happy_path() {
+    let store = MemoryBlockstore::new();
+    let mut v = VM::new_with_singletons(&store);
+    let addrs = create_accounts(&v, 2, TokenAmount::from(10_000e18 as u64));
+    let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
+    let (owner, worker) = (addrs[0], addrs[0]);
+    let (id_addr, _) =
+        create_miner(&mut v, owner, worker, seal_proof.registered_window_post_proof().unwrap());
+    let mut v = v.with_epoch(200);
+
+    let sector_number_base: SectorNumber = 100;
+    let precommits =
+        precommit_sectors(&mut v, 1, 1, worker, id_addr, seal_proof, sector_number_base, true, -1);
+
+    let balances = v.get_miner_balance(id_addr);
+    assert!(!balances.pre_commit_deposit.is_negative());
+
+    let prove_time =
+        v.get_epoch() + max_prove_commit_duration(&Policy::default(), seal_proof).unwrap();
+}
+
+fn create_miner(
+    v: &mut VM,
+    owner: Address,
+    worker: Address,
+    post_proof_type: RegisteredPoStProof,
+) -> (Address, Address) {
+    let multiaddrs = vec![BytesDe("multiaddr".as_bytes().to_vec())];
+    let peer_id = "miner".as_bytes().to_vec();
+    let params = CreateMinerParams {
+        owner,
+        worker: worker,
+        window_post_proof_type: post_proof_type,
+        peer: peer_id.clone(),
+        multiaddrs: multiaddrs.clone(),
+    };
+
+    let res: CreateMinerReturn = v
+        .apply_message(
+            owner,
+            *STORAGE_POWER_ACTOR_ADDR,
+            TokenAmount::from(1000u32),
+            PowerMethod::CreateMiner as u64,
+            params.clone(),
+        )
+        .unwrap()
+        .ret
+        .deserialize()
+        .unwrap();
+    (res.id_address, res.robust_address)
+}
+
+fn precommit_sectors(
+    v: &mut VM,
+    count: u64,
+    batch_size: i64,
+    worker: Address,
+    maddr: Address,
+    seal_proof: RegisteredSealProof,
+    sector_number_base: SectorNumber,
+    expect_cron_enroll: bool,
+    expiration: ChainEpoch,
+) -> Vec<SectorPreCommitOnChainInfo> {
+    let invocs_common = || -> Vec<ExpectInvocation> {
+        vec![
+            ExpectInvocation {
+                to: *REWARD_ACTOR_ADDR,
+                method: RewardMethod::ThisEpochReward as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: *STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::CurrentTotalPower as u64,
+                ..Default::default()
+            },
+        ]
+    };
+    let invoc_first = || -> ExpectInvocation {
+        ExpectInvocation {
+            to: *STORAGE_POWER_ACTOR_ADDR,
+            method: PowerMethod::EnrollCronEvent as u64,
+            ..Default::default()
+        }
+    };
+    let invoc_net_fee = |fee: TokenAmount| -> ExpectInvocation {
+        ExpectInvocation {
+            to: *BURNT_FUNDS_ACTOR_ADDR,
+            method: METHOD_SEND,
+            value: Some(fee),
+            ..Default::default()
+        }
+    };
+
+    let mut sector_idx = 0u64;
+    while sector_idx < count {
+        let msg_sector_idx_base = sector_idx;
+        let mut invocs = invocs_common();
+
+        let mut param_sectors = Vec::<SectorPreCommitInfo>::new();
+        let mut j = 0;
+        while j < batch_size && sector_idx < count {
+            let sector_number = sector_number_base + sector_idx;
+            param_sectors.push(SectorPreCommitInfo {
+                seal_proof,
+                sector_number,
+                sealed_cid: make_sealed_cid(format!("sn: {}", sector_number).as_bytes()),
+                seal_rand_epoch: v.get_epoch() - 1,
+                deal_ids: vec![],
+                ..Default::default()
+            });
+            sector_idx += 1;
+            j += 1;
+        }
+        if param_sectors.len() > 1 {
+            invocs.push(invoc_net_fee(aggregate_pre_commit_network_fee(
+                param_sectors.len() as i64,
+                &TokenAmount::zero(),
+            )));
+        }
+        if expect_cron_enroll && msg_sector_idx_base == 0 {
+            invocs.push(invoc_first());
+        }
+        apply_ok(
+            v,
+            worker,
+            maddr,
+            TokenAmount::zero(),
+            MinerMethod::PreCommitSectorBatch as u64,
+            PreCommitSectorBatchParams { sectors: param_sectors.clone() },
+        );
+        let expect = ExpectInvocation {
+            to: maddr,
+            method: MinerMethod::PreCommitSectorBatch as u64,
+            params: Some(
+                serialize(
+                    &PreCommitSectorBatchParams { sectors: param_sectors },
+                    "precommit batch params",
+                )
+                .unwrap(),
+            ),
+            subinvocs: Some(invocs),
+            ..Default::default()
+        };
+        expect.matches(v.take_invocations().last().unwrap())
+    }
+    // extract chain state
+    let mstate = v.get_state::<MinerState>(maddr).unwrap();
+    (0..count).map(|i| mstate.get_precommitted_sector(v.store, i).unwrap().unwrap()).collect()
+}
+
+// XXX: split this out somwhere shared between here and the miner unit test utils
+// multihash library doesn't support poseidon hashing, so we fake it
+#[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
+#[mh(alloc_size = 64)]
+enum MhCode {
+    #[mh(code = 0xb401, hasher = multihash::Sha2_256)]
+    PoseidonFake,
+    #[mh(code = 0x1012, hasher = multihash::Sha2_256)]
+    Sha256TruncPaddedFake,
+}
+
+fn make_sealed_cid(input: &[u8]) -> Cid {
+    // Note: multihash library doesn't support Poseidon hashing, so we fake it
+    let h = MhCode::PoseidonFake.digest(input);
+    Cid::new_v1(FIL_COMMITMENT_SEALED, h)
+}

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -165,10 +165,7 @@ fn commit_post_flow_happy_path() {
     let balances = v.get_miner_balance(id_addr);
     assert!(balances.initial_pledge.is_positive());
     let p_st = v.get_state::<PowerState>(*STORAGE_POWER_ACTOR_ADDR).unwrap();
-    assert_eq!(
-        sector_power.raw,
-        p_st.total_bytes_committed
-    );
+    assert_eq!(sector_power.raw, p_st.total_bytes_committed);
 }
 
 fn create_miner(

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -13,7 +13,7 @@ use fvm_shared::METHOD_SEND;
 use test_vm::{ExpectInvocation, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
 
 #[test]
-fn create_miner() {
+fn create_miner_test() {
     let store = MemoryBlockstore::new();
     let v = VM::new_with_singletons(&store);
 
@@ -51,18 +51,12 @@ fn create_miner() {
         to: *STORAGE_POWER_ACTOR_ADDR,
         method: PowerMethod::CreateMiner as u64,
         params: Some(serialize(&params, "power create miner params").unwrap()),
-        code: None,
-        from: None,
         ret: Some(res.ret),
         subinvocs: Some(vec![
             // request init actor construct miner
             ExpectInvocation {
                 to: *INIT_ACTOR_ADDR,
                 method: InitMethod::Exec as u64,
-                params: None,
-                code: None,
-                from: None,
-                ret: None,
                 subinvocs: Some(vec![ExpectInvocation {
                     // init then calls miner constructor
                     to: Address::new_id(FIRST_TEST_USER_ADDR + 1),
@@ -82,13 +76,12 @@ fn create_miner() {
                         )
                         .unwrap(),
                     ),
-                    code: None,
-                    from: None,
-                    ret: None,
-                    subinvocs: None,
+                    ..Default::default()
                 }]),
+                ..Default::default()
             },
         ]),
+        ..Default::default()
     };
     expect.matches(v.take_invocations().last().unwrap())
 }


### PR DESCRIPTION
This completes the first of four subcases of TestCommitPoStFlow.  It introduces helpers that are needed for other integration tests.  It also fixes some testing harness bugs.

Helpers:
 - `get_miner_balances`
 - `with_epoch`
 - `create_miner`
 - `precommit_sectors`
 - `advance_by_deadline` and variations
 - `submit_windowed_post`

Fixes:
 - `ExpectInvoction` can now match on `from`
 - Runtime methods no longer fall when acting on an receiver called with a non id address
 - Cron actor actually written at cron address by `new_with_singletons`