### PR TITLE
account actor invariant checks

### DIFF
--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -16,6 +16,7 @@ use fil_actors_runtime::{actor_error, ActorError};
 pub use self::state::State;
 
 mod state;
+pub mod testing;
 
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);

--- a/actors/account/src/testing.rs
+++ b/actors/account/src/testing.rs
@@ -1,0 +1,30 @@
+use fil_actors_runtime::{MessageAccumulator, FIRST_NON_SINGLETON_ADDR};
+use fvm_shared::address::{Address, Protocol};
+
+use crate::State;
+
+pub struct StateSummary {
+    pub pub_key_address: Address,
+}
+
+/// Checks internal invariants of account state.
+pub fn check_state_invariants(
+    state: &State,
+    id_address: &Address,
+) -> (StateSummary, MessageAccumulator) {
+    let acc = MessageAccumulator::default();
+
+    match id_address.id() {
+        Ok(id) if id >= FIRST_NON_SINGLETON_ADDR => {
+            acc.require(
+                state.address.protocol() == Protocol::BLS
+                    || state.address.protocol() == Protocol::Secp256k1,
+                format!("actor address {} must be BLS or SECP256K1 protocol", state.address),
+            );
+        }
+        Err(e) => acc.add(format!("error extracting actor ID from address: {e}")),
+        _ => (),
+    }
+
+    (StateSummary { pub_key_address: state.address }, acc)
+}

--- a/actors/account/tests/account_actor_test.rs
+++ b/actors/account/tests/account_actor_test.rs
@@ -1,12 +1,18 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fil_actor_account::{Actor as AccountActor, State};
+use fil_actor_account::{testing::check_state_invariants, Actor as AccountActor, State};
 use fil_actors_runtime::builtin::SYSTEM_ACTOR_ADDR;
 use fil_actors_runtime::test_utils::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::error::ExitCode;
+
+fn check_state(rt: &MockRuntime) {
+    let test_address = Address::new_id(1000);
+    let (_, acc) = check_state_invariants(&rt.get_state(), &test_address);
+    acc.assert_empty();
+}
 
 macro_rules! account_tests {
     ($($name:ident: $value:expr,)*) => {
@@ -36,6 +42,8 @@ macro_rules! account_tests {
                         .deserialize()
                         .unwrap();
                     assert_eq!(pk, addr);
+
+                    check_state(&rt);
                 } else {
                     expect_abort(
                         exit_code,


### PR DESCRIPTION
Implemented invariant checks from [here](https://github.com/filecoin-project/specs-actors/blob/0afe155bfffa036057af5519afdead845e0780de/actors/builtin/account/testing.go)