### PR TITLE
fix implementation of FIP-0028

### DIFF
--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -42,6 +42,7 @@ pub enum Method {
 }
 
 pub struct Actor;
+
 impl Actor {
     /// Constructor for Registry Actor
     pub fn constructor<BS, RT>(rt: &mut RT, root_key: Address) -> Result<(), ActorError>
@@ -563,7 +564,16 @@ impl Actor {
             })?;
 
             // check that `client` is currently a verified client
-            if !is_verifier(rt, st, client)? {
+            let is_verified_client = verified_clients
+                .get(&client.to_bytes())
+                .map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::USR_ILLEGAL_STATE,
+                        "failed to load verified clients",
+                    )
+                })?
+                .is_some();
+            if !is_verified_client {
                 return Err(actor_error!(not_found, "{} is not a verified client", client));
             }
 
@@ -579,12 +589,12 @@ impl Actor {
                 .cloned()
                 .unwrap_or_default();
 
-            // check that `verifier_1` is currently a verified client
+            // check that `verifier_1` is currently a verifier
             if !is_verifier(rt, st, verifier_1)? {
                 return Err(actor_error!(not_found, "{} is not a verified client", verifier_1));
             }
 
-            // check that `verifier_2` is currently a verified client
+            // check that `verifier_2` is currently a verifier
             if !is_verifier(rt, st, verifier_2)? {
                 return Err(actor_error!(not_found, "{} is not a verified client", verifier_2));
             }
@@ -672,17 +682,15 @@ where
     BS: Blockstore,
     RT: Runtime<BS>,
 {
-    let verified_clients = make_map_with_root_and_bitwidth::<_, BigIntDe>(
-        &st.verified_clients,
+    let verifiers = make_map_with_root_and_bitwidth::<_, BigIntDe>(
+        &st.verifiers,
         rt.store(),
         HAMT_BIT_WIDTH,
     )
-    .map_err(|e| {
-        e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load verified clients")
-    })?;
+    .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load verifiers"))?;
 
     // check that the `address` is currently a verified client
-    let found = verified_clients
+    let found = verifiers
         .contains_key(&address.to_bytes())
         .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get verifier"))?;
 
@@ -716,7 +724,7 @@ where
     };
 
     let next_id = RemoveDataCapProposalID(curr_id.0 + 1);
-    proposal_ids.set(BytesKey::from(key.to_bytes()), next_id.clone()).map_err(|e| {
+    proposal_ids.set(BytesKey::from(key.to_bytes()), next_id).map_err(|e| {
         actor_error!(
             illegal_state,
             "failed to update proposal id for verifier {} and client {}: {}",
@@ -726,7 +734,7 @@ where
         )
     })?;
 
-    Ok(next_id)
+    Ok(curr_id)
 }
 
 fn remove_data_cap_request_is_valid<BS, RT>(
@@ -751,8 +759,10 @@ where
                 serialization; "failed to marshal remove datacap request: {}", e)
     })?;
 
+    let payload = [SIGNATURE_DOMAIN_SEPARATION_REMOVE_DATA_CAP, b.bytes()].concat();
+
     // verify signature of proposal
-    rt.verify_signature(&request.signature, &request.verifier, &b).map_err(
+    rt.verify_signature(&request.signature, &request.verifier, &payload).map_err(
         |e| actor_error!(illegal_argument; "invalid signature for datacap removal request: {}", e),
     )
 }
@@ -793,8 +803,9 @@ impl ActorCode for Actor {
                 Ok(RawBytes::default())
             }
             Some(Method::RemoveVerifiedClientDataCap) => {
-                Self::remove_verified_client_data_cap(rt, cbor::deserialize_params(params)?)?;
-                Ok(RawBytes::default())
+                let res =
+                    Self::remove_verified_client_data_cap(rt, cbor::deserialize_params(params)?)?;
+                Ok(RawBytes::serialize(res)?)
             }
             None => Err(actor_error!(unhandled_message; "Invalid method")),
         }

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fvm_ipld_encoding::tuple::*;
+use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::sector::StoragePower;
 use serde::{Deserialize, Serialize};
