### PR TITLE
feat: exclude testing modules from actor builds

### DIFF
--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -16,6 +16,8 @@ use fil_actors_runtime::{actor_error, ActorError};
 pub use self::state::State;
 
 mod state;
+
+#[cfg(not(feature = "fil-actor"))]
 pub mod testing;
 
 #[cfg(feature = "fil-actor")]

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -15,6 +15,8 @@ use num_traits::FromPrimitive;
 pub use self::state::{Entry, State};
 
 mod state;
+
+#[cfg(not(feature = "fil-actor"))]
 pub mod testing;
 
 #[cfg(feature = "fil-actor")]

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -17,8 +17,10 @@ pub use self::state::State;
 pub use self::types::*;
 
 mod state;
-pub mod testing;
 mod types;
+
+#[cfg(not(feature = "fil-actor"))]
+pub mod testing;
 
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -43,6 +43,8 @@ pub mod balance_table;
 #[doc(hidden)]
 pub mod ext;
 pub mod policy;
+
+#[cfg(not(feature = "fil-actor"))]
 pub mod testing;
 
 mod deal;

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -79,9 +79,11 @@ mod sector_map;
 mod sectors;
 mod state;
 mod termination;
-pub mod testing;
 mod types;
 mod vesting_state;
+
+#[cfg(not(feature = "fil-actor"))]
+pub mod testing;
 
 // The first 1000 actor-specific codes are left open for user error, i.e. things that might
 // actually happen without programming error in the actor code.

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -25,8 +25,10 @@ pub use self::types::*;
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
 
-mod state;
+#[cfg(not(feature = "fil-actor"))]
 pub mod testing;
+
+mod state;
 mod types;
 
 // * Updated to specs-actors commit: 845089a6d2580e46055c24415a6c32ee688e5186 (v3.0.0)

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -22,8 +22,10 @@ pub use self::types::*;
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
 
-mod state;
+#[cfg(not(feature = "fil-actor"))]
 pub mod testing;
+
+mod state;
 mod types;
 
 // * Updated to specs-actors commit: f47f461b0588e9f0c20c999f6f129c85d669a7aa (v3.0.2)

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -32,11 +32,13 @@ pub use self::types::*;
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
 
+#[cfg(not(feature = "fil-actor"))]
+pub mod testing;
+
 #[doc(hidden)]
 pub mod ext;
 mod policy;
 mod state;
-pub mod testing;
 mod types;
 
 // * Updated to specs-actors commit: 999e57a151cc7ada020ca2844b651499ab8c0dec (v3.0.1)

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -25,10 +25,12 @@ pub use self::types::*;
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
 
+#[cfg(not(feature = "fil-actor"))]
+pub mod testing;
+
 pub(crate) mod expneg;
 mod logic;
 mod state;
-pub mod testing;
 mod types;
 
 // only exported for tests

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -22,8 +22,10 @@ pub use self::types::*;
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
 
-mod state;
+#[cfg(not(feature = "fil-actor"))]
 pub mod testing;
+
+mod state;
 mod types;
 
 // * Updated to specs-actors commit: 845089a6d2580e46055c24415a6c32ee688e5186 (v3.0.0)


### PR DESCRIPTION
This way, we can add-in additional dependencies without bloating the actors.

I need this so we can pull in blake2b for invariant checks, while using the blake2b syscall in the actors themselves.