### PR TITLE
Automatically approve built-in market as operator for all minted datacap

### DIFF
--- a/actors/datacap/src/types.rs
+++ b/actors/datacap/src/types.rs
@@ -9,7 +9,7 @@ pub struct MintParams {
     pub to: Address,
     // Amount of tokens to mint.
     pub amount: TokenAmount,
-    // Addresses to be granted operator allowance for the newly minted tokens.
+    // Addresses to be granted effectively-infinite operator allowance for the recipient.
     pub operators: Vec<Address>,
 }
 

--- a/actors/datacap/src/types.rs
+++ b/actors/datacap/src/types.rs
@@ -5,8 +5,12 @@ use fvm_shared::econ::TokenAmount;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct MintParams {
+    // Recipient of the newly minted tokens.
     pub to: Address,
+    // Amount of tokens to mint.
     pub amount: TokenAmount,
+    // Addresses to be granted operator allowance for the newly minted tokens.
+    pub operators: Vec<Address>,
 }
 
 impl Cbor for MintParams {}

--- a/actors/datacap/tests/datacap_actor_test.rs
+++ b/actors/datacap/tests/datacap_actor_test.rs
@@ -87,16 +87,19 @@ mod mint {
         let (mut rt, h) = make_harness();
 
         let amt = TokenAmount::from_whole(1);
+        let allowance = TokenAmount::from_whole(2_000_000_000);
         h.mint(&mut rt, &*ALICE, &amt, vec![*BOB]).unwrap();
-        assert_eq!(amt, h.get_allowance(&rt, &*ALICE, &BOB));
+        assert_eq!(allowance, h.get_allowance(&rt, &*ALICE, &BOB));
 
         h.mint(&mut rt, &*ALICE, &amt, vec![*BOB]).unwrap();
-        assert_eq!(&amt * 2, h.get_allowance(&rt, &*ALICE, &BOB));
+        // Note: the doubling of allowance here is unfortunate, should be resolved when
+        // the token library offers a set_allowance method.
+        assert_eq!(&allowance * 2, h.get_allowance(&rt, &*ALICE, &BOB));
 
         // Different operator
         h.mint(&mut rt, &*ALICE, &amt, vec![*CARLA]).unwrap();
-        assert_eq!(&amt * 2, h.get_allowance(&rt, &*ALICE, &BOB));
-        assert_eq!(amt, h.get_allowance(&rt, &*ALICE, &CARLA));
+        assert_eq!(&allowance * 2, h.get_allowance(&rt, &*ALICE, &BOB));
+        assert_eq!(allowance, h.get_allowance(&rt, &*ALICE, &CARLA));
 
         h.check_state(&rt);
     }

--- a/actors/datacap/tests/datacap_actor_test.rs
+++ b/actors/datacap/tests/datacap_actor_test.rs
@@ -1,27 +1,110 @@
 use fvm_shared::address::Address;
 use lazy_static::lazy_static;
 
