### PR TITLE
Adapt sector info and weight calculation for fip 0045

### DIFF
--- a/actors/market/src/deal.rs
+++ b/actors/market/src/deal.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::{Cid, Version};
-use fil_actors_runtime::DealWeight;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{BytesSer, Cbor};
 use fvm_shared::address::Address;
@@ -118,10 +117,6 @@ impl Cbor for DealProposal {}
 impl DealProposal {
     pub fn duration(&self) -> ChainEpoch {
         self.end_epoch - self.start_epoch
-    }
-    /// Computes weight for a deal proposal, which is a function of its size and duration.
-    pub fn weight(&self) -> DealWeight {
-        DealWeight::from(self.duration()) * self.piece_size.0
     }
     pub fn total_storage_fee(&self) -> TokenAmount {
         self.storage_price_per_epoch.clone() * self.duration() as u64

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -1121,7 +1121,7 @@ where
         }
     }
     if let Some(sector_size) = sector_size {
-        let total_deal_size = deal_size + verified_deal_size ;
+        let total_deal_size = deal_size + verified_deal_size;
         if total_deal_size > sector_size as u64 {
             return Err(actor_error!(
                 illegal_argument,
@@ -1133,10 +1133,7 @@ where
         }
     }
 
-    Ok(DealSizes {
-        deal_space: deal_size,
-        verified_deal_space: verified_deal_size,
-    })
+    Ok(DealSizes { deal_space: deal_size, verified_deal_space: verified_deal_size })
 }
 
 pub fn gen_rand_next_epoch(

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -534,7 +534,7 @@ impl Actor {
         let miner_addr = rt.message().caller();
         let curr_epoch = rt.curr_epoch();
 
-        let deal_sizes = {
+        let deal_spaces = {
             let st: State = rt.state()?;
             let proposals = DealArray::load(&st.proposals, rt.store()).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load deal proposals")
@@ -641,7 +641,7 @@ impl Actor {
             Ok(())
         })?;
 
-        Ok(ActivateDealsResult { sizes: deal_sizes })
+        Ok(ActivateDealsResult { spaces: deal_spaces })
     }
 
     /// Terminate a set of deals in response to their containing sector being terminated.
@@ -1091,7 +1091,7 @@ pub fn validate_and_compute_deal_weight<BS>(
     sector_expiry: ChainEpoch,
     sector_activation: ChainEpoch,
     sector_size: Option<SectorSize>,
-) -> anyhow::Result<DealSizes>
+) -> anyhow::Result<DealSpaces>
 where
     BS: Blockstore,
 {
@@ -1133,7 +1133,7 @@ where
         }
     }
 
-    Ok(DealSizes { deal_space: deal_size, verified_deal_space: verified_deal_size })
+    Ok(DealSpaces { deal_space: deal_size, verified_deal_space: verified_deal_size })
 }
 
 pub fn gen_rand_next_epoch(

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -1096,8 +1096,8 @@ where
     BS: Blockstore,
 {
     let mut seen_deal_ids = BTreeSet::new();
-    let mut deal_space = 0;
-    let mut verified_deal_space = 0;
+    let mut deal_space = BigInt::zero();
+    let mut verified_deal_space = BigInt::zero();
     for deal_id in deal_ids {
         if !seen_deal_ids.insert(deal_id) {
             return Err(actor_error!(
@@ -1121,8 +1121,8 @@ where
         }
     }
     if let Some(sector_size) = sector_size {
-        let total_deal_space = deal_space + verified_deal_space;
-        if total_deal_space > sector_size as u64 {
+        let total_deal_space = deal_space.clone() + verified_deal_space.clone();
+        if total_deal_space > BigInt::from(sector_size as u64) {
             return Err(actor_error!(
                 illegal_argument,
                 "deals too large to fit in sector {} > {}",

--- a/actors/market/src/policy.rs
+++ b/actors/market/src/policy.rs
@@ -5,7 +5,6 @@ use std::cmp::max;
 
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::Policy;
-use fil_actors_runtime::DealWeight;
 use fvm_shared::bigint::{BigInt, Integer};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
@@ -14,19 +13,10 @@ use fvm_shared::sector::StoragePower;
 use fvm_shared::TOTAL_FILECOIN;
 use num_traits::Zero;
 
-use super::deal::DealProposal;
-
 pub mod detail {
-    use super::*;
-
     /// Maximum length of a deal label.
     pub const DEAL_MAX_LABEL_SIZE: usize = 256;
 
-    /// Computes the weight for a deal proposal, which is a function of its size and duration.
-    pub fn deal_weight(proposal: &DealProposal) -> DealWeight {
-        let deal_duration = DealWeight::from(proposal.duration());
-        deal_duration * proposal.piece_size.0
-    }
 }
 
 /// Bounds (inclusive) on deal duration.

--- a/actors/market/src/policy.rs
+++ b/actors/market/src/policy.rs
@@ -16,7 +16,6 @@ use num_traits::Zero;
 pub mod detail {
     /// Maximum length of a deal label.
     pub const DEAL_MAX_LABEL_SIZE: usize = 256;
-
 }
 
 /// Bounds (inclusive) on deal duration.

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-use fil_actors_runtime::{Array, DealWeight};
+use fil_actors_runtime::{Array};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -7,6 +7,7 @@ use fvm_ipld_bitfield::BitField;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
+use fvm_shared::bigint::{bigint_ser, BigInt};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
@@ -101,8 +102,10 @@ pub struct ActivateDealsResult {
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Default)]
 pub struct DealSpaces {
-    pub deal_space: u64,
-    pub verified_deal_space: u64,
+    #[serde(with = "bigint_ser")]
+    pub deal_space: BigInt,
+    #[serde(with = "bigint_ser")]
+    pub verified_deal_space: BigInt,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-use fil_actors_runtime::{Array};
+use fil_actors_runtime::Array;
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -96,11 +96,11 @@ pub struct ActivateDealsParams {
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ActivateDealsResult {
-    pub sizes: DealSizes,
+    pub spaces: DealSpaces,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Default)]
-pub struct DealSizes {
+pub struct DealSpaces {
     pub deal_space: u64,
     pub verified_deal_space: u64,
 }

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -97,16 +97,13 @@ pub struct ActivateDealsParams {
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ActivateDealsResult {
-    pub weights: DealWeights,
+    pub sizes: DealSizes,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Default)]
-pub struct DealWeights {
+pub struct DealSizes {
     pub deal_space: u64,
-    #[serde(with = "bigint_ser")]
-    pub deal_weight: DealWeight,
-    #[serde(with = "bigint_ser")]
-    pub verified_deal_weight: DealWeight,
+    pub verified_deal_space: u64,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -134,14 +134,14 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
         },
     );
 
-    let verified_size = verified_deal_1.piece_size.0 + verified_deal_2.piece_size.0;
-    let unverified_weight = unverified_deal_1.piece_size.0 + unverified_deal_2.piece_size.0;
+    let verified_space = verified_deal_1.piece_size.0 + verified_deal_2.piece_size.0;
+    let unverified_space = unverified_deal_1.piece_size.0 + unverified_deal_2.piece_size.0;
 
     let a_response = activate_deals(&mut rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &deal_ids);
 
     assert_eq!(1, response.sectors.len());
-    assert_eq!(verified_size, a_response.spaces.verified_deal_space);
-    assert_eq!(unverified_weight, a_response.spaces.deal_space);
+    assert_eq!(verified_space, a_response.spaces.verified_deal_space);
+    assert_eq!(unverified_space, a_response.spaces.deal_space);
 
     check_state(&rt);
 }

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -29,7 +29,7 @@ const MINER_ADDRESSES: MinerAddresses = MinerAddresses {
 };
 
 #[test]
-fn verify_deal_and_activate_to_get_deal_weight_for_unverified_deal_proposal() {
+fn verify_deal_and_activate_to_get_deal_space_for_unverified_deal_proposal() {
     let mut rt = setup();
     let deal_id =
         generate_and_publish_deal(&mut rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
@@ -48,14 +48,14 @@ fn verify_deal_and_activate_to_get_deal_weight_for_unverified_deal_proposal() {
     let a_response = activate_deals(&mut rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
     assert_eq!(1, v_response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), v_response.sectors[0].commd);
-    assert_eq!(0, a_response.sizes.verified_deal_space);
-    assert_eq!(deal_proposal.piece_size.0, a_response.sizes.deal_space);
+    assert_eq!(0, a_response.spaces.verified_deal_space);
+    assert_eq!(deal_proposal.piece_size.0, a_response.spaces.deal_space);
 
     check_state(&rt);
 }
 
 #[test]
-fn verify_deal_and_activate_to_get_deal_weight_for_verified_deal_proposal() {
+fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
     let mut rt = setup();
     let deal_id = generate_and_publish_verified_deal(
         &mut rt,
@@ -81,8 +81,8 @@ fn verify_deal_and_activate_to_get_deal_weight_for_verified_deal_proposal() {
 
     assert_eq!(1, response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), response.sectors[0].commd);
-    assert_eq!(deal_proposal.piece_size.0, a_response.sizes.verified_deal_space);
-    assert_eq!(0, a_response.sizes.deal_space);
+    assert_eq!(deal_proposal.piece_size.0, a_response.spaces.verified_deal_space);
+    assert_eq!(0, a_response.spaces.deal_space);
 
     check_state(&rt);
 }
@@ -140,8 +140,8 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
     let a_response = activate_deals(&mut rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &deal_ids);
 
     assert_eq!(1, response.sectors.len());
-    assert_eq!(verified_size, a_response.sizes.verified_deal_space);
-    assert_eq!(unverified_weight, a_response.sizes.deal_space);
+    assert_eq!(verified_size, a_response.spaces.verified_deal_space);
+    assert_eq!(unverified_weight, a_response.spaces.deal_space);
 
     check_state(&rt);
 }

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -51,8 +51,8 @@ fn verify_deal_and_activate_to_get_deal_weight_for_unverified_deal_proposal() {
     let a_response = activate_deals(&mut rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
     assert_eq!(1, v_response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), v_response.sectors[0].commd);
-    assert_eq!(BigInt::zero(), a_response.weights.verified_deal_weight);
-    assert_eq!(deal_weight(&deal_proposal), a_response.weights.deal_weight);
+    assert_eq!(BigInt::zero(), a_response.sizes.verified_deal_space);
+    assert_eq!(&deal_proposal.piece_size.0, a_response.sizes.deal_space);
 
     check_state(&rt);
 }

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -11,11 +11,13 @@ use fil_actors_runtime::test_utils::{
 use fil_actors_runtime::EPOCHS_IN_DAY;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
+use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::RegisteredSealProof;
 use harness::*;
+use num_traits::Zero;
 
 const START_EPOCH: ChainEpoch = 10;
 const CURR_EPOCH: ChainEpoch = START_EPOCH;
@@ -48,8 +50,8 @@ fn verify_deal_and_activate_to_get_deal_space_for_unverified_deal_proposal() {
     let a_response = activate_deals(&mut rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
     assert_eq!(1, v_response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), v_response.sectors[0].commd);
-    assert_eq!(0, a_response.spaces.verified_deal_space);
-    assert_eq!(deal_proposal.piece_size.0, a_response.spaces.deal_space);
+    assert_eq!(BigInt::zero(), a_response.spaces.verified_deal_space);
+    assert_eq!(BigInt::from(deal_proposal.piece_size.0), a_response.spaces.deal_space);
 
     check_state(&rt);
 }
@@ -81,8 +83,8 @@ fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
 
     assert_eq!(1, response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), response.sectors[0].commd);
-    assert_eq!(deal_proposal.piece_size.0, a_response.spaces.verified_deal_space);
-    assert_eq!(0, a_response.spaces.deal_space);
+    assert_eq!(BigInt::from(deal_proposal.piece_size.0), a_response.spaces.verified_deal_space);
+    assert_eq!(BigInt::zero(), a_response.spaces.deal_space);
 
     check_state(&rt);
 }
@@ -134,8 +136,9 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
         },
     );
 
-    let verified_space = verified_deal_1.piece_size.0 + verified_deal_2.piece_size.0;
-    let unverified_space = unverified_deal_1.piece_size.0 + unverified_deal_2.piece_size.0;
+    let verified_space = BigInt::from(verified_deal_1.piece_size.0 + verified_deal_2.piece_size.0);
+    let unverified_space =
+        BigInt::from(unverified_deal_1.piece_size.0 + unverified_deal_2.piece_size.0);
 
     let a_response = activate_deals(&mut rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &deal_ids);
 

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -3,7 +3,6 @@
 
 mod harness;
 
-use fil_actor_market::policy::detail::deal_weight;
 use fil_actor_market::{Actor as MarketActor, Method, SectorDeals, VerifyDealsForActivationParams};
 use fil_actors_runtime::test_utils::{
     expect_abort, expect_abort_contains_message, make_piece_cid, ACCOUNT_ACTOR_CODE_ID,
@@ -12,13 +11,11 @@ use fil_actors_runtime::test_utils::{
 use fil_actors_runtime::EPOCHS_IN_DAY;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
-use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::RegisteredSealProof;
 use harness::*;
-use num_traits::Zero;
 
 const START_EPOCH: ChainEpoch = 10;
 const CURR_EPOCH: ChainEpoch = START_EPOCH;
@@ -51,8 +48,8 @@ fn verify_deal_and_activate_to_get_deal_weight_for_unverified_deal_proposal() {
     let a_response = activate_deals(&mut rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
     assert_eq!(1, v_response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), v_response.sectors[0].commd);
-    assert_eq!(BigInt::zero(), a_response.sizes.verified_deal_space);
-    assert_eq!(&deal_proposal.piece_size.0, a_response.sizes.deal_space);
+    assert_eq!(0, a_response.sizes.verified_deal_space);
+    assert_eq!(deal_proposal.piece_size.0, a_response.sizes.deal_space);
 
     check_state(&rt);
 }
@@ -84,8 +81,8 @@ fn verify_deal_and_activate_to_get_deal_weight_for_verified_deal_proposal() {
 
     assert_eq!(1, response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), response.sectors[0].commd);
-    assert_eq!(deal_weight(&deal_proposal), a_response.weights.verified_deal_weight);
-    assert_eq!(BigInt::zero(), a_response.weights.deal_weight);
+    assert_eq!(deal_proposal.piece_size.0, a_response.sizes.verified_deal_space);
+    assert_eq!(0, a_response.sizes.deal_space);
 
     check_state(&rt);
 }
@@ -137,14 +134,14 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
         },
     );
 
-    let verified_weight = deal_weight(&verified_deal_1) + deal_weight(&verified_deal_2);
-    let unverified_weight = deal_weight(&unverified_deal_1) + deal_weight(&unverified_deal_2);
+    let verified_size = verified_deal_1.piece_size.0 + verified_deal_2.piece_size.0;
+    let unverified_weight = unverified_deal_1.piece_size.0 + unverified_deal_2.piece_size.0;
 
     let a_response = activate_deals(&mut rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &deal_ids);
 
     assert_eq!(1, response.sectors.len());
-    assert_eq!(verified_weight, a_response.weights.verified_deal_weight);
-    assert_eq!(unverified_weight, a_response.weights.deal_weight);
+    assert_eq!(verified_size, a_response.sizes.verified_deal_space);
+    assert_eq!(unverified_weight, a_response.sizes.deal_space);
 
     check_state(&rt);
 }

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -36,11 +36,11 @@ pub mod market {
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct ActivateDealsResult {
-        pub sizes: DealSizes,
+        pub spaces: DealSpaces,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone, Default)]
-    pub struct DealSizes {
+    pub struct DealSpaces {
         pub deal_space: u64,
         pub verified_deal_space: u64,
     }

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -37,16 +37,13 @@ pub mod market {
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct ActivateDealsResult {
-        pub weights: DealWeights,
+        pub sizes: DealSizes,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone, Default)]
-    pub struct DealWeights {
+    pub struct DealSizes {
         pub deal_space: u64,
-        #[serde(with = "bigint_ser")]
-        pub deal_weight: DealWeight,
-        #[serde(with = "bigint_ser")]
-        pub verified_deal_weight: DealWeight,
+        pub verified_deal_space: u64,
     }
 
     #[derive(Serialize_tuple)]

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -1,7 +1,7 @@
 use cid::Cid;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::bigint::bigint_ser;
+use fvm_shared::bigint::{bigint_ser, BigInt};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
@@ -41,10 +41,11 @@ pub mod market {
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone, Default)]
     pub struct DealSpaces {
-        pub deal_space: u64,
-        pub verified_deal_space: u64,
+        #[serde(with = "bigint_ser")]
+        pub deal_space: BigInt,
+        #[serde(with = "bigint_ser")]
+        pub verified_deal_space: BigInt,
     }
-
     #[derive(Serialize_tuple)]
     pub struct ComputeDataCommitmentParamsRef<'a> {
         pub inputs: &'a [SectorDataSpec],

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -1,5 +1,4 @@
 use cid::Cid;
-use fil_actors_runtime::DealWeight;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::bigint::bigint_ser;

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1214,10 +1214,10 @@ impl Actor {
                     new_sector_info.deal_ids = with_details.update.deals.clone();
                     new_sector_info.activation = rt.curr_epoch();
 
-                    let duration = with_details.sector_info.expiration - rt.curr_epoch();
+                    let duration = new_sector_info.expiration - new_sector_info.activation;
 
-                    new_sector_info.deal_weight = DealWeight::from(with_details.deal_spaces.deal_space) * duration;
-                    new_sector_info.verified_deal_weight = DealWeight::from(with_details.deal_spaces.verified_deal_space) * duration;
+                    new_sector_info.deal_weight = with_details.deal_spaces.deal_space.clone() * duration;
+                    new_sector_info.verified_deal_weight = with_details.deal_spaces.verified_deal_space.clone() * duration;
 
                     // compute initial pledge
                     let qa_pow = qa_power_for_weight(
@@ -4610,8 +4610,8 @@ where
                 continue;
             }
 
-            let deal_weight = DealWeight::from(deal_spaces.deal_space) * duration;
-            let verified_deal_weight = DealWeight::from(deal_spaces.verified_deal_space) * duration;
+            let deal_weight = deal_spaces.deal_space * duration;
+            let verified_deal_weight = deal_spaces.verified_deal_space * duration;
 
             let power = qa_power_for_weight(
                 info.sector_size,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1074,11 +1074,7 @@ impl Actor {
 
             let expiration = sector_info.expiration;
             let seal_proof = sector_info.seal_proof;
-            validated_updates.push(UpdateAndSectorInfo {
-                update,
-                sector_info,
-                deal_sizes: deal_sizes,
-            });
+            validated_updates.push(UpdateAndSectorInfo { update, sector_info, deal_sizes });
 
             sectors_deals.push(ext::market::SectorDeals {
                 sector_type: seal_proof,
@@ -4658,8 +4654,8 @@ where
                 deal_ids: pre_commit.info.deal_ids,
                 expiration: pre_commit.info.expiration,
                 activation,
-                deal_weight: deal_weight,
-                verified_deal_weight: verified_deal_weight,
+                deal_weight,
+                verified_deal_weight,
                 initial_pledge,
                 expected_day_reward: day_reward,
                 expected_storage_pledge: storage_pledge,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -18,9 +18,8 @@ pub use deadlines::*;
 pub use expiration_queue::*;
 use fil_actors_runtime::runtime::{ActorCode, DomainSeparationTag, Policy, Runtime};
 use fil_actors_runtime::{
-    actor_error, cbor, ActorDowncast, ActorError, DealWeight, BURNT_FUNDS_ACTOR_ADDR,
-    CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
-    STORAGE_POWER_ACTOR_ADDR,
+    actor_error, cbor, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE,
+    INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
 };
 use fvm_ipld_bitfield::{BitField, UnvalidatedBitField, Validate};
 use fvm_ipld_blockstore::Blockstore;

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -329,6 +329,8 @@ pub struct SectorOnChainInfo {
     pub replaced_day_reward: TokenAmount,
     /// The original SealedSectorCID, only gets set on the first ReplicaUpdate
     pub sector_key_cid: Option<Cid>,
+    // Flag for QA power mechanism introduced in fip 0045
+    pub simple_qa_power: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize_tuple, Deserialize_tuple)]

--- a/actors/miner/tests/aggregate_prove_commit.rs
+++ b/actors/miner/tests/aggregate_prove_commit.rs
@@ -38,7 +38,6 @@ fn valid_precommits_then_aggregate_provecommit() {
     let expiration =
         dl_info.period_end() + rt.policy.wpost_proving_period * DEFAULT_SECTOR_EXPIRATION;
     // fill the sector with verified seals
-    //    let deal_space = actor.sector_size as u64 * (expiration - prove_commit_epoch) as u64;
     let duration = expiration - prove_commit_epoch;
     let deal_spaces = DealSpaces { deal_space: 0, verified_deal_space: actor.sector_size as u64 };
 

--- a/actors/miner/tests/aggregate_prove_commit.rs
+++ b/actors/miner/tests/aggregate_prove_commit.rs
@@ -39,7 +39,10 @@ fn valid_precommits_then_aggregate_provecommit() {
         dl_info.period_end() + rt.policy.wpost_proving_period * DEFAULT_SECTOR_EXPIRATION;
     // fill the sector with verified seals
     let duration = expiration - prove_commit_epoch;
-    let deal_spaces = DealSpaces { deal_space: 0, verified_deal_space: actor.sector_size as u64 };
+    let deal_spaces = DealSpaces {
+        deal_space: BigInt::zero(),
+        verified_deal_space: BigInt::from(actor.sector_size as u64),
+    };
 
     let mut precommits = vec![];
     let mut sector_nos_bf = BitField::new();
@@ -86,8 +89,8 @@ fn valid_precommits_then_aggregate_provecommit() {
     // The sector is exactly full with verified deals, so expect fully verified power.
     let expected_power = BigInt::from(actor.sector_size as i64)
         * (VERIFIED_DEAL_WEIGHT_MULTIPLIER.clone() / QUALITY_BASE_MULTIPLIER.clone());
-    let deal_weight = BigInt::from(deal_spaces.deal_space as i64 * duration);
-    let verified_deal_weight = BigInt::from(deal_spaces.verified_deal_space as i64 * duration);
+    let deal_weight = BigInt::from(deal_spaces.deal_space * duration);
+    let verified_deal_weight = BigInt::from(deal_spaces.verified_deal_space * duration);
     let qa_power = qa_power_for_weight(
         actor.sector_size,
         expiration - rt.epoch,

--- a/actors/miner/tests/aggregate_prove_commit.rs
+++ b/actors/miner/tests/aggregate_prove_commit.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::iter::FromIterator;
 
+use fil_actor_market::DealSizes;
 use fil_actor_miner::{
     initial_pledge_for_power, qa_power_for_weight, PowerPair, QUALITY_BASE_MULTIPLIER,
     VERIFIED_DEAL_WEIGHT_MULTIPLIER,
@@ -10,7 +11,6 @@ use fvm_ipld_bitfield::BitField;
 use fvm_shared::{bigint::BigInt, clock::ChainEpoch, econ::TokenAmount};
 
 mod util;
-use fil_actor_market::DealWeights;
 use fil_actors_runtime::test_utils::make_piece_cid;
 use num_traits::Zero;
 use util::*;
@@ -38,12 +38,9 @@ fn valid_precommits_then_aggregate_provecommit() {
     let expiration =
         dl_info.period_end() + rt.policy.wpost_proving_period * DEFAULT_SECTOR_EXPIRATION;
     // fill the sector with verified seals
-    let deal_space = actor.sector_size as u64 * (expiration - prove_commit_epoch) as u64;
-    let deal_weights = DealWeights {
-        deal_weight: BigInt::zero(),
-        deal_space,
-        verified_deal_weight: BigInt::from(deal_space),
-    };
+    //    let deal_space = actor.sector_size as u64 * (expiration - prove_commit_epoch) as u64;
+    let duration = expiration - prove_commit_epoch;
+    let deal_sizes = DealSizes { deal_space: 0, verified_deal_space: actor.sector_size as u64 };
 
     let mut precommits = vec![];
     let mut sector_nos_bf = BitField::new();
@@ -61,8 +58,8 @@ fn valid_precommits_then_aggregate_provecommit() {
     rt.set_balance(TokenAmount::from_whole(1000));
 
     let pcc = ProveCommitConfig {
-        deal_weights: HashMap::from_iter(
-            precommits.iter().map(|pc| (pc.info.sector_number, deal_weights.clone())),
+        deal_sizes: HashMap::from_iter(
+            precommits.iter().map(|pc| (pc.info.sector_number, deal_sizes.clone())),
         ),
         ..Default::default()
     };
@@ -90,11 +87,13 @@ fn valid_precommits_then_aggregate_provecommit() {
     // The sector is exactly full with verified deals, so expect fully verified power.
     let expected_power = BigInt::from(actor.sector_size as i64)
         * (VERIFIED_DEAL_WEIGHT_MULTIPLIER.clone() / QUALITY_BASE_MULTIPLIER.clone());
+    let deal_weight = BigInt::from(deal_sizes.deal_space as i64 * duration);
+    let verified_deal_weight = BigInt::from(deal_sizes.verified_deal_space as i64 * duration);
     let qa_power = qa_power_for_weight(
         actor.sector_size,
         expiration - rt.epoch,
-        &deal_weights.deal_weight,
-        &deal_weights.verified_deal_weight,
+        &deal_weight,
+        &verified_deal_weight,
     );
     assert_eq!(expected_power, qa_power);
     let expected_initial_pledge = initial_pledge_for_power(
@@ -111,8 +110,8 @@ fn valid_precommits_then_aggregate_provecommit() {
     for sector_no in sector_nos_bf.iter() {
         let sector = actor.get_sector(&rt, sector_no);
         // expect deal weights to be transferred to on chain info
-        assert_eq!(deal_weights.deal_weight, sector.deal_weight);
-        assert_eq!(deal_weights.verified_deal_weight, sector.verified_deal_weight);
+        assert_eq!(deal_weight, sector.deal_weight);
+        assert_eq!(verified_deal_weight, sector.verified_deal_weight);
 
         // expect activation epoch to be current epoch
         assert_eq!(rt.epoch, sector.activation);

--- a/actors/miner/tests/aggregate_prove_commit.rs
+++ b/actors/miner/tests/aggregate_prove_commit.rs
@@ -89,8 +89,8 @@ fn valid_precommits_then_aggregate_provecommit() {
     // The sector is exactly full with verified deals, so expect fully verified power.
     let expected_power = BigInt::from(actor.sector_size as i64)
         * (VERIFIED_DEAL_WEIGHT_MULTIPLIER.clone() / QUALITY_BASE_MULTIPLIER.clone());
-    let deal_weight = BigInt::from(deal_spaces.deal_space * duration);
-    let verified_deal_weight = BigInt::from(deal_spaces.verified_deal_space * duration);
+    let deal_weight = deal_spaces.deal_space * duration;
+    let verified_deal_weight = deal_spaces.verified_deal_space * duration;
     let qa_power = qa_power_for_weight(
         actor.sector_size,
         expiration - rt.epoch,

--- a/actors/miner/tests/aggregate_prove_commit.rs
+++ b/actors/miner/tests/aggregate_prove_commit.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::iter::FromIterator;
 
-use fil_actor_market::DealSizes;
+use fil_actor_market::DealSpaces;
 use fil_actor_miner::{
     initial_pledge_for_power, qa_power_for_weight, PowerPair, QUALITY_BASE_MULTIPLIER,
     VERIFIED_DEAL_WEIGHT_MULTIPLIER,
@@ -40,7 +40,7 @@ fn valid_precommits_then_aggregate_provecommit() {
     // fill the sector with verified seals
     //    let deal_space = actor.sector_size as u64 * (expiration - prove_commit_epoch) as u64;
     let duration = expiration - prove_commit_epoch;
-    let deal_sizes = DealSizes { deal_space: 0, verified_deal_space: actor.sector_size as u64 };
+    let deal_spaces = DealSpaces { deal_space: 0, verified_deal_space: actor.sector_size as u64 };
 
     let mut precommits = vec![];
     let mut sector_nos_bf = BitField::new();
@@ -58,8 +58,8 @@ fn valid_precommits_then_aggregate_provecommit() {
     rt.set_balance(TokenAmount::from_whole(1000));
 
     let pcc = ProveCommitConfig {
-        deal_sizes: HashMap::from_iter(
-            precommits.iter().map(|pc| (pc.info.sector_number, deal_sizes.clone())),
+        deal_spaces: HashMap::from_iter(
+            precommits.iter().map(|pc| (pc.info.sector_number, deal_spaces.clone())),
         ),
         ..Default::default()
     };
@@ -87,8 +87,8 @@ fn valid_precommits_then_aggregate_provecommit() {
     // The sector is exactly full with verified deals, so expect fully verified power.
     let expected_power = BigInt::from(actor.sector_size as i64)
         * (VERIFIED_DEAL_WEIGHT_MULTIPLIER.clone() / QUALITY_BASE_MULTIPLIER.clone());
-    let deal_weight = BigInt::from(deal_sizes.deal_space as i64 * duration);
-    let verified_deal_weight = BigInt::from(deal_sizes.verified_deal_space as i64 * duration);
+    let deal_weight = BigInt::from(deal_spaces.deal_space as i64 * duration);
+    let verified_deal_weight = BigInt::from(deal_spaces.verified_deal_space as i64 * duration);
     let qa_power = qa_power_for_weight(
         actor.sector_size,
         expiration - rt.epoch,

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -1,4 +1,4 @@
-use fil_actor_market::{DealWeights, SectorDealData};
+use fil_actor_market::{DealSizes, SectorDealData};
 use fil_actor_miner::{
     initial_pledge_for_power, max_prove_commit_duration, pre_commit_deposit_for_power,
     qa_power_for_weight, qa_power_max, PowerPair, PreCommitSectorBatchParams, VestSpec,
@@ -46,13 +46,7 @@ fn prove_single_sector() {
     let expiration =
         dl_info.period_end() + DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period; // something on deadline boundary but > 180 days
                                                                                            // Fill the sector with verified deals
-    let sector_weight =
-        DealWeight::from(h.sector_size as u64) * DealWeight::from(expiration - prove_commit_epoch);
-    let deal_weight = DealWeights {
-        deal_space: h.sector_size as u64,
-        deal_weight: DealWeight::zero(),
-        verified_deal_weight: sector_weight,
-    };
+    let deal_sizes = DealSizes { deal_space: 0, verified_deal_space: h.sector_size as u64 };
 
     // Pre-commit with a deal in order to exercise non-zero deal weights.
     let precommit_params =
@@ -76,7 +70,7 @@ fn prove_single_sector() {
     rt.set_epoch(prove_commit_epoch);
     rt.balance.replace(TokenAmount::from_whole(1000));
     let pcc = ProveCommitConfig {
-        deal_weights: HashMap::from([(sector_no, deal_weight.clone())]),
+        deal_sizes: HashMap::from([(sector_no, deal_sizes.clone())]),
         ..Default::default()
     };
 
@@ -104,21 +98,20 @@ fn prove_single_sector() {
     assert!(st.pre_commit_deposits.is_zero());
 
     // The sector is exactly full with verified deals, so expect fully verified power.
+    let duration = precommit.info.expiration - prove_commit_epoch;
+    let deal_weight = BigInt::from(deal_sizes.deal_space as i64 * duration);
+    let verified_deal_weight = BigInt::from(deal_sizes.verified_deal_space as i64 * duration);
     let expected_power = StoragePower::from(h.sector_size as u64)
         * (VERIFIED_DEAL_WEIGHT_MULTIPLIER / QUALITY_BASE_MULTIPLIER);
-    let qa_power = qa_power_for_weight(
-        h.sector_size,
-        precommit.info.expiration - rt.epoch,
-        &deal_weight.deal_weight,
-        &deal_weight.verified_deal_weight,
-    );
+    let qa_power =
+        qa_power_for_weight(h.sector_size, duration, &deal_weight, &verified_deal_weight);
     assert_eq!(expected_power, qa_power);
     let sector_power =
         PowerPair { raw: StoragePower::from(h.sector_size as u64), qa: qa_power.clone() };
 
     // expect deal weights to be transferred to on chain info
-    assert_eq!(deal_weight.deal_weight, sector.deal_weight);
-    assert_eq!(deal_weight.verified_deal_weight, sector.verified_deal_weight);
+    assert_eq!(deal_weight, sector.deal_weight);
+    assert_eq!(verified_deal_weight, sector.verified_deal_weight);
 
     // expect initial plege of sector to be set, and be total pledge requirement
     let expected_initial_pledge = initial_pledge_for_power(
@@ -188,11 +181,7 @@ fn prove_sectors_from_batch_pre_commit() {
     let deal_lifespan = sector_expiration - prove_commit_epoch;
     let verified_deal_weight = deal_space * DealWeight::from(deal_lifespan);
 
-    let deal_weights = DealWeights {
-        deal_space,
-        deal_weight: deal_weight.clone(),
-        verified_deal_weight: verified_deal_weight.clone(),
-    };
+    let deal_sizes = DealSizes { deal_space: 0, verified_deal_space: deal_space };
 
     let conf = PreCommitBatchConfig {
         sector_deal_data: vec![
@@ -271,7 +260,7 @@ fn prove_sectors_from_batch_pre_commit() {
     {
         let precommit = &precommits[1];
         let pcc = ProveCommitConfig {
-            deal_weights: HashMap::from([(precommit.info.sector_number, deal_weights.clone())]),
+            deal_sizes: HashMap::from([(precommit.info.sector_number, deal_sizes.clone())]),
             ..Default::default()
         };
         let sector = h
@@ -300,7 +289,7 @@ fn prove_sectors_from_batch_pre_commit() {
     {
         let precommit = &precommits[2];
         let pcc = ProveCommitConfig {
-            deal_weights: HashMap::from([(precommit.info.sector_number, deal_weights)]),
+            deal_sizes: HashMap::from([(precommit.info.sector_number, deal_sizes)]),
             ..Default::default()
         };
         let sector = h

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -46,7 +46,10 @@ fn prove_single_sector() {
     let expiration =
         dl_info.period_end() + DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period; // something on deadline boundary but > 180 days
                                                                                            // Fill the sector with verified deals
-    let deal_spaces = DealSpaces { deal_space: 0, verified_deal_space: h.sector_size as u64 };
+    let deal_spaces = DealSpaces {
+        deal_space: BigInt::zero(),
+        verified_deal_space: BigInt::from(h.sector_size as u64),
+    };
 
     // Pre-commit with a deal in order to exercise non-zero deal weights.
     let precommit_params =
@@ -99,8 +102,8 @@ fn prove_single_sector() {
 
     // The sector is exactly full with verified deals, so expect fully verified power.
     let duration = precommit.info.expiration - prove_commit_epoch;
-    let deal_weight = BigInt::from(deal_spaces.deal_space as i64 * duration);
-    let verified_deal_weight = BigInt::from(deal_spaces.verified_deal_space as i64 * duration);
+    let deal_weight = BigInt::from(deal_spaces.deal_space * duration);
+    let verified_deal_weight = BigInt::from(deal_spaces.verified_deal_space * duration);
     let expected_power = StoragePower::from(h.sector_size as u64)
         * (VERIFIED_DEAL_WEIGHT_MULTIPLIER / QUALITY_BASE_MULTIPLIER);
     let qa_power =
@@ -181,7 +184,8 @@ fn prove_sectors_from_batch_pre_commit() {
     let deal_lifespan = sector_expiration - prove_commit_epoch;
     let verified_deal_weight = deal_space * DealWeight::from(deal_lifespan);
 
-    let deal_spaces = DealSpaces { deal_space: 0, verified_deal_space: deal_space };
+    let deal_spaces =
+        DealSpaces { deal_space: BigInt::zero(), verified_deal_space: BigInt::from(deal_space) };
 
     let conf = PreCommitBatchConfig {
         sector_deal_data: vec![

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -102,8 +102,8 @@ fn prove_single_sector() {
 
     // The sector is exactly full with verified deals, so expect fully verified power.
     let duration = precommit.info.expiration - prove_commit_epoch;
-    let deal_weight = BigInt::from(deal_spaces.deal_space * duration);
-    let verified_deal_weight = BigInt::from(deal_spaces.verified_deal_space * duration);
+    let deal_weight = deal_spaces.deal_space * duration;
+    let verified_deal_weight = deal_spaces.verified_deal_space * duration;
     let expected_power = StoragePower::from(h.sector_size as u64)
         * (VERIFIED_DEAL_WEIGHT_MULTIPLIER / QUALITY_BASE_MULTIPLIER);
     let qa_power =

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -1,4 +1,4 @@
-use fil_actor_market::{DealSizes, SectorDealData};
+use fil_actor_market::{DealSpaces, SectorDealData};
 use fil_actor_miner::{
     initial_pledge_for_power, max_prove_commit_duration, pre_commit_deposit_for_power,
     qa_power_for_weight, qa_power_max, PowerPair, PreCommitSectorBatchParams, VestSpec,
@@ -46,7 +46,7 @@ fn prove_single_sector() {
     let expiration =
         dl_info.period_end() + DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period; // something on deadline boundary but > 180 days
                                                                                            // Fill the sector with verified deals
-    let deal_sizes = DealSizes { deal_space: 0, verified_deal_space: h.sector_size as u64 };
+    let deal_spaces = DealSpaces { deal_space: 0, verified_deal_space: h.sector_size as u64 };
 
     // Pre-commit with a deal in order to exercise non-zero deal weights.
     let precommit_params =
@@ -70,7 +70,7 @@ fn prove_single_sector() {
     rt.set_epoch(prove_commit_epoch);
     rt.balance.replace(TokenAmount::from_whole(1000));
     let pcc = ProveCommitConfig {
-        deal_sizes: HashMap::from([(sector_no, deal_sizes.clone())]),
+        deal_spaces: HashMap::from([(sector_no, deal_spaces.clone())]),
         ..Default::default()
     };
 
@@ -99,8 +99,8 @@ fn prove_single_sector() {
 
     // The sector is exactly full with verified deals, so expect fully verified power.
     let duration = precommit.info.expiration - prove_commit_epoch;
-    let deal_weight = BigInt::from(deal_sizes.deal_space as i64 * duration);
-    let verified_deal_weight = BigInt::from(deal_sizes.verified_deal_space as i64 * duration);
+    let deal_weight = BigInt::from(deal_spaces.deal_space as i64 * duration);
+    let verified_deal_weight = BigInt::from(deal_spaces.verified_deal_space as i64 * duration);
     let expected_power = StoragePower::from(h.sector_size as u64)
         * (VERIFIED_DEAL_WEIGHT_MULTIPLIER / QUALITY_BASE_MULTIPLIER);
     let qa_power =
@@ -181,7 +181,7 @@ fn prove_sectors_from_batch_pre_commit() {
     let deal_lifespan = sector_expiration - prove_commit_epoch;
     let verified_deal_weight = deal_space * DealWeight::from(deal_lifespan);
 
-    let deal_sizes = DealSizes { deal_space: 0, verified_deal_space: deal_space };
+    let deal_spaces = DealSpaces { deal_space: 0, verified_deal_space: deal_space };
 
     let conf = PreCommitBatchConfig {
         sector_deal_data: vec![
@@ -260,7 +260,7 @@ fn prove_sectors_from_batch_pre_commit() {
     {
         let precommit = &precommits[1];
         let pcc = ProveCommitConfig {
-            deal_sizes: HashMap::from([(precommit.info.sector_number, deal_sizes.clone())]),
+            deal_spaces: HashMap::from([(precommit.info.sector_number, deal_spaces.clone())]),
             ..Default::default()
         };
         let sector = h
@@ -289,7 +289,7 @@ fn prove_sectors_from_batch_pre_commit() {
     {
         let precommit = &precommits[2];
         let pcc = ProveCommitConfig {
-            deal_sizes: HashMap::from([(precommit.info.sector_number, deal_sizes)]),
+            deal_spaces: HashMap::from([(precommit.info.sector_number, deal_spaces)]),
             ..Default::default()
         };
         let sector = h

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -178,7 +178,7 @@ fn prove_sectors_from_batch_pre_commit() {
         h.make_pre_commit_params(102, precommit_epoch - 1, sector_expiration, vec![2, 3]), // 2 * 16GiB verified deals
     ];
 
-    let deal_space = 32 << 30;
+    let deal_space: i64 = 32 << 30;
     let deal_weight = DealWeight::zero();
     let prove_commit_epoch = precommit_epoch + rt.policy.pre_commit_challenge_delay + 1;
     let deal_lifespan = sector_expiration - prove_commit_epoch;

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2,7 +2,7 @@
 
 use fil_actor_account::Method as AccountMethod;
 use fil_actor_market::{
-    ActivateDealsParams, ActivateDealsResult, DealWeights, Method as MarketMethod,
+    ActivateDealsParams, ActivateDealsResult, Method as MarketMethod, DealSizes,
     OnMinerSectorsTerminateParams, SectorDealData, SectorDeals, VerifyDealsForActivationParams,
     VerifyDealsForActivationReturn,
 };
@@ -888,8 +888,8 @@ impl ActorHarness {
                 }
 
                 let ret = ActivateDealsResult {
-                    weights: cfg
-                        .deal_weights
+                    sizes: cfg
+                        .deal_sizes
                         .get(&pc.info.sector_number)
                         .cloned()
                         .unwrap_or_default(),
@@ -915,7 +915,7 @@ impl ActorHarness {
 
             for pc in valid_pcs {
                 let weights =
-                    cfg.deal_weights.get(&pc.info.sector_number).cloned().unwrap_or_default();
+                    cfg.deal_sizes.get(&pc.info.sector_number).cloned().unwrap_or_default();
 
                 let duration = pc.info.expiration - rt.epoch;
                 if duration >= rt.policy.min_sector_expiration {
@@ -2277,13 +2277,13 @@ impl PreCommitConfig {
 #[derive(Default, Clone)]
 pub struct ProveCommitConfig {
     pub verify_deals_exit: HashMap<SectorNumber, ExitCode>,
-    pub deal_weights: HashMap<SectorNumber, DealWeights>,
+    pub deal_sizes: HashMap<SectorNumber, DealSizes>,
 }
 
 #[allow(dead_code)]
 impl ProveCommitConfig {
     pub fn empty() -> ProveCommitConfig {
-        ProveCommitConfig { verify_deals_exit: HashMap::new(), deal_weights: HashMap::new() }
+        ProveCommitConfig { verify_deals_exit: HashMap::new(), deal_sizes: HashMap::new() }
     }
 }
 

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2,7 +2,7 @@
 
 use fil_actor_account::Method as AccountMethod;
 use fil_actor_market::{
-    ActivateDealsParams, ActivateDealsResult, DealSizes, Method as MarketMethod,
+    ActivateDealsParams, ActivateDealsResult, DealSpaces, Method as MarketMethod,
     OnMinerSectorsTerminateParams, SectorDealData, SectorDeals, VerifyDealsForActivationParams,
     VerifyDealsForActivationReturn,
 };
@@ -888,7 +888,7 @@ impl ActorHarness {
                 }
 
                 let ret = ActivateDealsResult {
-                    sizes: cfg.deal_sizes.get(&pc.info.sector_number).cloned().unwrap_or_default(),
+                    spaces: cfg.deal_spaces.get(&pc.info.sector_number).cloned().unwrap_or_default(),
                 };
 
                 rt.expect_send(
@@ -910,7 +910,7 @@ impl ActorHarness {
             let mut expected_raw_power = BigInt::from(0);
 
             for pc in valid_pcs {
-                let sizes = cfg.deal_sizes.get(&pc.info.sector_number).cloned().unwrap_or_default();
+                let sizes = cfg.deal_spaces.get(&pc.info.sector_number).cloned().unwrap_or_default();
 
                 let duration = pc.info.expiration - rt.epoch;
                 let deal_weight = sizes.deal_space as i64 * duration;
@@ -2274,13 +2274,13 @@ impl PreCommitConfig {
 #[derive(Default, Clone)]
 pub struct ProveCommitConfig {
     pub verify_deals_exit: HashMap<SectorNumber, ExitCode>,
-    pub deal_sizes: HashMap<SectorNumber, DealSizes>,
+    pub deal_spaces: HashMap<SectorNumber, DealSpaces>,
 }
 
 #[allow(dead_code)]
 impl ProveCommitConfig {
     pub fn empty() -> ProveCommitConfig {
-        ProveCommitConfig { verify_deals_exit: HashMap::new(), deal_sizes: HashMap::new() }
+        ProveCommitConfig { verify_deals_exit: HashMap::new(), deal_spaces: HashMap::new() }
     }
 }
 

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -918,14 +918,14 @@ impl ActorHarness {
                     cfg.deal_spaces.get(&pc.info.sector_number).cloned().unwrap_or_default();
 
                 let duration = pc.info.expiration - rt.epoch;
-                let deal_weight = spaces.deal_space as i64 * duration;
-                let verified_deal_weight = spaces.verified_deal_space as i64 * duration;
+                let deal_weight = spaces.deal_space * duration;
+                let verified_deal_weight = spaces.verified_deal_space * duration;
                 if duration >= rt.policy.min_sector_expiration {
                     let qa_power_delta = qa_power_for_weight(
                         self.sector_size,
                         duration,
-                        &BigInt::from(deal_weight),
-                        &BigInt::from(verified_deal_weight),
+                        &deal_weight,
+                        &verified_deal_weight,
                     );
                     expected_qa_power += &qa_power_delta;
                     expected_raw_power += self.sector_size as u64;

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -888,7 +888,11 @@ impl ActorHarness {
                 }
 
                 let ret = ActivateDealsResult {
-                    spaces: cfg.deal_spaces.get(&pc.info.sector_number).cloned().unwrap_or_default(),
+                    spaces: cfg
+                        .deal_spaces
+                        .get(&pc.info.sector_number)
+                        .cloned()
+                        .unwrap_or_default(),
                 };
 
                 rt.expect_send(
@@ -910,7 +914,8 @@ impl ActorHarness {
             let mut expected_raw_power = BigInt::from(0);
 
             for pc in valid_pcs {
-                let sizes = cfg.deal_spaces.get(&pc.info.sector_number).cloned().unwrap_or_default();
+                let sizes =
+                    cfg.deal_spaces.get(&pc.info.sector_number).cloned().unwrap_or_default();
 
                 let duration = pc.info.expiration - rt.epoch;
                 let deal_weight = sizes.deal_space as i64 * duration;

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -914,12 +914,12 @@ impl ActorHarness {
             let mut expected_raw_power = BigInt::from(0);
 
             for pc in valid_pcs {
-                let sizes =
+                let spaces =
                     cfg.deal_spaces.get(&pc.info.sector_number).cloned().unwrap_or_default();
 
                 let duration = pc.info.expiration - rt.epoch;
-                let deal_weight = sizes.deal_space as i64 * duration;
-                let verified_deal_weight = sizes.verified_deal_space as i64 * duration;
+                let deal_weight = spaces.deal_space as i64 * duration;
+                let verified_deal_weight = spaces.verified_deal_space as i64 * duration;
                 if duration >= rt.policy.min_sector_expiration {
                     let qa_power_delta = qa_power_for_weight(
                         self.sector_size,


### PR DESCRIPTION
- [x] add field to sector info
- [x] market deal activation just sends sizes
- [x] miner actor now caluclates weights
- ~[ ] change so that new sectors are done the right way~

Closes #528 (as I understand it) -- does not do any miner actor, FIL+ interaction to ensure claim terms are satisfied or any weight rebalancing during expiration extension.  I can do these here rather than in the planned follow ons if preferred.