### PR TITLE
ci: change CI trigger to pull_request + push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Continuous integration
 
 on:
   push:
+    branches:
+      - master
+  pull_request:
 
 env:
   RUSTFLAGS: -Dwarnings


### PR DESCRIPTION
This change makes CI trigger whenever:
- a pull request is opened/updated
- a commit is pushed to `master` branch

The main advantage of this setup is that it enables CI runs on PRs originating from forks.