### PR TITLE
WithdrawBalance fails when beneficiary is expired or out of quota

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3300,6 +3300,12 @@ impl Actor {
                 if info.beneficiary != info.owner {
                     // remaining_quota always zero and positive
                     let remaining_quota = info.beneficiary_term.available(rt.curr_epoch());
+                    if remaining_quota.is_zero() {
+                        return Err(actor_error!(
+                            illegal_state,
+                            "beneficiary expired or quota depleted. change or update beneficiary to withdraw funds"
+                        ));
+                    }
                     amount_withdrawn = std::cmp::min(amount_withdrawn, &remaining_quota);
                     if amount_withdrawn.is_positive() {
                         info.beneficiary_term.used_quota += amount_withdrawn;

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3302,8 +3302,11 @@ impl Actor {
                     let remaining_quota = info.beneficiary_term.available(rt.curr_epoch());
                     if remaining_quota.is_zero() {
                         return Err(actor_error!(
-                            illegal_state,
-                            "beneficiary expired or quota depleted. change or update beneficiary to withdraw funds"
+                            forbidden,
+                            "beneficiary expiration of epoch {} passed or quota of {} depleted with {} used",
+                            info.beneficiary_term.expiration,
+                            info.beneficiary_term.quota,
+                            info.beneficiary_term.used_quota
                         ));
                     }
                     amount_withdrawn = std::cmp::min(amount_withdrawn, &remaining_quota);

--- a/actors/miner/tests/change_beneficiary_test.rs
+++ b/actors/miner/tests/change_beneficiary_test.rs
@@ -281,7 +281,7 @@ fn successfully_change_quota_and_test_withdraw() {
         &TokenAmount::zero(),
         &TokenAmount::zero(),
     )
-    .unwrap();
+    .expect_err("expected error, but call succeeded");
 
     let increase_quota = TokenAmount::from_atto(120);
     let increase_beneficiary_change =

--- a/actors/miner/tests/change_beneficiary_test.rs
+++ b/actors/miner/tests/change_beneficiary_test.rs
@@ -1,5 +1,5 @@
 use fil_actor_miner::BeneficiaryTerm;
-use fil_actors_runtime::test_utils::{expect_abort, MockRuntime};
+use fil_actors_runtime::test_utils::{expect_abort, expect_abort_contains_message, MockRuntime};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode};
 use num_traits::Zero;
@@ -274,14 +274,14 @@ fn successfully_change_quota_and_test_withdraw() {
 
     //withdraw 0 zero
     let withdraw_left = TokenAmount::from_atto(20);
-    h.withdraw_funds(
+    let ret = h.withdraw_funds(
         &mut rt,
         h.beneficiary,
         &withdraw_left,
         &TokenAmount::zero(),
         &TokenAmount::zero(),
-    )
-    .expect_err("expected error, but call succeeded");
+    );
+    expect_abort_contains_message(ExitCode::USR_FORBIDDEN, "beneficiary expiration of epoch", ret);
 
     let increase_quota = TokenAmount::from_atto(120);
     let increase_beneficiary_change =

--- a/actors/miner/tests/withdraw_balance.rs
+++ b/actors/miner/tests/withdraw_balance.rs
@@ -160,7 +160,7 @@ fn allow_withdraw_but_no_send_when_beneficiary_not_efficient() {
     assert_eq!(PERIOD_OFFSET - 10, info.beneficiary_term.expiration);
     rt.set_epoch(100);
     h.withdraw_funds(&mut rt, h.beneficiary, quota, &TokenAmount::zero(), &TokenAmount::zero())
-        .unwrap();
+        .expect_err("expected error, but call succeeded");
     h.check_state(&rt);
 }
 

--- a/actors/miner/tests/withdraw_balance.rs
+++ b/actors/miner/tests/withdraw_balance.rs
@@ -142,7 +142,7 @@ fn successfully_withdraw_limited_to_quota() {
 }
 
 #[test]
-fn allow_withdraw_but_no_send_when_beneficiary_not_efficient() {
+fn withdraw_fail_when_beneficiary_expired() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
     let mut rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
@@ -159,8 +159,9 @@ fn allow_withdraw_but_no_send_when_beneficiary_not_efficient() {
     let info = h.get_info(&rt);
     assert_eq!(PERIOD_OFFSET - 10, info.beneficiary_term.expiration);
     rt.set_epoch(100);
-    h.withdraw_funds(&mut rt, h.beneficiary, quota, &TokenAmount::zero(), &TokenAmount::zero())
-        .expect_err("expected error, but call succeeded");
+    let ret =
+        h.withdraw_funds(&mut rt, h.beneficiary, quota, &TokenAmount::zero(), &TokenAmount::zero());
+    expect_abort_contains_message(ExitCode::USR_FORBIDDEN, "beneficiary expiration of epoch", ret);
     h.check_state(&rt);
 }
 


### PR DESCRIPTION
Related PR opened in FIPs repo [here](https://github.com/filecoin-project/FIPs/pull/454) 