### PR TITLE
feat: use Type from builtin-actors when building the bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,16 +325,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_bundler"
-version = "3.0.4"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715d3ad31a6e4715a49747e136d5daa1a6bbe7c078385bca7e11215c57884a35"
+checksum = "0c1e563d609dede95fb0a847ea4ebfe71f5d7074703fc3e92736c74be4b237c2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -584,7 +584,6 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_car",
  "fvm_ipld_encoding",
- "fvm_shared",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
@@ -832,6 +831,8 @@ dependencies = [
  "fil_actor_reward",
  "fil_actor_system",
  "fil_actor_verifreg",
+ "fil_actors_runtime",
+ "num-traits",
 ]
 
 [[package]]
@@ -1444,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.11.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b10983b38c53aebdf33f542c6275b0f58a238129d00c4ae0e6fb59738d783ca"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "os_str_bytes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,13 @@ fil_actor_system = { version = "9.0.0-alpha.1", path = "./actors/system", featur
 fil_actor_init = { version = "9.0.0-alpha.1", path = "./actors/init", features = ["fil-actor"] }
 
 [build-dependencies]
-fil_actor_bundler = "3.0.4"
+fil_actor_bundler = "4.0.0"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+fil_actors_runtime = { version = "9.0.0-alpha.1", path = "runtime" }
+num-traits = "0.2.15"
 
 [dependencies]
-clap = { version = "3.1.8", features = ["derive"] }
+clap = { version = "3.2.3", features = ["derive"] }
 
 [features]
 default = [] ## translates to mainnet

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,6 @@
 use fil_actor_bundler::Bundler;
+use fil_actors_runtime::runtime::builtins::Type;
+use num_traits::cast::FromPrimitive;
 use std::error::Error;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -16,11 +18,11 @@ const ACTORS: &[(&Package, &ID)] = &[
     ("init", "init"),
     ("cron", "cron"),
     ("account", "account"),
-    ("multisig", "multisig"),
     ("power", "storagepower"),
     ("miner", "storageminer"),
     ("market", "storagemarket"),
     ("paych", "paymentchannel"),
+    ("multisig", "multisig"),
     ("reward", "reward"),
     ("verifreg", "verifiedregistry"),
 ];
@@ -158,7 +160,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let dst = Path::new(&out_dir).join("bundle.car");
     let mut bundler = Bundler::new(&dst);
-    for (pkg, id) in ACTORS {
+    for (&(pkg, name), id) in ACTORS.iter().zip(1u32..) {
+        assert_eq!(
+            name,
+            Type::from_u32(id).expect("type not defined").name(),
+            "actor types don't match actors included in the bundle"
+        );
         let bytecode_path = Path::new(&out_dir)
             .join("wasm32-unknown-unknown/wasm")
             .join(format!("fil_actor_{}.wasm", pkg));
@@ -167,10 +174,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         // content-addressed CIDs.
         let forced_cid = None;
 
-        let cid = bundler.add_from_file(id, forced_cid, &bytecode_path).unwrap_or_else(|err| {
-            panic!("failed to add file {:?} to bundle for actor {}: {}", bytecode_path, id, err)
-        });
-        println!("cargo:warning=added actor {} to bundle with CID {}", id, cid);
+        let cid = bundler
+            .add_from_file(id, name.to_owned(), forced_cid, &bytecode_path)
+            .unwrap_or_else(|err| {
+                panic!("failed to add file {:?} to bundle for actor {}: {}", bytecode_path, id, err)
+            });
+        println!("cargo:warning=added {} ({}) to bundle with CID {}", name, id, cid);
     }
     bundler.finish().expect("failed to finish bundle");
 

--- a/runtime/src/runtime/builtins.rs
+++ b/runtime/src/runtime/builtins.rs
@@ -20,3 +20,21 @@ pub enum Type {
     Reward = 10,
     VerifiedRegistry = 11,
 }
+
+impl Type {
+    pub fn name(&self) -> &'static str {
+        match *self {
+            Type::System => "system",
+            Type::Init => "init",
+            Type::Cron => "cron",
+            Type::Account => "account",
+            Type::Power => "storagepower",
+            Type::Miner => "storageminer",
+            Type::Market => "storagemarket",
+            Type::PaymentChannel => "paymentchannel",
+            Type::Multisig => "multisig",
+            Type::Reward => "reward",
+            Type::VerifiedRegistry => "verifiedregistry",
+        }
+    }
+}


### PR DESCRIPTION
This change upgrades to the v4 bundler that _does not_ depend on the FVM to map actor types to IDs. Instead, it relies on the Type enum defined in this repo.

This means new actor types can be added here without having to make changes in multiple places.