### PR TITLE
feat:implement beneficiary fip0029

### DIFF
--- a/actors/miner/src/beneficiary.rs
+++ b/actors/miner/src/beneficiary.rs
@@ -1,0 +1,87 @@
+use fvm_ipld_encoding::tuple::*;
+use fvm_ipld_encoding::Cbor;
+use fvm_shared::address::Address;
+use fvm_shared::bigint::bigint_ser;
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::econ::TokenAmount;
+use std::cmp::max;
+
+#[derive(Debug, PartialEq, Serialize_tuple, Deserialize_tuple)]
+pub struct BeneficiaryTerm {
+    // Quota: The total amount the current beneficiary can withdraw. Monotonic, but reset when beneficiary changes.
+    #[serde(with = "bigint_ser")]
+    pub quota: TokenAmount,
+    // UsedQuota: The amount of quota the current beneficiary has already withdrawn
+    #[serde(with = "bigint_ser")]
+    pub used_quota: TokenAmount,
+    // Expiration: The epoch at which the beneficiary's rights expire and revert to the owner
+    pub expiration: ChainEpoch,
+}
+
+impl Cbor for BeneficiaryTerm {}
+
+impl BeneficiaryTerm {
+    pub fn default() -> BeneficiaryTerm {
+        BeneficiaryTerm {
+            quota: TokenAmount::default(),
+            expiration: 0,
+            used_quota: TokenAmount::default(),
+        }
+    }
+
+    pub fn new(
+        quota: TokenAmount,
+        used_quota: TokenAmount,
+        expiration: ChainEpoch,
+    ) -> BeneficiaryTerm {
+        BeneficiaryTerm { quota, expiration, used_quota }
+    }
+
+    // IsUsedUp check whether beneficiary has use up all quota
+    pub fn is_used_up(&self) -> bool {
+        self.used_quota >= self.quota
+    }
+
+    // IsExpire check if the beneficiary is within the validity period
+    pub fn is_expire(&self, cur: ChainEpoch) -> bool {
+        self.expiration <= cur
+    }
+
+    // Available get the amount that the beneficiary has not yet withdrawn
+    pub fn available(&self, cur: ChainEpoch) -> TokenAmount {
+        // Return 0 when the usedQuota > Quota for safe
+        if self.is_expire(cur) {
+            TokenAmount::default()
+        } else {
+            max(self.quota.clone() - self.used_quota.clone(), TokenAmount::default())
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize_tuple, Deserialize_tuple)]
+pub struct PendingBeneficiaryChange {
+    pub new_beneficiary: Address,
+    #[serde(with = "bigint_ser")]
+    pub new_quota: TokenAmount,
+    pub new_expiration: ChainEpoch,
+    pub approved_by_beneficiary: bool,
+    pub approved_by_nominee: bool,
+}
+
+impl Cbor for PendingBeneficiaryChange {}
+
+impl PendingBeneficiaryChange {
+    pub fn new(
+        new_beneficiary: Address,
+        new_quota: TokenAmount,
+        new_expiration: ChainEpoch,
+    ) -> Self {
+        PendingBeneficiaryChange {
+            new_beneficiary,
+            new_quota,
+            new_expiration,
+            approved_by_beneficiary: false,
+            approved_by_nominee: false,
+        }
+    }
+}

--- a/actors/miner/src/beneficiary.rs
+++ b/actors/miner/src/beneficiary.rs
@@ -7,7 +7,7 @@ use fvm_shared::econ::TokenAmount;
 use num_traits::Zero;
 use std::ops::Sub;
 
-#[derive(Debug, PartialEq, Clone, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct BeneficiaryTerm {
     /// The total amount the current beneficiary can withdraw. Monotonic, but reset when beneficiary changes.
     #[serde(with = "bigint_ser")]
@@ -51,7 +51,7 @@ impl BeneficiaryTerm {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct PendingBeneficiaryChange {
     pub new_beneficiary: Address,
     #[serde(with = "bigint_ser")]

--- a/actors/miner/src/beneficiary.rs
+++ b/actors/miner/src/beneficiary.rs
@@ -38,12 +38,14 @@ impl BeneficiaryTerm {
         BeneficiaryTerm { quota, expiration, used_quota }
     }
 
-    /// get the amount that the beneficiary has not yet withdrawn
+    /// Get the amount that the beneficiary has not yet withdrawn
+    /// return 0 when expired
+    /// return 0 when the usedQuota >= Quota for safe
+    /// otherwise Return quota-used_quota
     pub fn available(&self, cur: ChainEpoch) -> TokenAmount {
-        // Return 0 when the usedQuota > Quota for safe
         if self.expiration > cur {
             (&self.quota).sub(&self.used_quota).max(TokenAmount::zero())
-        }else{
+        } else {
             TokenAmount::zero()
         }
     }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -53,6 +53,7 @@ pub use state::*;
 pub use termination::*;
 pub use types::*;
 pub use vesting_state::*;
+pub use beneficiary::*;
 
 use crate::commd::{is_unsealed_sector, CompactCommD};
 use crate::Code::Blake2b256;
@@ -60,6 +61,7 @@ use crate::Code::Blake2b256;
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
 
+mod beneficiary;
 mod bitfield_queue;
 mod commd;
 mod deadline_assignment;
@@ -118,6 +120,8 @@ pub enum Method {
     ProveReplicaUpdates = 27,
     PreCommitSectorBatch2 = 28,
     ProveReplicaUpdates2 = 29,
+    ChangeBeneficiary   =30,
+    GetBeneficiary      =31,
 }
 
 pub const ERR_BALANCE_INVARIANTS_BROKEN: ExitCode = ExitCode::new(1000);
@@ -314,6 +318,15 @@ impl Actor {
                         new_address
                     ));
                 }
+
+                // Change beneficiary address to new owner if current beneficiary address equal to old owner address
+                if info.beneficiary == info.owner {
+                    info.beneficiary = pending_address;
+                }
+                // Cancel pending beneficiary term change when the owner changes
+                info.pending_beneficiary_term = None;
+
+                // Set the new owner address
                 info.owner = pending_address;
             }
 
@@ -3235,9 +3248,9 @@ impl Actor {
             ));
         }
 