+
+impl Cbor for VerifierParams {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct VerifierParams {
@@ -16,6 +19,7 @@ pub struct VerifierParams {
 }
 
 pub type AddVerifierParams = VerifierParams;
+
 pub type AddVerifierClientParams = VerifierParams;
 
 /// DataCap is an integer number of bytes.
@@ -34,6 +38,10 @@ pub struct BytesParams {
 pub type UseBytesParams = BytesParams;
 pub type RestoreBytesParams = BytesParams;
 
+pub const SIGNATURE_DOMAIN_SEPARATION_REMOVE_DATA_CAP: &[u8] = b"fil_removedatacap:";
+
+impl Cbor for RemoveDataCapParams {}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct RemoveDataCapParams {
     pub verified_client_to_remove: Address,
@@ -48,6 +56,8 @@ pub struct RemoveDataCapRequest {
     pub verifier: Address,
     pub signature: Signature,
 }
+
+impl Cbor for RemoveDataCapReturn {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct RemoveDataCapReturn {

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -1,0 +1,327 @@
+use fil_actor_verifreg::{
+    AddVerifierClientParams, AddVerifierParams, RemoveDataCapParams, RemoveDataCapRequest,
+    RemoveDataCapReturn, SIGNATURE_DOMAIN_SEPARATION_REMOVE_DATA_CAP,
+};
+use fil_actor_verifreg::{AddrPairKey, Method as VerifregMethod};
+use fil_actor_verifreg::{RemoveDataCapProposal, RemoveDataCapProposalID, State as VerifregState};
+use fil_actors_runtime::cbor::serialize;
+use fil_actors_runtime::{make_map_with_root_and_bitwidth, VERIFIED_REGISTRY_ACTOR_ADDR};
+use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_encoding::to_vec;
+use fvm_shared::bigint::bigint_ser::BigIntDe;
+use fvm_shared::bigint::{BigInt, Zero};
+use fvm_shared::crypto::signature::{Signature, SignatureType};
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::sector::StoragePower;
+use fvm_shared::HAMT_BIT_WIDTH;
+use std::ops::{Div, Sub};
+use test_vm::util::{apply_ok, create_accounts};
+use test_vm::{ExpectInvocation, VERIFREG_ROOT_KEY_ADDR, VM};
+
+#[test]
+fn remove_datacap_simple_successful_path() {
+    let store = MemoryBlockstore::new();
+    let v = VM::new_with_singletons(&store);
+    let addrs = create_accounts(&v, 4, TokenAmount::from(10_000e18 as i128));
+    let (verifier1, verifier2, verified_client) = (addrs[0], addrs[1], addrs[2]);
+    let verifier1_id_addr = v.normalize_address(&verifier1).unwrap();
+    let verifier2_id_addr = v.normalize_address(&verifier2).unwrap();
+    let verified_client_id_addr = v.normalize_address(&verified_client).unwrap();
+    let verifier_allowance = StoragePower::from(2 * 1048576);
+    let allowance_to_remove: StoragePower = verifier_allowance.clone().div(2);
+
+    // register verifier1
+    let mut add_verifier_params =
+        AddVerifierParams { address: verifier1, allowance: verifier_allowance.clone() };
+    let mut add_verifier_params_ser =
+        serialize(&add_verifier_params, "add verifier params").unwrap();
+    apply_ok(
+        &v,
+        VERIFREG_ROOT_KEY_ADDR,
+        *VERIFIED_REGISTRY_ACTOR_ADDR,
+        TokenAmount::zero(),
+        VerifregMethod::AddVerifier as u64,
+        add_verifier_params,
+    );
+
+    ExpectInvocation {
+        to: *VERIFIED_REGISTRY_ACTOR_ADDR,
+        method: VerifregMethod::AddVerifier as u64,
+        params: Some(add_verifier_params_ser),
+        subinvocs: Some(vec![]),
+        ..Default::default()
+    }
+    .matches(v.take_invocations().last().unwrap());
+
+    // register verifier2
+    add_verifier_params =
+        AddVerifierParams { address: verifier2, allowance: verifier_allowance.clone() };
+    add_verifier_params_ser = serialize(&add_verifier_params, "add verifier params").unwrap();
+    apply_ok(
+        &v,
+        VERIFREG_ROOT_KEY_ADDR,
+        *VERIFIED_REGISTRY_ACTOR_ADDR,
+        TokenAmount::zero(),
+        VerifregMethod::AddVerifier as u64,
+        add_verifier_params,
+    );
+
+    ExpectInvocation {
+        to: *VERIFIED_REGISTRY_ACTOR_ADDR,
+        method: VerifregMethod::AddVerifier as u64,
+        params: Some(add_verifier_params_ser),
+        subinvocs: Some(vec![]),
+        ..Default::default()
+    }
+    .matches(v.take_invocations().last().unwrap());
+
+    // register the verified client
+    let add_verified_client_params =
+        AddVerifierClientParams { address: verified_client, allowance: verifier_allowance.clone() };
+    let add_verified_client_params_ser =
+        serialize(&add_verified_client_params, "add verifier params").unwrap();
+    apply_ok(
+        &v,
+        verifier1,
+        *VERIFIED_REGISTRY_ACTOR_ADDR,
+        TokenAmount::zero(),
+        VerifregMethod::AddVerifiedClient as u64,
+        add_verified_client_params,
+    );
+
+    ExpectInvocation {
+        to: *VERIFIED_REGISTRY_ACTOR_ADDR,
+        method: VerifregMethod::AddVerifiedClient as u64,
+        params: Some(add_verified_client_params_ser),
+        subinvocs: Some(vec![]),
+        ..Default::default()
+    }
+    .matches(v.take_invocations().last().unwrap());
+
+    // state checks on the 2 verifiers and the client
+    let mut v_st = v.get_state::<VerifregState>(*VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
+    let verifiers =
+        make_map_with_root_and_bitwidth::<_, BigIntDe>(&v_st.verifiers, &store, HAMT_BIT_WIDTH)
+            .unwrap();
+
+    let BigIntDe(verifier1_data_cap) =
+        verifiers.get(&verifier1_id_addr.to_bytes()).unwrap().unwrap();
+    assert_eq!(BigInt::zero(), *verifier1_data_cap);
+
+    let BigIntDe(verifier2_data_cap) =
+        verifiers.get(&verifier2_id_addr.to_bytes()).unwrap().unwrap();
+    assert_eq!(verifier_allowance, *verifier2_data_cap);
+
+    let mut verified_clients = make_map_with_root_and_bitwidth::<_, BigIntDe>(
+        &v_st.verified_clients,
+        &store,
+        HAMT_BIT_WIDTH,
+    )
+    .unwrap();
+
+    let BigIntDe(data_cap) =
+        verified_clients.get(&verified_client_id_addr.to_bytes()).unwrap().unwrap();
+    assert_eq!(*data_cap, verifier_allowance);
+
+    let mut proposal_ids = make_map_with_root_and_bitwidth::<_, RemoveDataCapProposalID>(
+        &v_st.remove_data_cap_proposal_ids,
+        &store,
+        HAMT_BIT_WIDTH,
+    )
+    .unwrap();
+
+    assert!(proposal_ids
+        .get(&AddrPairKey::new(verifier1_id_addr, verified_client_id_addr).to_bytes())
+        .unwrap()
+        .is_none());
+
+    assert!(proposal_ids
+        .get(&AddrPairKey::new(verifier2_id_addr, verified_client_id_addr).to_bytes())
+        .unwrap()
+        .is_none());
+
+    // remove half the client's allowance
+    let mut verifier1_proposal = RemoveDataCapProposal {
+        verified_client: verified_client_id_addr,
+        data_cap_amount: allowance_to_remove.clone(),
+        removal_proposal_id: RemoveDataCapProposalID(0),
+    };
+
+    let mut verifier1_proposal_ser = to_vec(&verifier1_proposal).unwrap();
+    let mut verifier1_payload = SIGNATURE_DOMAIN_SEPARATION_REMOVE_DATA_CAP.to_vec();
+    verifier1_payload.append(&mut verifier1_proposal_ser);
+
+    let mut verifier2_proposal = RemoveDataCapProposal {
+        verified_client: verified_client_id_addr,
+        data_cap_amount: allowance_to_remove.clone(),
+        removal_proposal_id: RemoveDataCapProposalID(0),
+    };
+
+    let mut verifier2_proposal_ser = to_vec(&verifier2_proposal).unwrap();
+    let mut verifier2_payload = SIGNATURE_DOMAIN_SEPARATION_REMOVE_DATA_CAP.to_vec();
+    verifier2_payload.append(&mut verifier2_proposal_ser);
+
+    let mut remove_datacap_params = RemoveDataCapParams {
+        verified_client_to_remove: verified_client_id_addr,
+        data_cap_amount_to_remove: allowance_to_remove.clone(),
+        verifier_request_1: RemoveDataCapRequest {
+            verifier: verifier1_id_addr,
+            signature: Signature { sig_type: SignatureType::Secp256k1, bytes: verifier1_payload },
+        },
+        verifier_request_2: RemoveDataCapRequest {
+            verifier: verifier2_id_addr,
+            signature: Signature { sig_type: SignatureType::Secp256k1, bytes: verifier2_payload },
+        },
+    };
+
+    let mut remove_datacap_params_ser =
+        serialize(&remove_datacap_params, "add verifier params").unwrap();
+
+    let remove_datacap_ret: RemoveDataCapReturn = apply_ok(
+        &v,
+        VERIFREG_ROOT_KEY_ADDR,
+        *VERIFIED_REGISTRY_ACTOR_ADDR,
+        TokenAmount::zero(),
+        VerifregMethod::RemoveVerifiedClientDataCap as u64,
+        remove_datacap_params,
+    )
+    .deserialize()
+    .unwrap();
+
+    ExpectInvocation {
+        to: *VERIFIED_REGISTRY_ACTOR_ADDR,
+        method: VerifregMethod::RemoveVerifiedClientDataCap as u64,
+        params: Some(remove_datacap_params_ser),
+        subinvocs: Some(vec![]),
+        ..Default::default()
+    }
+    .matches(v.take_invocations().last().unwrap());
+
+    assert_eq!(verified_client_id_addr, remove_datacap_ret.verified_client);
+    assert_eq!(allowance_to_remove, remove_datacap_ret.data_cap_removed);
+
+    v_st = v.get_state::<VerifregState>(*VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
+
+    // confirm client's allowance has fallen by half
+    verified_clients = make_map_with_root_and_bitwidth::<_, BigIntDe>(
+        &v_st.verified_clients,
+        &store,
+        HAMT_BIT_WIDTH,
+    )
+    .unwrap();
+
+    let BigIntDe(data_cap) =
+        verified_clients.get(&verified_client_id_addr.to_bytes()).unwrap().unwrap();
+
+    assert_eq!(*data_cap, verifier_allowance.sub(allowance_to_remove.clone()));
+
+    // confirm proposalIds has changed as expected
+    proposal_ids =
+        make_map_with_root_and_bitwidth(&v_st.remove_data_cap_proposal_ids, &store, HAMT_BIT_WIDTH)
+            .unwrap();
+
+    let verifier1_proposal_id: &RemoveDataCapProposalID = proposal_ids
+        .get(&AddrPairKey::new(verifier1_id_addr, verified_client_id_addr).to_bytes())
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(1u64, verifier1_proposal_id.0);
+
+    let verifier2_proposal_id: &RemoveDataCapProposalID = proposal_ids
+        .get(&AddrPairKey::new(verifier2_id_addr, verified_client_id_addr).to_bytes())
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(1u64, verifier2_proposal_id.0);
+
+    // remove the second half of the client's allowance, this causes the client to be deleted
+
+    verifier1_proposal = RemoveDataCapProposal {
+        verified_client: verified_client_id_addr,
+        data_cap_amount: allowance_to_remove.clone(),
+        removal_proposal_id: verifier1_proposal_id.clone(),
+    };
+
+    verifier1_proposal_ser = to_vec(&verifier1_proposal).unwrap();
+    verifier1_payload = SIGNATURE_DOMAIN_SEPARATION_REMOVE_DATA_CAP.to_vec();
+    verifier1_payload.append(&mut verifier1_proposal_ser);
+
+    verifier2_proposal = RemoveDataCapProposal {
+        verified_client: verified_client_id_addr,
+        data_cap_amount: allowance_to_remove.clone(),
+        removal_proposal_id: verifier2_proposal_id.clone(),
+    };
+
+    verifier2_proposal_ser = to_vec(&verifier2_proposal).unwrap();
+    verifier2_payload = SIGNATURE_DOMAIN_SEPARATION_REMOVE_DATA_CAP.to_vec();
+    verifier2_payload.append(&mut verifier2_proposal_ser);
+
+    remove_datacap_params = RemoveDataCapParams {
+        verified_client_to_remove: verified_client_id_addr,
+        data_cap_amount_to_remove: allowance_to_remove.clone(),
+        verifier_request_1: RemoveDataCapRequest {
+            verifier: verifier1_id_addr,
+            signature: Signature { sig_type: SignatureType::Secp256k1, bytes: verifier1_payload },
+        },
+        verifier_request_2: RemoveDataCapRequest {
+            verifier: verifier2_id_addr,
+            signature: Signature { sig_type: SignatureType::Secp256k1, bytes: verifier2_payload },
+        },
+    };
+
+    remove_datacap_params_ser = serialize(&remove_datacap_params, "add verifier params").unwrap();
+
+    let remove_datacap_ret: RemoveDataCapReturn = apply_ok(
+        &v,
+        VERIFREG_ROOT_KEY_ADDR,
+        *VERIFIED_REGISTRY_ACTOR_ADDR,
+        TokenAmount::zero(),
+        VerifregMethod::RemoveVerifiedClientDataCap as u64,
+        remove_datacap_params,
+    )
+    .deserialize()
+    .unwrap();
+
+    ExpectInvocation {
+        to: *VERIFIED_REGISTRY_ACTOR_ADDR,
+        method: VerifregMethod::RemoveVerifiedClientDataCap as u64,
+        params: Some(remove_datacap_params_ser),
+        subinvocs: Some(vec![]),
+        ..Default::default()
+    }
+    .matches(v.take_invocations().last().unwrap());
+
+    assert_eq!(verified_client_id_addr, remove_datacap_ret.verified_client);
+    assert_eq!(allowance_to_remove, remove_datacap_ret.data_cap_removed);
+
+    // confirm client has been removed entirely
+
+    v_st = v.get_state::<VerifregState>(*VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
+    verified_clients = make_map_with_root_and_bitwidth::<_, BigIntDe>(
+        &v_st.verified_clients,
+        &store,
+        HAMT_BIT_WIDTH,
+    )
+    .unwrap();
+
+    assert!(verified_clients.get(&verified_client_id_addr.to_bytes()).unwrap().is_none());
+
+    // confirm proposalIds has changed as expected
+    proposal_ids =
+        make_map_with_root_and_bitwidth(&v_st.remove_data_cap_proposal_ids, &store, HAMT_BIT_WIDTH)
+            .unwrap();
+
+    let verifier1_proposal_id: &RemoveDataCapProposalID = proposal_ids
+        .get(&AddrPairKey::new(verifier1_id_addr, verified_client_id_addr).to_bytes())
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(2u64, verifier1_proposal_id.0);
+
+    let verifier2_proposal_id: &RemoveDataCapProposalID = proposal_ids
+        .get(&AddrPairKey::new(verifier2_id_addr, verified_client_id_addr).to_bytes())
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(2u64, verifier2_proposal_id.0);
+}


### PR DESCRIPTION
This PR fixes five bugs in https://github.com/filecoin-project/ref-fvm/pull/306:
- Checking status of verified clients using is_verifier is wrong
- is_verifier should load verifiers, not verified_clients
- use_proposal_id should return curr_id, not next_id
- introduce the domain separation of remove data cap signatures
- remove_verified_client_data_cap should actually return RemoveDataCapReturn

Also adds an equivalent test to https://github.com/filecoin-project/specs-actors/blob/master/actors/test/verifreg_remove_datacap_test.go, which resolves #86 