### PR TITLE
basic contract assembler for testing EVM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,10 +580,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "etk-asm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f930978593dfe8eb61901b68b083f5b08898f45ed7387ca627ede2f036b426a"
+dependencies = [
+ "hex",
+ "num-bigint",
+ "pest",
+ "pest_derive",
+ "rand",
+ "sha3",
+ "snafu",
+]
 
 [[package]]
 name = "event-listener"
@@ -655,6 +676,7 @@ dependencies = [
  "bytes",
  "cid",
  "derive_more",
+ "etk-asm",
  "fil_actors_runtime",
  "fixed-hash",
  "fvm_ipld_blockstore",
@@ -1617,6 +1639,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
+name = "pest"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "905708f7f674518498c1f8d644481440f476d39ca6ecae83319bba7c6c12da91"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5803d8284a629cc999094ecd630f55e91b561a1d1ba75e233b00ae13b91a69ad"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1538eb784f07615c6d9a8ab061089c6c54a344c5b4301db51990ca1c241e8c04"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha-1",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +1966,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,6 +2004,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "snafu"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2108,6 +2207,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "uint"

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -45,6 +45,7 @@ near-blake2 = { version = "0.9.1", git = "https://github.com/filecoin-project/ne
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
 libsecp256k1 = { version = "0.7.0", features = ["static-context"], default-features = false }
 hex-literal = "0.3.4"
+etk-asm = "^0.2.1"
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/evm/tests/asm.rs
+++ b/actors/evm/tests/asm.rs
@@ -1,6 +1,6 @@
 use etk_asm::ingest::Ingest;
-use fil_actor_evm as evm;
 use evm::interpreter::opcode::OpCode::*;
+use fil_actor_evm as evm;
 
 #[allow(dead_code)]
 pub fn new_contract(name: &str, init: &str, body: &str) -> Result<Vec<u8>, etk_asm::ingest::Error> {

--- a/actors/evm/tests/asm.rs
+++ b/actors/evm/tests/asm.rs
@@ -1,0 +1,55 @@
+use etk_asm::ingest::Ingest;
+use fil_actor_evm as evm;
+use evm::interpreter::opcode::OpCode::*;
+
+#[allow(dead_code)]
+pub fn new_contract(name: &str, init: &str, body: &str) -> Result<Vec<u8>, etk_asm::ingest::Error> {
+    // the contract code
+    let mut body_code = Vec::new();
+    let mut ingest_body = Ingest::new(&mut body_code);
+    ingest_body.ingest(name, &body)?;
+    // the initialization code
+    let mut init_code = Vec::new();
+    let mut ingest_init = Ingest::new(&mut init_code);
+    ingest_init.ingest(name, &init)?;
+    // synthesize contract constructor
+    let body_code_len = body_code.len();
+    let body_code_offset = init_code.len()
+        + 1 // PUSH4
+        + 4 // 4-bytes for code length
+        + 1 // DUP1
+        + 1 // PUSH4
+        + 4 // 4 bytes for the code offset itself
+        + 1 // PUSH1
+        + 1 // 0x00 -- destination memory offset
+        + 1 // CODECOPY
+        + 1 // PUSH1
+        + 1 // 0x00 -- source memory offset
+        + 1 // RETURN
+        ;
+    let mut constructor_code = Vec::<u8>::from([
+        PUSH4 as u8,
+        ((body_code_len >> 24) & 0xff) as u8,
+        ((body_code_len >> 16) & 0xff) as u8,
+        ((body_code_len >> 8) & 0xff) as u8,
+        (body_code_len & 0xff) as u8,
+        DUP1 as u8,
+        PUSH4 as u8,
+        ((body_code_offset >> 24) & 0xff) as u8,
+        ((body_code_offset >> 16) & 0xff) as u8,
+        ((body_code_offset >> 8) & 0xff) as u8,
+        (body_code_offset & 0xff) as u8,
+        PUSH1 as u8,
+        0x00,
+        CODECOPY as u8,
+        PUSH1 as u8,
+        0x00,
+        RETURN as u8,
+    ]);
+    // the actual contract code
+    let mut contract_code = Vec::new();
+    contract_code.append(&mut init_code);
+    contract_code.append(&mut constructor_code);
+    contract_code.append(&mut body_code);
+    Ok(contract_code)
+}

--- a/actors/evm/tests/asm.rs
+++ b/actors/evm/tests/asm.rs
@@ -7,11 +7,11 @@ pub fn new_contract(name: &str, init: &str, body: &str) -> Result<Vec<u8>, etk_a
     // the contract code
     let mut body_code = Vec::new();
     let mut ingest_body = Ingest::new(&mut body_code);
-    ingest_body.ingest(name, &body)?;
+    ingest_body.ingest(name, body)?;
     // the initialization code
     let mut init_code = Vec::new();
     let mut ingest_init = Ingest::new(&mut init_code);
-    ingest_init.ingest(name, &init)?;
+    ingest_init.ingest(name, init)?;
     // synthesize contract constructor
     let body_code_len = body_code.len();
     let body_code_offset = init_code.len()

--- a/actors/evm/tests/asm.rs
+++ b/actors/evm/tests/asm.rs
@@ -3,6 +3,11 @@ use evm::interpreter::opcode::OpCode::*;
 use fil_actor_evm as evm;
 
 #[allow(dead_code)]
+/// Creates a new EVM contract constructon bytecode (initcode), suitable for initializing the EVM actor.
+/// Arguments:
+/// - name is the name of the contract, for debug purposes.
+/// - init is the initializer code, which will run first at contract construction.
+/// - body is the actual contract code.
 pub fn new_contract(name: &str, init: &str, body: &str) -> Result<Vec<u8>, etk_asm::ingest::Error> {
     // the contract code
     let mut body_code = Vec::new();

--- a/actors/evm/tests/calc.rs
+++ b/actors/evm/tests/calc.rs
@@ -87,7 +87,7 @@ return
 
 "#;
 
-    asm::new_contract(&"magic-calc", &init, &body).unwrap()
+    asm::new_contract("magic-calc", init, body).unwrap()
 }
 
 #[test]

--- a/actors/evm/tests/calc.rs
+++ b/actors/evm/tests/calc.rs
@@ -1,0 +1,165 @@
+mod asm;
+
+use fil_actor_evm as evm;
+use evm::interpreter::U256;
+use fil_actors_runtime::test_utils::*;
+use fvm_ipld_encoding::RawBytes;
+
+#[allow(dead_code)]
+pub fn magic_calc_contract() -> Result<Vec<u8>, etk_asm::ingest::Error>{
+    let init = r#"
+push1 0x42  # magic value
+push1 0x00  # key of magic value
+sstore
+"#;
+    let body = r#"
+# method dispatch:
+# - 0x00000000 -> magic value
+# - 0x00000001 -> ADD arg, magic value
+# - 0x00000002 -> MUL arg, magic value
+
+push1 0x00
+calldataload
+push1 0xe0   # 28 byte shift == 224 bits
+shr
+
+# 0x00 -> jmp get_magic
+dup1
+iszero
+%push(get_magic)
+jumpi
+
+# 0x01 -> jmp add_magic
+dup1
+push1 0x01
+eq
+%push(add_magic)
+jumpi
+
+# 0x02 -> jmp mul_magic
+dup1
+push1 0x02
+eq
+%push(mul_magic)
+jumpi
+
+# unknown method, barf returning nothing
+push1 0x00
+dup1
+revert
+
+#### method implementation
+get_magic:
+jumpdest
+push1 0x20 # length of return data
+push1 0x00 # key of magic
+sload
+push1 0x00 # return memory offset
+mstore
+push1 0x00
+return
+
+add_magic:
+jumpdest
+push1 0x20   # length of return data
+push1 0x04
+calldataload # arg1
+push1 0x00   # key of magic
+sload
+add
+push1 0x00   # return memory offset
+mstore
+push1 0x00
+return
+
+mul_magic:
+jumpdest
+push1 0x20   # length of return dataa
+push1 0x04
+calldataload # arg1
+push1 0x00   # key of magic
+sload
+mul
+push1 0x00   # return memory offset
+mstore
+push1 0x00
+return
+
+"#;
+
+    asm::new_contract(
+        &"magic-calc",
+        &init,
+        &body,
+    )
+}
+
+#[test]
+fn test_magic_calc() {
+    let contract = magic_calc_contract().unwrap();
+
+    let mut rt = MockRuntime::default();
+
+    // invoke constructor
+    rt.expect_validate_caller_any();
+
+    let params = evm::ConstructorParams {
+        bytecode: contract.into(),
+        input_data: RawBytes::default(),
+    };
+
+    let result = rt
+        .call::<evm::EvmContractActor>(
+            evm::Method::Constructor as u64,
+            &RawBytes::serialize(params).unwrap(),
+        )
+        .unwrap();
+    expect_empty(result);
+    rt.verify();
+
+    // invoke contract -- get_magic
+    let contract_params = vec![0u8; 32];
+    let params = evm::InvokeParams { input_data: RawBytes::from(contract_params) };
+
+    rt.expect_validate_caller_any();
+    let result = rt
+        .call::<evm::EvmContractActor>(
+            evm::Method::InvokeContract as u64,
+            &RawBytes::serialize(params).unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(U256::from_big_endian(&result), U256::from(0x42));
+
+    // invoke contract -- add_magic
+    let mut contract_params = vec![0u8; 36];
+    contract_params[3] = 0x01;
+    contract_params[35] = 0x01;
+    let params = evm::InvokeParams { input_data: RawBytes::from(contract_params) };
+
+    rt.expect_validate_caller_any();
+    let result = rt
+        .call::<evm::EvmContractActor>(
+            evm::Method::InvokeContract as u64,
+            &RawBytes::serialize(params).unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(U256::from_big_endian(&result), U256::from(0x43));
+
+    // invoke contract -- mul_magic
+    let mut contract_params = vec![0u8; 36];
+    contract_params[3] = 0x02;
+    contract_params[35] = 0x02;
+    let params = evm::InvokeParams { input_data: RawBytes::from(contract_params) };
+
+    rt.expect_validate_caller_any();
+    let result = rt
+        .call::<evm::EvmContractActor>(
+            evm::Method::InvokeContract as u64,
+            &RawBytes::serialize(params).unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(U256::from_big_endian(&result), U256::from(0x84));
+}

--- a/actors/evm/tests/calc.rs
+++ b/actors/evm/tests/calc.rs
@@ -1,12 +1,12 @@
 mod asm;
 
-use fil_actor_evm as evm;
 use evm::interpreter::U256;
+use fil_actor_evm as evm;
 use fil_actors_runtime::test_utils::*;
 use fvm_ipld_encoding::RawBytes;
 
 #[allow(dead_code)]
-pub fn magic_calc_contract() -> Result<Vec<u8>, etk_asm::ingest::Error>{
+pub fn magic_calc_contract() -> Result<Vec<u8>, etk_asm::ingest::Error> {
     let init = r#"
 push1 0x42  # magic value
 push1 0x00  # key of magic value
@@ -87,11 +87,7 @@ return
 
 "#;
 
-    asm::new_contract(
-        &"magic-calc",
-        &init,
-        &body,
-    )
+    asm::new_contract(&"magic-calc", &init, &body)
 }
 
 #[test]
@@ -103,10 +99,8 @@ fn test_magic_calc() {
     // invoke constructor
     rt.expect_validate_caller_any();
 
-    let params = evm::ConstructorParams {
-        bytecode: contract.into(),
-        input_data: RawBytes::default(),
-    };
+    let params =
+        evm::ConstructorParams { bytecode: contract.into(), input_data: RawBytes::default() };
 
     let result = rt
         .call::<evm::EvmContractActor>(

--- a/actors/evm/tests/calc.rs
+++ b/actors/evm/tests/calc.rs
@@ -6,7 +6,7 @@ use fil_actors_runtime::test_utils::*;
 use fvm_ipld_encoding::RawBytes;
 
 #[allow(dead_code)]
-pub fn magic_calc_contract() -> Result<Vec<u8>, etk_asm::ingest::Error> {
+pub fn magic_calc_contract() -> Vec<u8> {
     let init = r#"
 push1 0x42  # magic value
 push1 0x00  # key of magic value
@@ -87,12 +87,12 @@ return
 
 "#;
 
-    asm::new_contract(&"magic-calc", &init, &body)
+    asm::new_contract(&"magic-calc", &init, &body).unwrap()
 }
 
 #[test]
 fn test_magic_calc() {
-    let contract = magic_calc_contract().unwrap();
+    let contract = magic_calc_contract();
 
     let mut rt = MockRuntime::default();
 


### PR DESCRIPTION
This integrates the etk assmbler, so that we can write EVM contracts in assembly for test purposes.
Also includes a magic calc test contract to make sure the whole contraption works.

See also https://github.com/filecoin-project/ref-fvm/issues/831