### PR TITLE
Upgrade fungible token library. Use standard exit codes. Use standard token method params/return types.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,10 +881,11 @@ dependencies = [
 [[package]]
 name = "fil_fungible_token"
 version = "0.1.0"
-source = "git+https://github.com/helix-onchain/filecoin?rev=b5c55eadf13946155d06d76a3409fc800b9a6e64#b5c55eadf13946155d06d76a3409fc800b9a6e64"
+source = "git+https://github.com/helix-onchain/filecoin?rev=0bffadc1897746cdae8e76f148fbbe3fe57f09f3#0bffadc1897746cdae8e76f148fbbe3fe57f09f3"
 dependencies = [
  "anyhow",
  "cid",
+ "frc42_dispatch",
  "fvm_ipld_amt",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
@@ -911,6 +912,41 @@ checksum = "edb061ad769411763a5d6ae39d596696657472b25a66387fbb0ba8c133bb6575"
 dependencies = [
  "cs_serde_bytes",
  "serde",
+]
+
+[[package]]
+name = "frc42_dispatch"
+version = "0.2.0"
+source = "git+https://github.com/helix-onchain/filecoin?rev=0bffadc1897746cdae8e76f148fbbe3fe57f09f3#0bffadc1897746cdae8e76f148fbbe3fe57f09f3"
+dependencies = [
+ "frc42_hasher",
+ "frc42_macros",
+ "fvm_ipld_encoding",
+ "fvm_sdk",
+ "fvm_shared",
+ "thiserror",
+]
+
+[[package]]
+name = "frc42_hasher"
+version = "0.1.0"
+source = "git+https://github.com/helix-onchain/filecoin?rev=0bffadc1897746cdae8e76f148fbbe3fe57f09f3#0bffadc1897746cdae8e76f148fbbe3fe57f09f3"
+dependencies = [
+ "fvm_sdk",
+ "fvm_shared",
+ "thiserror",
+]
+
+[[package]]
+name = "frc42_macros"
+version = "0.1.0"
+source = "git+https://github.com/helix-onchain/filecoin?rev=0bffadc1897746cdae8e76f148fbbe3fe57f09f3#0bffadc1897746cdae8e76f148fbbe3fe57f09f3"
+dependencies = [
+ "blake2b_simd",
+ "frc42_hasher",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "lib"]
 fil_actors_runtime = { version = "9.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-fil_fungible_token = { git = "https://github.com/helix-onchain/filecoin", rev = "b5c55eadf13946155d06d76a3409fc800b9a6e64" }
+fil_fungible_token = { git = "https://github.com/helix-onchain/filecoin", rev = "0bffadc1897746cdae8e76f148fbbe3fe57f09f3" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 fvm_ipld_hamt = "0.5.1"

--- a/actors/datacap/src/types.rs
+++ b/actors/datacap/src/types.rs
@@ -1,15 +1,7 @@
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::{bigint_ser, BigInt};
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct AllowanceParams {
-    pub owner: Address,
-    pub operator: Address,
-}
-
-impl Cbor for AllowanceParams {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct MintParams {
@@ -28,66 +20,3 @@ pub struct DestroyParams {
 }
 
 impl Cbor for DestroyParams {}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct TransferParams {
-    pub to: Address,
-    #[serde(with = "bigint_ser")]
-    pub amount: BigInt,
-    pub data: RawBytes,
-}
-
-impl Cbor for TransferParams {}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct TransferFromParams {
-    pub from: Address,
-    pub to: Address,
-    #[serde(with = "bigint_ser")]
-    pub amount: BigInt,
-    pub data: RawBytes,
-}
-
-impl Cbor for TransferFromParams {}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct IncreaseAllowanceParams {
-    pub operator: Address,
-    #[serde(with = "bigint_ser")]
-    pub amount: BigInt,
-}
-
-impl Cbor for IncreaseAllowanceParams {}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct DecreaseAllowanceParams {
-    pub operator: Address,
-    #[serde(with = "bigint_ser")]
-    pub amount: BigInt,
-}
-
-impl Cbor for DecreaseAllowanceParams {}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct RevokeAllowanceParams {
-    pub operator: Address,
-}
-
-impl Cbor for RevokeAllowanceParams {}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct BurnParams {
-    #[serde(with = "bigint_ser")]
-    pub amount: BigInt,
-}
-
-impl Cbor for BurnParams {}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct BurnFromParams {
-    pub from: Address,
-    #[serde(with = "bigint_ser")]
-    pub amount: BigInt,
-}
-
-impl Cbor for BurnFromParams {}


### PR DESCRIPTION
Updates to latest `main` commit on the token library branch.

The token receiver flow is a little awkward, the library has plans to improve this.

Closes #534. Closes #535.
FYI @alexytsu @abright