### PR TITLE
test runtime: use Rc<MemoryBlockstore>.

### DIFF
--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -680,7 +680,7 @@ pub fn assert_deal_deleted(rt: &mut MockRuntime, deal_id: DealID, p: DealProposa
     let pending_deals: Hamt<&fvm_ipld_blockstore::MemoryBlockstore, DealProposal> =
         fil_actors_runtime::make_map_with_root_and_bitwidth(
             &st.pending_proposals,
-            &rt.store,
+            &*rt.store,
             PROPOSALS_AMT_BITWIDTH,
         )
         .unwrap();

--- a/actors/miner/tests/expiration_queue.rs
+++ b/actors/miner/tests/expiration_queue.rs
@@ -716,7 +716,7 @@ fn empty_expiration_queue_with_quantizing(
     let empty_array =
         Amt::<(), _>::new_with_bit_width(&rt.store, TEST_AMT_BITWIDTH).flush().unwrap();
 
-    ExpirationQueue::new(&rt.store, &empty_array, quant).unwrap()
+    ExpirationQueue::new(&*rt.store, &empty_array, quant).unwrap()
 }
 
 fn empty_expiration_queue(rt: &MockRuntime) -> ExpirationQueue<MemoryBlockstore> {

--- a/actors/miner/tests/miner_actor_test_bitfield_queue.rs
+++ b/actors/miner/tests/miner_actor_test_bitfield_queue.rs
@@ -229,7 +229,7 @@ fn empty_bitfield_queue_with_quantizing(
 ) -> BitFieldQueue<MemoryBlockstore> {
     let cid = Amt::<(), _>::new_with_bit_width(&rt.store, bitwidth).flush().unwrap();
 
-    BitFieldQueue::new(&rt.store, &cid, quant).unwrap()
+    BitFieldQueue::new(&*rt.store, &cid, quant).unwrap()
 }
 
 fn empty_bitfield_queue(rt: &MockRuntime, bitwidth: u32) -> BitFieldQueue<MemoryBlockstore> {

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -217,7 +217,7 @@ impl Harness {
 
 fn load_verifiers(rt: &MockRuntime) -> Map<MemoryBlockstore, BigIntDe> {
     let state: State = rt.get_state();
-    make_map_with_root_and_bitwidth::<_, BigIntDe>(&state.verifiers, &rt.store, HAMT_BIT_WIDTH)
+    make_map_with_root_and_bitwidth::<_, BigIntDe>(&state.verifiers, &*rt.store, HAMT_BIT_WIDTH)
         .unwrap()
 }
 
@@ -225,7 +225,7 @@ fn load_clients(rt: &MockRuntime) -> Map<MemoryBlockstore, BigIntDe> {
     let state: State = rt.get_state();
     make_map_with_root_and_bitwidth::<_, BigIntDe>(
         &state.verified_clients,
-        &rt.store,
+        &*rt.store,
         HAMT_BIT_WIDTH,
     )
     .unwrap()

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -4,6 +4,7 @@
 use core::fmt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::rc::Rc;
 
 use anyhow::anyhow;
 use cid::multihash::{Code, Multihash as OtherMultihash};
@@ -122,7 +123,7 @@ pub struct MockRuntime {
 
     // VM Impl
     pub in_call: bool,
-    pub store: MemoryBlockstore,
+    pub store: Rc<MemoryBlockstore>,
     pub in_transaction: bool,
 
     // Expectations
@@ -665,7 +666,7 @@ impl MessageInfo for MockRuntime {
     }
 }
 
-impl Runtime<MemoryBlockstore> for MockRuntime {
+impl Runtime<Rc<MemoryBlockstore>> for MockRuntime {
     fn network_version(&self) -> NetworkVersion {
         self.network_version
     }
@@ -884,7 +885,7 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
         ret
     }
 
-    fn store(&self) -> &MemoryBlockstore {
+    fn store(&self) -> &Rc<MemoryBlockstore> {
         &self.store
     }
 


### PR DESCRIPTION
With the real FvmRuntime, we expect that cloning the &Blockstore returned by Runtime#store() would simply clone the reference.

This is because inside the FVM, blockstore calls proxy out to FVM syscalls; the proxy itself holds no state, and cloning it is
unimportant.

However, in the MockRuntime, we were using a owned MemoryBlockstore. Cloning it would return a new physical copy, thus breaking the expectation.

This commit makes MockRuntime use an Rc<MemoryBlockstore>, so all clones will point to the same MemoryBlockstore, thus preserving the expectation.