### PR TITLE
Implement Drop as a safeguard for programmer errors

### DIFF
--- a/actors/datacap/tests/datacap_actor_test.rs
+++ b/actors/datacap/tests/datacap_actor_test.rs
@@ -87,6 +87,7 @@ mod mint {
             "must be a multiple of 1000000000000000000",
             h.mint(&mut rt, &*ALICE, &amt, vec![]),
         );
+        rt.reset();
         h.check_state(&rt);
     }
 

--- a/actors/miner/tests/batch_method_network_fees_test.rs
+++ b/actors/miner/tests/batch_method_network_fees_test.rs
@@ -64,6 +64,7 @@ fn insufficient_funds_for_aggregated_prove_commit_network_fee() {
     );
 
     expect_abort(ExitCode::USR_INSUFFICIENT_FUNDS, res);
+    rt.reset();
 }
 
 #[test]
@@ -112,6 +113,7 @@ fn insufficient_funds_for_batch_precommit_network_fee() {
         "unlocked balance can not repay fee debt",
         res,
     );
+    rt.reset();
 }
 
 #[test]
@@ -167,6 +169,7 @@ fn insufficient_funds_for_batch_precommit_in_combination_of_fee_debt_and_network
         "unlocked balance can not repay fee debt",
         res,
     );
+    rt.reset();
 }
 
 #[test]
@@ -215,6 +218,7 @@ fn enough_funds_for_fee_debt_and_network_fee_but_not_for_pcd() {
         "insufficient funds 0.0 for pre-commit deposit",
         res,
     );
+    rt.reset();
 
     // state untouched
     let state: State = rt.get_state();

--- a/actors/miner/tests/change_owner_address_test.rs
+++ b/actors/miner/tests/change_owner_address_test.rs
@@ -99,6 +99,7 @@ fn proposed_must_be_valid() {
     for nominee in nominees {
         let result = h.change_owner_address(&mut rt, nominee);
         expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
+        rt.reset();
     }
 
     h.check_state(&rt);

--- a/actors/miner/tests/change_worker_address_test.rs
+++ b/actors/miner/tests/change_worker_address_test.rs
@@ -181,6 +181,7 @@ fn fails_if_control_addresses_length_exceeds_maximum_limit() {
         "control addresses length",
         result,
     );
+    rt.reset();
 
     h.check_state(&rt);
 }
@@ -188,10 +189,10 @@ fn fails_if_control_addresses_length_exceeds_maximum_limit() {
 #[test]
 fn fails_if_unable_to_resolve_control_address() {
     let (h, mut rt) = setup();
-
     let control_address = new_bls_addr(42);
     let result = h.change_worker_address(&mut rt, h.worker, vec![control_address]);
     expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
+    rt.reset();
 
     h.check_state(&rt);
 }
@@ -199,31 +200,28 @@ fn fails_if_unable_to_resolve_control_address() {
 #[test]
 fn fails_if_unable_to_resolve_worker_address() {
     let (h, mut rt) = setup();
-
     let new_worker = new_bls_addr(42);
     let result = h.change_worker_address(&mut rt, new_worker, vec![]);
     expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
-
+    rt.reset();
     h.check_state(&rt);
 }
 
 #[test]
 fn fails_if_worker_public_key_is_not_bls_but_id() {
     let (mut h, mut rt) = setup();
-
     let new_worker = Address::new_id(999);
     h.worker_key = Address::new_id(505);
 
     let result = h.change_worker_address(&mut rt, new_worker, vec![]);
     expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
-
+    rt.reset();
     h.check_state(&rt);
 }
 
 #[test]
 fn fails_if_worker_public_key_is_not_bls_but_secp() {
     let (mut h, mut rt) = setup();
-
     let new_worker = Address::new_id(999);
     h.worker_key = Address::new_secp256k1(&[0x42; 65]).unwrap();
 

--- a/actors/miner/tests/compact_partitions_test.rs
+++ b/actors/miner/tests/compact_partitions_test.rs
@@ -194,7 +194,7 @@ fn fails_if_deadline_out_of_range() {
         &format!("invalid deadline {w_post_period_deadlines}"),
         result,
     );
-
+    rt.reset();
     h.check_state(&rt);
 }
 

--- a/actors/miner/tests/compact_sector_numbers_tests.rs
+++ b/actors/miner/tests/compact_sector_numbers_tests.rs
@@ -116,14 +116,13 @@ mod compact_sector_numbers_test {
                 bitfield_from_slice(&[target_sector_num, target_sector_num + 1]),
             ),
         );
-
+        rt.reset();
         check_state_invariants_from_mock_runtime(&rt);
     }
 
     #[test]
     fn sector_number_range_limits() {
         let (h, mut rt) = setup();
-
         // Limits ok
         h.compact_sector_numbers(&mut rt, h.worker, bitfield_from_slice(&[0, MAX_SECTOR_NUMBER]));
 
@@ -136,18 +135,19 @@ mod compact_sector_numbers_test {
                 bitfield_from_slice(&[MAX_SECTOR_NUMBER + 1]),
             ),
         );
