### PR TITLE
test: modify test_vm's verify_signature behaviour

### DIFF
--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -517,7 +517,7 @@ pub fn submit_invalid_post(
         }],
         proofs: vec![PoStProof {
             post_proof: RegisteredPoStProof::StackedDRGWindow32GiBV1,
-            proof_bytes: TEST_VM_INVALID.as_bytes().to_vec(),
+            proof_bytes: TEST_VM_INVALID_POST.as_bytes().to_vec(),
         }],
         chain_commit_epoch: dline_info.challenge,
         chain_commit_rand: Randomness(TEST_VM_RAND_STRING.to_owned().into_bytes()),
@@ -588,8 +588,11 @@ pub fn publish_deal(
 
     let publish_params = PublishStorageDealsParams {
         deals: vec![ClientDealProposal {
-            proposal: deal,
-            client_signature: Signature { sig_type: SignatureType::BLS, bytes: vec![] },
+            proposal: deal.clone(),
+            client_signature: Signature {
+                sig_type: SignatureType::BLS,
+                bytes: serialize(&deal, "deal proposal").unwrap().to_vec(),
+            },
         }],
     };
     let ret: PublishStorageDealsReturn = apply_ok(

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -6,6 +6,7 @@ use fvm_shared::crypto::signature::{Signature, SignatureType};
 
 use fil_actor_miner::max_prove_commit_duration;
 use fil_actor_verifreg::{AddVerifierClientParams, Method as VerifregMethod};
+use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{test_utils::*, STORAGE_MARKET_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR};
@@ -604,7 +605,10 @@ impl<'bs> DealBatcher<'bs> {
             .iter_mut()
             .map(|deal| ClientDealProposal {
                 proposal: deal.clone(),
-                client_signature: Signature { sig_type: SignatureType::BLS, bytes: vec![] },
+                client_signature: Signature {
+                    sig_type: SignatureType::BLS,
+                    bytes: serialize(deal, "serializing deal proposal").unwrap().to_vec(),
+                },
             })
             .collect();
         let publish_params = PublishStorageDealsParams { deals: params_deals };


### PR DESCRIPTION
A "valid" signature has its bytes equal to the plaintext. Anything else is considered invalid.

More context here: https://github.com/filecoin-project/builtin-actors/pull/502#discussion_r932383910.