### PR TITLE
fix: remove dependency on getrandom.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,4 @@ jobs:
     - name: Checking no wasm-bindgen references
       run: |
         sudo apt-get update && sudo apt-get -y install wabt parallel
-        find ./target -name '*.wasm' -print0 | parallel -0 --halt now,fail=1 'wasm2wat --enable-bulk-memory {} | ! grep bindgen'
+        find ./target -name '*.wasm' -print0 | parallel -0 --halt now,fail=1 sh -c 'wasm2wat --enable-bulk-memory {} | grep bindgen; test $? -ne 0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,7 @@ jobs:
         BUILD_FIL_NETWORK: ${{ matrix.network }}
       run: |
         cargo run -- -o output/builtin-actors.car
+    - name: Checking no wasm-bindgen references
+      run: |
+        sudo apt-get update && sudo apt-get -y install wabt parallel
+        find ./target -name '*.wasm' -print0 | parallel -0 --halt now,fail=1 'wasm2wat --enable-bulk-memory {} | ! grep bindgen'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,18 +15,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
+checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
 
 [[package]]
 name = "arrayref"
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab006897723d9352f63e2b13047177c3982d8d79709d713ce7747a8f19fd1b0"
+checksum = "83e21f3a490c72b3b0cf44962180e60045de2925d8dff97918f7ee43c8f637c7"
 dependencies = [
  "autocfg",
  "concurrent-queue",
@@ -239,18 +239,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
@@ -333,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.19"
+version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d43934757334b5c0519ff882e1ab9647ac0258b47c24c4f490d78e42697fd5"
+checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
  "bitflags",
@@ -402,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -584,7 +575,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer",
  "crypto-common",
 ]
 
@@ -881,7 +872,6 @@ dependencies = [
  "fvm_ipld_hamt",
  "fvm_sdk",
  "fvm_shared",
- "getrandom",
  "hex",
  "indexmap",
  "integer-encoding",
@@ -896,7 +886,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_repr",
- "sha2 0.10.3",
+ "sha2",
  "thiserror",
  "unsigned-varint",
 ]
@@ -1171,7 +1161,7 @@ dependencies = [
  "multihash",
  "once_cell",
  "serde",
- "sha2 0.10.3",
+ "sha2",
  "thiserror",
 ]
 
@@ -1236,10 +1226,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1286,27 +1274,6 @@ name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
-
-[[package]]
-name = "hmac"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array",
- "hmac",
-]
 
 [[package]]
 name = "ident_case"
@@ -1431,14 +1398,11 @@ dependencies = [
  "arrayref",
  "base64",
  "digest 0.9.0",
- "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand",
  "serde",
- "sha2 0.9.9",
- "typenum",
 ]
 
 [[package]]
@@ -1512,7 +1476,7 @@ dependencies = [
  "ripemd",
  "serde",
  "serde-big-array",
- "sha2 0.10.3",
+ "sha2",
  "sha3",
  "unsigned-varint",
 ]
@@ -1630,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "opaque-debug"
@@ -1937,22 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899bf02746a2c92bf1053d9327dadb252b01af1f81f90cdb902411f518bc7215"
+checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1961,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
+checksum = "eaedf34ed289ea47c2b741bb72e5357a209512d67bcd4bda44359e5bf0470f56"
 dependencies = [
  "digest 0.10.3",
  "keccak",
@@ -2125,18 +2076,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0a539a918745651435ac7db7a18761589a94cd7e94cd56999f828bf73c8a57"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -39,7 +39,7 @@ impl-serde = { version = "0.3.2", default-features = false }
 arrayvec = { version = "0.7.2", features = ["serde"] }
 hex = "0.4.3"
 substrate-bn = { version = "0.6.0", default-features = false }
-near-blake2 = {version = "0.9.1", git = "https://github.com/filecoin-project/near-blake2.git"}
+near-blake2 = { version = "0.9.1", git = "https://github.com/filecoin-project/near-blake2.git" }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -38,12 +38,12 @@ fixed-hash = { version = "0.7.0", default-features = false }
 impl-serde = { version = "0.3.2", default-features = false }
 arrayvec = { version = "0.7.2", features = ["serde"] }
 hex = "0.4.3"
-substrate-bn = "0.6.0"
+substrate-bn = { version = "0.6.0", default-features = false }
 near-blake2 = {version = "0.9.1", git = "https://github.com/filecoin-project/near-blake2.git"}
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
-libsecp256k1 = { version = "0.7.0", features = ["static-context"] }
+libsecp256k1 = { version = "0.7.0", features = ["static-context"], default-features = false }
 hex-literal = "0.3.4"
 
 [features]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -23,8 +23,6 @@ base64 = "0.13.0"
 log = "0.4.14"
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 thiserror = "1.0.30"
-# enforce wasm compat
-getrandom = { version = "0.2.5", features = ["js"] }
 hex = { version = "0.4.3", optional = true }
 anyhow = "1.0.56"
 fvm_sdk = { version = "3.0.0-alpha.2", optional = true }
@@ -32,11 +30,12 @@ blake2b_simd = "1.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 multihash = { version = "0.16.1", default-features = false }
-rand = "0.8.5"
+rand = { version = "0.8.5", default-features = false }
 serde_repr = "0.1.8"
 regex = "1"
 itertools = "0.10"
-libsecp256k1 = { version = "0.7.1"}
+libsecp256k1 = { version = "0.7.1", default-features = false }
+
 
 [dependencies.sha2]
 version = "0.10"
@@ -44,6 +43,7 @@ version = "0.10"
 [dev-dependencies]
 derive_builder = "0.10.2"
 hex = "0.4.3"
+rand = { version = "0.8.5" }
 
 [features]
 default = []


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/ref-fvm/issues/840.

We were depending on getrandom as a result of not disabling default features in the brand new runtime dependencies libsecp256k1, substrate-bn. `rand` with default features also drags in `getrandom`, but I'm not sure why this wasn't failing already because `rand` also pulls in `getrandom` through default features 🤷  Maybe tree shaking? 

Also adds a CI check to verify that Wasm bytecode has no references to bindgen, so this shouldn't happen again.