+        rt.reset();
         check_state_invariants_from_mock_runtime(&rt);
     }
 
     #[test]
     fn compacting_no_sector_numbers_aborts() {
         let (h, mut rt) = setup();
-
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
             // compact nothing
             h.compact_sector_numbers_raw(&mut rt, h.worker, bitfield_from_slice(&[])),
         );
+        rt.reset();
         check_state_invariants_from_mock_runtime(&rt);
     }
 }

--- a/actors/miner/tests/declare_recoveries.rs
+++ b/actors/miner/tests/declare_recoveries.rs
@@ -53,6 +53,7 @@ fn recovery_must_pay_back_fee_debt() {
     let (mut h, mut rt) = setup();
     let one_sector =
         h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
+
     // advance to first proving period and submit so we'll have time to declare the fault next cycle
     h.advance_and_submit_posts(&mut rt, &one_sector);
 

--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -769,6 +769,7 @@ fn update_expiration_legacy_fails_on_new_sector_with_deals() {
         "cannot use legacy sector extension for simple qa power with deal weight",
         h.extend_sectors(&mut rt, params),
     );
+    rt.reset();
     check_for_expiration(
         &mut h,
         &mut rt,

--- a/actors/miner/tests/miner_actor_test_commitment.rs
+++ b/actors/miner/tests/miner_actor_test_commitment.rs
@@ -112,6 +112,7 @@ mod miner_actor_test_commitment {
         let mut h = ActorHarness::new(period_offset);
         h.set_proof_type(RegisteredSealProof::StackedDRG64GiBV1);
         let mut rt = h.new_runtime();
+
         rt.set_balance(insufficient_balance);
         rt.set_received(TokenAmount::zero());
 
@@ -129,6 +130,7 @@ mod miner_actor_test_commitment {
             ExitCode::USR_INSUFFICIENT_FUNDS,
             h.pre_commit_sector(&mut rt, precommit_params, util::PreCommitConfig::default(), true),
         );
+        rt.reset();
         h.check_state(&rt);
     }
 
@@ -169,6 +171,7 @@ mod miner_actor_test_commitment {
 
         let mut h = ActorHarness::new(period_offset);
         let mut rt = h.new_runtime();
+
         rt.set_balance(BIG_BALANCE.clone());
         rt.set_received(TokenAmount::zero());
 
@@ -468,6 +471,7 @@ mod miner_actor_test_commitment {
             let mut h = ActorHarness::new(period_offset);
             h.set_proof_type(proof);
             let mut rt = h.new_runtime();
+
             rt.set_balance(BIG_BALANCE.clone());
             rt.set_received(TokenAmount::zero());
 
@@ -508,6 +512,7 @@ mod miner_actor_test_commitment {
                 "too many deals for sector",
                 ret,
             );
+            rt.reset();
 
             // sector at or below limit succeeds
             let (mut rt, h, _) = setup(proof);
@@ -533,6 +538,7 @@ mod miner_actor_test_commitment {
 
         let h = ActorHarness::new(period_offset);
         let mut rt = h.new_runtime();
+
         rt.set_balance(BIG_BALANCE.clone());
         rt.set_received(TokenAmount::zero());
 

--- a/actors/miner/tests/miner_actor_test_precommit_batch.rs
+++ b/actors/miner/tests/miner_actor_test_precommit_batch.rs
@@ -282,6 +282,7 @@ mod miner_actor_precommit_batch {
         });
 
         let mut rt = h.new_runtime();
+
         rt.set_balance(BIG_BALANCE.clone());
         rt.set_received(TokenAmount::zero());
 
@@ -321,6 +322,7 @@ mod miner_actor_precommit_batch {
             proving_period_offset: period_offset,
         });
         let mut rt = h.new_runtime();
+
         rt.set_balance(BIG_BALANCE.clone());
         rt.set_received(TokenAmount::zero());
 
@@ -359,6 +361,7 @@ mod miner_actor_precommit_batch {
             proving_period_offset: period_offset,
         });
         let mut rt = h.new_runtime();
+
         rt.set_balance(BIG_BALANCE.clone());
         rt.set_received(TokenAmount::zero());
 
@@ -433,6 +436,7 @@ mod miner_actor_precommit_batch {
                 "and passed CompactCommD",
                 result,
             );
+            rt.reset();
         }
     }
 }

