### PR TITLE
Make test verify if selfdestruct actually works

### DIFF
--- a/actors/evm/tests/selfdestruct.rs
+++ b/actors/evm/tests/selfdestruct.rs
@@ -39,4 +39,5 @@ fn test_selfdestruct() {
         &RawBytes::serialize(params).unwrap(),
     )
     .unwrap();
+    rt.verify();
 }


### PR DESCRIPTION
Before this change, even if we commented out [the selfdestruct execution logic](https://github.com/filecoin-project/builtin-actors/blob/next/actors/evm/src/interpreter/execution.rs#L849) the test was still passing.