### PR TITLE
optimized tests & ci caching

### DIFF
--- a/.github/actions/rust-cargo-run/action.yml
+++ b/.github/actions/rust-cargo-run/action.yml
@@ -17,6 +17,10 @@ inputs:
   save_cache:
     description: Whether to save the SSCACHE
     required: false
+  cache_name:
+    description: The name of the cache to save/restore
+    required: true
+    default: test
 
 runs:
   using: composite
@@ -37,7 +41,7 @@ runs:
       CACHE_SKIP_SAVE: ${{ inputs.save_cache == '' || inputs.save_cache == 'false' }}
     with:
       version: v0.2.15
-      shared-key: v1  # change this to invalidate sccache for this job
+      shared-key: v2-${{ inputs.cache_name }}  # change this to invalidate sccache for this job
   - name: Running ${{ inputs.command }}
     uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ jobs:
         command: test
         args: --locked --all --no-fail-fast
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        save_cache: true
 
   build:
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: 0
-      CACHE_SKIP_SAVE: ${{ matrix.push == '' || matrix.push == 'false' }}
     strategy:
       matrix:
         network: [ 'mainnet', 'caterpillarnet', 'butterflynet', 'calibrationnet', 'devnet', 'testing', 'testing-fake-proofs' ]
@@ -64,7 +64,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CARGO_INCREMENTAL: 0
-      CACHE_SKIP_SAVE: ${{ matrix.push == '' || matrix.push == 'false' }}
     steps:
     - name: Checking out
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       uses: ./.github/actions/rust-cargo-run
       with:
         command: test
-        args: --locked --all --no-fail-fast
+        args: --locked --all --no-fail-fast --exclude=fil_builtin_actors_bundle
         github_token: ${{ secrets.GITHUB_TOKEN }}
         save_cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
         command: version
         components: llvm-tools-preview
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        cache_name: cov
+        save_cache: true
     - name: Put LLVM tools into the PATH
       run: echo "${HOME}/.rustup/toolchains/$(cat rust-toolchain)-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin" >> $GITHUB_PATH
     - name: Install demangler

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,17 @@ lto = "thin"
 opt-level = "z"
 strip = true
 codegen-units = 1
+
+## So tests don't take ages.
+
+[profile.dev.package."num-bigint"]
+opt-level = 2
+
+[profile.dev.package."sha2"]
+opt-level = 2
+
+[profile.dev.package."blake2b_simd"]
+opt-level = 2
+
+[profile.dev.package."test_vm"]
+opt-level = 2


### PR DESCRIPTION
- Enable CI caching. Not that it seems to help much...
- Optimize critical dependencies (hashing, test_vm, bigint).
- Avoid building bundles when testing. That gets tested in a separate step.

Ideally we'd just optimize all dependencies, but caching doesn't seem very effective for some reason.