### PR TITLE
chore: bump version to 9.0.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "cid",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "cid",
  "clap",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_state"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "cid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_builtin_actors_bundle"
 description = "Bundle of FVM-compatible Wasm bytecode for Filecoin builtin actors"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -10,17 +10,17 @@ keywords = ["filecoin", "web3", "wasm"]
 exclude = ["examples", ".github"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fil_actor_account = { version = "8.0.0-rc.1", path = "./actors/account", features = ["fil-actor"] }
-fil_actor_verifreg = { version = "8.0.0-rc.1", path = "./actors/verifreg", features = ["fil-actor"] }
-fil_actor_cron = { version = "8.0.0-rc.1", path = "./actors/cron", features = ["fil-actor"] }
-fil_actor_market = { version = "8.0.0-rc.1", path = "./actors/market", features = ["fil-actor"] }
-fil_actor_multisig = { version = "8.0.0-rc.1", path = "./actors/multisig", features = ["fil-actor"] }
-fil_actor_paych = { version = "8.0.0-rc.1", path = "./actors/paych", features = ["fil-actor"] }
-fil_actor_power = { version = "8.0.0-rc.1", path = "./actors/power", features = ["fil-actor"] }
-fil_actor_miner = { version = "8.0.0-rc.1", path = "./actors/miner", features = ["fil-actor"] }
-fil_actor_reward = { version = "8.0.0-rc.1", path = "./actors/reward", features = ["fil-actor"] }
-fil_actor_system = { version = "8.0.0-rc.1", path = "./actors/system", features = ["fil-actor"] }
-fil_actor_init = { version = "8.0.0-rc.1", path = "./actors/init", features = ["fil-actor"] }
+fil_actor_account = { version = "9.0.0-alpha.1", path = "./actors/account", features = ["fil-actor"] }
+fil_actor_verifreg = { version = "9.0.0-alpha.1", path = "./actors/verifreg", features = ["fil-actor"] }
+fil_actor_cron = { version = "9.0.0-alpha.1", path = "./actors/cron", features = ["fil-actor"] }
+fil_actor_market = { version = "9.0.0-alpha.1", path = "./actors/market", features = ["fil-actor"] }
+fil_actor_multisig = { version = "9.0.0-alpha.1", path = "./actors/multisig", features = ["fil-actor"] }
+fil_actor_paych = { version = "9.0.0-alpha.1", path = "./actors/paych", features = ["fil-actor"] }
+fil_actor_power = { version = "9.0.0-alpha.1", path = "./actors/power", features = ["fil-actor"] }
+fil_actor_miner = { version = "9.0.0-alpha.1", path = "./actors/miner", features = ["fil-actor"] }
+fil_actor_reward = { version = "9.0.0-alpha.1", path = "./actors/reward", features = ["fil-actor"] }
+fil_actor_system = { version = "9.0.0-alpha.1", path = "./actors/system", features = ["fil-actor"] }
+fil_actor_init = { version = "9.0.0-alpha.1", path = "./actors/init", features = ["fil-actor"] }
 
 [build-dependencies]
 fil_actor_bundler = "3.0.4"

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,12 @@ test: deps-build
 	cargo test --workspace
 
 # Release a new version. Specify the version "bump" with BUMP
-bump-version: check-clean deps-release check test
+bump-version: check-clean deps-release check
 	echo "$(ORDERED_PACKAGES)" | xargs -n1 cargo set-version --bump $(BUMP) -p
 	cargo update --workspace
 	@echo "Bumped actors to version $$($(MAKE) --quiet version)"
 
-set-version: check-clean deps-release check test
+set-version: check-clean deps-release check
 	echo "$(ORDERED_PACKAGES)" | xargs -n1 cargo set-version $(VERSION) -p
 	cargo update --workspace
 	@echo "Set actors to version $(VERSION)"

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_account"
 description = "Builtin account actor for Filecoin"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -13,7 +13,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.8.0", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
@@ -22,7 +22,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
 
 [features]
 fil-actor = []

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_cron"
 description = "Builtin cron actor for Filecoin"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.8.0", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -24,7 +24,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []
 

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_init"
 description = "Builtin init actor for Filecoin"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.8.0", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -27,7 +27,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []
 

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_market"
 description = "Builtin market actor for Filecoin"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_ipld_hamt = "0.5.1"
 fvm_shared = { version = "0.8.0", default-features = false }
 fvm_ipld_bitfield = "0.5.2"
@@ -29,10 +29,10 @@ fvm_ipld_encoding = "0.2.2"
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 
 [dev-dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
-fil_actor_power = { version = "8.0.0-rc.1", path = "../power" }
-fil_actor_reward = { version = "8.0.0-rc.1", path = "../reward" }
-fil_actor_verifreg = { version = "8.0.0-rc.1", path = "../verifreg" }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actor_power = { version = "9.0.0-alpha.1", path = "../power" }
+fil_actor_reward = { version = "9.0.0-alpha.1", path = "../reward" }
+fil_actor_verifreg = { version = "9.0.0-alpha.1", path = "../verifreg" }
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
 multihash = { version = "0.16.1", default-features = false }
 regex = "1"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_miner"
 description = "Builtin miner actor for Filecoin"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.8.0", default-features = false }
 fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
@@ -32,11 +32,11 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
-fil_actor_account = { version = "8.0.0-rc.1", path = "../account" }
-fil_actor_reward = { version = "8.0.0-rc.1", path = "../reward" }
-fil_actor_power = { version = "8.0.0-rc.1", path = "../power" }
-fil_actor_market = { version = "8.0.0-rc.1", path = "../market" }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actor_account = { version = "9.0.0-alpha.1", path = "../account" }
+fil_actor_reward = { version = "9.0.0-alpha.1", path = "../reward" }
+fil_actor_power = { version = "9.0.0-alpha.1", path = "../power" }
+fil_actor_market = { version = "9.0.0-alpha.1", path = "../market" }
 rand = "0.8.5"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.1", default-features = false }

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_multisig"
 description = "Builtin multisig actor for Filecoin"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.8.0", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
@@ -28,7 +28,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []
 

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_paych"
 description = "Builtin paych actor for Filecoin"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.8.0", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -25,7 +25,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
 derive_builder = "0.10.2"
 [features]

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_power"
 description = "Builtin power actor for Filecoin"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.8.0", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
@@ -30,8 +30,8 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
-fil_actor_reward = { version = "8.0.0-rc.1", path = "../reward" }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actor_reward = { version = "9.0.0-alpha.1", path = "../reward" }
 [features]
 fil-actor = []
 

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_reward"
 description = "Builtin reward actor for Filecoin"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.8.0", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -25,7 +25,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
 num = "0.4.0"
 [features]
 fil-actor = []

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_system"
 description = "Builtin system actor for Filecoin"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.8.0", default-features = false }
 fvm_ipld_encoding = "0.2.2"
 fvm_ipld_blockstore = "0.1.1"
@@ -25,7 +25,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 
 [dev-dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []
 

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_verifreg"
 description = "Builtin verifreg actor for Filecoin"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["fil-actor"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_shared = { version = "0.8.0", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
@@ -27,7 +27,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 
 [dev-dependencies]
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = []
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actors_runtime"
 description = "System actors for the Filecoin protocol"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_builtin_actors_state"
 description = "Builtin Actor state utils for Filecoin"
-version = "8.0.0-rc.1"
+version = "9.0.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -14,18 +14,18 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actor_account = { version = "8.0.0-rc.1", path = "../actors/account"}
-fil_actor_verifreg = { version = "8.0.0-rc.1", path = "../actors/verifreg"}
-fil_actor_cron = { version = "8.0.0-rc.1", path = "../actors/cron"}
-fil_actor_market = { version = "8.0.0-rc.1", path = "../actors/market"}
-fil_actor_multisig = { version = "8.0.0-rc.1", path = "../actors/multisig"}
-fil_actor_paych = { version = "8.0.0-rc.1", path = "../actors/paych"}
-fil_actor_power = { version = "8.0.0-rc.1", path = "../actors/power"}
-fil_actor_miner = { version = "8.0.0-rc.1", path = "../actors/miner"}
-fil_actor_reward = { version = "8.0.0-rc.1", path = "../actors/reward"}
-fil_actor_system = { version = "8.0.0-rc.1", path = "../actors/system"}
-fil_actor_init = { version = "8.0.0-rc.1", path = "../actors/init"}
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../runtime"}
+fil_actor_account = { version = "9.0.0-alpha.1", path = "../actors/account"}
+fil_actor_verifreg = { version = "9.0.0-alpha.1", path = "../actors/verifreg"}
+fil_actor_cron = { version = "9.0.0-alpha.1", path = "../actors/cron"}
+fil_actor_market = { version = "9.0.0-alpha.1", path = "../actors/market"}
+fil_actor_multisig = { version = "9.0.0-alpha.1", path = "../actors/multisig"}
+fil_actor_paych = { version = "9.0.0-alpha.1", path = "../actors/paych"}
+fil_actor_power = { version = "9.0.0-alpha.1", path = "../actors/power"}
+fil_actor_miner = { version = "9.0.0-alpha.1", path = "../actors/miner"}
+fil_actor_reward = { version = "9.0.0-alpha.1", path = "../actors/reward"}
+fil_actor_system = { version = "9.0.0-alpha.1", path = "../actors/system"}
+fil_actor_init = { version = "9.0.0-alpha.1", path = "../actors/init"}
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../runtime"}
 fvm_shared = { version = "0.8.0", default-features = false }
 fvm_ipld_encoding = "0.2.2"
 fvm_ipld_blockstore = "0.1.1"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -10,19 +10,19 @@ keywords = ["filecoin", "web3", "wasm"]
 [lib]
 
 [dependencies]
-fil_builtin_actors_state = { version = "8.0.0-rc.1", path = "../state"}
-fil_actors_runtime = { version = "8.0.0-rc.1", path = "../runtime", features = [ "test_utils" ] }
-fil_actor_init = { version = "8.0.0-rc.1", path = "../actors/init" }
-fil_actor_cron = { version = "8.0.0-rc.1", path = "../actors/cron" }
-fil_actor_system = { version = "8.0.0-rc.1", path = "../actors/system" }
-fil_actor_account = { version = "8.0.0-rc.1", path = "../actors/account" }
-fil_actor_multisig = { version = "8.0.0-rc.1", path = "../actors/multisig" }
-fil_actor_paych = { version = "8.0.0-rc.1", path = "../actors/paych" }
-fil_actor_reward = { version = "8.0.0-rc.1", path = "../actors/reward" }
-fil_actor_power = { version = "8.0.0-rc.1", path = "../actors/power" }
-fil_actor_market = { version = "8.0.0-rc.1", path = "../actors/market" }
-fil_actor_verifreg = { version = "8.0.0-rc.1", path = "../actors/verifreg" }
-fil_actor_miner = { version = "8.0.0-rc.1", path = "../actors/miner" }
+fil_builtin_actors_state = { version = "9.0.0-alpha.1", path = "../state"}
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../runtime", features = [ "test_utils" ] }
+fil_actor_init = { version = "9.0.0-alpha.1", path = "../actors/init" }
+fil_actor_cron = { version = "9.0.0-alpha.1", path = "../actors/cron" }
+fil_actor_system = { version = "9.0.0-alpha.1", path = "../actors/system" }
+fil_actor_account = { version = "9.0.0-alpha.1", path = "../actors/account" }
+fil_actor_multisig = { version = "9.0.0-alpha.1", path = "../actors/multisig" }
+fil_actor_paych = { version = "9.0.0-alpha.1", path = "../actors/paych" }
+fil_actor_reward = { version = "9.0.0-alpha.1", path = "../actors/reward" }
+fil_actor_power = { version = "9.0.0-alpha.1", path = "../actors/power" }
+fil_actor_market = { version = "9.0.0-alpha.1", path = "../actors/market" }
+fil_actor_verifreg = { version = "9.0.0-alpha.1", path = "../actors/verifreg" }
+fil_actor_miner = { version = "9.0.0-alpha.1", path = "../actors/miner" }
 lazy_static = "1.4.0"
 fvm_shared = { version = "0.8.0", default-features = false }
 fvm_ipld_encoding = { version = "0.2.2", default-features = false }


### PR DESCRIPTION
Also removes testing from the set-version target, as it's _really_ slow and we test in CI anyways.