### PR TITLE
chore: upgrade the FVM and strip the actor binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -576,7 +576,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_car",
  "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_shared 0.7.1",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
@@ -589,7 +589,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "log",
  "num-derive",
  "num-traits",
@@ -607,7 +607,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "log",
  "num-derive",
  "num-traits",
@@ -628,7 +628,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "libipld-core",
  "log",
  "num-derive",
@@ -652,7 +652,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "itertools",
  "lazy_static",
  "log",
@@ -673,7 +673,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "indexmap",
  "integer-encoding",
  "num-derive",
@@ -693,7 +693,7 @@ dependencies = [
  "fvm_ipld_amt",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -710,7 +710,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -728,7 +728,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "lazy_static",
  "log",
  "num-derive",
@@ -744,7 +744,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -760,7 +760,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "lazy_static",
  "num-derive",
  "num-traits",
@@ -783,7 +783,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_sdk",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "getrandom",
  "hex",
  "indexmap",
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_amt"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbe1fb55191eec39304eccc690e94bfe2462a829dbc0a227559d2bf1c33b4dc"
+checksum = "48d09e5aa7de45452676d18fcb70b750acd65faae7a4fe18fe784b4c85f869fb"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1000,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_encoding"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a5b85beb7f0c612abbe36ce013d50fd4c5304098f7b439a32c82526d7d800a"
+checksum = "ce9cfcb4ae444801009182fded790dd56aff9c9a567e54510e2ccf14fb9daf8e"
 dependencies = [
  "anyhow",
  "cid",
@@ -1039,13 +1039,13 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5823623e85fa75b779c12ac793485a01d6f3a420b2b96eabeef26e1ce1aa3fc8"
+checksum = "3bd162cff8cab78c3798762bc6879429ecbd0f5515856bcb3bc31d197208db70"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_shared 0.8.0",
  "lazy_static",
  "log",
  "num-traits",
@@ -1057,6 +1057,36 @@ name = "fvm_shared"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282f5fb4f2eb9f916badd253aa4898d7ba20bdda3e76a2f94d42ee67acb6ba2e"
+dependencies = [
+ "anyhow",
+ "bimap",
+ "blake2b_simd",
+ "byteorder",
+ "cid",
+ "cs_serde_bytes",
+ "data-encoding",
+ "data-encoding-macro",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "lazy_static",
+ "log",
+ "multihash",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "serde_repr",
+ "serde_tuple",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "fvm_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94c2485c563703b730df0502e2e8fcea86bc183b7018a080c6a5b15b7a29c5d0"
 dependencies = [
  "anyhow",
  "bimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,4 @@ panic = "unwind"
 overflow-checks = true
 lto = "thin"
 opt-level = "z"
+strip = true

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -14,12 +14,12 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime" }
-fvm_shared = { version = "0.7.1", default-features = false }
+fvm_shared = { version = "0.8.0", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.1"
+fvm_ipld_encoding = "0.2.2"
 serde_tuple = "0.5.0"
 
 [dev-dependencies]

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -15,13 +15,13 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime" }
-fvm_shared = { version = "0.7.1", default-features = false }
+fvm_shared = { version = "0.8.0", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"
 serde = { version = "1.0.136", features = ["derive"] }
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.1"
+fvm_ipld_encoding = "0.2.2"
 serde_tuple = "0.5.0"
 
 [dev-dependencies]

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime" }
-fvm_shared = { version = "0.7.1", default-features = false }
+fvm_shared = { version = "0.8.0", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5.0"
@@ -25,7 +25,7 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 anyhow = "1.0.56"
 log = "0.4.14"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.1"
+fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime" }
 fvm_ipld_hamt = "0.5.1"
-fvm_shared = { version = "0.7.1", default-features = false }
+fvm_shared = { version = "0.8.0", default-features = false }
 bitfield = { version = "0.5.2", package = "fvm_ipld_bitfield" }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -27,9 +27,9 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 log = "0.4.14"
 anyhow = "1.0.56"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.1"
+fvm_ipld_encoding = "0.2.2"
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime", features = ["test_utils", "sector-default"] }
-fvm_ipld_amt = { version = "0.4.1", features = ["go-interop"] }
+fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -15,11 +15,11 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime" }
-fvm_shared = { version = "0.7.1", default-features = false }
+fvm_shared = { version = "0.8.0", default-features = false }
 bitfield = { version = "0.5.2", package = "fvm_ipld_bitfield" }
-fvm_ipld_amt = { version = "0.4.1", features = ["go-interop"] }
+fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.1"
+fvm_ipld_encoding = "0.2.2"
 fvm_ipld_hamt = "0.5.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5.0"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime" }
-fvm_shared = { version = "0.7.1", default-features = false }
+fvm_shared = { version = "0.8.0", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -26,7 +26,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5.0"
 anyhow = "1.0.56"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.1"
+fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime" }
-fvm_shared = { version = "0.7.1", default-features = false }
+fvm_shared = { version = "0.8.0", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -23,9 +23,9 @@ serde_tuple = "0.5.0"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 anyhow = "1.0.56"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.1"
+fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime", features = ["test_utils", "sector-default"] }
-fvm_ipld_amt = { version = "0.4.1", features = ["go-interop"] }
+fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
 derive_builder = "0.10.2"

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime" }
-fvm_shared = { version = "0.7.1", default-features = false }
+fvm_shared = { version = "0.8.0", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -28,7 +28,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5.0"
 anyhow = "1.0.56"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.1"
+fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -15,14 +15,14 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime" }
-fvm_shared = { version = "0.7.1", default-features = false }
+fvm_shared = { version = "0.8.0", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"
 lazy_static = "1.4.0"
 serde = { version = "1.0.136", features = ["derive"] }
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.1"
+fvm_ipld_encoding = "0.2.2"
 serde_tuple = "0.5.0"
 
 [dev-dependencies]

--- a/actors/runtime/Cargo.toml
+++ b/actors/runtime/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 
 [dependencies]
 fvm_ipld_hamt = "0.5.1"
-fvm_ipld_amt = { version = "0.4.1", features = ["go-interop"] }
-fvm_shared = { version = "0.7.1", default-features = false }
+fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
+fvm_shared = { version = "0.8.0", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -30,13 +30,13 @@ hex = { version = "0.4.3", optional = true }
 anyhow = "1.0.56"
 blake2b_simd = "1.0"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.1"
+fvm_ipld_encoding = "0.2.2"
 multihash = { version = "0.16.1", default-features = false }
 rand = "0.8.5"
 serde_repr = "0.1.8"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fvm_sdk = "1.0.0-rc.2"
+fvm_sdk = "1.0.0-rc.3"
 
 [dev-dependencies]
 derive_builder = "0.10.2"

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime" }
-fvm_shared = { version = "0.7.1", default-features = false }
-fvm_ipld_encoding = "0.2.1"
+fvm_shared = { version = "0.8.0", default-features = false }
+fvm_ipld_encoding = "0.2.2"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime" }
-fvm_shared = { version = "0.7.1", default-features = false }
+fvm_shared = { version = "0.8.0", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5.0"
 num-traits = "0.2.14"
@@ -25,7 +25,7 @@ lazy_static = "1.4.0"
 anyhow = "1.0.56"
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.1"
+fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "7.5.1", path = "../runtime", features = ["test_utils", "sector-default"] }


### PR DESCRIPTION
This should slim some things down for embedding in lotus.