+use fil_actors_runtime::test_utils::MockRuntime;
+use fil_actors_runtime::VERIFIED_REGISTRY_ACTOR_ADDR;
+
+use crate::harness::{new_runtime, Harness};
+
 mod harness;
 
 lazy_static! {
-    static ref VERIFIER: Address = Address::new_id(201);
-    static ref VERIFIER2: Address = Address::new_id(202);
-    static ref CLIENT: Address = Address::new_id(301);
-    static ref CLIENT2: Address = Address::new_id(302);
-    static ref CLIENT3: Address = Address::new_id(303);
-    static ref CLIENT4: Address = Address::new_id(304);
+    static ref ALICE: Address = Address::new_id(101);
+    static ref BOB: Address = Address::new_id(102);
+    static ref CARLA: Address = Address::new_id(103);
 }
 
 mod construction {
-    use harness::*;
-
     use crate::*;
+    use fil_actors_runtime::VERIFIED_REGISTRY_ACTOR_ADDR;
 
     #[test]
     fn construct_with_verified() {
         let mut rt = new_runtime();
-        let h = Harness { registry: *REGISTRY_ADDR };
+        let h = Harness { registry: *VERIFIED_REGISTRY_ACTOR_ADDR };
         h.construct_and_verify(&mut rt, &h.registry);
         h.check_state(&rt);
     }
+}
+
+mod mint {
+    use fvm_shared::econ::TokenAmount;
+    use fvm_shared::error::ExitCode;
+    use fvm_shared::MethodNum;
+
+    use fil_actor_datacap::{Actor, Method, MintParams};
+    use fil_actors_runtime::cbor::serialize;
+    use fil_actors_runtime::test_utils::{expect_abort_contains_message, MARKET_ACTOR_CODE_ID};
+    use fil_actors_runtime::{STORAGE_MARKET_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR};
+
+    use crate::*;
+
+    #[test]
+    fn mint_balances() {
+        // The token library has far more extensive tests, this is just a sanity check.
+        let (mut rt, h) = make_harness();
+
+        let amt = TokenAmount::from_whole(1);
+        h.mint(&mut rt, &*ALICE, &amt, vec![]).unwrap();
+        assert_eq!(amt, h.get_supply(&rt));
+        assert_eq!(amt, h.get_balance(&rt, &*ALICE));
+
+        h.mint(&mut rt, &*BOB, &amt, vec![]).unwrap();
+        assert_eq!(&amt * 2, h.get_supply(&rt));
+        assert_eq!(amt, h.get_balance(&rt, &*BOB));
+
+        h.check_state(&rt);
+    }
+
+    #[test]
+    fn requires_verifreg_caller() {
+        let (mut rt, _) = make_harness();
+        let amt = TokenAmount::from_whole(1);
+        let params = MintParams { to: *ALICE, amount: amt, operators: vec![] };
+
+        rt.expect_validate_caller_addr(vec![*VERIFIED_REGISTRY_ACTOR_ADDR]);
+        rt.set_caller(*MARKET_ACTOR_CODE_ID, *STORAGE_MARKET_ACTOR_ADDR);
+        expect_abort_contains_message(
+            ExitCode::USR_FORBIDDEN,
+            "caller address",
+            rt.call::<Actor>(Method::Mint as MethodNum, &serialize(&params, "params").unwrap()),
+        );
+    }
+
+    #[test]
+    fn requires_whole_tokens() {
+        let (mut rt, h) = make_harness();
+        let amt = TokenAmount::from_atto(100);
+        expect_abort_contains_message(
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            "must be a multiple of 1000000000000000000",
+            h.mint(&mut rt, &*ALICE, &amt, vec![]),
+        );
+    }
+
+    #[test]
+    fn adds_allowance_for_operator() {
+        let (mut rt, h) = make_harness();
+
+        let amt = TokenAmount::from_whole(1);
+        h.mint(&mut rt, &*ALICE, &amt, vec![*BOB]).unwrap();
+        assert_eq!(amt, h.get_allowance(&rt, &*ALICE, &BOB));
+
+        h.mint(&mut rt, &*ALICE, &amt, vec![*BOB]).unwrap();
+        assert_eq!(&amt * 2, h.get_allowance(&rt, &*ALICE, &BOB));
+
+        // Different operator
+        h.mint(&mut rt, &*ALICE, &amt, vec![*CARLA]).unwrap();
+        assert_eq!(&amt * 2, h.get_allowance(&rt, &*ALICE, &BOB));
+        assert_eq!(amt, h.get_allowance(&rt, &*ALICE, &CARLA));
+
+        h.check_state(&rt);
+    }
+}
+
+fn make_harness() -> (MockRuntime, Harness) {
+    let mut rt = new_runtime();
+    let h = Harness { registry: *VERIFIED_REGISTRY_ACTOR_ADDR };
+    h.construct_and_verify(&mut rt, &h.registry);
+    (rt, h)
 }

--- a/actors/datacap/tests/harness/mod.rs
+++ b/actors/datacap/tests/harness/mod.rs
@@ -1,22 +1,26 @@
+use fil_fungible_token::receiver::types::{
+    FRC46TokenReceived, UniversalReceiverParams, FRC46_TOKEN_TYPE,
+};
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
 use fvm_shared::MethodNum;