--- a/actors/miner/tests/miner_actor_test_wpost.rs
+++ b/actors/miner/tests/miner_actor_test_wpost.rs
@@ -104,6 +104,7 @@ fn invalid_submissions() {
 
     let mut h = ActorHarness::new(period_offset);
     let mut rt = h.new_runtime();
+
     rt.epoch = precommit_epoch;
     rt.balance.replace(BIG_BALANCE.clone());
 
@@ -500,6 +501,7 @@ fn duplicate_proof_rejected() {
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
     let mut rt = h.new_runtime();
+
     rt.epoch = precommit_epoch;
     rt.balance.replace(BIG_BALANCE.clone());
 
@@ -585,6 +587,7 @@ fn duplicate_proof_rejected_with_many_partitions() {
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
     let mut rt = h.new_runtime();
+
     rt.epoch = precommit_epoch;
     rt.balance.replace(BIG_BALANCE.clone());
 
@@ -762,6 +765,7 @@ fn skipped_faults_adjust_power() {
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
     let mut rt = h.new_runtime();
+
     rt.epoch = precommit_epoch;
     rt.balance.replace(BIG_BALANCE.clone());
 
@@ -1290,6 +1294,6 @@ fn bad_post_fails_when_verified() {
         "invalid post was submitted",
         result,
     );
-
+    rt.reset();
     h.check_state(&rt);
 }

--- a/actors/miner/tests/report_consensus_fault.rs
+++ b/actors/miner/tests/report_consensus_fault.rs
@@ -24,6 +24,7 @@ fn setup() -> (ActorHarness, MockRuntime) {
 #[test]
 fn invalid_report_rejected() {
     let (h, mut rt) = setup();
+
     rt.set_epoch(1);
 
     let test_addr = Address::new_actor("satoshi".as_bytes());
@@ -31,6 +32,7 @@ fn invalid_report_rejected() {
         ExitCode::USR_ILLEGAL_ARGUMENT,
         h.report_consensus_fault(&mut rt, test_addr, None),
     );
+    rt.reset();
     check_state_invariants(rt.policy(), &h.get_state(&rt), rt.store(), &rt.get_balance());
 }
 
@@ -53,6 +55,7 @@ fn mistargeted_report_rejected() {
             }),
         ),
     );
+    rt.reset();
     check_state_invariants(rt.policy(), &h.get_state(&rt), rt.store(), &rt.get_balance());
 }
 
@@ -208,5 +211,6 @@ fn double_report_of_consensus_fault_fails() {
             }),
         ),
     );
+    rt.reset();
     check_state_invariants(rt.policy(), &h.get_state(&rt), rt.store(), &rt.get_balance());
 }

