### PR TITLE
Tests: allow submit_windowed_post to check for unchanged power

### DIFF
--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -132,7 +132,7 @@ fn batch_onboarding() {
     new_power.raw *= proven_count;
     new_power.qa *= proven_count;
 
-    submit_windowed_post(&v, worker, id_addr, dline_info, p_idx, new_power.clone());
+    submit_windowed_post(&v, worker, id_addr, dline_info, p_idx, Some(new_power.clone()));
 
     let balances = v.get_miner_balance(id_addr);
     assert!(balances.initial_pledge.is_positive());

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -189,7 +189,7 @@ fn submit_post_succeeds() {
         miner_info.miner_id,
         sector_info.deadline_info,
         sector_info.partition_index,
-        sector_power.clone(),
+        Some(sector_power.clone()),
     );
     let balances = v.get_miner_balance(miner_info.miner_id);
     assert!(balances.initial_pledge.is_positive());

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -189,7 +189,7 @@ fn extend_sector_with_deals() {
         miner_id,
         deadline_info,
         partition_index,
-        expected_power_delta,
+        Some(expected_power_delta),
     );
 
     // move forward one deadline so advanceWhileProving doesn't fail double submitting posts

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -207,7 +207,7 @@ fn terminate_sectors() {
     let st = v.get_state::<MinerState>(id_addr).unwrap();
     let sector = st.get_sector(v.store, sector_number).unwrap().unwrap();
     let sector_power = power_for_sector(seal_proof.sector_size().unwrap(), &sector);
-    submit_windowed_post(&v, worker, id_addr, dline_info, p_idx, sector_power);
+    submit_windowed_post(&v, worker, id_addr, dline_info, p_idx, Some(sector_power));
     let v = v.with_epoch(dline_info.last());
 
     v.apply_message(


### PR DESCRIPTION
Calling submit_windowed_post with PowerPair::zero() will now assert that the miner's power has not changed by asserting that there are no subinvocations in the call to SubmitWindowedPoSt.

Closes https://github.com/filecoin-project/builtin-actors/issues/465