### PR TITLE
Unlink "Type" from ref-fvm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,8 +628,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_bundler"
-version = "3.0.4"
-source = "git+https://github.com/filecoin-project/builtin-actors-bundler?branch=next#f2fbadfa810d1544d1a60ebef41ffa4fe08dbf95"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1e563d609dede95fb0a847ea4ebfe71f5d7074703fc3e92736c74be4b237c2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -639,7 +640,6 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_car",
  "fvm_ipld_encoding",
- "fvm_shared",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
@@ -921,6 +921,8 @@ dependencies = [
  "fil_actor_reward",
  "fil_actor_system",
  "fil_actor_verifreg",
+ "fil_actors_runtime",
+ "num-traits",
 ]
 
 [[package]]
@@ -1119,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_car"
-version = "0.5.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af5e410b349533e8b1a2b46a7ca3d66cd68c53a477e2cf3d005845c1a346428"
+checksum = "ade8c2f76a9e014f2fdaeb693a0884f49eca5ee663958e1c8c1db8d23290817c"
 dependencies = [
  "cid",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ name = "fil_builtin_actors_state"
 version = "10.0.0-alpha.1"
 dependencies = [
  "anyhow",
+ "bimap",
  "cid",
  "fil_actor_account",
  "fil_actor_cron",
@@ -2050,6 +2051,7 @@ name = "test_vm"
 version = "10.0.0-alpha.1"
 dependencies = [
  "anyhow",
+ "bimap",
  "blake2b_simd",
  "cid",
  "fil_actor_account",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,13 @@ fil_actor_init = { version = "10.0.0-alpha.1", path = "./actors/init", features 
 fil_actor_evm = { version = "10.0.0-alpha.1", path = "./actors/evm", features = ["fil-actor"] }
 
 [build-dependencies]
-fil_actor_bundler = { git = "https://github.com/filecoin-project/builtin-actors-bundler", branch = "next" }
+fil_actor_bundler = "4.0.0"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+fil_actors_runtime = { version = "10.0.0-alpha.1", path = "runtime" }
+num-traits = "0.2.15"
 
 [dependencies]
-clap = { version = "3.1.8", features = ["derive"] }
+clap = { version = "3.2.3", features = ["derive"] }
 
 [features]
 default = [] ## translates to mainnet

--- a/README.md
+++ b/README.md
@@ -35,18 +35,7 @@ characteristics:
   entry represents a built-in actor.
 - Manifest keys (CID) point to the Wasm bytecode of an actor as a single block.
 - Manifest values (i32) identify the actor type, to be parsed as the
-  `fvm_shared::actor::builtin::Type` enum:
-    - System = 1
-    - Init = 2
-    - Cron = 3
-    - Account = 4
-    - Power = 5
-    - Miner = 6
-    - Market = 7
-    - PaymentChannel = 8
-    - Multisig = 9
-    - Reward = 10
-    - VerifiedRegistry = 11
+  `runtime::builtins::Type` enum.
 
 Precompiled actor bundles are provided as [release binaries][releases] in this repo. The
 [`fil_builtin_actors_bundle`](https://crates.io/crates/fil_builtin_actors_bundle) crate on

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
+use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{actor_error, cbor, ActorDowncast, ActorError, SYSTEM_ACTOR_ADDR};
 use fvm_ipld_blockstore::Blockstore;
@@ -21,8 +22,6 @@ mod types;
 
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
-
-// * Updated to specs-actors commit: 999e57a151cc7ada020ca2844b651499ab8c0dec (v3.0.1)
 
 /// Init actor methods available
 #[derive(FromPrimitive)]

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{actor_error, cbor, ActorDowncast, ActorError, SYSTEM_ACTOR_ADDR};
 use fvm_ipld_blockstore::Blockstore;
@@ -192,7 +191,7 @@ where
     BS: Blockstore,
     RT: Runtime<BS>,
 {
-    use fvm_shared::actor::builtin::Type;
+    use fil_actors_runtime::runtime::builtins::Type;
 
     rt.resolve_builtin_actor_type(exec)
         .map(|typ| match typ {

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -6,7 +6,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{Cbor, RawBytes};
-use fvm_shared::actor::builtin::{Type, CALLER_TYPES_SIGNABLE};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED};
@@ -22,10 +21,12 @@ use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Signed, Zero};
 
 use fil_actors_runtime::cbor::serialize_vec;
+use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Policy, Runtime};
 use fil_actors_runtime::{
-    actor_error, cbor, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR,
-    REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+    actor_error, cbor, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE,
+    CRON_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 
 use crate::ext::verifreg::UseBytesParams;
@@ -35,16 +36,15 @@ use self::policy::*;
 pub use self::state::*;
 pub use self::types::*;
 
+// exports for testing
 pub mod balance_table;
-// export for testing
-mod deal;
 #[doc(hidden)]
 pub mod ext;
-// export for testing
 pub mod policy;
-// export for testing
-mod state;
 pub mod testing;
+
+mod deal;
+mod state;
 mod types;
 
 #[cfg(feature = "fil-actor")]

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -18,8 +18,8 @@ pub use deadlines::*;
 pub use expiration_queue::*;
 use fil_actors_runtime::runtime::{ActorCode, DomainSeparationTag, Policy, Runtime};
 use fil_actors_runtime::{
-    actor_error, cbor, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, INIT_ACTOR_ADDR,
-    REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
+    actor_error, cbor, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE,
+    INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
 };
 use fvm_ipld_bitfield::{BitField, UnvalidatedBitField, Validate};
 use fvm_ipld_blockstore::Blockstore;
@@ -34,7 +34,7 @@ use fvm_shared::econ::TokenAmount;
 // They're not expected to ever happen, but if they do, distinguished codes can help us
 // diagnose the problem.
 use fil_actors_runtime::cbor::{deserialize, serialize, serialize_vec};
-use fvm_shared::actor::builtin::{Type, CALLER_TYPES_SIGNABLE};
+use fil_actors_runtime::runtime::builtins::Type;
 use fvm_shared::error::*;
 use fvm_shared::randomness::*;
 use fvm_shared::reward::ThisEpochRewardReturn;
@@ -3880,7 +3880,7 @@ where
     let is_principal = rt
         .resolve_builtin_actor_type(&owner_code)
         .as_ref()
-        .map(Type::is_principal)
+        .map(|t| CALLER_TYPES_SIGNABLE.contains(t))
         .unwrap_or(false);
 
     if !is_principal {

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -7,11 +7,10 @@ use fil_actors_runtime::cbor::serialize_vec;
 use fil_actors_runtime::runtime::{ActorCode, Primitives, Runtime};
 use fil_actors_runtime::{
     actor_error, cbor, make_empty_map, make_map_with_root, resolve_to_id_addr, ActorDowncast,
-    ActorError, Map, INIT_ACTOR_ADDR,
+    ActorError, Map, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::actor::builtin::CALLER_TYPES_SIGNABLE;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Sign;
 use fvm_shared::econ::TokenAmount;

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -1,11 +1,11 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{actor_error, cbor, resolve_to_id_addr, ActorDowncast, ActorError, Array};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::{BigInt, Sign};
 use fvm_shared::econ::TokenAmount;
@@ -85,7 +85,6 @@ impl Actor {
             .ok_or_else(|| actor_error!(illegal_argument, "no code for address {}", resolved))?;
 
         let typ = rt.resolve_builtin_actor_type(&code_cid);
-
         if typ != Some(Type::Account) {
             Err(actor_error!(
                 forbidden,

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -6,14 +6,14 @@ use std::convert::TryInto;
 
 use anyhow::anyhow;
 use ext::init;
+use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
     actor_error, cbor, make_map_with_root_and_bitwidth, ActorDowncast, ActorError, Multimap,
-    CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    CALLER_TYPES_SIGNABLE, CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::actor::builtin::{Type, CALLER_TYPES_SIGNABLE};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser::{BigIntDe, BigIntSer};
 use fvm_shared::econ::TokenAmount;

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,6 @@
 use fil_actor_bundler::Bundler;
+use fil_actors_runtime::runtime::builtins::Type;
+use num_traits::cast::FromPrimitive;
 use std::error::Error;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -16,11 +18,11 @@ const ACTORS: &[(&Package, &ID)] = &[
     ("init", "init"),
     ("cron", "cron"),
     ("account", "account"),
-    ("multisig", "multisig"),
     ("power", "storagepower"),
     ("miner", "storageminer"),
     ("market", "storagemarket"),
     ("paych", "paymentchannel"),
+    ("multisig", "multisig"),
     ("reward", "reward"),
     ("verifreg", "verifiedregistry"),
     ("evm", "evm"),
@@ -183,7 +185,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let dst = Path::new(&out_dir).join("bundle.car");
     let mut bundler = Bundler::new(&dst);
-    for (pkg, id) in ACTORS {
+    for (&(pkg, name), id) in ACTORS.iter().zip(1u32..) {
+        assert_eq!(
+            name,
+            Type::from_u32(id).expect("type not defined").name(),
+            "actor types don't match actors included in the bundle"
+        );
         let bytecode_path = Path::new(&out_dir)
             .join("wasm32-unknown-unknown/wasm")
             .join(format!("fil_actor_{}.wasm", pkg));
@@ -192,10 +199,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         // content-addressed CIDs.
         let forced_cid = None;
 
-        let cid = bundler.add_from_file(id, forced_cid, &bytecode_path).unwrap_or_else(|err| {
-            panic!("failed to add file {:?} to bundle for actor {}: {}", bytecode_path, id, err)
-        });
-        println!("cargo:warning=added actor {} to bundle with CID {}", id, cid);
+        let cid = bundler
+            .add_from_file(id, name.to_owned(), forced_cid, &bytecode_path)
+            .unwrap_or_else(|err| {
+                panic!("failed to add file {:?} to bundle for actor {}: {}", bytecode_path, id, err)
+            });
+        println!("cargo:warning=added {} ({}) to bundle with CID {}", name, id, cid);
     }
     bundler.finish().expect("failed to finish bundle");
 

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -5,9 +5,15 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::address::Address;
 use fvm_shared::METHOD_SEND;
 
+use crate::runtime::builtins::Type;
 use crate::runtime::Runtime;
 
 pub const HAMT_BIT_WIDTH: u32 = 5;
+
+/// Types of built-in actors that can be treated as principles.
+/// This distinction is legacy and should be removed prior to FVM support for
+/// user-programmable actors.
+pub const CALLER_TYPES_SIGNABLE: &[Type] = &[Type::Account, Type::Multisig];
 
 /// ResolveToIDAddr resolves the given address to it's ID address form.
 /// If an ID address for the given address dosen't exist yet, it tries to create one by sending

--- a/runtime/src/runtime/builtins.rs
+++ b/runtime/src/runtime/builtins.rs
@@ -19,4 +19,24 @@ pub enum Type {
     Multisig = 9,
     Reward = 10,
     VerifiedRegistry = 11,
+    EVM = 12,
+}
+
+impl Type {
+    pub fn name(&self) -> &'static str {
+        match *self {
+            Type::System => "system",
+            Type::Init => "init",
+            Type::Cron => "cron",
+            Type::Account => "account",
+            Type::Power => "storagepower",
+            Type::Miner => "storageminer",
+            Type::Market => "storagemarket",
+            Type::PaymentChannel => "paymentchannel",
+            Type::Multisig => "multisig",
+            Type::Reward => "reward",
+            Type::VerifiedRegistry => "verifiedregistry",
+            Type::EVM => "evm",
+        }
+    }
 }

--- a/runtime/src/runtime/builtins.rs
+++ b/runtime/src/runtime/builtins.rs
@@ -1,0 +1,22 @@
+use num_derive::FromPrimitive;
+
+/// Identifies the builtin actor types for usage with the
+/// actor::resolve_builtin_actor_type syscall.
+/// Note that there is a mirror of this enum in the FVM SDK src/actors/builtins.rs.
+/// These must be kept in sync for the syscall to work correctly, without either side
+/// importing the other.
+#[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord, FromPrimitive, Debug)]
+#[repr(i32)]
+pub enum Type {
+    System = 1,
+    Init = 2,
+    Cron = 3,
+    Account = 4,
+    Power = 5,
+    Miner = 6,
+    Market = 7,
+    PaymentChannel = 8,
+    Multisig = 9,
+    Reward = 10,
+    VerifiedRegistry = 11,
+}

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -5,7 +5,6 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{to_vec, Cbor, CborStore, RawBytes, DAG_CBOR};
 use fvm_sdk as fvm;
 use fvm_sdk::NO_DATA_BLOCK_ID;
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::Signature;
@@ -19,10 +18,12 @@ use fvm_shared::sector::{
 };
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum};
+use num_traits::FromPrimitive;
 #[cfg(feature = "fake-proofs")]
 use sha2::{Digest, Sha256};
 
 use crate::runtime::actor_blockstore::ActorBlockstore;
+use crate::runtime::builtins::Type;
 use crate::runtime::{
     ActorCode, ConsensusFault, DomainSeparationTag, MessageInfo, Policy, Primitives, RuntimePolicy,
     Verifier,
@@ -169,11 +170,12 @@ where
     }
 
     fn resolve_builtin_actor_type(&self, code_id: &Cid) -> Option<Type> {
-        fvm::actor::get_builtin_actor_type(code_id)
+        fvm::actor::get_builtin_actor_type(code_id).and_then(|t| Type::from_i32(t as i32))
     }
 
     fn get_code_cid_for_type(&self, typ: Type) -> Cid {
-        fvm::actor::get_code_cid_for_type(typ)
+        let t = fvm_shared::actor::builtin::Type::from_i32(typ as i32).unwrap();
+        fvm::actor::get_code_cid_for_type(t)
     }
 
     fn get_randomness_from_tickets(

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -4,7 +4,6 @@
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{Cbor, RawBytes};
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
@@ -22,17 +21,17 @@ use fvm_shared::{ActorID, MethodNum};
 pub use self::actor_code::*;
 pub use self::policy::*;
 pub use self::randomness::DomainSeparationTag;
+use crate::runtime::builtins::Type;
 use crate::ActorError;
-
-mod actor_code;
-
-#[cfg(feature = "fil-actor")]
-pub mod fvm;
 
 #[cfg(feature = "fil-actor")]
 mod actor_blockstore;
-
+#[cfg(feature = "fil-actor")]
+pub mod builtins;
+pub mod fvm;
 pub mod policy;
+
+mod actor_code;
 mod randomness;
 
 /// Runtime is the VM's internal runtime object.

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -24,15 +24,15 @@ pub use self::randomness::DomainSeparationTag;
 use crate::runtime::builtins::Type;
 use crate::ActorError;
 
+mod actor_code;
+pub mod builtins;
+pub mod policy;
+mod randomness;
+
 #[cfg(feature = "fil-actor")]
 mod actor_blockstore;
 #[cfg(feature = "fil-actor")]
-pub mod builtins;
 pub mod fvm;
-pub mod policy;
-
-mod actor_code;
-mod randomness;
 
 /// Runtime is the VM's internal runtime object.
 /// this is everything that is accessible to actors, beyond parameters.

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -11,10 +11,8 @@ use cid::Cid;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::de::DeserializeOwned;
 use fvm_ipld_encoding::{Cbor, CborStore, RawBytes};
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::{Address, Protocol};
 use fvm_shared::clock::ChainEpoch;
-
 use fvm_shared::commcid::{FIL_COMMITMENT_SEALED, FIL_COMMITMENT_UNSEALED};
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::signature::Signature;
@@ -34,6 +32,7 @@ use multihash::MultihashDigest;
 
 use rand::prelude::*;
 
+use crate::runtime::builtins::Type;
 use crate::runtime::{
     ActorCode, DomainSeparationTag, MessageInfo, Policy, Primitives, Runtime, RuntimePolicy,
     Verifier,

--- a/runtime/src/util/chaos/mod.rs
+++ b/runtime/src/util/chaos/mod.rs
@@ -4,7 +4,6 @@
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::error::ExitCode;
 use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
@@ -13,6 +12,7 @@ use num_traits::FromPrimitive;
 pub use state::*;
 pub use types::*;
 
+use crate::runtime::builtins::Type;
 use crate::runtime::{ActorCode, Runtime};
 use crate::{actor_error, cbor, ActorError};
 

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -31,6 +31,7 @@ fvm_ipld_encoding = "0.2.2"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"
 anyhow = "1.0.56"
+bimap = { version = "0.6.2" }
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 
 use anyhow::bail;
+use bimap::BiBTreeMap;
 use cid::Cid;
 use fil_actor_account::State as AccountState;
 use fil_actor_cron::State as CronState;
@@ -25,8 +26,6 @@ use fil_actors_runtime::MessageAccumulator;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::from_slice;
 use fvm_ipld_encoding::CborStore;
-use fvm_shared::actor::builtin::Manifest;
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::Address;
 use fvm_shared::address::Protocol;
 use fvm_shared::bigint::BigInt;
@@ -48,6 +47,7 @@ use fil_actor_paych::testing as paych;
 use fil_actor_power::testing as power;
 use fil_actor_reward::testing as reward;
 use fil_actor_verifreg::testing as verifreg;
+use fil_actors_runtime::runtime::builtins::Type;
 
 /// Value type of the top level of the state tree.
 /// Represents the on-chain state of a single actor.
@@ -103,8 +103,12 @@ macro_rules! get_state {
     };
 }
 
+// Note: BiBTreeMap is an overly constrained type for what we are doing here, but chosen
+// to match the Manifest implementation in the FVM.
+// It could be replaced with a custom mapping trait (while Rust doesn't support
+// abstract collection traits).
 pub fn check_state_invariants<'a, BS: Blockstore + Debug>(
-    manifest: &Manifest,
+    manifest: &BiBTreeMap<Cid, Type>,
     policy: &Policy,
     tree: Tree<'a, BS>,
     expected_balance_total: &TokenAmount,

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -41,6 +41,7 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 anyhow = "1.0.56"
+bimap = { version = "0.6.2" }
 blake2b_simd = "1.0"
 integer-encoding = { version = "3.0.3", default-features = false }
 regex = "1"

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use bimap::BiBTreeMap;
 use cid::multihash::Code;
 use cid::Cid;
 use fil_actor_account::{Actor as AccountActor, State as AccountState};
@@ -14,6 +15,7 @@ use fil_actor_reward::{Actor as RewardActor, State as RewardState};
 use fil_actor_system::{Actor as SystemActor, State as SystemState};
 use fil_actor_verifreg::{Actor as VerifregActor, State as VerifRegState};
 use fil_actors_runtime::cbor::serialize;
+use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{
     ActorCode, DomainSeparationTag, MessageInfo, Policy, Primitives, Runtime, RuntimePolicy,
     Verifier,
@@ -31,8 +33,6 @@ use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{Cbor, CborStore, RawBytes};
 use fvm_ipld_hamt::{BytesKey, Hamt, Sha256};
-use fvm_shared::actor::builtin::Manifest;
-use fvm_shared::actor::builtin::Type;
 use fvm_shared::address::{Address, Protocol};
 use fvm_shared::bigint::{bigint_ser, BigInt, Zero};
 use fvm_shared::clock::ChainEpoch;
@@ -448,7 +448,7 @@ impl<'bs> VM<'bs> {
         )
         .unwrap();
 
-        let mut manifest = Manifest::new();
+        let mut manifest = BiBTreeMap::new();
         actors
             .for_each(|_, actor| {
                 manifest.insert(actor.code, ACTOR_TYPES.get(&actor.code).unwrap().to_owned());


### PR DESCRIPTION
This ports two changes from master to avoid depending on ref-fvm's Type definition.