### PR TITLE
Implement could-be-standard token receiver hook in account and multisig

### DIFF
--- a/actors/account/tests/account_actor_test.rs
+++ b/actors/account/tests/account_actor_test.rs
@@ -1,76 +1,87 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fil_actor_account::{testing::check_state_invariants, Actor as AccountActor, State};
-use fil_actors_runtime::builtin::SYSTEM_ACTOR_ADDR;
-use fil_actors_runtime::test_utils::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::error::ExitCode;
+use fvm_shared::MethodNum;
+
+use fil_actor_account::{testing::check_state_invariants, Actor as AccountActor, Method, State};
+use fil_actors_runtime::builtin::SYSTEM_ACTOR_ADDR;
+use fil_actors_runtime::test_utils::*;
+
+#[test]
+fn construction() {
+    fn construct(addr: Address, exit_code: ExitCode) {
+        let mut rt = MockRuntime {
+            receiver: Address::new_id(100),
+            caller: *SYSTEM_ACTOR_ADDR,
+            caller_type: *SYSTEM_ACTOR_CODE_ID,
+            ..Default::default()
+        };
+        rt.expect_validate_caller_addr(vec![*SYSTEM_ACTOR_ADDR]);
+
+        if exit_code.is_success() {
+            rt.call::<AccountActor>(
+                Method::Constructor as MethodNum,
+                &RawBytes::serialize(addr).unwrap(),
+            )
+            .unwrap();
+
+            let state: State = rt.get_state();
+            assert_eq!(state.address, addr);
+            rt.expect_validate_caller_any();
+
+            let pk: Address = rt
+                .call::<AccountActor>(Method::PubkeyAddress as MethodNum, &RawBytes::default())
+                .unwrap()
+                .deserialize()
+                .unwrap();
+            assert_eq!(pk, addr);
+            check_state(&rt);
+        } else {
+            expect_abort(exit_code, rt.call::<AccountActor>(1, &RawBytes::serialize(addr).unwrap()))
+        }
+        rt.verify();
+    }
+
+    construct(
+        Address::new_secp256k1(&[2; fvm_shared::address::SECP_PUB_LEN]).unwrap(),
+        ExitCode::OK,
+    );
+    construct(Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap(), ExitCode::OK);
+    construct(Address::new_id(1), ExitCode::USR_ILLEGAL_ARGUMENT);
+    construct(Address::new_actor(&[1, 2, 3]), ExitCode::USR_ILLEGAL_ARGUMENT);
+}
+
+#[test]
+fn token_receiver() {
+    let mut rt = MockRuntime {
+        receiver: Address::new_id(100),
+        caller: *SYSTEM_ACTOR_ADDR,
+        caller_type: *SYSTEM_ACTOR_CODE_ID,
+        ..Default::default()
+    };
+    rt.expect_validate_caller_addr(vec![*SYSTEM_ACTOR_ADDR]);
+
+    let param = Address::new_secp256k1(&[2; fvm_shared::address::SECP_PUB_LEN]).unwrap();
+    rt.call::<AccountActor>(
+        Method::Constructor as MethodNum,
+        &RawBytes::serialize(&param).unwrap(),
+    )
+    .unwrap();
+
+    rt.expect_validate_caller_any();
+    let ret = rt.call::<AccountActor>(
+        Method::FungibleTokenReceiverHook as MethodNum,
+        &RawBytes::new(vec![1, 2, 3]),
+    );
+    assert!(ret.is_ok());
+    assert_eq!(RawBytes::default(), ret.unwrap());
+}
 
 fn check_state(rt: &MockRuntime) {
     let test_address = Address::new_id(1000);
     let (_, acc) = check_state_invariants(&rt.get_state(), &test_address);
     acc.assert_empty();
-}
-
-macro_rules! account_tests {
-    ($($name:ident: $value:expr,)*) => {
-        $(
-            #[test]
-            fn $name() {
-                let (addr, exit_code) = $value;
-
-                let mut rt = MockRuntime {
-                    receiver: fvm_shared::address::Address::new_id(100),
-                    caller: SYSTEM_ACTOR_ADDR.clone(),
-                    caller_type: SYSTEM_ACTOR_CODE_ID.clone(),
-                    ..Default::default()
-                };
-                rt.expect_validate_caller_addr(vec![*SYSTEM_ACTOR_ADDR]);
-
-                if exit_code.is_success() {
-                    rt.call::<AccountActor>(1, &RawBytes::serialize(addr).unwrap()).unwrap();
-
-                    let state: State = rt.get_state();
-                    assert_eq!(state.address, addr);
-                    rt.expect_validate_caller_any();
-
-                    let pk: Address = rt
-                        .call::<AccountActor>(2, &RawBytes::default())
-                        .unwrap()
-                        .deserialize()
-                        .unwrap();
-                    assert_eq!(pk, addr);
-
-                    check_state(&rt);
-                } else {
-                    expect_abort(
-                        exit_code,
-                        rt.call::<AccountActor>(1,&RawBytes::serialize(addr).unwrap())
-                    )
-                }
-                rt.verify();
-            }
-        )*
-    }
-}
-
-account_tests! {
-    happy_construct_secp256k1_address: (
-        Address::new_secp256k1(&[2; fvm_shared::address::SECP_PUB_LEN]).unwrap(),
-        ExitCode::OK
-    ),
-    happy_construct_bls_address: (
-        Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap(),
-        ExitCode::OK
-    ),
-    fail_construct_id_address: (
-        Address::new_id(1),
-        ExitCode::USR_ILLEGAL_ARGUMENT
-    ),
-    fail_construct_actor_address: (
-        Address::new_actor(&[1, 2, 3]),
-        ExitCode::USR_ILLEGAL_ARGUMENT
-    ),
 }

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -15,7 +15,7 @@ use fvm_shared::bigint::Zero;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::METHOD_SEND;
+use fvm_shared::{MethodNum, METHOD_SEND};
 
 mod util;
 