-use lazy_static::lazy_static;
+use num_traits::Zero;
 
 use fil_actor_datacap::testing::check_state_invariants;
-use fil_actor_datacap::{Actor as DataCapActor, Method, State};
+use fil_actor_datacap::{Actor as DataCapActor, Method, MintParams, State};
+use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::test_utils::*;
-use fil_actors_runtime::{SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR};
-
-lazy_static! {
-    pub static ref RECEIVER_ADDR: Address = Address::new_id(10);
-    pub static ref REGISTRY_ADDR: Address = *VERIFIED_REGISTRY_ACTOR_ADDR;
-}
+use fil_actors_runtime::{
+    ActorError, DATACAP_TOKEN_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, UNIVERSAL_RECEIVER_HOOK_METHOD_NUM,
+    VERIFIED_REGISTRY_ACTOR_ADDR,
+};
 
 pub fn new_runtime() -> MockRuntime {
     MockRuntime {
-        receiver: *RECEIVER_ADDR,
+        receiver: *DATACAP_TOKEN_ACTOR_ADDR,
         caller: *SYSTEM_ACTOR_ADDR,
         caller_type: *SYSTEM_ACTOR_CODE_ID,
         ..Default::default()
@@ -26,7 +30,7 @@ pub fn new_runtime() -> MockRuntime {
 #[allow(dead_code)]
 pub fn new_harness() -> (Harness, MockRuntime) {
     let mut rt = new_runtime();
-    let h = Harness { registry: *REGISTRY_ADDR };
+    let h = Harness { registry: *VERIFIED_REGISTRY_ACTOR_ADDR };
     h.construct_and_verify(&mut rt, &h.registry);
     (h, rt)
 }
@@ -50,6 +54,73 @@ impl Harness {
 
         let state: State = rt.get_state();
         assert_eq!(self.registry, state.registry);
+    }
+
+    pub fn mint(
+        &self,
+        rt: &mut MockRuntime,
+        to: &Address,
+        amount: &TokenAmount,
+        operators: Vec<Address>,
+    ) -> Result<(), ActorError> {
+        rt.expect_validate_caller_addr(vec![*VERIFIED_REGISTRY_ACTOR_ADDR]);
+
+        // Expect the token receiver hook to be called.
+        let hook_params = UniversalReceiverParams {
+            type_: FRC46_TOKEN_TYPE,
+            payload: serialize(
+                &FRC46TokenReceived {
+                    from: DATACAP_TOKEN_ACTOR_ADDR.id().unwrap(),
+                    to: to.id().unwrap(),
+                    operator: VERIFIED_REGISTRY_ACTOR_ADDR.id().unwrap(),
+                    amount: amount.clone(),
+                    operator_data: Default::default(),
+                    token_data: Default::default(),
+                },
+                "hook payload",
+            )?,
+        };
+        // UniversalReceiverParams
+        rt.expect_send(
+            *to,
+            UNIVERSAL_RECEIVER_HOOK_METHOD_NUM,
+            serialize(&hook_params, "hook params")?,
+            TokenAmount::zero(),
+            RawBytes::default(),
+            ExitCode::OK,
+        );
+
+        let params = MintParams { to: *to, amount: amount.clone(), operators };
+        rt.set_caller(*VERIFREG_ACTOR_CODE_ID, *VERIFIED_REGISTRY_ACTOR_ADDR);
+        let ret =
+            rt.call::<DataCapActor>(Method::Mint as MethodNum, &serialize(&params, "params")?)?;
+
+        assert_eq!(RawBytes::default(), ret);
+        rt.verify();
+        Ok(())
+    }
+
+    // Reads the total supply from state directly.
+    pub fn get_supply(&self, rt: &MockRuntime) -> TokenAmount {
+        rt.get_state::<State>().token.supply
+    }
+
+    // Reads a balance from state directly.
+    pub fn get_balance(&self, rt: &MockRuntime, address: &Address) -> TokenAmount {
+        rt.get_state::<State>().token.get_balance(rt.store(), address.id().unwrap()).unwrap()
+    }
+
+    // Reads an allowance from state directly.
+    pub fn get_allowance(
+        &self,
+        rt: &MockRuntime,
+        owner: &Address,
+        operator: &Address,
+    ) -> TokenAmount {
+        rt.get_state::<State>()
+            .token
+            .get_allowance_between(rt.store(), owner.id().unwrap(), operator.id().unwrap())
+            .unwrap()
     }
 
     pub fn check_state(&self, rt: &MockRuntime) {

--- a/actors/verifreg/src/ext.rs
+++ b/actors/verifreg/src/ext.rs
@@ -29,6 +29,7 @@ pub mod datacap {
     pub struct MintParams {
         pub to: Address,
         pub amount: TokenAmount,
+        pub operators: Vec<Address>,
     }
 
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -210,7 +210,8 @@ impl Actor {
         })?;
 
         // Credit client token allowance.
-        mint(rt, &st.token, &client, &params.allowance).context(format!(
+        let operators = vec![*STORAGE_MARKET_ACTOR_ADDR];
+        mint(rt, &st.token, &client, &params.allowance, operators).context(format!(
             "failed to mint {} data cap to client {}",
             &params.allowance, client
         ))?;
@@ -299,7 +300,8 @@ impl Actor {
             ));
         }
 
-        mint(rt, &st.token, &client, &params.deal_size).context(format!(
+        let operators = vec![*STORAGE_MARKET_ACTOR_ADDR];
+        mint(rt, &st.token, &client, &params.deal_size, operators).context(format!(
             "failed to restore {} to allowance for {}",
             &params.deal_size, &client
         ))
@@ -617,13 +619,14 @@ fn mint<BS, RT>(
     token: &Address,
     to: &Address,
     amount: &DataCap,
+    operators: Vec<Address>,
 ) -> Result<(), ActorError>
 where
     BS: Blockstore,
     RT: Runtime<BS>,
 {
     let token_amt = datacap_to_tokens(amount);
-    let params = MintParams { to: *to, amount: token_amt };
+    let params = MintParams { to: *to, amount: token_amt, operators };
     rt.send(
         token,
         ext::datacap::Method::Mint as u64,

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -166,6 +166,7 @@ impl Harness {
         let mint_params = ext::datacap::MintParams {
             to: client_resolved,
             amount: TokenAmount::from_whole(allowance.to_i64().unwrap()),
+            operators: vec![*STORAGE_MARKET_ACTOR_ADDR],
         };
         rt.expect_send(
             *DATACAP_TOKEN_ACTOR_ADDR,
@@ -257,6 +258,7 @@ impl Harness {
         let mint_params = ext::datacap::MintParams {
             to: client_resolved,
             amount: TokenAmount::from_whole(amount.to_i64().unwrap()),
+            operators: vec![*STORAGE_MARKET_ACTOR_ADDR],
         };
         rt.expect_send(
             *DATACAP_TOKEN_ACTOR_ADDR,

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -22,7 +22,8 @@ use fil_actor_verifreg::{AddrPairKey, Method as VerifregMethod};
 use fil_actor_verifreg::{RemoveDataCapProposal, RemoveDataCapProposalID, State as VerifregState};
 use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::{
-    make_map_with_root_and_bitwidth, DATACAP_TOKEN_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+    make_map_with_root_and_bitwidth, DATACAP_TOKEN_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use test_vm::util::{add_verifier, apply_ok, create_accounts};
 use test_vm::{ExpectInvocation, TEST_VERIFREG_ROOT_ADDR, VM};
@@ -50,6 +51,7 @@ fn remove_datacap_simple_successful_path() {
     let mint_params = MintParams {
         to: verified_client,
         amount: TokenAmount::from_whole(verifier_allowance.to_i64().unwrap()),
+        operators: vec![*STORAGE_MARKET_ACTOR_ADDR],
     };
     apply_ok(
         &v,


### PR DESCRIPTION
Minting is not a standard token method, so adding a parameter to mint allows this to happen with the business logic of which account to approve encapsulated in the verified registry, but no additional inter-actor sends.

Closes #529.