### PR TITLE
chore: update sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977dc7824079d057d149ea9b42ac50072928f5f37f941e07860eb2432f62fa1f"
+checksum = "19f90eee234e07d5879e174167700a14bfcf2b87965fdacf94e98871a37126db"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0.30"
 getrandom = { version = "0.2.5", features = ["js"] }
 hex = { version = "0.4.3", optional = true }
 anyhow = "1.0.56"
-fvm_sdk = { version = "3.0.0-alpha.1", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.2", optional = true }
 blake2b_simd = "1.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -430,7 +430,7 @@ where
     }
 
     fn hash(&self, hasher: fvm_shared::crypto::hash::SupportedHashes, data: &[u8]) -> Vec<u8> {
-        fvm::crypto::hash(hasher, data)
+        fvm::crypto::hash_owned(hasher, data)
     }
 
     fn recover_secp_public_key(


### PR DESCRIPTION
We renamed hash to hash_owned to allow for a hash_into method.