@@ -2398,4 +2398,23 @@ mod lock_balance_tests {
         );
         check_state(&rt);
     }
+}
+
+#[test]
+fn token_receiver() {
+    let msig = Address::new_id(1000);
+    let anne = Address::new_id(101);
+    let bob = Address::new_id(102);
+
+    let mut rt = construct_runtime(msig);
+    let h = util::ActorHarness::new();
+    h.construct_and_verify(&mut rt, 2, 0, 0, vec![anne, bob]);
+
+    rt.expect_validate_caller_any();
+    let ret = rt.call::<MultisigActor>(
+        Method::FungibleTokenReceiverHook as MethodNum,
+        &RawBytes::new(vec![1, 2, 3]),
+    );
+    assert!(ret.is_ok());
+    assert_eq!(RawBytes::default(), ret.unwrap());
 }

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -15,6 +15,12 @@ pub const HAMT_BIT_WIDTH: u32 = 5;
 /// user-programmable actors.
 pub const CALLER_TYPES_SIGNABLE: &[Type] = &[Type::Account, Type::Multisig];
 
+// TODO: use the fvm_dispatch crate here when we can depend on a published crate.
+// This method number comes from taking the name as "TokensReceived" and applying
+// the transformation described in https://github.com/filecoin-project/FIPs/pull/399.
+// This matches the value in the fungible token library used by the datacap token actor.
+pub const FUNGIBLE_TOKEN_RECEIVER_HOOK_METHOD_NUM: u64 = 1361519036;
+
 /// ResolveToIDAddr resolves the given address to it's ID address form.
 /// If an ID address for the given address dosen't exist yet, it tries to create one by sending
 /// a zero balance to the given address.


### PR DESCRIPTION
Implements a token receiver hook that always succeeds. The receivers don't deserialise parameters because they don't inspect them.

I've avoided adding a dependency on the fungible token library from runtime/shared by copying the method number, and avoiding the hook parameter type. I don't think it would be a big deal to add the dep, but it's painful while we depend on a github hash[*].

Even if the calling convention or receiver hook is not standardised, this is a reasonable way for the data cap token specifically to interact with account-type actors, and opens it up to user contracts. But hopefully this standard will be adopted.

*: We depend on a hash because no crates yet, because name will depend on FIP number, which we have't allocated yet).