### PR TITLE
Verifreg uses a constant for datacap token actor addr, rather than state.

### DIFF
--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -68,18 +68,18 @@ pub struct Actor;
 
 impl Actor {
     /// Constructor for DataCap Actor
-    pub fn constructor<BS, RT>(rt: &mut RT, verifreg: Address) -> Result<(), ActorError>
+    pub fn constructor<BS, RT>(rt: &mut RT, governor: Address) -> Result<(), ActorError>
     where
         BS: Blockstore,
         RT: Runtime<BS>,
     {
         rt.validate_immediate_caller_is(std::iter::once(&*SYSTEM_ACTOR_ADDR))?;
 
-        // Confirm the registry address is an ID.
-        rt.resolve_address(&verifreg)
-            .ok_or_else(|| actor_error!(illegal_argument, "failed to resolve registry address"))?;
+        // Confirm the governor address is an ID.
+        rt.resolve_address(&governor)
+            .ok_or_else(|| actor_error!(illegal_argument, "failed to resolve governor address"))?;
 
-        let st = State::new(rt.store(), verifreg).context("failed to create verifreg state")?;
+        let st = State::new(rt.store(), governor).context("failed to create datacap state")?;
         rt.create(&st)?;
         Ok(())
     }
@@ -139,7 +139,7 @@ impl Actor {
 
     /// Mints new data cap tokens for an address (a verified client).
     /// Simultaneously sets the allowance for any specified operators to effectively infinite.
-    /// Only the registry can call this method.
+    /// Only the governor can call this method.
     /// This method is not part of the fungible token standard.
     // TODO: return the new balance when the token library does
     pub fn mint<BS, RT>(rt: &mut RT, params: MintParams) -> Result<(), ActorError>
@@ -149,9 +149,9 @@ impl Actor {
     {
         let (mut hook, _result) = rt
             .transaction(|st: &mut State, rt| {
-                // Only the registry can mint datacap tokens.
-                rt.validate_immediate_caller_is(std::iter::once(&st.registry))?;
-                let operator = st.registry;
+                // Only the governor can mint datacap tokens.
+                rt.validate_immediate_caller_is(std::iter::once(&st.governor))?;
+                let operator = st.governor;
 
                 let msg = Messenger { rt, dummy: Default::default() };
                 let mut token = as_token(st, &msg);
@@ -184,7 +184,7 @@ impl Actor {
     }
 
     /// Destroys data cap tokens for an address (a verified client).
-    /// Only the registry can call this method.
+    /// Only the governor can call this method.
     /// This method is not part of the fungible token standard, and is named distinctly from
     /// "burn" to reflect that distinction.
     pub fn destroy<BS, RT>(rt: &mut RT, params: DestroyParams) -> Result<BurnReturn, ActorError>
@@ -193,13 +193,13 @@ impl Actor {
         RT: Runtime<BS>,
     {
         rt.transaction(|st: &mut State, rt| {
-            // Only the registry can destroy datacap tokens on behalf of a holder.
-            rt.validate_immediate_caller_is(std::iter::once(&st.registry))?;
+            // Only the governor can destroy datacap tokens on behalf of a holder.
+            rt.validate_immediate_caller_is(std::iter::once(&st.governor))?;
 
             let msg = Messenger { rt, dummy: Default::default() };
             let mut token = as_token(st, &msg);
             // Burn tokens as if the holder had invoked burn() themselves.
-            // The registry doesn't need an allowance.
+            // The governor doesn't need an allowance.
             token.burn(&params.owner, &params.amount).actor_result()
         })
         .context("state transaction failed")
@@ -207,7 +207,7 @@ impl Actor {
 
     /// Transfers data cap tokens to an address.
     /// Data cap tokens are not generally transferable.
-    /// Succeeds if the to address is the registry, otherwise always fails.
+    /// Succeeds if the to address is the governor, otherwise always fails.
     pub fn transfer<BS, RT>(
         rt: &mut RT,
         params: TransferParams,
@@ -219,7 +219,7 @@ impl Actor {
         rt.validate_immediate_caller_accept_any()?;
         let operator = &rt.message().caller();
         let from = operator;
-        // Resolve to address for comparison with registry address.
+        // Resolve to address for comparison with governor address.
         let to = rt
             .resolve_address(&params.to)
             .context_code(ExitCode::USR_ILLEGAL_ARGUMENT, "to must be ID address")?;
@@ -227,7 +227,7 @@ impl Actor {
 
         let (mut hook, result) = rt
             .transaction(|st: &mut State, rt| {
-                let allowed = to_address == st.registry;
+                let allowed = to_address == st.governor;
                 if !allowed {
                     return Err(actor_error!(forbidden, "transfer not allowed"));
                 }
@@ -253,7 +253,7 @@ impl Actor {
 
     /// Transfers data cap tokens between addresses.
     /// Data cap tokens are not generally transferable between addresses.
-    /// Succeeds if the to address is the registry, otherwise always fails.
+    /// Succeeds if the to address is the governor, otherwise always fails.
     pub fn transfer_from<BS, RT>(
         rt: &mut RT,
         params: TransferFromParams,
@@ -265,7 +265,7 @@ impl Actor {
         rt.validate_immediate_caller_accept_any()?;
         let operator = rt.message().caller();
         let from = params.from;
-        // Resolve to address for comparison with registry.
+        // Resolve to address for comparison with governor.
         let to = rt
             .resolve_address(&params.to)
             .context_code(ExitCode::USR_ILLEGAL_ARGUMENT, "to must be an ID address")?;
@@ -273,7 +273,7 @@ impl Actor {
 
         let (mut hook, result) = rt
             .transaction(|st: &mut State, rt| {
-                let allowed = to_address == st.registry;
+                let allowed = to_address == st.governor;
                 if !allowed {
                     return Err(actor_error!(forbidden, "transfer not allowed"));
                 }

--- a/actors/datacap/src/state.rs
+++ b/actors/datacap/src/state.rs
@@ -11,15 +11,15 @@ use fil_actors_runtime::{ActorError, AsActorError};
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct State {
-    pub registry: Address,
+    pub governor: Address,
     pub token: token::state::TokenState,
 }
 
 impl State {
-    pub fn new<BS: Blockstore>(store: &BS, registry: Address) -> Result<State, ActorError> {
+    pub fn new<BS: Blockstore>(store: &BS, governor: Address) -> Result<State, ActorError> {
         let token_state = token::state::TokenState::new(store)
             .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to create token state")?;
-        Ok(State { registry, token: token_state })
+        Ok(State { governor, token: token_state })
     }
 
     // Visible for testing

--- a/actors/datacap/src/testing.rs
+++ b/actors/datacap/src/testing.rs
@@ -13,7 +13,7 @@ pub fn check_state_invariants<BS: Blockstore>(
     store: &BS,
 ) -> (StateSummary, MessageAccumulator) {
     let acc = MessageAccumulator::default();
-    acc.require(state.registry.protocol() == Protocol::ID, "registry must be ID address");
+    acc.require(state.governor.protocol() == Protocol::ID, "registry must be ID address");
     let r = state.token.check_invariants(store);
     if let Err(e) = r {
         acc.add(e.to_string());

--- a/actors/datacap/tests/harness/mod.rs
+++ b/actors/datacap/tests/harness/mod.rs
@@ -53,7 +53,7 @@ impl Harness {
         rt.verify();
 
         let state: State = rt.get_state();
-        assert_eq!(self.registry, state.registry);
+        assert_eq!(self.registry, state.governor);
     }
 
     pub fn mint(

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -77,7 +77,7 @@ impl Actor {
             .resolve_address(&root_key)
             .context_code(ExitCode::USR_ILLEGAL_ARGUMENT, "root should be an ID address")?;
 
-        let st = State::new(rt.store(), Address::new_id(id_addr), *DATACAP_TOKEN_ACTOR_ADDR)
+        let st = State::new(rt.store(), Address::new_id(id_addr))
             .context("failed to create verifreg state")?;
 
         rt.create(&st)?;
@@ -114,7 +114,7 @@ impl Actor {
         }
 
         // Disallow existing clients as verifiers.
-        let token_balance = balance_of(rt, &st.token, &verifier)?;
+        let token_balance = balance_of(rt, &verifier)?;
         if token_balance.is_positive() {
             return Err(actor_error!(
                 illegal_argument,
@@ -216,7 +216,7 @@ impl Actor {
 
         // Credit client token allowance.
         let operators = vec![*STORAGE_MARKET_ACTOR_ADDR];
-        mint(rt, &st.token, &client, &params.allowance, operators).context(format!(
+        mint(rt, &client, &params.allowance, operators).context(format!(
             "failed to mint {} data cap to client {}",
             &params.allowance, client
         ))?;
@@ -249,17 +249,15 @@ impl Actor {
             ));
         }
 
-        let st: State = rt.state()?;
-
         // Deduct from client's token allowance.
-        let remaining = destroy(rt, &st.token, &client, &params.deal_size).context(format!(
+        let remaining = destroy(rt, &client, &params.deal_size).context(format!(
             "failed to deduct {} from allowance for {}",
             &params.deal_size, &client
         ))?;
 
         // Destroy any remaining balance below minimum verified deal size.
         if remaining.is_positive() && remaining < rt.policy().minimum_verified_allocation_size {
-            destroy(rt, &st.token, &client, &remaining).context(format!(
+            destroy(rt, &client, &remaining).context(format!(
                 "failed to destroy remaining {} from allowance for {}",
                 &remaining, &client
             ))?;
@@ -306,7 +304,7 @@ impl Actor {
         }
 
         let operators = vec![*STORAGE_MARKET_ACTOR_ADDR];
-        mint(rt, &st.token, &client, &params.deal_size, operators).context(format!(
+        mint(rt, &client, &params.deal_size, operators).context(format!(
             "failed to restore {} to allowance for {}",
             &params.deal_size, &client
         ))
@@ -360,7 +358,7 @@ impl Actor {
         }
 
         // Validate and then remove the proposal.
-        let token = rt.transaction(|st: &mut State, rt| {
+        rt.transaction(|st: &mut State, rt| {
             rt.validate_immediate_caller_is(std::iter::once(&st.root_key))?;
 
             if !is_verifier(rt, st, verifier_1)? {
@@ -405,13 +403,13 @@ impl Actor {
             st.remove_data_cap_proposal_ids = proposal_ids
                 .flush()
                 .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush proposal ids")?;
-            Ok(st.token)
+            Ok(())
         })?;
 
         // Burn the client's data cap tokens.
-        let balance = balance_of(rt, &token, &client).context("failed to fetch balance")?;
+        let balance = balance_of(rt, &client).context("failed to fetch balance")?;
         let burnt = std::cmp::min(balance, params.data_cap_amount_to_remove);
-        destroy(rt, &token, &client, &burnt)
+        destroy(rt, &client, &burnt)
             .context(format!("failed to destroy {} from allowance for {}", &burnt, &client))?;
 
         Ok(RemoveDataCapReturn {
@@ -435,45 +433,44 @@ impl Actor {
         let client = params.client;
         let mut ret_gen = BatchReturnGen::new(params.allocation_ids.len());
         let mut recovered_datacap = DataCap::zero();
-        let token_addr = rt
-            .transaction(|st: &mut State, rt| {
-                let mut allocs = st.load_allocs(rt.store())?;
-                for alloc_id in params.allocation_ids {
-                    let maybe_alloc = allocs.get(client, alloc_id).context_code(
-                        ExitCode::USR_ILLEGAL_STATE,
-                        "HAMT lookup failure getting allocation",
-                    )?;
-                    let alloc = match maybe_alloc {
-                        None => {
-                            ret_gen.add_fail(ExitCode::USR_NOT_FOUND);
-                            info!(
+        rt.transaction(|st: &mut State, rt| {
+            let mut allocs = st.load_allocs(rt.store())?;
+            for alloc_id in params.allocation_ids {
+                let maybe_alloc = allocs.get(client, alloc_id).context_code(
+                    ExitCode::USR_ILLEGAL_STATE,
+                    "HAMT lookup failure getting allocation",
+                )?;
+                let alloc = match maybe_alloc {
+                    None => {
+                        ret_gen.add_fail(ExitCode::USR_NOT_FOUND);
+                        info!(
                             "claim references allocation id {} that does not belong to client {}",
                             alloc_id, client,
                         );
-                            continue;
-                        }
-                        Some(a) => a,
-                    };
-                    if alloc.expiration > rt.curr_epoch() {
-                        ret_gen.add_fail(ExitCode::USR_FORBIDDEN);
-                        info!("cannot revoke allocation {} that has not expired", alloc_id);
                         continue;
                     }
-                    recovered_datacap += alloc.size.0;
-
-                    allocs.remove(client, alloc_id).context_code(
-                        ExitCode::USR_ILLEGAL_STATE,
-                        format!("failed to remove allocation {}", alloc_id),
-                    )?;
-                    ret_gen.add_success();
+                    Some(a) => a,
+                };
+                if alloc.expiration > rt.curr_epoch() {
+                    ret_gen.add_fail(ExitCode::USR_FORBIDDEN);
+                    info!("cannot revoke allocation {} that has not expired", alloc_id);
+                    continue;
                 }
-                st.save_allocs(&mut allocs)?;
-                Ok(st.token)
-            })
-            .context("state transaction failed")?;
+                recovered_datacap += alloc.size.0;
+
+                allocs.remove(client, alloc_id).context_code(
+                    ExitCode::USR_ILLEGAL_STATE,
+                    format!("failed to remove allocation {}", alloc_id),
+                )?;
+                ret_gen.add_success();
+            }
+            st.save_allocs(&mut allocs)?;
+            Ok(())
+        })
+        .context("state transaction failed")?;
 
         // Transfer the recovered datacap back to the client.
-        transfer(rt, &token_addr, &client, &recovered_datacap).with_context(|| {
+        transfer(rt, &client, &recovered_datacap).with_context(|| {
             format!(
                 "failed to transfer recovered datacap {} back to client {}",
                 &recovered_datacap, &client
@@ -501,81 +498,80 @@ impl Actor {
         }
         let mut datacap_claimed = DataCap::zero();
         let mut ret_gen = BatchReturnGen::new(params.sectors.len());
-        let token = rt
-            .transaction(|st: &mut State, rt| {
-                let mut claims = st.load_claims(rt.store())?;
-                let mut allocs = st.load_allocs(rt.store())?;
+        rt.transaction(|st: &mut State, rt| {
+            let mut claims = st.load_claims(rt.store())?;
+            let mut allocs = st.load_allocs(rt.store())?;
 
-                for claim_alloc in params.sectors {
-                    let maybe_alloc =
-                        allocs.get(claim_alloc.client, claim_alloc.allocation_id).context_code(
-                            ExitCode::USR_ILLEGAL_STATE,
-                            "HAMT lookup failure getting allocation",
-                        )?;
-
-                    let alloc: &Allocation = match maybe_alloc {
-                        None => {
-                            ret_gen.add_fail(ExitCode::USR_NOT_FOUND);
-                            info!(
-                                "no allocation {} for client {}",
-                                claim_alloc.allocation_id, claim_alloc.client,
-                            );
-                            continue;
-                        }
-                        Some(a) => a,
-                    };
-
-                    if !can_claim_alloc(&claim_alloc, provider, alloc, rt.curr_epoch()) {
-                        ret_gen.add_fail(ExitCode::USR_FORBIDDEN);
-                        info!(
-                            "invalid sector {:?} for allocation {}",
-                            claim_alloc.sector, claim_alloc.allocation_id,
-                        );
-                        continue;
-                    }
-
-                    let new_claim = Claim {
-                        provider,
-                        client: alloc.client,
-                        data: alloc.data,
-                        size: alloc.size,
-                        term_min: alloc.term_min,
-                        term_max: alloc.term_max,
-                        term_start: rt.curr_epoch(),
-                        sector: claim_alloc.sector,
-                    };
-
-                    let inserted = claims
-                        .put_if_absent(provider, claim_alloc.allocation_id, new_claim)
-                        .context_code(
-                            ExitCode::USR_ILLEGAL_STATE,
-                            format!("failed to write claim {}", claim_alloc.allocation_id),
-                        )?;
-                    if !inserted {
-                        ret_gen.add_fail(ExitCode::USR_ILLEGAL_STATE); // should be unreachable since claim and alloc can't exist at once
-                        info!(
-                            "claim for allocation {} could not be inserted as it already exists",
-                            claim_alloc.allocation_id,
-                        );
-                        continue;
-                    }
-
-                    allocs.remove(claim_alloc.client, claim_alloc.allocation_id).context_code(
+            for claim_alloc in params.sectors {
+                let maybe_alloc =
+                    allocs.get(claim_alloc.client, claim_alloc.allocation_id).context_code(
                         ExitCode::USR_ILLEGAL_STATE,
-                        format!("failed to remove allocation {}", claim_alloc.allocation_id),
+                        "HAMT lookup failure getting allocation",
                     )?;
 
-                    datacap_claimed += DataCap::from(claim_alloc.size.0);
-                    ret_gen.add_success();
+                let alloc: &Allocation = match maybe_alloc {
+                    None => {
+                        ret_gen.add_fail(ExitCode::USR_NOT_FOUND);
+                        info!(
+                            "no allocation {} for client {}",
+                            claim_alloc.allocation_id, claim_alloc.client,
+                        );
+                        continue;
+                    }
+                    Some(a) => a,
+                };
+
+                if !can_claim_alloc(&claim_alloc, provider, alloc, rt.curr_epoch()) {
+                    ret_gen.add_fail(ExitCode::USR_FORBIDDEN);
+                    info!(
+                        "invalid sector {:?} for allocation {}",
+                        claim_alloc.sector, claim_alloc.allocation_id,
+                    );
+                    continue;
                 }
-                st.save_allocs(&mut allocs)?;
-                st.save_claims(&mut claims)?;
-                Ok(st.token)
-            })
-            .context("state transaction failed")?;
+
+                let new_claim = Claim {
+                    provider,
+                    client: alloc.client,
+                    data: alloc.data,
+                    size: alloc.size,
+                    term_min: alloc.term_min,
+                    term_max: alloc.term_max,
+                    term_start: rt.curr_epoch(),
+                    sector: claim_alloc.sector,
+                };
+
+                let inserted = claims
+                    .put_if_absent(provider, claim_alloc.allocation_id, new_claim)
+                    .context_code(
+                        ExitCode::USR_ILLEGAL_STATE,
+                        format!("failed to write claim {}", claim_alloc.allocation_id),
+                    )?;
+                if !inserted {
+                    ret_gen.add_fail(ExitCode::USR_ILLEGAL_STATE); // should be unreachable since claim and alloc can't exist at once
+                    info!(
+                        "claim for allocation {} could not be inserted as it already exists",
+                        claim_alloc.allocation_id,
+                    );
+                    continue;
+                }
+
+                allocs.remove(claim_alloc.client, claim_alloc.allocation_id).context_code(
+                    ExitCode::USR_ILLEGAL_STATE,
+                    format!("failed to remove allocation {}", claim_alloc.allocation_id),
+                )?;
+
+                datacap_claimed += DataCap::from(claim_alloc.size.0);
+                ret_gen.add_success();
+            }
+            st.save_allocs(&mut allocs)?;
+            st.save_claims(&mut claims)?;
+            Ok(())
+        })
+        .context("state transaction failed")?;
 
         // Burn the datacap tokens from verified registry's own balance.
-        burn(rt, &token, &datacap_claimed)?;
+        burn(rt, &datacap_claimed)?;
 
         Ok(ret_gen.gen())
     }
@@ -588,9 +584,8 @@ impl Actor {
         BS: Blockstore,
         RT: Runtime<BS>,
     {
-        let st: State = rt.state()?;
         // Accept only the data cap token.
-        rt.validate_immediate_caller_is(&[st.token])?;
+        rt.validate_immediate_caller_is(&[*DATACAP_TOKEN_ACTOR_ADDR])?;
 
         let my_id = rt.message().receiver().id().unwrap();
         let curr_epoch = rt.curr_epoch();
@@ -650,16 +645,21 @@ where
     Ok(found)
 }
 
-// Invokes BalanceOf on a data cap token actor, and converts the result to whole units of data cap.
-fn balance_of<BS, RT>(rt: &mut RT, token: &Address, owner: &Address) -> Result<DataCap, ActorError>
+// Invokes BalanceOf on the data cap token actor, and converts the result to whole units of data cap.
+fn balance_of<BS, RT>(rt: &mut RT, owner: &Address) -> Result<DataCap, ActorError>
 where
     BS: Blockstore,
     RT: Runtime<BS>,
 {
     let params = serialize(owner, "owner address")?;
     let ret = rt
-        .send(token, ext::datacap::Method::BalanceOf as u64, params, TokenAmount::zero())
-        .context(format!("failed to query balance of {} for {}", token, owner))?;
+        .send(
+            &DATACAP_TOKEN_ACTOR_ADDR,
+            ext::datacap::Method::BalanceOf as u64,
+            params,
+            TokenAmount::zero(),
+        )
+        .context(format!("failed to query datacap balance of {}", owner))?;
     let x: TokenAmount = deserialize(&ret, "balance result")?;
     Ok(tokens_to_datacap(&x))
 }
@@ -667,7 +667,6 @@ where
 // Invokes Mint on a data cap token actor for whole units of data cap.
 fn mint<BS, RT>(
     rt: &mut RT,
-    token: &Address,
     to: &Address,
     amount: &DataCap,
     operators: Vec<Address>,
@@ -679,17 +678,17 @@ where
     let token_amt = datacap_to_tokens(amount);
     let params = MintParams { to: *to, amount: token_amt, operators };
     rt.send(
-        token,
+        &DATACAP_TOKEN_ACTOR_ADDR,
         ext::datacap::Method::Mint as u64,
         serialize(&params, "mint params")?,
         TokenAmount::zero(),
     )
-    .context(format!("failed to send mint {:?} to {}", params, token))?;
+    .context(format!("failed to send mint {:?} to datacap", params))?;
     Ok(())
 }
 
 // Invokes Burn on a data cap token actor for whole units of data cap.
-fn burn<BS, RT>(rt: &mut RT, token: &Address, amount: &DataCap) -> Result<DataCap, ActorError>
+fn burn<BS, RT>(rt: &mut RT, amount: &DataCap) -> Result<DataCap, ActorError>
 where
     BS: Blockstore,
     RT: Runtime<BS>,
@@ -698,23 +697,18 @@ where
     let params = BurnParams { amount: token_amt };
     let ret: BurnReturn = rt
         .send(
-            token,
+            &DATACAP_TOKEN_ACTOR_ADDR,
             ext::datacap::Method::Burn as u64,
             serialize(&params, "burn params")?,
             TokenAmount::zero(),
         )
-        .context(format!("failed to send burn {:?} to {}", params, token))?
+        .context(format!("failed to send burn {:?} to datacap", params))?
         .deserialize()?;
     Ok(tokens_to_datacap(&ret.balance))
 }
 
 // Invokes Destroy on a data cap token actor for whole units of data cap.
-fn destroy<BS, RT>(
-    rt: &mut RT,
-    token: &Address,
-    owner: &Address,
-    amount: &DataCap,
-) -> Result<DataCap, ActorError>
+fn destroy<BS, RT>(rt: &mut RT, owner: &Address, amount: &DataCap) -> Result<DataCap, ActorError>
 where
     BS: Blockstore,
     RT: Runtime<BS>,
@@ -723,23 +717,18 @@ where
     let params = DestroyParams { owner: *owner, amount: token_amt };
     let ret: BurnReturn = rt
         .send(
-            token,
+            &DATACAP_TOKEN_ACTOR_ADDR,
             ext::datacap::Method::Destroy as u64,
             serialize(&params, "destroy params")?,
             TokenAmount::zero(),
         )
-        .context(format!("failed to send destroy {:?} to {}", params, token))?
+        .context(format!("failed to send destroy {:?} to datacap", params))?
         .deserialize()?;
     Ok(tokens_to_datacap(&ret.balance))
 }
 
 // Invokes transfer on a data cap token actor for whole units of data cap.
-fn transfer<BS, RT>(
-    rt: &mut RT,
-    token: &Address,
-    to: &Address,
-    amount: &DataCap,
-) -> Result<(), ActorError>
+fn transfer<BS, RT>(rt: &mut RT, to: &Address, amount: &DataCap) -> Result<(), ActorError>
 where
     BS: Blockstore,
     RT: Runtime<BS>,
@@ -747,12 +736,12 @@ where
     let token_amt = datacap_to_tokens(amount);
     let params = TransferParams { to: *to, amount: token_amt, operator_data: Default::default() };
     rt.send(
-        token,
+        &DATACAP_TOKEN_ACTOR_ADDR,
         ext::datacap::Method::Transfer as u64,
         serialize(&params, "transfer params")?,
         TokenAmount::zero(),
     )
-    .context(format!("failed to send transfer {:?} to {}", params, token))?;
+    .context(format!("failed to send transfer to datacap {:?}", params))?;
     Ok(())
 }
 

--- a/actors/verifreg/src/state.rs
+++ b/actors/verifreg/src/state.rs
@@ -24,8 +24,6 @@ use crate::{AllocationID, ClaimID};
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct State {
     pub root_key: Address,
-    // Address of the data cap token actor
-    pub token: Address,
     // Maps verifier addresses to data cap minting allowance (in bytes).
     pub verifiers: Cid,
     pub remove_data_cap_proposal_ids: Cid,
@@ -35,11 +33,7 @@ pub struct State {
 }
 
 impl State {
-    pub fn new<BS: Blockstore>(
-        store: &BS,
-        root_key: Address,
-        token: Address,
-    ) -> Result<State, ActorError> {
+    pub fn new<BS: Blockstore>(store: &BS, root_key: Address) -> Result<State, ActorError> {
         let empty_map = make_empty_map::<_, ()>(store, HAMT_BIT_WIDTH)
             .flush()
             .map_err(|e| actor_error!(illegal_state, "failed to create empty map: {}", e))?;
@@ -53,7 +47,6 @@ impl State {
 
         Ok(State {
             root_key,
-            token,
             verifiers: empty_map,
             remove_data_cap_proposal_ids: empty_map,
             allocations: empty_mapmap,
@@ -142,7 +135,7 @@ impl State {
     ) -> Result<(), ActorError> {
         self.allocations = allocs
             .flush()
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush allocation table")?;
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush allocations table")?;
         Ok(())
     }
 

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -227,9 +227,7 @@ impl<'bs> VM<'bs> {
         let root_msig_addr = msig_ctor_ret.id_address;
         assert_eq!(TEST_VERIFREG_ROOT_ADDR, root_msig_addr);
         // verifreg
-        let verifreg_head = v.put_store(
-            &VerifRegState::new(&v.store, root_msig_addr, *DATACAP_TOKEN_ACTOR_ADDR).unwrap(),
-        );
+        let verifreg_head = v.put_store(&VerifRegState::new(&v.store, root_msig_addr).unwrap());
         v.set_actor(
             *VERIFIED_REGISTRY_ACTOR_ADDR,
             actor(*VERIFREG_ACTOR_CODE_ID, verifreg_head, 0, TokenAmount::zero()),


### PR DESCRIPTION
@ZenGround0 challenged me on this earlier, and now I think I was wrong. We'll be deploying new code any time this could possibly change anyway.

I still think the datacap token actor holding the address of its governor (the verified registry) in state makes sense, so that the datacap actor has no conceptual dependency back on the other builtins.