### PR TITLE
Raise market allowance infinite constant

### DIFF
--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -39,8 +39,8 @@ pub const DATACAP_GRANULARITY: u64 = TOKEN_PRECISION as u64;
 
 lazy_static! {
     static ref INFINITE_ALLOWANCE: TokenAmount = TokenAmount::from_atto(
-        BigInt::from(1_000_000_000_000_000_000 as i64)
-            * BigInt::from(1_000_000_000_000_000_000_000 as i128)
+        BigInt::from(1_000_000_000_000_000_000_i64)
+            * BigInt::from(1_000_000_000_000_000_000_000_i128)
     );
 }
 /// Static method numbers for builtin-actor private dispatch.

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -38,8 +38,9 @@ mod types;
 pub const DATACAP_GRANULARITY: u64 = TOKEN_PRECISION as u64;
 
 lazy_static! {
+    // > 800 EiB
     static ref INFINITE_ALLOWANCE: TokenAmount = TokenAmount::from_atto(
-        BigInt::from(1_000_000_000_000_000_000_i64)
+        BigInt::from(TOKEN_PRECISION)
             * BigInt::from(1_000_000_000_000_000_000_000_i128)
     );
 }

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -10,6 +10,7 @@ use fil_fungible_token::token::{Token, TokenError, TOKEN_PRECISION};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
+use fvm_shared::bigint::BigInt;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::receipt::Receipt;
@@ -37,9 +38,11 @@ mod types;
 pub const DATACAP_GRANULARITY: u64 = TOKEN_PRECISION as u64;
 
 lazy_static! {
-    static ref INFINITE_ALLOWANCE: TokenAmount = TokenAmount::from_whole(2_000_000_000);
+    static ref INFINITE_ALLOWANCE: TokenAmount = TokenAmount::from_atto(
+        BigInt::from(1_000_000_000_000_000_000 as i64)
+            * BigInt::from(1_000_000_000_000_000_000_000 as i128)
+    );
 }
-
 /// Static method numbers for builtin-actor private dispatch.
 /// The methods are also expected to be exposed via FRC-XXXX standard calling convention,
 /// with numbers determined by name.

--- a/actors/datacap/tests/datacap_actor_test.rs
+++ b/actors/datacap/tests/datacap_actor_test.rs
@@ -81,28 +81,6 @@ mod mint {
             h.mint(&mut rt, &*ALICE, &amt, vec![]),
         );
     }
-
-    #[test]
-    fn adds_allowance_for_operator() {
-        let (mut rt, h) = make_harness();
-
-        let amt = TokenAmount::from_whole(1);
-        let allowance = TokenAmount::from_whole(2_000_000_000);
-        h.mint(&mut rt, &*ALICE, &amt, vec![*BOB]).unwrap();
-        assert_eq!(allowance, h.get_allowance(&rt, &*ALICE, &BOB));
-
-        h.mint(&mut rt, &*ALICE, &amt, vec![*BOB]).unwrap();
-        // Note: the doubling of allowance here is unfortunate, should be resolved when
-        // the token library offers a set_allowance method.
-        assert_eq!(&allowance * 2, h.get_allowance(&rt, &*ALICE, &BOB));
-
-        // Different operator
-        h.mint(&mut rt, &*ALICE, &amt, vec![*CARLA]).unwrap();
-        assert_eq!(&allowance * 2, h.get_allowance(&rt, &*ALICE, &BOB));
-        assert_eq!(allowance, h.get_allowance(&rt, &*ALICE, &CARLA));
-
-        h.check_state(&rt);
-    }
 }
 
 fn make_harness() -> (MockRuntime, Harness) {

--- a/actors/datacap/tests/harness/mod.rs
+++ b/actors/datacap/tests/harness/mod.rs
@@ -110,19 +110,6 @@ impl Harness {
         rt.get_state::<State>().token.get_balance(rt.store(), address.id().unwrap()).unwrap()
     }
 
-    // Reads an allowance from state directly.
-    pub fn get_allowance(
-        &self,
-        rt: &MockRuntime,
-        owner: &Address,
-        operator: &Address,
-    ) -> TokenAmount {
-        rt.get_state::<State>()
-            .token
-            .get_allowance_between(rt.store(), owner.id().unwrap(), operator.id().unwrap())
-            .unwrap()
-    }
-
     pub fn check_state(&self, rt: &MockRuntime) {
         let (_, acc) = check_state_invariants(&rt.get_state(), rt.store());
         acc.assert_empty();


### PR DESCRIPTION
If I understand the way datacap works with the TokenAmount type it is 1) measured in units of bytes 2) measured at a base level of atto bytes when tokenized.  That is a token amount of 10^18 should represent one byte.

If these assumptions are correct then the [recent infinite limit](https://github.com/filecoin-project/builtin-actors/pull/611/files#diff-b372537e46dbaa904e6da0d0c5d07314a080245f3146a86a0fde77d718b54e20R40) is not actually that big ~GBs.  This PR changes it to ~1000 EiB.  Unfortunately `TokenAmount::from_whole` takes i64 not i128 so creating this constant is now messy.