### PR TITLE
Use ActorID rather than addresses in new verifreg state

### DIFF
--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -12,6 +12,7 @@ use fvm_shared::crypto::signature::Signature;
 use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::SectorNumber;
 use fvm_shared::sector::StoragePower;
+use fvm_shared::ActorID;
 
 pub type AllocationID = u64;
 pub type ClaimID = u64;
@@ -106,7 +107,7 @@ impl AddrPairKey {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct RemoveExpiredAllocationsParams {
-    pub client: Address,
+    pub client: ActorID,
     pub allocation_ids: Vec<AllocationID>,
 }
 impl Cbor for RemoveExpiredAllocationsParams {}
@@ -115,7 +116,7 @@ pub type RemoveExpiredAllocationsReturn = BatchReturn;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct SectorAllocationClaim {
-    pub client: Address,
+    pub client: ActorID,
     pub allocation_id: AllocationID,
     pub data: Cid,
     pub size: PaddedPieceSize,
@@ -134,7 +135,7 @@ pub type ClaimAllocationsReturn = BatchReturn;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ClaimTerm {
-    provider: Address,
+    provider: ActorID,
     claim_id: ClaimID,
     term_max: ChainEpoch,
 }

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -314,7 +314,8 @@ impl Harness {
             ExitCode::OK,
         );
 
-        let params = RemoveExpiredAllocationsParams { client: *client, allocation_ids };
+        let params =
+            RemoveExpiredAllocationsParams { client: client.id().unwrap(), allocation_ids };
         let ret = rt
             .call::<VerifregActor>(
                 Method::RemoveExpiredAllocations as MethodNum,
@@ -350,8 +351,8 @@ impl Harness {
 
 pub fn make_alloc(data_id: &str, client: &Address, provider: &Address, size: u64) -> Allocation {
     Allocation {
-        client: *client,
-        provider: *provider,
+        client: client.id().unwrap(),
+        provider: provider.id().unwrap(),
         data: make_piece_cid(data_id.as_bytes()),
         size: PaddedPieceSize(size),
         term_min: 1000,
@@ -373,10 +374,10 @@ pub fn make_alloc_req(rt: &MockRuntime, provider: ActorID, size: u64) -> Allocat
 }
 
 // Creates the expected allocation from a request.
-pub fn alloc_from_req(client: &Address, req: &AllocationRequest) -> Allocation {
+pub fn alloc_from_req(client: ActorID, req: &AllocationRequest) -> Allocation {
     Allocation {
-        client: *client,
-        provider: req.provider,
+        client,
+        provider: req.provider.id().unwrap(),
         data: req.data,
         size: req.size,
         term_min: req.term_min,

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -512,15 +512,17 @@ mod claims {
         let store = rt.store();
         let mut allocs = st.load_allocs(&store).unwrap();
         // allocs deleted
-        assert!(allocs.get(*CLIENT, 1).unwrap().is_none());
-        assert!(allocs.get(*CLIENT, 2).unwrap().is_none());
-        assert!(allocs.get(*CLIENT, 3).unwrap().is_none());
+        let client_id = CLIENT.id().unwrap();
+        assert!(allocs.get(client_id, 1).unwrap().is_none());
+        assert!(allocs.get(client_id, 2).unwrap().is_none());
+        assert!(allocs.get(client_id, 3).unwrap().is_none());
 
         // claims inserted
         let mut claims = st.load_claims(&store).unwrap();
-        assert_eq!(claims.get(provider, 1).unwrap().unwrap().client, *CLIENT);
-        assert_eq!(claims.get(provider, 2).unwrap().unwrap().client, *CLIENT);
-        assert_eq!(claims.get(provider, 3).unwrap().unwrap().client, *CLIENT);
+        let provider_id = provider.id().unwrap();
+        assert_eq!(claims.get(provider_id, 1).unwrap().unwrap().client, client_id);
+        assert_eq!(claims.get(provider_id, 2).unwrap().unwrap().client, client_id);
+        assert_eq!(claims.get(provider_id, 3).unwrap().unwrap().client, client_id);
     }
 }
 
@@ -574,14 +576,13 @@ mod datacap {
             let store = &rt.store();
             let mut allocs = st.load_allocs(store).unwrap();
 
-            let client_addr = Address::new_id(CLIENT1);
             assert_eq!(
-                &alloc_from_req(&client_addr, &reqs[0]),
-                allocs.get(client_addr, 1).unwrap().unwrap()
+                &alloc_from_req(CLIENT1, &reqs[0]),
+                allocs.get(CLIENT1, 1).unwrap().unwrap()
             );
             assert_eq!(
-                &alloc_from_req(&client_addr, &reqs[1]),
-                allocs.get(client_addr, 2).unwrap().unwrap()
+                &alloc_from_req(CLIENT1, &reqs[1]),
+                allocs.get(CLIENT1, 2).unwrap().unwrap()
             );
             assert_eq!(3, st.next_allocation_id);
         }
@@ -595,10 +596,9 @@ mod datacap {
             let st: State = rt.get_state();
             let store = &rt.store();
             let mut allocs = st.load_allocs(store).unwrap();
-            let client_addr = Address::new_id(CLIENT2);
             assert_eq!(
-                &alloc_from_req(&client_addr, &reqs[0]),
-                allocs.get(client_addr, 3).unwrap().unwrap()
+                &alloc_from_req(CLIENT2, &reqs[0]),
+                allocs.get(CLIENT2, 3).unwrap().unwrap()
             );
             assert_eq!(4, st.next_allocation_id);
         }


### PR DESCRIPTION
As discussed.

In this PR I haven't also migrated the `verifiers` map to be keyed by actor ID. This would require a migration, but a small one and we're touching this actor anyway. LMK whether you think I should do that, and if so in this PR or a follow-up.