--- a/actors/miner/tests/withdraw_balance.rs
+++ b/actors/miner/tests/withdraw_balance.rs
@@ -33,6 +33,7 @@ fn happy_path_withdraws_funds() {
 fn fails_if_miner_cant_repay_fee_debt() {
     let h = ActorHarness::new(PERIOD_OFFSET);
     let mut rt = h.new_runtime();
+
     rt.set_balance(BIG_BALANCE.clone());
     h.construct_and_verify(&mut rt);
 
@@ -50,6 +51,7 @@ fn fails_if_miner_cant_repay_fee_debt() {
             &TokenAmount::zero(),
         ),
     );
+    rt.reset();
     h.check_state(&rt);
 }
 

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -516,7 +516,7 @@ mod vesting_tests {
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
         rt.set_received(MSIG_INITIAL_BALANCE.clone());
-        h.construct_and_verify(&mut rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
+        h.construct_and_verify(&mut rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
         rt.set_received(TokenAmount::zero());
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
@@ -528,6 +528,7 @@ mod vesting_tests {
             RawBytes::default(),
             ExitCode::OK,
         );
+        h.propose_ok(&mut rt, BOB, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
         check_state(&rt);
     }
 

--- a/actors/paych/tests/paych_actor_test.rs
+++ b/actors/paych/tests/paych_actor_test.rs
@@ -1005,12 +1005,6 @@ mod actor_settle {
         state = rt.get_state();
         rt.epoch = state.settling_at + 40;
         rt.expect_validate_caller_addr(vec![state.from, state.to]);
-        rt.expect_verify_signature(ExpectedVerifySig {
-            sig: sv.clone().signature.unwrap(),
-            signer: Address::new_id(PAYEE_ID),
-            plaintext: sv.signing_bytes().unwrap(),
-            result: Ok(()),
-        });
         expect_abort(
             &mut rt,
             Method::UpdateChannelState as u64,
@@ -1100,14 +1094,17 @@ mod actor_collect {
 
             // "wait" for SettlingAt epoch
             rt.epoch = state.settling_at + 1;
-            rt.expect_send(
-                state.to,
-                METHOD_SEND,
-                Default::default(),
-                state.to_send.clone(),
-                Default::default(),
-                tc.exp_send_to,
-            );
+
+            if !tc.dont_settle {
+                rt.expect_send(
+                    state.to,
+                    METHOD_SEND,
+                    Default::default(),
+                    state.to_send.clone(),
+                    Default::default(),
+                    tc.exp_send_to,
+                );
+            }
 
             // Collect.
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, state.from);

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -447,8 +447,11 @@ impl Harness {
         rt: &mut MockRuntime,
         miner_address: Address,
         seal_info: SealVerifyInfo,
+        expect_success: bool,
     ) -> Result<(), ActorError> {
-        rt.expect_gas_charge(GAS_ON_SUBMIT_VERIFY_SEAL);
+        if expect_success {
+            rt.expect_gas_charge(GAS_ON_SUBMIT_VERIFY_SEAL);
+        }
         rt.expect_validate_caller_type(vec![Type::Miner]);
         rt.set_caller(*MINER_ACTOR_CODE_ID, miner_address);
         rt.call::<PowerActor>(

--- a/actors/reward/tests/reward_actor_test.rs
+++ b/actors/reward/tests/reward_actor_test.rs
@@ -90,43 +90,41 @@ mod test_award_block_reward {
 
         rt.set_balance(TokenAmount::from_atto(9));
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
-        assert_eq!(
-            ExitCode::USR_ILLEGAL_STATE,
-            award_block_reward(
-                &mut rt,
-                *WINNER,
-                TokenAmount::zero(),
-                TokenAmount::from_atto(10),
-                1,
-                TokenAmount::zero()
-            )
-            .unwrap_err()
-            .exit_code()
-        );
+
+        let params = AwardBlockRewardParams {
+            miner: *WINNER,
+            penalty: TokenAmount::zero(),
+            gas_reward: TokenAmount::from_atto(10),
+            win_count: 1,
+        };
+
+        let serialized_params = RawBytes::serialize(params).unwrap();
+        let result = rt.call::<RewardActor>(Method::AwardBlockReward as u64, &serialized_params);
+
+        expect_abort(ExitCode::USR_ILLEGAL_STATE, result);
     }
 
     #[test]
     fn rejects_negative_penalty_or_reward() {
         let mut rt = construct_and_verify(&StoragePower::default());
         rt.set_balance(TokenAmount::from_whole(1));
-        rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
 
         let reward_penalty_pairs = [(-1, 0), (0, -1)];
 
         for (reward, penalty) in &reward_penalty_pairs {
-            assert_eq!(
-                ExitCode::USR_ILLEGAL_ARGUMENT,
-                award_block_reward(
-                    &mut rt,
-                    *WINNER,
-                    TokenAmount::from_atto(*penalty),
-                    TokenAmount::from_atto(*reward),
-                    1,
-                    TokenAmount::zero()
-                )
-                .unwrap_err()
-                .exit_code()
-            );
+            rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
+            let params = AwardBlockRewardParams {
+                miner: *WINNER,
+                penalty: TokenAmount::from_atto(*penalty),
+                gas_reward: TokenAmount::from_atto(*reward),
+                win_count: 1,
+            };
+
+            let serialized_params = RawBytes::serialize(params).unwrap();
+            let result =
+                rt.call::<RewardActor>(Method::AwardBlockReward as u64, &serialized_params);
+
+            expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
             rt.reset();
         }
     }
@@ -137,16 +135,18 @@ mod test_award_block_reward {
         rt.set_balance(TokenAmount::from_whole(1));
 
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
-        assert!(award_block_reward(
-            &mut rt,
-            *WINNER,
-            TokenAmount::zero(),
-            TokenAmount::zero(),
-            0,
-            TokenAmount::zero()
-        )
-        .is_err());
-        rt.reset();
+
+        let params = AwardBlockRewardParams {
+            miner: *WINNER,
+            penalty: TokenAmount::zero(),
+            gas_reward: TokenAmount::zero(),
+            win_count: 0,
+        };
+
+        let serialized_params = RawBytes::serialize(params).unwrap();
+        let result = rt.call::<RewardActor>(Method::AwardBlockReward as u64, &serialized_params);
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -109,11 +109,14 @@ mod verifiers {
     #[test]
     fn add_verifier_enforces_min_size() {
         let (h, mut rt) = new_harness();
-        let allowance = rt.policy.minimum_verified_allocation_size.clone() - 1;
-        expect_abort(
-            ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.add_verifier(&mut rt, &VERIFIER, &allowance),
+        let allowance: DataCap = rt.policy.minimum_verified_allocation_size.clone() - 1;
+
+        let params = AddVerifierParams { address: *VERIFIER, allowance };
+        let result = rt.call::<VerifregActor>(
+            Method::AddVerifier as MethodNum,
+            &RawBytes::serialize(params).unwrap(),
         );
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
         h.check_state(&rt);
     }
 
@@ -125,6 +128,7 @@ mod verifiers {
             ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_verifier(&mut rt, &ROOT_ADDR, &allowance),
         );
+        rt.reset();
         h.check_state(&rt);
     }
 
@@ -154,10 +158,14 @@ mod verifiers {
             RawBytes::default(),
             ExitCode::OK,
         );
-        expect_abort(
-            ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.add_verifier(&mut rt, &verifier_key_address, &allowance),
+
+        let params = AddVerifierParams { address: verifier_key_address, allowance };
+        let result = rt.call::<VerifregActor>(
+            Method::AddVerifier as MethodNum,
+            &RawBytes::serialize(params).unwrap(),
         );
+
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
         h.check_state(&rt);
     }
 
@@ -277,7 +285,7 @@ mod clients {
             ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&mut rt, &VERIFIER, &CLIENT2, &allowance),
         );
-
+        rt.reset();
         h.assert_verifier_allowance(&rt, &VERIFIER, &DataCap::zero());
         h.check_state(&rt);
     }
@@ -335,6 +343,7 @@ mod clients {
             ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&mut rt, &VERIFIER, &client, &allowance_client),
         );
+        rt.reset();
         h.check_state(&rt);
     }
 
@@ -349,6 +358,7 @@ mod clients {
             ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&mut rt, &VERIFIER, &CLIENT, &allowance),
         );
+        rt.reset();
         h.check_state(&rt);
     }
 
@@ -384,6 +394,7 @@ mod clients {
             ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&mut rt, &VERIFIER, &h.root, &allowance),
         );
+        rt.reset();
         h.check_state(&rt);
     }
 
@@ -397,6 +408,7 @@ mod clients {
             ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&mut rt, &VERIFIER, &h.root, &allowance_client),
         );
