### PR TITLE
all invariants check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,6 +748,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actor_state"
+version = "8.0.0-alpha.1"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actor_account",
+ "fil_actor_cron",
+ "fil_actor_init",
+ "fil_actor_market",
+ "fil_actor_miner",
+ "fil_actor_multisig",
+ "fil_actor_paych",
+ "fil_actor_power",
+ "fil_actor_reward",
+ "fil_actor_system",
+ "fil_actor_verifreg",
+ "fil_actors_runtime",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "fil_actor_system"
 version = "8.0.0-alpha.1"
 dependencies = [
@@ -828,6 +854,7 @@ dependencies = [
  "fil_actor_paych",
  "fil_actor_power",
  "fil_actor_reward",
+ "fil_actor_state",
  "fil_actor_system",
  "fil_actor_verifreg",
  "fil_actors_runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ fil_actor_reward = { version = "8.0.0-alpha.1", path = "./actors/reward", featur
 fil_actor_system = { version = "8.0.0-alpha.1", path = "./actors/system", features = ["fil-actor"] }
 fil_actor_init = { version = "8.0.0-alpha.1", path = "./actors/init", features = ["fil-actor"] }
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "./actors/runtime", features = ["fil-actor"] }
+fil_actor_state = { version = "8.0.0-alpha.1", path = "./actors/state", features = ["fil-actor"] }
 
 [build-dependencies]
 fil_actor_bundler = "3.0.3"

--- a/actors/market/src/testing.rs
+++ b/actors/market/src/testing.rs
@@ -54,7 +54,7 @@ pub struct StateSummary {
 
 /// Checks internal invariants of market state
 pub fn check_state_invariants<BS: Blockstore + Debug>(
-    state: State,
+    state: &State,
     store: &BS,
     balance: &TokenAmount,
     current_epoch: ChainEpoch,

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -96,7 +96,7 @@ pub fn setup() -> MockRuntime {
 /// Checks internal invariants of market state asserting none of them are broken.
 pub fn check_state(rt: &MockRuntime) {
     let (_, acc) =
-        check_state_invariants(rt.get_state::<State>(), rt.store(), &rt.get_balance(), rt.epoch);
+        check_state_invariants(&rt.get_state::<State>(), rt.store(), &rt.get_balance(), rt.epoch);
     acc.assert_empty();
 }
 
@@ -104,7 +104,7 @@ pub fn check_state(rt: &MockRuntime) {
 /// provided order.
 pub fn check_state_with_expected(rt: &MockRuntime, expected_patterns: &[Regex]) {
     let (_, acc) =
-        check_state_invariants(rt.get_state::<State>(), rt.store(), &rt.get_balance(), rt.epoch);
+        check_state_invariants(&rt.get_state::<State>(), rt.store(), &rt.get_balance(), rt.epoch);
 
     let messages = acc.messages();
     assert!(

--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 pub fn check_state_invariants<BS: Blockstore>(
     policy: &Policy,
-    state: State,
+    state: &State,
     store: &BS,
     balance: &TokenAmount,
 ) -> (StateSummary, MessageAccumulator) {
@@ -42,7 +42,7 @@ pub fn check_state_invariants<BS: Blockstore>(
         }
     };
 
-    check_miner_balances(policy, &state, store, balance, &acc);
+    check_miner_balances(policy, state, store, balance, &acc);
 
     let allocated_sectors = match store.get_cbor::<BitField>(&state.allocated_sectors) {
         Ok(Some(allocated_sectors)) => {
@@ -63,7 +63,7 @@ pub fn check_state_invariants<BS: Blockstore>(
         }
     };
 
-    check_precommits(policy, &state, store, &allocated_sectors, &acc);
+    check_precommits(policy, state, store, &allocated_sectors, &acc);
 
     let mut all_sectors: BTreeMap<SectorNumber, SectorOnChainInfo> = BTreeMap::new();
     match Sectors::load(&store, &state.sectors) {

--- a/actors/miner/tests/apply_rewards.rs
+++ b/actors/miner/tests/apply_rewards.rs
@@ -81,7 +81,7 @@ fn funds_vest() {
     let (locked_amt, _) = locked_reward_from_reward(amt);
     assert_eq!(locked_amt, st.locked_funds);
     // technically applying rewards without first activating cron is an impossible state but convenient for testing
-    let (_, acc) = check_state_invariants(rt.policy(), st, rt.store(), &rt.get_balance());
+    let (_, acc) = check_state_invariants(rt.policy(), &st, rt.store(), &rt.get_balance());
     assert_eq!(1, acc.len());
     assert!(acc.messages().first().unwrap().contains("DeadlineCronActive == false"));
 }
@@ -103,7 +103,7 @@ fn penalty_is_burnt() {
     assert_eq!(expected_lock_amt, h.get_locked_funds(&rt));
     // technically applying rewards without first activating cron is an impossible state but convenient for testing
     let (_, acc) =
-        check_state_invariants(rt.policy(), h.get_state(&rt), rt.store(), &rt.get_balance());
+        check_state_invariants(rt.policy(), &h.get_state(&rt), rt.store(), &rt.get_balance());
     assert_eq!(1, acc.len());
     assert!(acc.messages().first().unwrap().contains("DeadlineCronActive == false"));
 }
@@ -226,7 +226,7 @@ fn rewards_pay_back_fee_debt() {
     // remaining funds locked in vesting table
     assert_eq!(remaining_locked, st.locked_funds);
     // technically applying rewards without first activating cron is an impossible state but convenient for testing
-    let (_, acc) = check_state_invariants(rt.policy(), st, rt.store(), &rt.get_balance());
+    let (_, acc) = check_state_invariants(rt.policy(), &st, rt.store(), &rt.get_balance());
     assert_eq!(1, acc.len());
     assert!(acc.messages().first().unwrap().contains("DeadlineCronActive == false"));
 }

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -3467,7 +3467,11 @@ pub fn require_no_expiration_groups_before(
 }
 
 pub fn check_state_invariants_from_mock_runtime(rt: &MockRuntime) {
-    let (_, acc) =
-        check_state_invariants(rt.policy(), rt.get_state::<State>(), rt.store(), &rt.get_balance());
+    let (_, acc) = check_state_invariants(
+        rt.policy(),
+        &rt.get_state::<State>(),
+        rt.store(),
+        &rt.get_balance(),
+    );
     assert!(acc.is_empty(), "{}", acc.messages().join("\n"));
 }

--- a/actors/power/src/testing.rs
+++ b/actors/power/src/testing.rs
@@ -22,7 +22,7 @@ pub struct MinerCronEvent {
     pub payload: RawBytes,
 }
 
-type CronEventsByAddress = HashMap<Address, MinerCronEvent>;
+type CronEventsByAddress = HashMap<Address, Vec<MinerCronEvent>>;
 type ClaimsByAddress = HashMap<Address, Claim>;
 type ProofsByAddress = HashMap<Address, SealVerifyInfo>;
 
@@ -126,8 +126,7 @@ fn check_cron_invariants<BS: Blockstore>(
                 );
                 events
                     .for_each(|_, event| {
-                        cron_events_by_address.insert(
-                            event.miner_addr,
+                        cron_events_by_address.entry(event.miner_addr).or_insert(Vec::new()).push(
                             MinerCronEvent { epoch, payload: event.callback_payload.clone() },
                         );
                         Ok(())

--- a/actors/state/Cargo.toml
+++ b/actors/state/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "fil_actor_state"
+description = "Builtin Actor state utils for Filecoin"
+version = "8.0.0-alpha.1"
+license = "MIT OR Apache-2.0"
+authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
+edition = "2018"
+repository = "https://github.com/filecoin-project/builtin-actors"
+keywords = ["filecoin", "web3", "wasm"]
+
+[lib]
+## lib is necessary for integration tests
+## cdylib is necessary for Wasm build
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+fil_actor_account = { version = "8.0.0-alpha.1", path = "../account"}
+fil_actor_verifreg = { version = "8.0.0-alpha.1", path = "../verifreg"}
+fil_actor_cron = { version = "8.0.0-alpha.1", path = "../cron"}
+fil_actor_market = { version = "8.0.0-alpha.1", path = "../market"}
+fil_actor_multisig = { version = "8.0.0-alpha.1", path = "../multisig"}
+fil_actor_paych = { version = "8.0.0-alpha.1", path = "../paych"}
+fil_actor_power = { version = "8.0.0-alpha.1", path = "../power"}
+fil_actor_miner = { version = "8.0.0-alpha.1", path = "../miner"}
+fil_actor_reward = { version = "8.0.0-alpha.1", path = "../reward"}
+fil_actor_system = { version = "8.0.0-alpha.1", path = "../system"}
+fil_actor_init = { version = "8.0.0-alpha.1", path = "../init"}
+fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime"}
+fvm_shared = { version = "0.7.1", default-features = false }
+fvm_ipld_encoding = "0.2.1"
+fvm_ipld_blockstore = "0.1.1"
+num-traits = "0.2.14"
+anyhow = "1.0.56"
+num-derive = "0.3.3"
+serde = { version = "1.0.136", features = ["derive"] }
+cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+
+[dev-dependencies]
+[features]
+fil-actor = []
+

--- a/actors/state/src/check.rs
+++ b/actors/state/src/check.rs
@@ -282,6 +282,10 @@ fn check_miner_against_power(
         } else {
             // with deferred and discontinued crons it is normal for a miner actor to have no cron
             // events
+            acc.require(
+                !miner_summary.deadline_cron_active,
+                format!("miner {address} has no cron events but the deadline cron is active"),
+            );
         }
     }
 }

--- a/actors/state/src/check.rs
+++ b/actors/state/src/check.rs
@@ -1,0 +1,358 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+use anyhow::bail;
+use cid::Cid;
+use fil_actor_account::State as AccountState;
+use fil_actor_cron::State as CronState;
+use fil_actor_init::State as InitState;
+use fil_actor_market::State as MarketState;
+use fil_actor_miner::CronEventPayload;
+use fil_actor_miner::PowerPair;
+use fil_actor_miner::State as MinerState;
+use fil_actor_miner::CRON_EVENT_PROCESS_EARLY_TERMINATIONS;
+use fil_actor_miner::CRON_EVENT_PROVING_DEADLINE;
+use fil_actor_multisig::State as MultisigState;
+use fil_actor_paych::State as PaychState;
+use fil_actor_power::testing::MinerCronEvent;
+use fil_actor_power::State as PowerState;
+use fil_actor_reward::State as RewardState;
+use fil_actor_verifreg::State as VerifregState;
+
+use fil_actors_runtime::runtime::Policy;
+use fil_actors_runtime::Map;
+use fil_actors_runtime::MessageAccumulator;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::from_slice;
+use fvm_ipld_encoding::CborStore;
+use fvm_shared::actor::builtin::Manifest;
+use fvm_shared::actor::builtin::Type;
+use fvm_shared::address::Address;
+use fvm_shared::address::Protocol;
+use fvm_shared::bigint::BigInt;
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::econ::TokenAmount;
+use num_traits::Zero;
+
+use anyhow::anyhow;
+use fvm_ipld_encoding::tuple::*;
+use fvm_shared::bigint::bigint_ser;
+
+use fil_actor_account::testing as account;
+use fil_actor_cron::testing as cron;
+use fil_actor_init::testing as init;
+use fil_actor_market::testing as market;
+use fil_actor_miner::testing as miner;
+use fil_actor_multisig::testing as multisig;
+use fil_actor_paych::testing as paych;
+use fil_actor_power::testing as power;
+use fil_actor_reward::testing as reward;
+use fil_actor_verifreg::testing as verifreg;
+
+/// Value type of the top level of the state tree.
+/// Represents the on-chain state of a single actor.
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, PartialEq, Debug)]
+pub struct Actor {
+    /// CID representing the code associated with the actor
+    pub code: Cid,
+    /// CID of the head state object for the actor
+    pub head: Cid,
+    /// `call_seq_num` for the next message to be received by the actor (non-zero for accounts only)
+    pub call_seq_num: u64,
+    #[serde(with = "bigint_ser")]
+    /// Token balance of the actor
+    pub balance: TokenAmount,
+}
+
+/// A specialization of a map of ID-addresses to actor heads.
+pub struct Tree<'a, BS>
+where
+    BS: Blockstore,
+{
+    pub map: Map<'a, BS, Actor>,
+    pub store: &'a BS,
+}
+
+impl<'a, BS: Blockstore> Tree<'a, BS> {
+    /// Loads a tree from a root CID and store
+    pub fn load(store: &'a BS, root: &Cid) -> anyhow::Result<Self> {
+        let map = Map::load(root, store)?;
+
+        Ok(Tree { map, store })
+    }
+
+    pub fn for_each<F>(&self, mut f: F) -> anyhow::Result<()>
+    where
+        F: FnMut(&Address, &Actor) -> anyhow::Result<()>,
+    {
+        self.map
+            .for_each(|key, val| {
+                let address = Address::from_bytes(key)?;
+                f(&address, val)
+            })
+            .map_err(|e| anyhow!("Failed iterating map: {}", e))
+    }
+}
+
+macro_rules! get_state {
+    ($tree:ident, $actor:ident, $state:ty) => {
+        $tree
+            .store
+            .get_cbor::<$state>(&$actor.head)?
+            .ok_or_else(|| anyhow!("{} is empty", stringify!($state)))?
+    };
+}
+
+pub fn check_state_invariants<'a, BS: Blockstore + Debug>(
+    manifest: &Manifest,
+    policy: &Policy,
+    tree: Tree<'a, BS>,
+    expected_balance_total: &TokenAmount,
+    prior_epoch: ChainEpoch,
+) -> anyhow::Result<MessageAccumulator> {
+    let acc = MessageAccumulator::default();
+    let mut total_fil = BigInt::zero();
+
+    let mut init_summary: Option<init::StateSummary> = None;
+    let mut cron_summary: Option<cron::StateSummary> = None;
+    let mut account_summaries = Vec::<account::StateSummary>::new();
+    let mut power_summary: Option<power::StateSummary> = None;
+    let mut miner_summaries = HashMap::<Address, miner::StateSummary>::new();
+    let mut market_summary: Option<market::StateSummary> = None;
+    let mut paych_summaries = Vec::<paych::StateSummary>::new();
+    let mut multisig_summaries = Vec::<multisig::StateSummary>::new();
+    let mut reward_summary: Option<reward::StateSummary> = None;
+    let mut verifreg_summary: Option<verifreg::StateSummary> = None;
+
+    tree.for_each(|key, actor| {
+        let acc = acc.with_prefix(format!("{key} "));
+
+        if key.protocol() != Protocol::ID {
+            acc.add(format!("unexpected address protocol in state tree root: {key}"));
+        }
+        total_fil += &actor.balance;
+
+        match manifest.get_by_left(&actor.code) {
+            Some(Type::System) => (),
+            Some(Type::Init) => {
+                let state = get_state!(tree, actor, InitState);
+                let (summary, msgs) = init::check_state_invariants(&state, tree.store);
+                acc.with_prefix("init: ").add_all(&msgs);
+                init_summary = Some(summary);
+            }
+            Some(Type::Cron) => {
+                let state = get_state!(tree, actor, CronState);
+                let (summary, msgs) = cron::check_state_invariants(&state);
+                acc.with_prefix("cron: ").add_all(&msgs);
+                cron_summary = Some(summary);
+            }
+            Some(Type::Account) => {
+                let state = get_state!(tree, actor, AccountState);
+                let (summary, msgs) = account::check_state_invariants(&state, key);
+                acc.with_prefix("account: ").add_all(&msgs);
+                account_summaries.push(summary);
+            }
+            Some(Type::Power) => {
+                let state = get_state!(tree, actor, PowerState);
+                let (summary, msgs) = power::check_state_invariants(policy, &state, tree.store);
+                acc.with_prefix("power: ").add_all(&msgs);
+                power_summary = Some(summary);
+            }
+            Some(Type::Miner) => {
+                let state = get_state!(tree, actor, MinerState);
+                let (summary, msgs) =
+                    miner::check_state_invariants(policy, &state, tree.store, &actor.balance);
+                acc.with_prefix("miner: ").add_all(&msgs);
+                miner_summaries.insert(*key, summary);
+            }
+            Some(Type::Market) => {
+                let state = get_state!(tree, actor, MarketState);
+                let (summary, msgs) =
+                    market::check_state_invariants(&state, tree.store, &actor.balance, prior_epoch);
+                acc.with_prefix("market: ").add_all(&msgs);
+                market_summary = Some(summary);
+            }
+            Some(Type::PaymentChannel) => {
+                let state = get_state!(tree, actor, PaychState);
+                let (summary, msgs) =
+                    paych::check_state_invariants(&state, tree.store, &actor.balance);
+                acc.with_prefix("paych: ").add_all(&msgs);
+                paych_summaries.push(summary);
+            }
+            Some(Type::Multisig) => {
+                let state = get_state!(tree, actor, MultisigState);
+                let (summary, msgs) = multisig::check_state_invariants(&state, tree.store);
+                acc.with_prefix("multisig: ").add_all(&msgs);
+                multisig_summaries.push(summary);
+            }
+            Some(Type::Reward) => {
+                let state = get_state!(tree, actor, RewardState);
+                let (summary, msgs) =
+                    reward::check_state_invariants(&state, prior_epoch, &actor.balance);
+                acc.with_prefix("reward: ").add_all(&msgs);
+                reward_summary = Some(summary);
+            }
+            Some(Type::VerifiedRegistry) => {
+                let state = get_state!(tree, actor, VerifregState);
+                let (summary, msgs) = verifreg::check_state_invariants(&state, tree.store);
+                acc.with_prefix("verifreg: ").add_all(&msgs);
+                verifreg_summary = Some(summary);
+            }
+            None => {
+                bail!("unexpected actor code CID {} for address {}", actor.code, key);
+            }
+        };
+
+        Ok(())
+    })?;
+
+    // Perform cross-actor checks from state summaries here.
+    if let Some(power_summary) = power_summary {
+        check_miner_against_power(&acc, &miner_summaries, &power_summary);
+    }
+
+    if let Some(market_summary) = market_summary {
+        check_deal_states_against_sectors(&acc, &miner_summaries, &market_summary);
+    }
+
+    acc.require(
+        &total_fil == expected_balance_total,
+        format!("total token balance is {total_fil}, expected {expected_balance_total}"),
+    );
+
+    Ok(acc)
+}
+
+fn check_miner_against_power(
+    acc: &MessageAccumulator,
+    miner_summaries: &HashMap<Address, miner::StateSummary>,
+    power_summary: &power::StateSummary,
+) {
+    for (address, miner_summary) in miner_summaries {
+        //check claim
+        if let Some(claim) = power_summary.claims.get(address) {
+            let claim_power =
+                PowerPair::new(claim.raw_byte_power.clone(), claim.quality_adj_power.clone());
+            acc.require(miner_summary.active_power == claim_power, format!("miner {address} computed active power {:?} does not match claim {claim_power:?}", miner_summary.active_power));
+            acc.require(
+                miner_summary.window_post_proof_type == claim.window_post_proof_type,
+                format!(
+                    "miner seal proof type {:?} does not match claim proof type {:?}",
+                    miner_summary.window_post_proof_type, claim.window_post_proof_type
+                ),
+            );
+        } else {
+            acc.add(format!("miner {address} has no power claim"));
+        }
+
+        //check crons
+        let mut proving_period_cron: Option<&MinerCronEvent> = None;
+        if let Some(crons) = power_summary.crons.get(address) {
+            for event in crons {
+                match from_slice::<CronEventPayload>(event.payload.bytes()) {
+                    Ok(payload) => {
+                        acc.require(
+                            matches!(
+                                payload.event_type,
+                                CRON_EVENT_PROCESS_EARLY_TERMINATIONS | CRON_EVENT_PROVING_DEADLINE
+                            ),
+                            format!(
+                                "miner {address} has unexpected cron event type {}",
+                                payload.event_type
+                            ),
+                        );
+                        if payload.event_type == CRON_EVENT_PROVING_DEADLINE {
+                            if proving_period_cron.is_some() {
+                                acc.add(format!("miner {address} has duplicate proving period crons at epoch {} and {}", proving_period_cron.as_ref().unwrap().epoch, event.epoch));
+                            }
+                            proving_period_cron = Some(event);
+                        }
+                    }
+                    Err(e) => acc.add(format!(
+                        "miner {address} registered cron at epoch {} with wrong or corrupt payload: {e}",
+                        event.epoch
+                    )),
+                }
+                acc.require(proving_period_cron.is_some() == miner_summary.deadline_cron_active, format!("miner {address} has invalid deadline_cron_active ({}) for proving_period_cron status ({})", miner_summary.deadline_cron_active, proving_period_cron.is_some()));
+                acc.require(
+                    proving_period_cron.is_some(),
+                    format!("miner {address} has no proving period cron"),
+                );
+            }
+        } else {
+            // with deferred and discontinued crons it is normal for a miner actor to have no cron
+            // events
+        }
+    }
+}
+
+fn check_deal_states_against_sectors(
+    acc: &MessageAccumulator,
+    miner_summaries: &HashMap<Address, miner::StateSummary>,
+    market_summary: &market::StateSummary,
+) {
+    // Check that all active deals are included within a non-terminated sector.
+    // We cannot check that all deals referenced within a sector are in the market, because deals
+    // can be terminated independently of the sector in which they are included.
+    for (deal_id, deal) in &market_summary.deals {
+        if deal.sector_start_epoch == -1 {
+            // deal hasn't been activated yet, make no assertions about sector state
+            continue;
+        }
+
+        let miner_summary = if let Some(miner_summary) = miner_summaries.get(&deal.provider) {
+            miner_summary
+        } else {
+            acc.add(format!(
+                "provider {} for deal {} not found among miners",
+                deal.provider, &deal_id
+            ));
+            continue;
+        };
+
+        let sector_deal = if let Some(sector_deal) = miner_summary.deals.get(deal_id) {
+            sector_deal
+        } else {
+            acc.require(
+                deal.slash_epoch >= 0,
+                format!(
+                    "un-slashed deal {deal_id} not referenced in active sectors of miner {}",
+                    deal.provider
+                ),
+            );
+            continue;
+        };
+
+        acc.require(
+            deal.sector_start_epoch == sector_deal.sector_start,
+            format!(
+                "deal state start {} does not match sector start {} for miner {}",
+                deal.sector_start_epoch, sector_deal.sector_start, deal.provider
+            ),
+        );
+
+        acc.require(
+            deal.sector_start_epoch <= sector_deal.sector_expiration,
+            format!(
+                "deal state start {} activated after sector expiration {} for miner {}",
+                deal.sector_start_epoch, sector_deal.sector_expiration, deal.provider
+            ),
+        );
+
+        acc.require(
+            deal.last_update_epoch <= sector_deal.sector_expiration,
+            format!(
+                "deal state update at {} after sector expiration {} for miner {}",
+                deal.last_update_epoch, sector_deal.sector_expiration, deal.provider
+            ),
+        );
+
+        acc.require(
+            deal.slash_epoch <= sector_deal.sector_expiration,
+            format!(
+                "deal state slashed at {} after sector expiration {} for miner {}",
+                deal.slash_epoch, sector_deal.sector_expiration, deal.provider
+            ),
+        );
+    }
+}

--- a/actors/state/src/lib.rs
+++ b/actors/state/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod check;


### PR DESCRIPTION
Mother of all invariant checks from [here](https://github.com/filecoin-project/specs-actors/blob/master/actors/states/check.go). I extracted it into a separate crate to not bloat runtime crate dependencies.

Fixed some minor issues with existing invariant checks:
* always pass `State` by reference and not move it,
* Power actor check didn't aggregate cron events, only the last one was in the `StateSummary`.

Closes https://github.com/filecoin-project/builtin-actors/issues/44