### PR TITLE
invariant checks in integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_state"
-version = "8.0.0-alpha.1"
+version = "8.0.0-rc.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -825,12 +825,14 @@ dependencies = [
  "hex",
  "indexmap",
  "integer-encoding",
+ "itertools",
  "lazy_static",
  "log",
  "multihash",
  "num-derive",
  "num-traits",
  "rand",
+ "regex",
  "serde",
  "serde_repr",
  "sha2",
@@ -1803,6 +1805,7 @@ dependencies = [
  "num-traits",
  "rand",
  "rand_chacha",
+ "regex",
  "serde",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,6 +1785,7 @@ dependencies = [
  "fil_actor_paych",
  "fil_actor_power",
  "fil_actor_reward",
+ "fil_actor_state",
  "fil_actor_system",
  "fil_actor_verifreg",
  "fil_actors_runtime",

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
 use cid::Cid;
-use itertools::Itertools;
 use num_traits::{FromPrimitive, Zero};
 use regex::Regex;
 use std::{cell::RefCell, collections::HashMap};
@@ -105,23 +104,7 @@ pub fn check_state(rt: &MockRuntime) {
 pub fn check_state_with_expected(rt: &MockRuntime, expected_patterns: &[Regex]) {
     let (_, acc) =
         check_state_invariants(&rt.get_state::<State>(), rt.store(), &rt.get_balance(), rt.epoch);
-
-    let messages = acc.messages();
-    assert!(
-        messages.len() == expected_patterns.len(),
-        "Incorrect number of broken invariants. Failed: {}.\nExpected: {}",
-        messages.join("\n"),
-        expected_patterns.iter().map(|regex| regex.as_str()).join("\n")
-    );
-
-    messages.iter().zip(expected_patterns).for_each(|(message, pattern)| {
-        assert!(
-            pattern.is_match(message),
-            "invariant failures did not match. Actual: {}, expected: {}",
-            message,
-            pattern.as_str()
-        );
-    });
+    acc.assert_expected(expected_patterns);
 }
 pub fn construct_and_verify(rt: &mut MockRuntime) {
     rt.expect_validate_caller_addr(vec![*SYSTEM_ACTOR_ADDR]);

--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -896,7 +896,7 @@ pub fn check_deadline_state_invariants<BS: Blockstore>(
     };
 
     // Check that we don't have any proofs proving partitions that are not in the snapshot.
-    match deadline.optimistic_proofs_amt(store) {
+    match deadline.optimistic_proofs_snapshot_amt(store) {
         Ok(proofs_snapshot) => {
             if let Ok(partitions_snapshot) = deadline.partitions_snapshot_amt(store) {
                 let ret = proofs_snapshot.for_each(|_, proof| {
@@ -904,7 +904,7 @@ pub fn check_deadline_state_invariants<BS: Blockstore>(
                         match partitions_snapshot.get(partition) {
                             Ok(snapshot) => acc.require(
                                 snapshot.is_some(),
-                                "failed to find partition for recorded proof in the snapshot",
+                                format!("failed to find partition {partition} for recorded proof in the snapshot"),
                             ),
                             Err(e) => acc.add(format!("error loading partition snapshot: {e}")),
                         }

--- a/actors/reward/src/testing.rs
+++ b/actors/reward/src/testing.rs
@@ -1,4 +1,4 @@
-use crate::State;
+use crate::{baseline_power_from_prev, State};
 use fil_actors_runtime::MessageAccumulator;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::{clock::ChainEpoch, econ::TokenAmount};
@@ -53,11 +53,16 @@ pub fn check_state_invariants(
         !state.cumsum_realized.is_negative(),
         format!("cumsum realized negative ({})", state.cumsum_realized),
     );
+
+    // Theoretically we should compare effective_baseline_power <= this_epoch_baseline_power but
+    // because of rounding issues explained and tracked in https://github.com/filecoin-project/builtin-actors/issues/459
+    // we settled on this workaround.
+    let baseline_power_from_prev = baseline_power_from_prev(&state.this_epoch_baseline_power);
     acc.require(
-        state.effective_baseline_power <= state.this_epoch_baseline_power,
+        state.effective_baseline_power <= baseline_power_from_prev,
         format!(
-            "effective baseline power ({}) > baseline power ({})",
-            state.effective_baseline_power, state.this_epoch_baseline_power
+            "effective baseline power ({}) > baseline power (from prev) ({})",
+            state.effective_baseline_power, baseline_power_from_prev
         ),
     );
 

--- a/actors/reward/src/testing.rs
+++ b/actors/reward/src/testing.rs
@@ -57,12 +57,12 @@ pub fn check_state_invariants(
     // Theoretically we should compare effective_baseline_power <= this_epoch_baseline_power but
     // because of rounding issues explained and tracked in https://github.com/filecoin-project/builtin-actors/issues/459
     // we settled on this workaround.
-    let baseline_power_from_prev = baseline_power_from_prev(&state.this_epoch_baseline_power);
+    let next_epoch_baseline_power = baseline_power_from_prev(&state.this_epoch_baseline_power);
     acc.require(
-        state.effective_baseline_power <= baseline_power_from_prev,
+        state.effective_baseline_power <= next_epoch_baseline_power,
         format!(
-            "effective baseline power ({}) > baseline power (from prev) ({})",
-            state.effective_baseline_power, baseline_power_from_prev
+            "effective baseline power ({}) > next_epoch_baseline_power ({})",
+            state.effective_baseline_power, next_epoch_baseline_power
         ),
     );
 

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -34,6 +34,8 @@ fvm_ipld_encoding = "0.2.2"
 multihash = { version = "0.16.1", default-features = false }
 rand = "0.8.5"
 serde_repr = "0.1.8"
+regex = "1"
+itertools = "0.10"
 
 [dependencies.sha2]
 version = "0.10"

--- a/actors/runtime/src/util/message_accumulator.rs
+++ b/actors/runtime/src/util/message_accumulator.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, fmt::Display, rc::Rc};
 
 /// Accumulates a sequence of messages (e.g. validation failures).
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct MessageAccumulator {
     /// Accumulated messages.
     /// This is a `Rc<RefCell>` to support accumulators derived from `with_prefix()` accumulating to

--- a/actors/state/Cargo.toml
+++ b/actors/state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_state"
 description = "Builtin Actor state utils for Filecoin"
-version = "8.0.0-alpha.1"
+version = "8.0.0-rc.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"

--- a/actors/state/src/check.rs
+++ b/actors/state/src/check.rs
@@ -168,7 +168,7 @@ pub fn check_state_invariants<'a, BS: Blockstore + Debug>(
             Some(Type::Market) => {
                 let state = get_state!(tree, actor, MarketState);
                 let (summary, msgs) =
-                    market::check_state_invariants(&state, tree.store, &actor.balance, prior_epoch);
+                    market::check_state_invariants(&state, tree.store, &actor.balance, prior_epoch+1);
                 acc.with_prefix("market: ").add_all(&msgs);
                 market_summary = Some(summary);
             }

--- a/actors/state/src/check.rs
+++ b/actors/state/src/check.rs
@@ -167,8 +167,12 @@ pub fn check_state_invariants<'a, BS: Blockstore + Debug>(
             }
             Some(Type::Market) => {
                 let state = get_state!(tree, actor, MarketState);
-                let (summary, msgs) =
-                    market::check_state_invariants(&state, tree.store, &actor.balance, prior_epoch+1);
+                let (summary, msgs) = market::check_state_invariants(
+                    &state,
+                    tree.store,
+                    &actor.balance,
+                    prior_epoch + 1,
+                );
                 acc.with_prefix("market: ").add_all(&msgs);
                 market_summary = Some(summary);
             }

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -41,9 +41,8 @@ thiserror = "1.0.30"
 anyhow = "1.0.56"
 blake2b_simd = "1.0"
 integer-encoding = { version = "3.0.3", default-features = false }
+regex = "1"
+
 [dev-dependencies]
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.1", default-features = false }
-
-
-

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["filecoin", "web3", "wasm"]
 
 [dependencies]
 fil_actors_runtime = { version = "8.0.0-rc.1", path = "../actors/runtime", features = [ "test_utils" ] }
+fil_actor_state = { version = "8.0.0-rc.1", path = "../actors/state"}
 fil_actor_init = { version = "8.0.0-rc.1", path = "../actors/init" }
 fil_actor_cron = { version = "8.0.0-rc.1", path = "../actors/cron" }
 fil_actor_system = { version = "8.0.0-rc.1", path = "../actors/system" }

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -641,3 +641,12 @@ pub fn make_bitfield(bits: &[u64]) -> UnvalidatedBitField {
 pub fn bf_all(bf: BitField) -> Vec<u64> {
     bf.bounded_iter(Policy::default().addressed_sectors_max).unwrap().collect()
 }
+
+pub mod invariant_failure_patterns {
+    use lazy_static::lazy_static;
+    use regex::Regex;
+    lazy_static! {
+        pub static ref REWARD_STATE_MISMATCH: Regex =
+            Regex::new("^reward state epoch \\d+ does not match prior_epoch\\+1 \\d+$").unwrap();
+    }
+}

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -646,7 +646,7 @@ pub mod invariant_failure_patterns {
     use lazy_static::lazy_static;
     use regex::Regex;
     lazy_static! {
-        pub static ref REWARD_STATE_MISMATCH: Regex =
+        pub static ref REWARD_STATE_EPOCH_MISMATCH: Regex =
             Regex::new("^reward state epoch \\d+ does not match prior_epoch\\+1 \\d+$").unwrap();
     }
 }

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -309,7 +309,7 @@ fn missed_first_post_deadline() {
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
 
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_MISMATCH.to_owned()]);
+    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -422,7 +422,7 @@ fn overdue_precommit() {
     assert!(network_stats.total_raw_byte_power.is_zero());
     assert!(network_stats.total_quality_adj_power.is_zero());
 
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_MISMATCH.to_owned()]);
+    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -500,7 +500,7 @@ fn aggregate_bad_sector_number() {
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_MISMATCH.to_owned()]);
+    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -632,7 +632,7 @@ fn aggregate_size_limits() {
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_MISMATCH.to_owned()]);
+    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -706,7 +706,7 @@ fn aggregate_bad_sender() {
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_MISMATCH.to_owned()]);
+    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -843,5 +843,5 @@ fn aggregate_one_precommit_expires() {
     assert!(balances.initial_pledge.is_positive());
     assert!(balances.pre_commit_deposit.is_positive());
 
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_MISMATCH.to_owned()]);
+    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -194,6 +194,8 @@ fn submit_post_succeeds() {
     assert!(balances.initial_pledge.is_positive());
     let p_st = v.get_state::<PowerState>(*STORAGE_POWER_ACTOR_ADDR).unwrap();
     assert_eq!(sector_power.raw, p_st.total_bytes_committed);
+
+    v.assert_state_invariants();
 }
 
 #[test]

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -309,7 +309,9 @@ fn missed_first_post_deadline() {
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
 
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    v.expect_state_invariants(
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -422,7 +424,9 @@ fn overdue_precommit() {
     assert!(network_stats.total_raw_byte_power.is_zero());
     assert!(network_stats.total_quality_adj_power.is_zero());
 
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    v.expect_state_invariants(
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -500,7 +504,9 @@ fn aggregate_bad_sector_number() {
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    v.expect_state_invariants(
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -632,7 +638,9 @@ fn aggregate_size_limits() {
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    v.expect_state_invariants(
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -706,7 +714,9 @@ fn aggregate_bad_sender() {
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    v.expect_state_invariants(
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -843,5 +853,7 @@ fn aggregate_one_precommit_expires() {
     assert!(balances.initial_pledge.is_positive());
     assert!(balances.pre_commit_deposit.is_positive());
 
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    v.expect_state_invariants(
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }

--- a/test_vm/tests/multisig_test.rs
+++ b/test_vm/tests/multisig_test.rs
@@ -95,6 +95,7 @@ fn test_proposal_hash() {
     };
     expect.matches(v.take_invocations().last().unwrap());
     assert_eq!(sys_act_start_bal + fil_delta, v.get_actor(*SYSTEM_ACTOR_ADDR).unwrap().balance);
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -163,6 +164,7 @@ fn test_delete_self() {
         let new_signers: HashSet<Address> = HashSet::from_iter(st.signers);
         let diff: Vec<&Address> = old_signers.symmetric_difference(&new_signers).collect();
         assert_eq!(vec![&(addrs[remove_idx])], diff);
+        v.assert_state_invariants();
     };
     test(2, 3, 0); // 2 of 3 removed is proposer
     test(2, 3, 1); // 2 of 3 removed is approver
@@ -195,7 +197,8 @@ fn swap_self_1_of_2() {
         propose_swap_signer_params,
     );
     let st = v.get_state::<MsigState>(msig_addr).unwrap();
-    assert_eq!(vec![bob, chuck], st.signers)
+    assert_eq!(vec![bob, chuck], st.signers);
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -267,7 +270,8 @@ fn swap_self_2_of_3() {
         approve_swap_signer_params,
     );
     let st = v.get_state::<MsigState>(msig_addr).unwrap();
-    assert_eq!(vec![bob, chuck, alice], st.signers)
+    assert_eq!(vec![bob, chuck, alice], st.signers);
+    v.assert_state_invariants();
 }
 
 fn create_msig(v: &VM, signers: Vec<Address>, threshold: u64) -> Address {

--- a/test_vm/tests/multisig_test.rs
+++ b/test_vm/tests/multisig_test.rs
@@ -99,7 +99,6 @@ fn test_proposal_hash() {
 }
 
 #[test]
-
 fn test_delete_self() {
     let test = |threshold: usize, signers: u64, remove_idx: usize| {
         let store = MemoryBlockstore::new();

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -94,7 +94,8 @@ fn create_miner_test() {
         ]),
         ..Default::default()
     };
-    expect.matches(v.take_invocations().last().unwrap())
+    expect.matches(v.take_invocations().last().unwrap());
+    v.assert_state_invariants();
 }
 
 #[test]

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -229,5 +229,5 @@ fn test_cron_tick() {
     }
     .matches(v.take_invocations().first().unwrap());
 
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_MISMATCH.to_owned()]);
+    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -229,5 +229,7 @@ fn test_cron_tick() {
     }
     .matches(v.take_invocations().first().unwrap());
 
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    v.expect_state_invariants(
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -20,7 +20,9 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof};
 use fvm_shared::METHOD_SEND;
 use num_traits::Zero;
-use test_vm::util::{apply_ok, create_accounts, create_miner, miner_dline_info};
+use test_vm::util::{
+    apply_ok, create_accounts, create_miner, invariant_failure_patterns, miner_dline_info,
+};
 use test_vm::{ExpectInvocation, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
 
 #[test]
@@ -226,4 +228,6 @@ fn test_cron_tick() {
         ..Default::default()
     }
     .matches(v.take_invocations().first().unwrap());
+
+    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -163,6 +163,7 @@ fn psd_bad_piece_size() {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
+    v.assert_state_invariants();
 }
 
 #[test]

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -142,7 +142,9 @@ fn psd_mistmatched_provider() {
 
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
-    assert_eq!(vec![0, 2], good_inputs)
+    assert_eq!(vec![0, 2], good_inputs);
+
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -183,6 +185,7 @@ fn psd_start_time_in_past() {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -198,6 +201,7 @@ fn psd_client_address_cannot_be_resolved() {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -211,7 +215,8 @@ fn psd_no_client_lockup() {
 
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
-    assert_eq!(vec![1], good_inputs)
+    assert_eq!(vec![1], good_inputs);
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -241,6 +246,7 @@ fn psd_not_enought_client_lockup_for_batch() {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -283,6 +289,7 @@ fn psd_not_enough_provider_lockup_for_batch() {
     let deal_ret = batcher.publish_ok(cheap_worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -309,6 +316,7 @@ fn psd_duplicate_deal_in_batch() {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 4], good_inputs);
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -334,6 +342,7 @@ fn psd_duplicate_deal_in_state() {
     let deal_ret2 = batcher.publish_ok(a.worker);
     let good_inputs2 = bf_all(deal_ret2.valid_deals);
     assert_eq!(vec![0], good_inputs2);
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -368,6 +377,7 @@ fn psd_verified_deal_fails_getting_datacap() {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1], good_inputs);
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -436,6 +446,7 @@ fn psd_random_assortment_of_failures() {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 2, 8], good_inputs);
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -465,6 +476,7 @@ fn psd_all_deals_are_bad() {
     );
 
     batcher.publish_fail(a.worker);
+    v.assert_state_invariants();
 }
 
 #[test]
@@ -484,6 +496,7 @@ fn psd_all_deals_are_good() {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 2, 3, 4], good_inputs);
+    v.assert_state_invariants();
 }
 
 #[derive(Clone, Default)]

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -29,8 +29,9 @@ use num_traits::sign::Signed;
 use test_vm::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_index, advance_to_proving_deadline,
     apply_code, apply_ok, bf_all, check_sector_active, check_sector_faulty, create_accounts,
-    create_miner, deadline_state, declare_recovery, make_bitfield, miner_power, precommit_sectors,
-    prove_commit_sectors, publish_deal, sector_info, submit_invalid_post, submit_windowed_post, invariant_failure_patterns,
+    create_miner, deadline_state, declare_recovery, invariant_failure_patterns, make_bitfield,
+    miner_power, precommit_sectors, prove_commit_sectors, publish_deal, sector_info,
+    submit_invalid_post, submit_windowed_post,
 };
 use test_vm::VM;
 
@@ -393,7 +394,9 @@ fn unhealthy_sector_failure() {
         ProveReplicaUpdatesParams { updates: vec![replica_update] },
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    v.expect_state_invariants(
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -918,7 +918,7 @@ fn deal_included_in_multiple_sectors_failure() {
         deadline: 0,
         partition: 0,
         new_sealed_cid: new_sealed_cid1,
-        deals: deal_ids[0..1].to_vec(),
+        deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
         replica_proof: vec![],
     };
@@ -926,10 +926,10 @@ fn deal_included_in_multiple_sectors_failure() {
     let new_sealed_cid2 = make_sealed_cid(b"replica2");
     let replica_update_2 = ReplicaUpdate {
         sector_number: first_sector_number + 1,
-        deadline: 1,
+        deadline: 0,
         partition: 0,
         new_sealed_cid: new_sealed_cid2,
-        deals: deal_ids[1..].to_vec(),
+        deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
         replica_proof: vec![],
     };
@@ -950,8 +950,7 @@ fn deal_included_in_multiple_sectors_failure() {
     assert!(!ret_bf.get(first_sector_number + 1));
 
     let new_sector_info_p1 = sector_info(&v, maddr, first_sector_number);
-    assert_eq!(deal_ids[0], new_sector_info_p1.deal_ids[0]);
-    assert_eq!(1, new_sector_info_p1.deal_ids.len());
+    assert_eq!(deal_ids, new_sector_info_p1.deal_ids);
     assert_eq!(new_sealed_cid1, new_sector_info_p1.sealed_cid);
 
     let new_sector_info_p2 = sector_info(&v, maddr, first_sector_number + 1);

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -27,8 +27,8 @@ use fvm_shared::METHOD_SEND;
 use num_traits::cast::FromPrimitive;
 use test_vm::util::{
     add_verifier, advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
-    advance_to_proving_deadline, apply_ok, create_accounts, create_miner, make_bitfield,
-    publish_deal, submit_windowed_post,
+    advance_to_proving_deadline, apply_ok, create_accounts, create_miner,
+    invariant_failure_patterns, make_bitfield, publish_deal, submit_windowed_post,
 };
 use test_vm::{ExpectInvocation, VM};
 
@@ -361,4 +361,6 @@ fn terminate_sectors() {
     // before the slash and should be << 1 FIL. Actual amount withdrawn should be between 58 and 59 FIL.
     assert!(TokenAmount::from(58e18 as u128) < value_withdrawn);
     assert!(TokenAmount::from(59e18 as u128) > value_withdrawn);
+
+    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -362,5 +362,5 @@ fn terminate_sectors() {
     assert!(TokenAmount::from(58e18 as u128) < value_withdrawn);
     assert!(TokenAmount::from(59e18 as u128) > value_withdrawn);
 
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_MISMATCH.to_owned()]);
+    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -362,5 +362,7 @@ fn terminate_sectors() {
     assert!(TokenAmount::from(58e18 as u128) < value_withdrawn);
     assert!(TokenAmount::from(59e18 as u128) > value_withdrawn);
 
-    v.expect_state_invariants(&[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    v.expect_state_invariants(
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }

--- a/test_vm/tests/test_vm_test.rs
+++ b/test_vm/tests/test_vm_test.rs
@@ -32,6 +32,10 @@ fn state_control() {
     // a2 is gone
     assert_eq!(None, v.get_actor(addr2));
     assert_eq!(v.get_actor(addr1).unwrap(), a1);
+
+    let invariants_check = v.check_state_invariants();
+    assert!(invariants_check.is_err());
+    assert!(invariants_check.unwrap_err().to_string().contains("AccountState is empty"));
 }
 
 fn assert_account_actor(
@@ -106,6 +110,7 @@ fn test_sent() {
     assert_eq!(ExitCode::SYS_INVALID_RECEIVER, mres.code);
     assert_account_actor(3, TokenAmount::from(42u8), addr1, &v, expect_id_addr1);
     assert_account_actor(2, TokenAmount::from(0u8), addr2, &v, expect_id_addr2);
+    v.assert_state_invariants();
 }
 
 #[test]

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -284,4 +284,5 @@ fn remove_datacap_simple_successful_path() {
         .unwrap();
 
     assert_eq!(2u64, verifier2_proposal_id.0);
+    v.assert_state_invariants();
 }


### PR DESCRIPTION
Added invariant checks in some of the integration tests. Many of the existing ones are breaking those invariants on purpose so the checks should be added carefully considering each case.

Fixed one bug in miner invariant check and introduced a workaround for reward invariant, see more in https://github.com/filecoin-project/builtin-actors/issues/459.