### PR TITLE
EVM runtime: implement GetBytecode and GetStorageAt getters.

### DIFF
--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -205,11 +205,10 @@ pub fn call<'r, BS: Blockstore, RT: Runtime<BS>>(
     // TODO this limits addressable output to 2G (31 bits full),
     //      but it is still probably too much and we should consistently limit further.
     //      See also https://github.com/filecoin-project/ref-fvm/issues/851
-    let output_usize = if output_size.bits() < 32 {
-        output_size.as_usize()
-    } else {
-        return Err(StatusCode::InvalidMemoryAccess);
-    };
+    let output_usize = (output_size.bits() < 32)
+        .then(|| output_size.as_usize())
+        .ok_or(StatusCode::InvalidMemoryAccess)?;
+
     if output_usize > 0 {
         let output_region = get_memory_region(memory, output_offset, output_size)
             .map_err(|_| StatusCode::InvalidMemoryAccess)?;

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -205,9 +205,10 @@ pub fn call<'r, BS: Blockstore, RT: Runtime<BS>>(
     // TODO this limits addressable output to 2G (31 bits full),
     //      but it is still probably too much and we should consistently limit further.
     //      See also https://github.com/filecoin-project/ref-fvm/issues/851
-    let output_usize = (output_size.bits() < 32)
-        .then(|| output_size.as_usize())
-        .ok_or(StatusCode::InvalidMemoryAccess)?;
+    if output_size.bits() >= 32 {
+        return Err(StatusCode::InvalidMemoryAccess);
+    }
+    let output_usize = output_size.as_usize();
 
     if output_usize > 0 {
         let output_region = get_memory_region(memory, output_offset, output_size)


### PR DESCRIPTION
- `GetBytecode` returns the CID of the bytecode block. In the future, the FVM's reachability analysis should add this CID to the reachable set of the caller. `GetBytecode` is publicly callable.

- `GetStorageAt` returns the value stored in the supplied EVM storage key. This method is private and only intended for calls from instrumentation and client functionality, such as the `eth_getStorageAt` JSON-RPC API operation. In order to make it private, it validates that the caller is the zero address. It needs to be private to preserve EVM guarantees: no contract is able to arbitrarily access storage keys from another contract. The client must form a message from the 0x0 sender address for this method to work.

Supports https://github.com/filecoin-project/ref-fvm/issues/838
Supports https://github.com/filecoin-project/ref-fvm/issues/854