### PR TITLE
Duplicate fvm_shared::actor::builtin::Type into runtime::builtins::Type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,7 @@ name = "fil_builtin_actors_state"
 version = "9.0.0-alpha.1"
 dependencies = [
  "anyhow",
+ "bimap",
  "cid",
  "fil_actor_account",
  "fil_actor_cron",
@@ -1774,6 +1775,7 @@ name = "test_vm"
 version = "9.0.0-alpha.1"
 dependencies = [
  "anyhow",
+ "bimap",
  "blake2b_simd",
  "cid",
  "fil_actor_account",

--- a/README.md
+++ b/README.md
@@ -35,18 +35,7 @@ characteristics:
   entry represents a built-in actor.
 - Manifest keys (CID) point to the Wasm bytecode of an actor as a single block.
 - Manifest values (i32) identify the actor type, to be parsed as the
-  `fvm_shared::actor::builtin::Type` enum:
-    - System = 1
-    - Init = 2
-    - Cron = 3
-    - Account = 4
-    - Power = 5
-    - Miner = 6
-    - Market = 7
-    - PaymentChannel = 8
-    - Multisig = 9
-    - Reward = 10
-    - VerifiedRegistry = 11
+  `runtime::builtins::Type` enum.
 
 Precompiled actor bundles are provided as [release binaries][releases] in this repo. The
 [`fil_builtin_actors_bundle`](https://crates.io/crates/fil_builtin_actors_bundle) crate on

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
+use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{actor_error, cbor, ActorDowncast, ActorError, SYSTEM_ACTOR_ADDR};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::error::ExitCode;
 use fvm_shared::{ActorID, MethodNum, METHOD_CONSTRUCTOR};
@@ -22,8 +22,6 @@ mod types;
 
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
-
-// * Updated to specs-actors commit: 999e57a151cc7ada020ca2844b651499ab8c0dec (v3.0.1)
 
 /// Init actor methods available
 #[derive(FromPrimitive)]

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -7,7 +7,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{Cbor, RawBytes};
-use fvm_shared::actor::builtin::{Type, CALLER_TYPES_SIGNABLE};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED};
@@ -23,10 +22,12 @@ use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Signed, Zero};
 
 use fil_actors_runtime::cbor::serialize_vec;
+use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Policy, Runtime};
 use fil_actors_runtime::{
-    actor_error, cbor, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR,
-    REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+    actor_error, cbor, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE,
+    CRON_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 
 use crate::ext::verifreg::UseBytesParams;
@@ -36,16 +37,15 @@ use self::policy::*;
 pub use self::state::*;
 pub use self::types::*;
 
+// exports for testing
 pub mod balance_table;
-// export for testing
-mod deal;
 #[doc(hidden)]
 pub mod ext;
-// export for testing
 pub mod policy;
-// export for testing
-mod state;
 pub mod testing;
+
+mod deal;
+mod state;
 mod types;
 
 #[cfg(feature = "fil-actor")]

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -18,8 +18,8 @@ pub use deadlines::*;
 pub use expiration_queue::*;
 use fil_actors_runtime::runtime::{ActorCode, DomainSeparationTag, Policy, Runtime};
 use fil_actors_runtime::{
-    actor_error, cbor, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, INIT_ACTOR_ADDR,
-    REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
+    actor_error, cbor, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE,
+    INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
 };
 use fvm_ipld_bitfield::{BitField, UnvalidatedBitField, Validate};
 use fvm_ipld_blockstore::Blockstore;
@@ -34,7 +34,7 @@ use fvm_shared::econ::TokenAmount;
 // They're not expected to ever happen, but if they do, distinguished codes can help us
 // diagnose the problem.
 use fil_actors_runtime::cbor::{deserialize, serialize, serialize_vec};
-use fvm_shared::actor::builtin::{Type, CALLER_TYPES_SIGNABLE};
+use fil_actors_runtime::runtime::builtins::Type;
 use fvm_shared::error::*;
 use fvm_shared::randomness::*;
 use fvm_shared::reward::ThisEpochRewardReturn;
@@ -4014,7 +4014,7 @@ where
     let is_principal = rt
         .resolve_builtin_actor_type(&owner_code)
         .as_ref()
-        .map(Type::is_principal)
+        .map(|t| CALLER_TYPES_SIGNABLE.contains(t))
         .unwrap_or(false);
 
     if !is_principal {

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -7,11 +7,10 @@ use fil_actors_runtime::cbor::serialize_vec;
 use fil_actors_runtime::runtime::{ActorCode, Primitives, Runtime};
 use fil_actors_runtime::{
     actor_error, cbor, make_empty_map, make_map_with_root, resolve_to_id_addr, ActorDowncast,
-    ActorError, Map, INIT_ACTOR_ADDR,
+    ActorError, Map, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::actor::builtin::CALLER_TYPES_SIGNABLE;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Sign;
 use fvm_shared::econ::TokenAmount;

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -1,11 +1,11 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{actor_error, cbor, resolve_to_id_addr, ActorDowncast, ActorError, Array};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::{BigInt, Sign};
 use fvm_shared::econ::TokenAmount;
@@ -85,7 +85,6 @@ impl Actor {
             .ok_or_else(|| actor_error!(illegal_argument, "no code for address {}", resolved))?;
 
         let typ = rt.resolve_builtin_actor_type(&code_cid);
-
         if typ != Some(Type::Account) {
             Err(actor_error!(
                 forbidden,

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -6,14 +6,14 @@ use std::convert::TryInto;
 
 use anyhow::anyhow;
 use ext::init;
+use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
     actor_error, cbor, make_map_with_root_and_bitwidth, ActorDowncast, ActorError, Multimap,
-    CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    CALLER_TYPES_SIGNABLE, CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::actor::builtin::{Type, CALLER_TYPES_SIGNABLE};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser::{BigIntDe, BigIntSer};
 use fvm_shared::econ::TokenAmount;

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -5,9 +5,15 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::address::Address;
 use fvm_shared::METHOD_SEND;
 
+use crate::runtime::builtins::Type;
 use crate::runtime::Runtime;
 
 pub const HAMT_BIT_WIDTH: u32 = 5;
+
+/// Types of built-in actors that can be treated as principles.
+/// This distinction is legacy and should be removed prior to FVM support for
+/// user-programmable actors.
+pub const CALLER_TYPES_SIGNABLE: &[Type] = &[Type::Account, Type::Multisig];
 
 /// ResolveToIDAddr resolves the given address to it's ID address form.
 /// If an ID address for the given address dosen't exist yet, it tries to create one by sending

--- a/runtime/src/runtime/builtins.rs
+++ b/runtime/src/runtime/builtins.rs
@@ -1,0 +1,22 @@
+use num_derive::FromPrimitive;
+
+/// Identifies the builtin actor types for usage with the
+/// actor::resolve_builtin_actor_type syscall.
+/// Note that there is a mirror of this enum in the FVM SDK src/actors/builtins.rs.
+/// These must be kept in sync for the syscall to work correctly, without either side
+/// importing the other.
+#[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord, FromPrimitive, Debug)]
+#[repr(i32)]
+pub enum Type {
+    System = 1,
+    Init = 2,
+    Cron = 3,
+    Account = 4,
+    Power = 5,
+    Miner = 6,
+    Market = 7,
+    PaymentChannel = 8,
+    Multisig = 9,
+    Reward = 10,
+    VerifiedRegistry = 11,
+}

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -5,7 +5,6 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{to_vec, Cbor, CborStore, RawBytes, DAG_CBOR};
 use fvm_sdk as fvm;
 use fvm_sdk::NO_DATA_BLOCK_ID;
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::Signature;
@@ -19,10 +18,12 @@ use fvm_shared::sector::{
 };
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum};
+use num_traits::FromPrimitive;
 #[cfg(feature = "fake-proofs")]
 use sha2::{Digest, Sha256};
 
 use crate::runtime::actor_blockstore::ActorBlockstore;
+use crate::runtime::builtins::Type;
 use crate::runtime::{
     ActorCode, ConsensusFault, DomainSeparationTag, MessageInfo, Policy, Primitives, RuntimePolicy,
     Verifier,
@@ -165,11 +166,12 @@ where
     }
 
     fn resolve_builtin_actor_type(&self, code_id: &Cid) -> Option<Type> {
-        fvm::actor::get_builtin_actor_type(code_id)
+        fvm::actor::get_builtin_actor_type(code_id).and_then(|t| Type::from_i32(t as i32))
     }
 
     fn get_code_cid_for_type(&self, typ: Type) -> Cid {
-        fvm::actor::get_code_cid_for_type(typ)
+        let t = fvm_shared::actor::builtin::Type::from_i32(typ as i32).unwrap();
+        fvm::actor::get_code_cid_for_type(t)
     }
 
     fn get_randomness_from_tickets(

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -4,7 +4,6 @@
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{Cbor, RawBytes};
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
@@ -22,17 +21,17 @@ use fvm_shared::{ActorID, MethodNum};
 pub use self::actor_code::*;
 pub use self::policy::*;
 pub use self::randomness::DomainSeparationTag;
+use crate::runtime::builtins::Type;
 use crate::ActorError;
-
-mod actor_code;
-
-#[cfg(feature = "fil-actor")]
-pub mod fvm;
 
 #[cfg(feature = "fil-actor")]
 mod actor_blockstore;
-
+#[cfg(feature = "fil-actor")]
+pub mod builtins;
+pub mod fvm;
 pub mod policy;
+
+mod actor_code;
 mod randomness;
 
 /// Runtime is the VM's internal runtime object.

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -11,10 +11,8 @@ use cid::Cid;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::de::DeserializeOwned;
 use fvm_ipld_encoding::{Cbor, CborStore, RawBytes};
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::{Address, Protocol};
 use fvm_shared::clock::ChainEpoch;
-
 use fvm_shared::commcid::{FIL_COMMITMENT_SEALED, FIL_COMMITMENT_UNSEALED};
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::signature::Signature;
@@ -34,6 +32,7 @@ use multihash::MultihashDigest;
 
 use rand::prelude::*;
 
+use crate::runtime::builtins::Type;
 use crate::runtime::{
     ActorCode, DomainSeparationTag, MessageInfo, Policy, Primitives, Runtime, RuntimePolicy,
     Verifier,

--- a/runtime/src/util/chaos/mod.rs
+++ b/runtime/src/util/chaos/mod.rs
@@ -4,7 +4,6 @@
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::error::ExitCode;
 use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
@@ -13,6 +12,7 @@ use num_traits::FromPrimitive;
 pub use state::*;
 pub use types::*;
 
+use crate::runtime::builtins::Type;
 use crate::runtime::{ActorCode, Runtime};
 use crate::{actor_error, cbor, ActorError};
 

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -31,6 +31,7 @@ fvm_ipld_encoding = "0.2.2"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"
 anyhow = "1.0.56"
+bimap = { version = "0.6.2" }
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 
 use anyhow::bail;
+use bimap::BiBTreeMap;
 use cid::Cid;
 use fil_actor_account::State as AccountState;
 use fil_actor_cron::State as CronState;
@@ -25,8 +26,6 @@ use fil_actors_runtime::MessageAccumulator;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::from_slice;
 use fvm_ipld_encoding::CborStore;
-use fvm_shared::actor::builtin::Manifest;
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::address::Protocol;
 use fvm_shared::bigint::BigInt;
@@ -48,6 +47,7 @@ use fil_actor_paych::testing as paych;
 use fil_actor_power::testing as power;
 use fil_actor_reward::testing as reward;
 use fil_actor_verifreg::testing as verifreg;
+use fil_actors_runtime::runtime::builtins::Type;
 
 /// Value type of the top level of the state tree.
 /// Represents the on-chain state of a single actor.
@@ -103,8 +103,12 @@ macro_rules! get_state {
     };
 }
 
+// Note: BiBTreeMap is an overly constrained type for what we are doing here, but chosen
+// to match the Manifest implementation in the FVM.
+// It could be replaced with a custom mapping trait (while Rust doesn't support
+// abstract collection traits).
 pub fn check_state_invariants<'a, BS: Blockstore + Debug>(
-    manifest: &Manifest,
+    manifest: &BiBTreeMap<Cid, Type>,
     policy: &Policy,
     tree: Tree<'a, BS>,
     expected_balance_total: &TokenAmount,

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -40,6 +40,7 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 anyhow = "1.0.56"
+bimap = { version = "0.6.2" }
 blake2b_simd = "1.0"
 integer-encoding = { version = "3.0.3", default-features = false }
 regex = "1"

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use bimap::BiBTreeMap;
 use cid::multihash::Code;
 use cid::Cid;
 use fil_actor_account::{Actor as AccountActor, State as AccountState};
@@ -13,6 +14,7 @@ use fil_actor_reward::{Actor as RewardActor, State as RewardState};
 use fil_actor_system::{Actor as SystemActor, State as SystemState};
 use fil_actor_verifreg::{Actor as VerifregActor, State as VerifRegState};
 use fil_actors_runtime::cbor::serialize;
+use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{
     ActorCode, DomainSeparationTag, MessageInfo, Policy, Primitives, Runtime, RuntimePolicy,
     Verifier,
@@ -30,8 +32,6 @@ use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{Cbor, CborStore, RawBytes};
 use fvm_ipld_hamt::{BytesKey, Hamt, Sha256};
-use fvm_shared::actor::builtin::Manifest;
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::{Address, Protocol};
 use fvm_shared::bigint::{bigint_ser, BigInt, Zero};
 use fvm_shared::clock::ChainEpoch;
@@ -447,7 +447,7 @@ impl<'bs> VM<'bs> {
         )
         .unwrap();
 
-        let mut manifest = Manifest::new();
+        let mut manifest = BiBTreeMap::new();
         actors
             .for_each(|_, actor| {
                 manifest.insert(actor.code, ACTOR_TYPES.get(&actor.code).unwrap().to_owned());


### PR DESCRIPTION
This PR copies the builtin actor `Type` enum out of the FVM SDK into the built-in actors repo.

Breaking coupling is necessary to enable development of the built-in actors (e.g. adding a new one) without depending on changes to the FVM SDK. Since the FVM doesn't want to depend on the actors, any changes to the enum need to be propagated to the FVM.

This removes all but one reference to the path `fvm_shared::actor`, the holdout being the conversion between the two `Type` enums at the SDK syscall. This last one should be removed by changing the SDK to pass through the bare i32 value that it wrapped.
```
[~/p/f/builtin-actors](anorth/builtin-type)$ rg 'fvm_shared::actor'
runtime/src/runtime/fvm.rs
173:        let t = fvm_shared::actor::builtin::Type::from_i32(typ as i32).unwrap();
```

Closes #520.