-        let (info, newly_vested, fee_to_burn, available_balance, state) =
+        let (info, amount_withdrawn, newly_vested, fee_to_burn, state) =
             rt.transaction(|state: &mut State, rt| {
-                let info = get_miner_info(rt.store(), state)?;
+                let mut info = get_miner_info(rt.store(), state)?;
 
                 // Only the owner is allowed to withdraw the balance as it belongs to/is controlled by the owner
                 // and not the worker.
@@ -3273,29 +3286,40 @@ impl Actor {
                 // Verify unlocked funds cover both InitialPledgeRequirement and FeeDebt
                 // and repay fee debt now.
                 let fee_to_burn = repay_debts_or_abort(rt, state)?;
-
-                Ok((info, newly_vested, fee_to_burn, available_balance, state.clone()))
+                let mut amount_withdrawn = std::cmp::min(&available_balance, &params.amount_requested);
+                if amount_withdrawn.is_negative() {
+                        return Err(actor_error!(
+                            illegal_state,
+                            "negative amount to withdraw: {}",
+                            amount_withdrawn
+                        ));
+                }
+                if info.beneficiary != info.owner {
+                    let remaining_quota = info.beneficiary_term.available(rt.curr_epoch());
+                    if !remaining_quota.is_positive() {
+                        return Err(actor_error!(
+                            forbidden,
+                            "beneficiary{}  quota {} used quota {} expiration epoch {}  current epoch {}",
+                            info.beneficiary,
+                            info.beneficiary_term.quota,
+                            info.beneficiary_term.used_quota,
+                            info.beneficiary_term.expiration,
+                            rt.curr_epoch()
+                        ));
+                    }
+                    amount_withdrawn = std::cmp::min(amount_withdrawn, &remaining_quota);
+                    info.beneficiary_term.used_quota = info.beneficiary_term.used_quota + amount_withdrawn;
+                    state.save_info(rt.store(), &info).map_err(|e| {
+                        e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to save miner info")
+                    })?;
+                    Ok((info, amount_withdrawn.clone(), newly_vested, fee_to_burn, state.clone()))
+                }else{
+                    Ok((info, amount_withdrawn.clone(), newly_vested, fee_to_burn, state.clone()))
+                }
             })?;
 
-        let amount_withdrawn = std::cmp::min(&available_balance, &params.amount_requested);
-        if amount_withdrawn.is_negative() {
-            return Err(actor_error!(
-                illegal_state,
-                "negative amount to withdraw: {}",
-                amount_withdrawn
-            ));
-        }
-        if amount_withdrawn > &available_balance {
-            return Err(actor_error!(
-                illegal_state,
-                "amount to withdraw {} < available {}",
-                amount_withdrawn,
-                available_balance
-            ));
-        }
-
         if amount_withdrawn.is_positive() {
-            rt.send(info.owner, METHOD_SEND, RawBytes::default(), amount_withdrawn.clone())?;
+            rt.send(info.beneficiary, METHOD_SEND, RawBytes::default(), amount_withdrawn.clone())?;
         }
 
         burn_funds(rt, fee_to_burn)?;
@@ -3303,6 +3327,148 @@ impl Actor {
 
         state.check_balance_invariants(&rt.current_balance()).map_err(balance_invariants_broken)?;
         Ok(WithdrawBalanceReturn { amount_withdrawn: amount_withdrawn.clone() })
+    }
+
+    /// Proposes or confirms a change of owner address.
+    /// If invoked by the current owner, proposes a new owner address for confirmation. If the proposed address is the
+    /// current owner address, revokes any existing proposal.
+    /// If invoked by the previously proposed address, with the same proposal, changes the current owner address to be
+    /// that proposed address.
+    fn change_beneficiary<BS, RT>(
+        rt: &mut RT,
+        params: ChangeBeneficiaryParams,
+    ) -> Result<(), ActorError>
+    where
+        BS: Blockstore,
+        RT: Runtime<BS>,
+    {
+        let new_beneficiary = rt.resolve_address(&params.new_beneficiary).ok_or_else(|| {
+            actor_error!(illegal_argument, "unable to resolve address: {}", params.new_beneficiary)
+        })?;
+
+        rt.transaction(|state: &mut State, rt| {
+            let mut info = get_miner_info(rt.store(), state)?;
+            if rt.message().caller() == info.owner {
+                // This is a ChangeBeneficiary proposal when the caller is Owner
+                if new_beneficiary != info.owner {
+                    // When beneficiary is not owner, just check quota in params,
+                    // Expiration maybe an expiration value, but wouldn't cause problem, just the new beneficiary never get any benefit
+                    if !params.new_quota.is_positive() {
+                        return Err(actor_error!(
+                            illegal_argument,
+                            "beneficial quota {} must bigger than zero",
+                            params.new_quota
+                        ));
+                    }
+                } else {
+                    // Expiration/quota must set to 0 while change beneficiary to owner
+                    if !params.new_quota.is_zero() {
+                        return Err(actor_error!(
+                            illegal_argument,
+                            "owner beneficial quota {} must be zero",
+                            params.new_quota
+                        ));
+                    }
+
+                    if params.new_expiration != 0 {
+                        return Err(actor_error!(
+                            illegal_argument,
+                            "owner beneficial expiration {} must be zero",
+                            params.new_expiration
+                        ));
+                    }
+                }
+
+                let mut pending_beneficiary_term = PendingBeneficiaryChange::new(
+                    new_beneficiary,
+                    params.new_quota,
+                    params.new_expiration,
+                );
+                if info.beneficiary_term.available(rt.curr_epoch()).is_zero() {
+                    // Set current beneficiary to approved when current beneficiary is not effective
+                    pending_beneficiary_term.approved_by_beneficiary = true;
+                }
+                info.pending_beneficiary_term = Some(pending_beneficiary_term);
+            } else {
+                if info.pending_beneficiary_term.is_none() {
+                    return Err(actor_error!(forbidden, "No changeBeneficiary proposal exists"));
+                }
+                if let Some(pending_term) = &info.pending_beneficiary_term {
+                    if pending_term.new_beneficiary != new_beneficiary {
+                        return Err(actor_error!(
+                            forbidden,
+                            "new beneficiary address must be equal expect {}, but got {}",
+                            pending_term.new_beneficiary,
+                            params.new_beneficiary
+                        ));
+                    }
+                    if pending_term.new_quota != params.new_quota {
+                        return Err(actor_error!(
+                            forbidden,
+                            "new beneficiary quota must be equal expect {}, but got {}",
+                            pending_term.new_quota,
+                            params.new_quota
+                        ));
+                    }
+                    if pending_term.new_expiration != params.new_expiration {
+                        return Err(actor_error!(
+                            forbidden,
+                            "new beneficiary expire date must be equal expect {}, but got {}",
+                            pending_term.new_expiration,
+                            params.new_expiration
+                        ));
+                    }
+                }
+            }
+
+            if let Some(pending_term) = info.pending_beneficiary_term.as_mut() {
+                if rt.message().caller() == info.beneficiary {
+                    pending_term.approved_by_beneficiary = true
+                }
+
+                if rt.message().caller() == new_beneficiary {
+                    pending_term.approved_by_nominee = true
+                }
+
+                if pending_term.approved_by_beneficiary && pending_term.approved_by_nominee {
+                    //approved by both beneficiary and nominee
+                    info.beneficiary = new_beneficiary;
+                    info.beneficiary_term.quota = pending_term.new_quota.clone();
+                    info.beneficiary_term.expiration = pending_term.new_expiration;
+                    if new_beneficiary != info.beneficiary {
+                        info.beneficiary_term.used_quota = TokenAmount::default();
+                    }
+                    // Clear the pending proposal
+                    info.pending_beneficiary_term = None;
+                }
+            }
+
+            state.save_info(rt.store(), &info).map_err(|e| {
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to save miner info")
+            })?;
+            Ok(())
+        })
+    }
+
+    // GetBeneficiary retrieves the currently active and proposed beneficiary information.
+    // This method is for use by other actors (such as those acting as beneficiaries),
+    // and to abstract the state representation for clients.
+    fn get_beneficiary<BS, RT>(rt: &mut RT) -> Result<GetBeneficiaryReturn, ActorError>
+    where
+        BS: Blockstore,
+        RT: Runtime<BS>,
+    {
+        rt.validate_immediate_caller_accept_any()?;
+        let info =
+            rt.transaction(|state: &mut State, rt| Ok(get_miner_info(rt.store(), &state)?))?;
+
+        Ok(GetBeneficiaryReturn {
+            active: ActiveBeneficiary {
+                beneficiary: info.beneficiary,
+                term: info.beneficiary_term,
+            },
+            proposed: info.pending_beneficiary_term,
+        })
     }
 
     fn repay_debt<BS, RT>(rt: &mut RT) -> Result<(), ActorError>
@@ -4687,6 +4853,14 @@ impl ActorCode for Actor {
             Some(Method::ProveReplicaUpdates2) => {
                 return Err(actor_error!(unhandled_message, "Invalid method"));
                 let res = Self::prove_replica_updates2(rt, cbor::deserialize_params(params)?)?;
+                Ok(RawBytes::serialize(res)?)
+            }
+            Some(Method::ChangeBeneficiary) => {
+                Self::change_beneficiary(rt, cbor::deserialize_params(params)?)?;
+                Ok(RawBytes::default())
+            }
+            Some(Method::GetBeneficiary) => {
+                let res = Self::get_beneficiary(rt)?;
                 Ok(RawBytes::serialize(res)?)
             }
             None => Err(actor_error!(unhandled_message, "Invalid method")),

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3339,9 +3339,14 @@ impl Actor {
         RT: Runtime<BS>,
     {
         let caller = rt.message().caller();
-        let new_beneficiary = rt.resolve_address(&params.new_beneficiary).ok_or_else(|| {
-            actor_error!(illegal_argument, "unable to resolve address: {}", params.new_beneficiary)
-        })?;
+        let new_beneficiary =
+            Address::new_id(rt.resolve_address(&params.new_beneficiary).ok_or_else(|| {
+                actor_error!(
+                    illegal_argument,
+                    "unable to resolve address: {}",
+                    params.new_beneficiary
+                )
+            })?);
 
         rt.transaction(|state: &mut State, rt| {
             let mut info = get_miner_info(rt.store(), state)?;

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -30,6 +30,7 @@ use num_traits::{Signed, Zero};
 use super::deadlines::new_deadline_info;
 use super::policy::*;
 use super::types::*;
+use super::beneficiary::*;
 use super::{
     assign_deadlines, deadline_is_mutable, new_deadline_info_from_offset_and_epoch,
     quant_spec_for_deadline, BitFieldQueue, Deadline, DeadlineInfo, DeadlineSectorMap, Deadlines,
@@ -1230,6 +1231,12 @@ pub struct MinerInfo {
     /// Optional worker key to update at an epoch
     pub pending_worker_key: Option<WorkerKeyChange>,
 
+    // Beneficiary account for receive miner benefits, withdraw on miner must send to this address,
+    // beneficiary set owner address by default when create miner
+    pub beneficiary: Address,
+    pub beneficiary_term: BeneficiaryTerm,
+    pub pending_beneficiary_term: Option<PendingBeneficiaryChange>,
+
     /// Libp2p identity that should be used when connecting to this miner
     #[serde(with = "serde_bytes")]
     pub peer_id: Vec<u8>,
@@ -1278,6 +1285,9 @@ impl MinerInfo {
             worker,
             control_addresses,
             pending_worker_key: None,
+            beneficiary: owner,
+            beneficiary_term: BeneficiaryTerm::default(),
+            pending_beneficiary_term: None,
             peer_id,
             multi_address,
             window_post_proof_type,

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -27,10 +27,10 @@ use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, SectorSize, MAX_SECT
 use fvm_shared::HAMT_BIT_WIDTH;
 use num_traits::{Signed, Zero};
 
+use super::beneficiary::*;
 use super::deadlines::new_deadline_info;
 use super::policy::*;
 use super::types::*;
-use super::beneficiary::*;
 use super::{
     assign_deadlines, deadline_is_mutable, new_deadline_info_from_offset_and_epoch,
     quant_spec_for_deadline, BitFieldQueue, Deadline, DeadlineInfo, DeadlineSectorMap, Deadlines,
@@ -1231,12 +1231,6 @@ pub struct MinerInfo {
     /// Optional worker key to update at an epoch
     pub pending_worker_key: Option<WorkerKeyChange>,
 
-    // Beneficiary account for receive miner benefits, withdraw on miner must send to this address,
-    // beneficiary set owner address by default when create miner
-    pub beneficiary: Address,
-    pub beneficiary_term: BeneficiaryTerm,
-    pub pending_beneficiary_term: Option<PendingBeneficiaryChange>,
-
     /// Libp2p identity that should be used when connecting to this miner
     #[serde(with = "serde_bytes")]
     pub peer_id: Vec<u8>,
@@ -1261,6 +1255,17 @@ pub struct MinerInfo {
     /// A proposed new owner account for this miner.
     /// Must be confirmed by a message from the pending address itself.
     pub pending_owner_address: Option<Address>,
+
+    /// Account for receive miner benefits, withdraw on miner must send to this address,
+    /// set owner address by default when create miner
+    pub beneficiary: Address,
+
+    /// beneficiary's total quota, how much quota has been withdraw,
+    /// and when this beneficiary expired
+    pub beneficiary_term: BeneficiaryTerm,
+
+    /// A proposal new beneficiary message for this miner
+    pub pending_beneficiary_term: Option<PendingBeneficiaryChange>,
 }
 
 impl MinerInfo {

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::commd::CompactCommD;
-use crate::beneficiary_term::BeneficiaryTerm;
-use crate::PendingBeneficiaryChange;
+use super::beneficiary::*;
 use cid::Cid;
 use fil_actors_runtime::DealWeight;
 use fvm_ipld_bitfield::UnvalidatedBitField;
@@ -20,7 +19,6 @@ use fvm_shared::sector::{
     StoragePower,
 };
 use fvm_shared::smooth::FilterEstimate;
-use super::beneficiary::*;
 
 pub type CronEvent = i64;
 

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -1,8 +1,8 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::commd::CompactCommD;
 use super::beneficiary::*;
+use crate::commd::CompactCommD;
 use cid::Cid;
 use fil_actors_runtime::DealWeight;
 use fvm_ipld_bitfield::UnvalidatedBitField;
@@ -408,7 +408,6 @@ pub struct ProveReplicaUpdatesParams2 {
 }
 
 impl Cbor for ProveReplicaUpdatesParams2 {}
-
 
 #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct ChangeBeneficiaryParams {

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::commd::CompactCommD;
+use crate::beneficiary_term::BeneficiaryTerm;
+use crate::PendingBeneficiaryChange;
 use cid::Cid;
 use fil_actors_runtime::DealWeight;
 use fvm_ipld_bitfield::UnvalidatedBitField;
@@ -18,6 +20,7 @@ use fvm_shared::sector::{
     StoragePower,
 };
 use fvm_shared::smooth::FilterEstimate;
+use super::beneficiary::*;
 
 pub type CronEvent = i64;
 
@@ -407,3 +410,30 @@ pub struct ProveReplicaUpdatesParams2 {
 }
 
 impl Cbor for ProveReplicaUpdatesParams2 {}
+
+
+#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct ChangeBeneficiaryParams {
+    pub new_beneficiary: Address,
+    #[serde(with = "bigint_ser")]
+    pub new_quota: TokenAmount,
+    pub new_expiration: ChainEpoch,
+}
+
+impl Cbor for ChangeBeneficiaryParams {}
+
+#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct ActiveBeneficiary {
+    pub beneficiary: Address,
+    pub term: BeneficiaryTerm,
+}
+
+impl Cbor for ActiveBeneficiary {}
+
+#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct GetBeneficiaryReturn {
+    pub active: ActiveBeneficiary,
+    pub proposed: Option<PendingBeneficiaryChange>,
+}
+
+impl Cbor for GetBeneficiaryReturn {}

--- a/actors/miner/tests/change_beneficiary_test.rs
+++ b/actors/miner/tests/change_beneficiary_test.rs
@@ -29,10 +29,10 @@ fn successfully_change_owner_to_another_address_two_message() {
     // proposal beneficiary change
     h.change_beneficiary(&mut rt, h.owner, beneficiary_change.clone(), None).unwrap();
     // assert change has been made in state
-    let mut info = h.get_info(&mut rt);
+    let mut info = h.get_info(&rt);
     let pending_beneficiary_term = info.pending_beneficiary_term.unwrap();
     assert_eq!(beneficiary_change.expiration, pending_beneficiary_term.new_expiration);
-    assert_eq!(beneficiary_change.quota.clone(), pending_beneficiary_term.new_quota);
+    assert_eq!(beneficiary_change.quota, pending_beneficiary_term.new_quota);
     assert_eq!(first_beneficiary_id, pending_beneficiary_term.new_beneficiary);
 
     //confirm proposal
@@ -44,10 +44,10 @@ fn successfully_change_owner_to_another_address_two_message() {
     )
     .unwrap();
 
-    info = h.get_info(&mut rt);
+    info = h.get_info(&rt);
     assert_eq!(None, info.pending_beneficiary_term);
     assert_eq!(first_beneficiary_id, info.beneficiary);
-    assert_eq!(beneficiary_change.quota.clone(), info.beneficiary_term.quota);
+    assert_eq!(beneficiary_change.quota, info.beneficiary_term.quota);
     assert_eq!(beneficiary_change.expiration, info.beneficiary_term.expiration);
 
     h.check_state(&rt);
@@ -70,31 +70,31 @@ fn successfully_change_from_not_owner_beneficiary_to_another_address_three_messa
         ChainEpoch::from(201),
     );
     h.change_beneficiary(&mut rt, h.owner, second_beneficiary_change.clone(), None).unwrap();
-    let mut info = h.get_info(&mut rt);
+    let mut info = h.get_info(&rt);
     assert_eq!(first_beneficiary_id, info.beneficiary);
 
     let mut pending_beneficiary_term = info.pending_beneficiary_term.unwrap();
     assert_eq!(second_beneficiary_change.expiration, pending_beneficiary_term.new_expiration);
-    assert_eq!(second_beneficiary_change.quota.clone(), pending_beneficiary_term.new_quota);
+    assert_eq!(second_beneficiary_change.quota, pending_beneficiary_term.new_quota);
     assert_eq!(second_beneficiary_id, pending_beneficiary_term.new_beneficiary);
     assert!(!pending_beneficiary_term.approved_by_beneficiary);
     assert!(!pending_beneficiary_term.approved_by_nominee);
 
     h.change_beneficiary(&mut rt, first_beneficiary_id, second_beneficiary_change.clone(), None)
         .unwrap();
-    info = h.get_info(&mut rt);
+    info = h.get_info(&rt);
     assert_eq!(first_beneficiary_id, info.beneficiary);
 
     pending_beneficiary_term = info.pending_beneficiary_term.unwrap();
     assert_eq!(second_beneficiary_change.expiration, pending_beneficiary_term.new_expiration);
-    assert_eq!(second_beneficiary_change.quota.clone(), pending_beneficiary_term.new_quota);
+    assert_eq!(second_beneficiary_change.quota, pending_beneficiary_term.new_quota);
     assert_eq!(second_beneficiary_id, pending_beneficiary_term.new_beneficiary);
     assert!(pending_beneficiary_term.approved_by_beneficiary);
     assert!(!pending_beneficiary_term.approved_by_nominee);
 
     h.change_beneficiary(&mut rt, second_beneficiary_id, second_beneficiary_change.clone(), None)
         .unwrap();
-    info = h.get_info(&mut rt);
+    info = h.get_info(&rt);
     assert_eq!(second_beneficiary_id, info.beneficiary);
 
     assert_eq!(None, info.pending_beneficiary_term);
@@ -115,7 +115,7 @@ fn successfully_change_from_not_owner_beneficiary_to_another_address_when_benefi
     h.propose_approve_initial_beneficiary(
         &mut rt,
         first_beneficiary_id,
-        BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), expiration),
+        BeneficiaryTerm::new(quota, TokenAmount::zero(), expiration),
     )
     .unwrap();
 
@@ -125,7 +125,7 @@ fn successfully_change_from_not_owner_beneficiary_to_another_address_when_benefi
     let another_beneficiary_change =
         BeneficiaryChange::new(second_beneficiary_id, another_quota.clone(), another_expiration);
     h.change_beneficiary(&mut rt, h.owner, another_beneficiary_change.clone(), None).unwrap();
-    let mut info = h.get_info(&mut rt);
+    let mut info = h.get_info(&rt);
 
     let pending_beneficiary_term = info.pending_beneficiary_term.unwrap();
     assert_eq!(second_beneficiary_id, pending_beneficiary_term.new_beneficiary);
@@ -133,7 +133,7 @@ fn successfully_change_from_not_owner_beneficiary_to_another_address_when_benefi
     assert_eq!(another_expiration, pending_beneficiary_term.new_expiration);
 
     h.change_beneficiary(&mut rt, second_beneficiary_id, another_beneficiary_change, None).unwrap();
-    info = h.get_info(&mut rt);
+    info = h.get_info(&rt);
     assert_eq!(None, info.pending_beneficiary_term);
     assert_eq!(second_beneficiary_id, info.beneficiary);
     assert_eq!(another_quota, info.beneficiary_term.quota);
@@ -152,7 +152,7 @@ fn successfully_owner_immediate_revoking_unapproved_proposal() {
     // proposal beneficiary change
     h.change_beneficiary(&mut rt, h.owner, beneficiary_change.clone(), None).unwrap();
     // assert change has been made in state
-    let mut info = h.get_info(&mut rt);
+    let mut info = h.get_info(&rt);
     let pending_beneficiary_term = info.pending_beneficiary_term.unwrap();
     assert_eq!(beneficiary_change.expiration, pending_beneficiary_term.new_expiration);
     assert_eq!(beneficiary_change.quota, pending_beneficiary_term.new_quota);
@@ -167,7 +167,7 @@ fn successfully_owner_immediate_revoking_unapproved_proposal() {
     )
     .unwrap();
 
-    info = h.get_info(&mut rt);
+    info = h.get_info(&rt);
     assert_eq!(None, info.pending_beneficiary_term);
     assert_eq!(h.owner, info.beneficiary);
 
@@ -197,7 +197,7 @@ fn successfully_immediately_change_back_to_owner_address_while_used_up_quota() {
     )
     .unwrap();
 
-    let info = h.get_info(&mut rt);
+    let info = h.get_info(&rt);
     assert_eq!(None, info.pending_beneficiary_term);
     assert_eq!(h.owner, info.beneficiary);
     assert_eq!(TokenAmount::zero(), info.beneficiary_term.quota);
@@ -216,7 +216,7 @@ fn successfully_immediately_change_back_to_owner_while_expired() {
     h.propose_approve_initial_beneficiary(
         &mut rt,
         first_beneficiary_id,
-        BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), expiration),
+        BeneficiaryTerm::new(quota, TokenAmount::zero(), expiration),
     )
     .unwrap();
 
@@ -229,7 +229,7 @@ fn successfully_immediately_change_back_to_owner_while_expired() {
     )
     .unwrap();
 
-    let info = h.get_info(&mut rt);
+    let info = h.get_info(&rt);
     assert_eq!(None, info.pending_beneficiary_term);
     assert_eq!(h.owner, info.beneficiary);
     assert_eq!(TokenAmount::zero(), info.beneficiary_term.quota);
@@ -255,7 +255,7 @@ fn successfully_increase_quota() {
         beneficiary_term.expiration,
     );
     h.change_beneficiary(&mut rt, h.owner, increase_beneficiary_change.clone(), None).unwrap();
-    let mut info = h.get_info(&mut rt);
+    let mut info = h.get_info(&rt);
     let pending_beneficiary_term = info.pending_beneficiary_term.unwrap();
     assert_eq!(first_beneficiary_id, info.beneficiary);
     assert_eq!(increase_quota, pending_beneficiary_term.new_quota);
@@ -269,7 +269,7 @@ fn successfully_increase_quota() {
         Some(first_beneficiary_id),
     )
     .unwrap();
-    info = h.get_info(&mut rt);
+    info = h.get_info(&rt);
     assert_eq!(None, info.pending_beneficiary_term);
     assert_eq!(first_beneficiary_id, info.beneficiary);
     assert_eq!(increase_quota, info.beneficiary_term.quota);
@@ -290,7 +290,7 @@ fn fails_approval_message_with_invalidate_params() {
         None,
     )
     .unwrap();
-    assert!(h.get_info(&mut rt).pending_beneficiary_term.is_some());
+    assert!(h.get_info(&rt).pending_beneficiary_term.is_some());
 
     //expiration in approval message must equal with proposal
     expect_abort(
@@ -380,7 +380,7 @@ fn fails_proposal_beneficiary_with_invalidate_params() {
 #[test]
 fn successfully_get_beneficiary() {
     let (mut h, mut rt) = setup();
-    let mut info = h.get_info(&mut rt);
+    let mut info = h.get_info(&rt);
     assert_eq!(h.owner, info.beneficiary);
     assert_eq!(ChainEpoch::from(0), info.beneficiary_term.expiration);
     assert_eq!(TokenAmount::zero(), info.beneficiary_term.quota);
@@ -392,7 +392,7 @@ fn successfully_get_beneficiary() {
     h.propose_approve_initial_beneficiary(&mut rt, first_beneficiary_id, beneficiary_term.clone())
         .unwrap();
 
-    info = h.get_info(&mut rt);
+    info = h.get_info(&rt);
     assert_eq!(first_beneficiary_id, info.beneficiary);
     assert_eq!(beneficiary_term.expiration, info.beneficiary_term.expiration);
     assert_eq!(beneficiary_term.quota, info.beneficiary_term.quota);
@@ -403,7 +403,7 @@ fn successfully_get_beneficiary() {
     h.withdraw_funds(&mut rt, h.beneficiary, &withdraw_fund, &withdraw_fund, &TokenAmount::zero())
         .unwrap();
 
-    info = h.get_info(&mut rt);
+    info = h.get_info(&rt);
     assert_eq!(first_beneficiary_id, info.beneficiary);
     assert_eq!(beneficiary_term.expiration, info.beneficiary_term.expiration);
     assert_eq!(left_quota, info.beneficiary_term.available(rt.epoch));

--- a/actors/miner/tests/change_beneficiary_test.rs
+++ b/actors/miner/tests/change_beneficiary_test.rs
@@ -1,0 +1,411 @@
+use fil_actor_miner::BeneficiaryTerm;
+use fil_actors_runtime::test_utils::{expect_abort, MockRuntime};
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode};
+use num_traits::Zero;
+
+mod util;
+use util::*;
+
+fn setup() -> (ActorHarness, MockRuntime) {
+    let big_balance = 20u128.pow(23);
+    let period_offset = 100;
+
+    let h = ActorHarness::new(period_offset);
+    let mut rt = h.new_runtime();
+    h.construct_and_verify(&mut rt);
+    rt.balance.replace(TokenAmount::from(big_balance));
+
+    (h, rt)
+}
+
+#[test]
+fn successfully_change_owner_to_another_address_two_message() {
+    let (mut h, mut rt) = setup();
+    let first_beneficiary_id = Address::new_id(999);
+
+    let beneficiary_change =
+        BeneficiaryChange::new(first_beneficiary_id, TokenAmount::from(100), ChainEpoch::from(200));
+    // proposal beneficiary change
+    h.change_beneficiary(&mut rt, h.owner, beneficiary_change.clone(), None).unwrap();
+    // assert change has been made in state
+    let mut info = h.get_info(&mut rt);
+    let pending_beneficiary_term = info.pending_beneficiary_term.unwrap();
+    assert_eq!(beneficiary_change.expiration, pending_beneficiary_term.new_expiration);
+    assert_eq!(beneficiary_change.quota.clone(), pending_beneficiary_term.new_quota);
+    assert_eq!(first_beneficiary_id, pending_beneficiary_term.new_beneficiary);
+
+    //confirm proposal
+    h.change_beneficiary(
+        &mut rt,
+        first_beneficiary_id,
+        beneficiary_change.clone(),
+        Some(first_beneficiary_id),
+    )
+    .unwrap();
+
+    info = h.get_info(&mut rt);
+    assert_eq!(None, info.pending_beneficiary_term);
+    assert_eq!(first_beneficiary_id, info.beneficiary);
+    assert_eq!(beneficiary_change.quota.clone(), info.beneficiary_term.quota);
+    assert_eq!(beneficiary_change.expiration, info.beneficiary_term.expiration);
+
+    h.check_state(&rt);
+}
+
+#[test]
+fn successfully_change_from_not_owner_beneficiary_to_another_address_three_message() {
+    let (mut h, mut rt) = setup();
+    let first_beneficiary_id = Address::new_id(999);
+    let second_beneficiary_id = Address::new_id(1001);
+
+    let first_beneficiary_term =
+        BeneficiaryTerm::new(TokenAmount::from(100), TokenAmount::zero(), ChainEpoch::from(200));
+    h.propose_approve_initial_beneficiary(&mut rt, first_beneficiary_id, first_beneficiary_term)
+        .unwrap();
+
+    let second_beneficiary_change = BeneficiaryChange::new(
+        second_beneficiary_id,
+        TokenAmount::from(101),
+        ChainEpoch::from(201),
+    );
+    h.change_beneficiary(&mut rt, h.owner, second_beneficiary_change.clone(), None).unwrap();
+    let mut info = h.get_info(&mut rt);
+    assert_eq!(first_beneficiary_id, info.beneficiary);
+
+    let mut pending_beneficiary_term = info.pending_beneficiary_term.unwrap();
+    assert_eq!(second_beneficiary_change.expiration, pending_beneficiary_term.new_expiration);
+    assert_eq!(second_beneficiary_change.quota.clone(), pending_beneficiary_term.new_quota);
+    assert_eq!(second_beneficiary_id, pending_beneficiary_term.new_beneficiary);
+    assert!(!pending_beneficiary_term.approved_by_beneficiary);
+    assert!(!pending_beneficiary_term.approved_by_nominee);
+
+    h.change_beneficiary(&mut rt, first_beneficiary_id, second_beneficiary_change.clone(), None)
+        .unwrap();
+    info = h.get_info(&mut rt);
+    assert_eq!(first_beneficiary_id, info.beneficiary);
+
+    pending_beneficiary_term = info.pending_beneficiary_term.unwrap();
+    assert_eq!(second_beneficiary_change.expiration, pending_beneficiary_term.new_expiration);
+    assert_eq!(second_beneficiary_change.quota.clone(), pending_beneficiary_term.new_quota);
+    assert_eq!(second_beneficiary_id, pending_beneficiary_term.new_beneficiary);
+    assert!(pending_beneficiary_term.approved_by_beneficiary);
+    assert!(!pending_beneficiary_term.approved_by_nominee);
+
+    h.change_beneficiary(&mut rt, second_beneficiary_id, second_beneficiary_change.clone(), None)
+        .unwrap();
+    info = h.get_info(&mut rt);
+    assert_eq!(second_beneficiary_id, info.beneficiary);
+
+    assert_eq!(None, info.pending_beneficiary_term);
+    assert_eq!(second_beneficiary_change.expiration, info.beneficiary_term.expiration);
+    assert_eq!(second_beneficiary_change.quota, info.beneficiary_term.quota);
+    assert_eq!(TokenAmount::zero(), info.beneficiary_term.used_quota);
+}
+
+#[test]
+fn successfully_change_from_not_owner_beneficiary_to_another_address_when_beneficiary_inefficient_two_message(
+) {
+    let (mut h, mut rt) = setup();
+    let first_beneficiary_id = Address::new_id(999);
+    let second_beneficiary_id = Address::new_id(1000);
+
+    let quota = TokenAmount::from(100);
+    let expiration = ChainEpoch::from(200);
+    h.propose_approve_initial_beneficiary(
+        &mut rt,
+        first_beneficiary_id,
+        BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), expiration),
+    )
+    .unwrap();
+
+    rt.set_epoch(201);
+    let another_quota = TokenAmount::from(1001);
+    let another_expiration = ChainEpoch::from(3);
+    let another_beneficiary_change =
+        BeneficiaryChange::new(second_beneficiary_id, another_quota.clone(), another_expiration);
+    h.change_beneficiary(&mut rt, h.owner, another_beneficiary_change.clone(), None).unwrap();
+    let mut info = h.get_info(&mut rt);
+
+    let pending_beneficiary_term = info.pending_beneficiary_term.unwrap();
+    assert_eq!(second_beneficiary_id, pending_beneficiary_term.new_beneficiary);
+    assert_eq!(another_quota, pending_beneficiary_term.new_quota);
+    assert_eq!(another_expiration, pending_beneficiary_term.new_expiration);
+
+    h.change_beneficiary(&mut rt, second_beneficiary_id, another_beneficiary_change, None).unwrap();
+    info = h.get_info(&mut rt);
+    assert_eq!(None, info.pending_beneficiary_term);
+    assert_eq!(second_beneficiary_id, info.beneficiary);
+    assert_eq!(another_quota, info.beneficiary_term.quota);
+    assert_eq!(another_expiration, info.beneficiary_term.expiration);
+    assert_eq!(TokenAmount::zero(), info.beneficiary_term.used_quota);
+    h.check_state(&rt);
+}
+
+#[test]
+fn successfully_owner_immediate_revoking_unapproved_proposal() {
+    let (mut h, mut rt) = setup();
+    let first_beneficiary_id = Address::new_id(999);
+
+    let beneficiary_change =
+        BeneficiaryChange::new(first_beneficiary_id, TokenAmount::from(100), ChainEpoch::from(200));
+    // proposal beneficiary change
+    h.change_beneficiary(&mut rt, h.owner, beneficiary_change.clone(), None).unwrap();
+    // assert change has been made in state
+    let mut info = h.get_info(&mut rt);
+    let pending_beneficiary_term = info.pending_beneficiary_term.unwrap();
+    assert_eq!(beneficiary_change.expiration, pending_beneficiary_term.new_expiration);
+    assert_eq!(beneficiary_change.quota, pending_beneficiary_term.new_quota);
+    assert_eq!(first_beneficiary_id, pending_beneficiary_term.new_beneficiary);
+
+    //revoking unapprovel proposal
+    h.change_beneficiary(
+        &mut rt,
+        h.owner,
+        BeneficiaryChange::new(h.owner, TokenAmount::zero(), ChainEpoch::from(0)),
+        Some(h.owner),
+    )
+    .unwrap();
+
+    info = h.get_info(&mut rt);
+    assert_eq!(None, info.pending_beneficiary_term);
+    assert_eq!(h.owner, info.beneficiary);
+
+    h.check_state(&rt);
+}
+
+#[test]
+fn successfully_immediately_change_back_to_owner_address_while_used_up_quota() {
+    let (mut h, mut rt) = setup();
+    let first_beneficiary_id = Address::new_id(999);
+
+    let quota = TokenAmount::from(100);
+    let expiration = ChainEpoch::from(200);
+    h.propose_approve_initial_beneficiary(
+        &mut rt,
+        first_beneficiary_id,
+        BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), expiration),
+    )
+    .unwrap();
+
+    h.withdraw_funds(&mut rt, h.beneficiary, &quota, &quota, &TokenAmount::zero()).unwrap();
+    h.change_beneficiary(
+        &mut rt,
+        h.owner,
+        BeneficiaryChange::new(h.owner, TokenAmount::zero(), ChainEpoch::from(0)),
+        Some(h.owner),
+    )
+    .unwrap();
+
+    let info = h.get_info(&mut rt);
+    assert_eq!(None, info.pending_beneficiary_term);
+    assert_eq!(h.owner, info.beneficiary);
+    assert_eq!(TokenAmount::zero(), info.beneficiary_term.quota);
+    assert_eq!(ChainEpoch::from(0), info.beneficiary_term.expiration);
+    assert_eq!(TokenAmount::zero(), info.beneficiary_term.used_quota);
+    h.check_state(&rt);
+}
+
+#[test]
+fn successfully_immediately_change_back_to_owner_while_expired() {
+    let (mut h, mut rt) = setup();
+    let first_beneficiary_id = Address::new_id(999);
+
+    let quota = TokenAmount::from(100);
+    let expiration = ChainEpoch::from(200);
+    h.propose_approve_initial_beneficiary(
+        &mut rt,
+        first_beneficiary_id,
+        BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), expiration),
+    )
+    .unwrap();
+
+    rt.set_epoch(201);
+    h.change_beneficiary(
+        &mut rt,
+        h.owner,
+        BeneficiaryChange::new(h.owner, TokenAmount::zero(), ChainEpoch::from(0)),
+        Some(h.owner),
+    )
+    .unwrap();
+
+    let info = h.get_info(&mut rt);
+    assert_eq!(None, info.pending_beneficiary_term);
+    assert_eq!(h.owner, info.beneficiary);
+    assert_eq!(TokenAmount::zero(), info.beneficiary_term.quota);
+    assert_eq!(ChainEpoch::from(0), info.beneficiary_term.expiration);
+    assert_eq!(TokenAmount::zero(), info.beneficiary_term.used_quota);
+    h.check_state(&rt);
+}
+
+#[test]
+fn successfully_increase_quota() {
+    let (mut h, mut rt) = setup();
+    let first_beneficiary_id = Address::new_id(999);
+    let beneficiary_term =
+        BeneficiaryTerm::new(TokenAmount::from(100), TokenAmount::zero(), ChainEpoch::from(200));
+    h.propose_approve_initial_beneficiary(&mut rt, first_beneficiary_id, beneficiary_term.clone())
+        .unwrap();
+
+    //increase quota
+    let increase_quota = TokenAmount::from(100) + beneficiary_term.quota.clone();
+    let increase_beneficiary_change = BeneficiaryChange::new(
+        first_beneficiary_id,
+        increase_quota.clone(),
+        beneficiary_term.expiration,
+    );
+    h.change_beneficiary(&mut rt, h.owner, increase_beneficiary_change.clone(), None).unwrap();
+    let mut info = h.get_info(&mut rt);
+    let pending_beneficiary_term = info.pending_beneficiary_term.unwrap();
+    assert_eq!(first_beneficiary_id, info.beneficiary);
+    assert_eq!(increase_quota, pending_beneficiary_term.new_quota);
+    assert_eq!(beneficiary_term.expiration, pending_beneficiary_term.new_expiration);
+
+    //confirm increase quota
+    h.change_beneficiary(
+        &mut rt,
+        first_beneficiary_id,
+        increase_beneficiary_change,
+        Some(first_beneficiary_id),
+    )
+    .unwrap();
+    info = h.get_info(&mut rt);
+    assert_eq!(None, info.pending_beneficiary_term);
+    assert_eq!(first_beneficiary_id, info.beneficiary);
+    assert_eq!(increase_quota, info.beneficiary_term.quota);
+    assert_eq!(beneficiary_term.expiration, info.beneficiary_term.expiration);
+    h.check_state(&rt);
+}
+
+#[test]
+fn fails_approval_message_with_invalidate_params() {
+    let (mut h, mut rt) = setup();
+    let first_beneficiary_id = Address::new_id(999);
+
+    // proposal beneficiary
+    h.change_beneficiary(
+        &mut rt,
+        h.owner,
+        BeneficiaryChange::new(first_beneficiary_id, TokenAmount::from(100), 200),
+        None,
+    )
+    .unwrap();
+    assert!(h.get_info(&mut rt).pending_beneficiary_term.is_some());
+
+    //expiration in approval message must equal with proposal
+    expect_abort(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        h.change_beneficiary(
+            &mut rt,
+            first_beneficiary_id,
+            BeneficiaryChange::new(first_beneficiary_id, TokenAmount::from(100), 201),
+            None,
+        ),
+    );
+
+    //quota in approval message must equal with proposal
+    expect_abort(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        h.change_beneficiary(
+            &mut rt,
+            first_beneficiary_id,
+            BeneficiaryChange::new(first_beneficiary_id, TokenAmount::from(101), 200),
+            None,
+        ),
+    );
+
+    //beneficiary in approval message must equal with proposal
+    let second_beneficiary_id = Address::new_id(1010);
+    expect_abort(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        h.change_beneficiary(
+            &mut rt,
+            first_beneficiary_id,
+            BeneficiaryChange::new(second_beneficiary_id, TokenAmount::from(100), 200),
+            None,
+        ),
+    );
+}
+
+#[test]
+fn fails_proposal_beneficiary_with_invalidate_params() {
+    let (mut h, mut rt) = setup();
+    let first_beneficiary_id = Address::new_id(999);
+
+    //not-call unable to proposal beneficiary
+    expect_abort(
+        ExitCode::USR_FORBIDDEN,
+        h.change_beneficiary(
+            &mut rt,
+            first_beneficiary_id,
+            BeneficiaryChange::new(first_beneficiary_id, TokenAmount::from(100), 200),
+            None,
+        ),
+    );
+
+    //quota must bigger than zero while change beneficiary to address(not owner)
+    expect_abort(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        h.change_beneficiary(
+            &mut rt,
+            h.owner,
+            BeneficiaryChange::new(first_beneficiary_id, TokenAmount::from(0), 200),
+            None,
+        ),
+    );
+
+    //quota must be zero while change beneficiary to owner address
+    expect_abort(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        h.change_beneficiary(
+            &mut rt,
+            h.owner,
+            BeneficiaryChange::new(h.owner, TokenAmount::from(20), 0),
+            None,
+        ),
+    );
+
+    //expiration must be zero while change beneficiary to owner address
+    expect_abort(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        h.change_beneficiary(
+            &mut rt,
+            h.owner,
+            BeneficiaryChange::new(h.owner, TokenAmount::from(0), 1),
+            None,
+        ),
+    );
+}
+
+#[test]
+fn successfully_get_beneficiary() {
+    let (mut h, mut rt) = setup();
+    let mut info = h.get_info(&mut rt);
+    assert_eq!(h.owner, info.beneficiary);
+    assert_eq!(ChainEpoch::from(0), info.beneficiary_term.expiration);
+    assert_eq!(TokenAmount::zero(), info.beneficiary_term.quota);
+    assert_eq!(TokenAmount::zero(), info.beneficiary_term.used_quota);
+
+    let first_beneficiary_id = Address::new_id(999);
+    let beneficiary_term =
+        BeneficiaryTerm::new(TokenAmount::from(100), TokenAmount::zero(), ChainEpoch::from(200));
+    h.propose_approve_initial_beneficiary(&mut rt, first_beneficiary_id, beneficiary_term.clone())
+        .unwrap();
+
+    info = h.get_info(&mut rt);
+    assert_eq!(first_beneficiary_id, info.beneficiary);
+    assert_eq!(beneficiary_term.expiration, info.beneficiary_term.expiration);
+    assert_eq!(beneficiary_term.quota, info.beneficiary_term.quota);
+    assert_eq!(TokenAmount::zero(), info.beneficiary_term.used_quota);
+
+    let withdraw_fund = TokenAmount::from(40);
+    let left_quota = TokenAmount::from(60);
+    h.withdraw_funds(&mut rt, h.beneficiary, &withdraw_fund, &withdraw_fund, &TokenAmount::zero())
+        .unwrap();
+
+    info = h.get_info(&mut rt);
+    assert_eq!(first_beneficiary_id, info.beneficiary);
+    assert_eq!(beneficiary_term.expiration, info.beneficiary_term.expiration);
+    assert_eq!(left_quota, info.beneficiary_term.available(rt.epoch));
+    assert_eq!(withdraw_fund, info.beneficiary_term.used_quota);
+}

--- a/actors/miner/tests/change_owner_address_test.rs
+++ b/actors/miner/tests/change_owner_address_test.rs
@@ -37,6 +37,7 @@ fn successful_change() {
 
     let info = h.get_info(&rt);
     assert_eq!(NEW_ADDRESS, info.owner);
+    assert_eq!(NEW_ADDRESS, info.beneficiary);
     assert!(info.pending_owner_address.is_none());
 
     h.check_state(&rt);

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1947,14 +1947,18 @@ impl ActorHarness {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, from_address);
         rt.expect_validate_caller_addr(vec![self.owner, self.beneficiary]);
 
-        rt.expect_send(
-            self.beneficiary,
-            METHOD_SEND,
-            RawBytes::default(),
-            expected_withdrawn.clone(),
-            RawBytes::default(),
-            ExitCode::OK,
-        );
+        if expected_withdrawn.is_positive() {
+            //no send when real withdraw amount is zero
+            rt.expect_send(
+                self.beneficiary,
+                METHOD_SEND,
+                RawBytes::default(),
+                expected_withdrawn.clone(),
+                RawBytes::default(),
+                ExitCode::OK,
+            );
+        }
+
         if expected_debt_repaid.is_positive() {
             rt.expect_send(
                 *BURNT_FUNDS_ACTOR_ADDR,

--- a/actors/miner/tests/withdraw_balance.rs
+++ b/actors/miner/tests/withdraw_balance.rs
@@ -1,4 +1,6 @@
-use fil_actors_runtime::test_utils::expect_abort_contains_message;
+use fil_actor_miner::BeneficiaryTerm;
+use fil_actors_runtime::test_utils::{expect_abort, expect_abort_contains_message};
+use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
@@ -21,6 +23,7 @@ fn happy_path_withdraws_funds() {
 
     h.withdraw_funds(
         &mut rt,
+        h.owner,
         &TokenAmount::from(ONE_PERCENT_BALANCE),
         &TokenAmount::from(ONE_PERCENT_BALANCE),
         &TokenAmount::zero(),
@@ -44,6 +47,7 @@ fn fails_if_miner_cant_repay_fee_debt() {
         "unlocked balance can not repay fee debt",
         h.withdraw_funds(
             &mut rt,
+            h.owner,
             &TokenAmount::from(ONE_PERCENT_BALANCE),
             &TokenAmount::from(ONE_PERCENT_BALANCE),
             &TokenAmount::zero(),
@@ -66,6 +70,99 @@ fn withdraw_only_what_we_can_after_fee_debt() {
 
     let requested = rt.balance.borrow().to_owned();
     let expected_withdraw = &requested - &fee_debt;
-    h.withdraw_funds(&mut rt, &requested, &expected_withdraw, &fee_debt).unwrap();
+    h.withdraw_funds(&mut rt, h.owner, &requested, &expected_withdraw, &fee_debt).unwrap();
+    h.check_state(&rt);
+}
+
+#[test]
+fn successfully_withdraw() {
+    let mut h = ActorHarness::new(PERIOD_OFFSET);
+    let mut rt = h.new_runtime();
+    rt.set_balance(TokenAmount::from(BIG_BALANCE));
+    h.construct_and_verify(&mut rt);
+
+    let one = TokenAmount::from(1);
+    h.withdraw_funds(&mut rt, h.owner, &one, &one, &TokenAmount::zero()).unwrap();
+
+    let first_beneficiary_id = Address::new_id(999);
+    let quota = TokenAmount::from(ONE_PERCENT_BALANCE);
+    h.propose_approve_initial_beneficiary(
+        &mut rt,
+        first_beneficiary_id,
+        BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), PERIOD_OFFSET + 100),
+    )
+    .unwrap();
+    h.withdraw_funds(&mut rt, h.owner, &one, &one, &TokenAmount::zero()).unwrap();
+    h.withdraw_funds(&mut rt, h.beneficiary, &one, &one, &TokenAmount::zero()).unwrap();
+    h.check_state(&rt);
+}
+
+#[test]
+fn successfully_withdraw_from_non_main_beneficiary_and_failure_when_used_all_quota() {
+    let mut h = ActorHarness::new(PERIOD_OFFSET);
+    let mut rt = h.new_runtime();
+    rt.set_balance(TokenAmount::from(BIG_BALANCE));
+    h.construct_and_verify(&mut rt);
+
+    let first_beneficiary_id = Address::new_id(999);
+    let quota = TokenAmount::from(ONE_PERCENT_BALANCE);
+    h.propose_approve_initial_beneficiary(
+        &mut rt,
+        first_beneficiary_id,
+        BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), PERIOD_OFFSET + 100),
+    )
+    .unwrap();
+    h.withdraw_funds(&mut rt, h.beneficiary, &quota, &quota, &TokenAmount::zero()).unwrap();
+    expect_abort(
+        ExitCode::USR_FORBIDDEN,
+        h.withdraw_funds(&mut rt, h.beneficiary, &quota, &quota, &TokenAmount::zero()),
+    );
+    h.check_state(&rt);
+}
+
+#[test]
+fn successfully_withdraw_more_than_quota() {
+    let mut h = ActorHarness::new(PERIOD_OFFSET);
+    let mut rt = h.new_runtime();
+    rt.set_balance(TokenAmount::from(BIG_BALANCE));
+    h.construct_and_verify(&mut rt);
+
+    let first_beneficiary_id = Address::new_id(999);
+    let quota = TokenAmount::from(ONE_PERCENT_BALANCE);
+    h.propose_approve_initial_beneficiary(
+        &mut rt,
+        first_beneficiary_id,
+        BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), PERIOD_OFFSET + 100),
+    )
+    .unwrap();
+
+    let withdraw_amount = TokenAmount::from(ONE_PERCENT_BALANCE * 2);
+    h.withdraw_funds(&mut rt, h.beneficiary, &withdraw_amount, &quota, &TokenAmount::zero())
+        .unwrap();
+    h.check_state(&rt);
+}
+
+#[test]
+fn fails_withdraw_when_beneficiary_expired() {
+    let mut h = ActorHarness::new(PERIOD_OFFSET);
+    let mut rt = h.new_runtime();
+    rt.set_balance(TokenAmount::from(BIG_BALANCE));
+    h.construct_and_verify(&mut rt);
+
+    let first_beneficiary_id = Address::new_id(999);
+    let quota = TokenAmount::from(ONE_PERCENT_BALANCE);
+    h.propose_approve_initial_beneficiary(
+        &mut rt,
+        first_beneficiary_id,
+        BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), PERIOD_OFFSET - 10),
+    )
+    .unwrap();
+    let info = h.get_info(&mut rt);
+    assert_eq!(PERIOD_OFFSET - 10, info.beneficiary_term.expiration);
+    rt.set_epoch(100);
+    expect_abort(
+        ExitCode::USR_FORBIDDEN,
+        h.withdraw_funds(&mut rt, h.beneficiary, &quota, &quota, &TokenAmount::zero()),
+    );
     h.check_state(&rt);
 }

--- a/actors/miner/tests/withdraw_balance.rs
+++ b/actors/miner/tests/withdraw_balance.rs
@@ -123,7 +123,7 @@ fn successfully_withdraw_allow_zero() {
 }
 
 #[test]
-fn successfully_withdraw_more_than_quota() {
+fn successfully_withdraw_limited_to_quota() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
     let mut rt = h.new_runtime();
     rt.set_balance(TokenAmount::from(BIG_BALANCE));


### PR DESCRIPTION
This is an implementation for FIP-0029 PR https://github.com/filecoin-project/specs-actors/pull/1571 to provide Beneficiary address support. In this implementation, version and upgrading is not considered, that is, directly put the code change into the current version. The back-compliance could be done once the next version content is determined.

Closes #422 