### PR TITLE
adjust Wallaby parameters.

### DIFF
--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -11,7 +11,11 @@ static NETWORKS: &[(&[&str], &[&str])] = &[
             "min-power-2k",
         ],
     ),
-    (&["butterflynet", "wallaby"], &["sector-512m", "sector-32g", "sector-64g", "min-power-2g"]),
+    (&["butterflynet"], &["sector-512m", "sector-32g", "sector-64g", "min-power-2g"]),
+    (
+        &["wallaby"],
+        &["sector-512m", "sector-32g", "sector-64g", "min-power-16g", "short-precommit"],
+    ),
     (&["calibrationnet"], &["sector-32g", "sector-64g", "min-power-32g"]),
     (
         &["devnet", "devnet-wasm" /*devnet-fevm*/],

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -267,7 +267,8 @@ pub mod policy_constants {
     /// The period over which all a miner's active sectors will be challenged.
     pub const WPOST_PROVING_PERIOD: ChainEpoch = EPOCHS_IN_DAY;
     /// The duration of a deadline's challenge window, the period before a deadline when the challenge is available.
-    pub const WPOST_CHALLENGE_WINDOW: ChainEpoch = 30 * 60 / EPOCH_DURATION_SECONDS; // Half an hour (=48 per day)
+    pub const WPOST_CHALLENGE_WINDOW: ChainEpoch = 30 * 60 / EPOCH_DURATION_SECONDS;
+    // Half an hour (=48 per day)
     /// The number of non-overlapping PoSt deadlines in each proving period.
     pub const WPOST_PERIOD_DEADLINES: u64 = 48;
     /// The maximum distance back that a valid Window PoSt must commit to the current chain.
@@ -392,6 +393,7 @@ pub mod policy_constants {
     #[cfg(not(any(
         feature = "min-power-2k",
         feature = "min-power-2g",
+        feature = "min-power-16g",
         feature = "min-power-32g"
     )))]
     pub const MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -385,6 +385,8 @@ pub mod policy_constants {
     pub const MINIMUM_CONSENSUS_POWER: i64 = 2 << 10;
     #[cfg(feature = "min-power-2g")]
     pub const MINIMUM_CONSENSUS_POWER: i64 = 2 << 30;
+    #[cfg(feature = "min-power-16g")]
+    pub const MINIMUM_CONSENSUS_POWER: i64 = 16 << 30;
     #[cfg(feature = "min-power-32g")]
     pub const MINIMUM_CONSENSUS_POWER: i64 = 32 << 30;
     #[cfg(not(any(


### PR DESCRIPTION
- minimum consensus power is 16GiB.
- short precommit challenge delay (10 epochs).