### PR TITLE
Include datacap actor in build bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "fil_actor_account",
  "fil_actor_bundler",
  "fil_actor_cron",
+ "fil_actor_datacap",
  "fil_actor_init",
  "fil_actor_market",
  "fil_actor_miner",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,17 @@ publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fil_actor_account = { version = "9.0.0-alpha.1", path = "./actors/account", features = ["fil-actor"] }
-fil_actor_verifreg = { version = "9.0.0-alpha.1", path = "./actors/verifreg", features = ["fil-actor"] }
 fil_actor_cron = { version = "9.0.0-alpha.1", path = "./actors/cron", features = ["fil-actor"] }
+fil_actor_datacap = { version = "9.0.0-alpha.1", path = "./actors/datacap", features = ["fil-actor"] }
+fil_actor_init = { version = "9.0.0-alpha.1", path = "./actors/init", features = ["fil-actor"] }
 fil_actor_market = { version = "9.0.0-alpha.1", path = "./actors/market", features = ["fil-actor"] }
+fil_actor_miner = { version = "9.0.0-alpha.1", path = "./actors/miner", features = ["fil-actor"] }
 fil_actor_multisig = { version = "9.0.0-alpha.1", path = "./actors/multisig", features = ["fil-actor"] }
 fil_actor_paych = { version = "9.0.0-alpha.1", path = "./actors/paych", features = ["fil-actor"] }
 fil_actor_power = { version = "9.0.0-alpha.1", path = "./actors/power", features = ["fil-actor"] }
-fil_actor_miner = { version = "9.0.0-alpha.1", path = "./actors/miner", features = ["fil-actor"] }
 fil_actor_reward = { version = "9.0.0-alpha.1", path = "./actors/reward", features = ["fil-actor"] }
 fil_actor_system = { version = "9.0.0-alpha.1", path = "./actors/system", features = ["fil-actor"] }
-fil_actor_init = { version = "9.0.0-alpha.1", path = "./actors/init", features = ["fil-actor"] }
+fil_actor_verifreg = { version = "9.0.0-alpha.1", path = "./actors/verifreg", features = ["fil-actor"] }
 
 [build-dependencies]
 fil_actor_bundler = "4.0.0"

--- a/build.rs
+++ b/build.rs
@@ -25,6 +25,7 @@ const ACTORS: &[(&Package, &ID)] = &[
     ("multisig", "multisig"),
     ("reward", "reward"),
     ("verifreg", "verifiedregistry"),
+    ("datacap", "datacap"),
 ];
 
 const WASM_FEATURES: &[&str] = &["+bulk-memory", "+crt-static"];

--- a/runtime/src/runtime/builtins.rs
+++ b/runtime/src/runtime/builtins.rs
@@ -19,8 +19,7 @@ pub enum Type {
     Multisig = 9,
     Reward = 10,
     VerifiedRegistry = 11,
-    // EVM = 12,
-    DataCap = 13,
+    DataCap = 12,
 }
 
 impl Type {


### PR DESCRIPTION
I realised we need to add extra configuration to have a new builtin actor build for use in a network.

@Stebalien I'm more or less forced to use `Datacap = 12` here because the build requires these to be sequential. When EVM merges into main some time after this, it'll have to take `13`.