### PR TITLE
EVM: don't encode contract invocation output data

### DIFF
--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -135,10 +135,7 @@ impl EvmContractActor {
 
             // XXX is this correct handling of reverts? or should we fail execution?
             if exec_status.status_code == StatusCode::Success {
-                let result = RawBytes::serialize(U256::from_big_endian(&exec_status.output_data))
-                    .map_err(|e| {
-                    ActorError::unspecified(format!("failed to serialize return data: {e:?}"))
-                })?;
+                let result = RawBytes::from(exec_status.output_data.to_vec());
 
                 if !exec_status.reverted {
                     state.contract_state = system.flush_state()?;

--- a/actors/evm/tests/basic.rs
+++ b/actors/evm/tests/basic.rs
@@ -30,11 +30,13 @@ fn basic_contract_construction_and_invocation() {
     rt.verify();
 
     // invoke contract -- getBalance
+    // first we invoke without specifying an address, so it would be the system actor and have
+    // a balance of 0
+
     let mut solidity_params = vec![];
     solidity_params.append(&mut hex::decode("f8b2cb4f").unwrap()); // function selector
                                                                    // caller id address in U256 form
     let mut arg0 = vec![0u8; 32];
-    arg0[31] = 100; // the contract address
     solidity_params.append(&mut arg0);
 
     let params = evm::InvokeParams { input_data: RawBytes::from(solidity_params) };
@@ -47,5 +49,25 @@ fn basic_contract_construction_and_invocation() {
         )
         .unwrap();
 
-    assert_eq!(RawBytes::deserialize::<U256>(&result).unwrap(), U256::from(10000));
+    assert_eq!(U256::from_big_endian(&result), U256::from(0));
+
+    // invoke contract -- getBalance
+    // now we invoke with the owner address, which should have a balance of 10k
+    let mut solidity_params = vec![];
+    solidity_params.append(&mut hex::decode("f8b2cb4f").unwrap()); // function selector
+                                                                   // caller id address in U256 form
+    let mut arg0 = vec![0u8; 32];
+    arg0[31] = 100; // the owner address
+    solidity_params.append(&mut arg0);
+
+    let params = evm::InvokeParams { input_data: RawBytes::from(solidity_params) };
+
+    rt.expect_validate_caller_any();
+    let result = rt
+        .call::<evm::EvmContractActor>(
+            evm::Method::InvokeContract as u64,
+            &RawBytes::serialize(params).unwrap(),
+        )
+        .unwrap();
+    assert_eq!(U256::from_big_endian(&result), U256::from(10000));
 }


### PR DESCRIPTION
Let's avoid wearing clown shoes, bytes are bytes.
Also improves the test to check both condition for balances. 