+        rt.reset();
         h.check_state(&rt);
     }
 
@@ -417,6 +429,7 @@ mod clients {
             ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&mut rt, &VERIFIER, &VERIFIER2, &allowance_client),
         );
+        rt.reset();
         h.check_state(&rt);
     }
 }

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -155,6 +155,7 @@ pub struct Expectations {
     pub expect_aggregate_verify_seals: Option<ExpectAggregateVerifySeals>,
     pub expect_replica_verify: Option<ExpectReplicaVerify>,
     pub expect_gas_charge: VecDeque<i64>,
+    skip_verification_on_drop: bool,
 }
 
 impl Expectations {
@@ -244,6 +245,10 @@ impl Expectations {
             "expect_gas_charge {:?}, not received",
             self.expect_gas_charge
         );
+    }
+
+    fn skip_verification_on_drop(&mut self) {
+        self.skip_verification_on_drop = true;
     }
 }
 
@@ -469,6 +474,7 @@ impl<BS: Blockstore> MockRuntime<BS> {
 
     /// Clears all mock expectations.
     pub fn reset(&mut self) {
+        self.expectations.borrow_mut().skip_verification_on_drop();
         self.expectations.borrow_mut().reset();
     }
 
@@ -1224,6 +1230,16 @@ impl<BS> Verifier for MockRuntime<BS> {
 impl<BS> RuntimePolicy for MockRuntime<BS> {
     fn policy(&self) -> &Policy {
         &self.policy
+    }
+}
+
+// The Expectations are by default verified on drop().
+// In order to clear the unsatisfied expectations in tests, use MockRuntime#reset().
+impl Drop for Expectations {
+    fn drop(&mut self) {
+        if !self.skip_verification_on_drop {
+            self.verify();
+        }
     }
 }
 


### PR DESCRIPTION
It addresses https://github.com/filecoin-project/builtin-actors/issues/605

Another idea was to throw error if there's any unverified `expectation` which would be less automagical. But it would require checking all parts of `expectations` 1 by 1 which would be tedious to maintain. 