### PR TITLE
set codegen units to 1 for wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,3 +91,4 @@ overflow-checks = true
 lto = "thin"
 opt-level = "z"
 strip = true
+codegen-units = 1


### PR DESCRIPTION
Locally, it reduces the size of the bundle by over 5%.
Before `5505513B`. After `5224309`.

The drawback is that it may increase compilation time, but if I understand correctly, creating the bundle is not done very often in the development cycle.

I took the suggestion from [here](https://github.com/johnthagen/min-sized-rust#reduce-parallel-code-generation-units-to-increase-optimization). There may be some other automatic tricks we could use, e.g. treating the wasm bundle with [wasm-opt](https://github.com/WebAssembly/binaryen#binaryen-optimizations).