### PR TITLE
reward invariant checks

### DIFF
--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -27,6 +27,7 @@ fil_actors_runtime::wasm_trampoline!(Actor);
 pub(crate) mod expneg;
 mod logic;
 mod state;
+pub mod testing;
 mod types;
 
 // only exported for tests
@@ -35,7 +36,7 @@ pub mod ext;
 
 // * Updated to specs-actors commit: 999e57a151cc7ada020ca2844b651499ab8c0dec (v3.0.1)
 
-/// PenaltyMultiplier is the factor miner penaltys are scaled up by
+/// PenaltyMultiplier is the factor miner penalties are scaled up by
 pub const PENALTY_MULTIPLIER: u64 = 3;
 
 /// Reward actor methods available

--- a/actors/reward/src/testing.rs
+++ b/actors/reward/src/testing.rs
@@ -1,0 +1,65 @@
+use crate::State;
+use fil_actors_runtime::MessageAccumulator;
+use fvm_shared::bigint::BigInt;
+use fvm_shared::{clock::ChainEpoch, econ::TokenAmount};
+use num_traits::Signed;
+
+#[derive(Default)]
+pub struct StateSummary {}
+
+pub fn check_state_invariants(
+    state: &State,
+    prior_epoch: ChainEpoch,
+    balance: &TokenAmount,
+) -> (StateSummary, MessageAccumulator) {
+    let acc = MessageAccumulator::default();
+
+    let fil = 10u64.pow(18);
+    let storage_mining_allocation_check = BigInt::from(1_100_000_000) * fil;
+
+    // Can't assert equality because anyone can send funds to reward actor (and already have on mainnet)
+    acc.require(
+        &state.total_storage_power_reward + balance >= storage_mining_allocation_check,
+        format!(
+            "reward given {} + reward left {} < storage mining allocation {}",
+            state.total_storage_power_reward, balance, storage_mining_allocation_check
+        ),
+    );
+
+    acc.require(
+        state.epoch == prior_epoch + 1,
+        format!(
+            "reward state epoch {} does not match prior_epoch+1 {}",
+            state.epoch,
+            prior_epoch + 1
+        ),
+    );
+    acc.require(
+        state.effective_network_time <= state.epoch,
+        format!(
+            "effective network time {} greater than state epoch {}",
+            state.effective_network_time, state.epoch
+        ),
+    );
+
+    acc.require(
+        state.cumsum_realized <= state.cumsum_baseline,
+        format!(
+            "cumsum realized {} > cumsum baseline {}",
+            state.cumsum_realized, state.cumsum_baseline
+        ),
+    );
+    acc.require(
+        !state.cumsum_realized.is_negative(),
+        format!("cumsum realized negative ({})", state.cumsum_realized),
+    );
+    acc.require(
+        state.effective_baseline_power <= state.this_epoch_baseline_power,
+        format!(
+            "effective baseline power ({}) > baseline power ({})",
+            state.effective_baseline_power, state.this_epoch_baseline_power
+        ),
+    );
+
+    (StateSummary::default(), acc)
+}


### PR DESCRIPTION
Implemented checks from [here](https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/reward/testing.go). 

I didn't add those checks in the existing crate tests as it fails on several invariants, just like Go tests do (they don't include the checks as well).