### PR TITLE
build: avoid RUSTFLAGS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,10 @@ rustflags = [
     # Force unwrapping Result<_, Err>, especially for tests.
     "-D", "unused_must_use",
 ]
+
+[target.wasm32-unknown-unknown]
+rustflags = [
+    "-Ctarget-feature=+bulk-memory",
+    "-Ctarget-feature=+crt-static",
+    "-Clink-arg=--export-table",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    env:
-      CARGO_INCREMENTAL: 0
     strategy:
       matrix:
         network: [ 'mainnet', 'caterpillarnet', 'butterflynet', 'calibrationnet', 'devnet', 'testing', 'testing-fake-proofs' ]
@@ -63,7 +61,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CARGO_INCREMENTAL: 0
     steps:
     - name: Checking out
       uses: actions/checkout@v2
@@ -81,20 +78,10 @@ jobs:
       run: cargo install rustfilt
     - name: Create coverage report
       env:
-        # Incremental build is not supported when profiling.
-        CARGO_INCREMENTAL: 0
         # Make sure that each run of an executable creates a new profile file,
         # with the default name they would override each other.
         LLVM_PROFILE_FILE: "%m.profraw"
-        # -Cinstrument-coverage: enable llvm coverage instrumentation
-        # -Ccodegen-units=1: building in parallel is not supported when profiling
-        # -Copt-level=0: disable optimizations for more accurate coverage
-        # -Coverflow-checks=off: checking for overflow is not needed for coverage reporting
-        # -Cinline-threshold=0: do not inline
-        # For code coverage the `-Clink-dead-code` flag should be set, as dead
-        # code should be considered as not covered code. Though this would make
-        # the build fail, hence it is not set.
-        RUSTFLAGS: -Cinstrument-coverage -Ccodegen-units=1 -Copt-level=0 -Coverflow-checks=off -Cinline-threshold=0
+        RUSTFLAGS: "-Cinstrument-coverage"
       run: cargo test --workspace --exclude fil_builtin_actors_bundle
     - name: Merge profiling data
       # Do *not* use sparse output. It leads to more lines that are not taken

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ lto = "thin"
 opt-level = "z"
 strip = true
 codegen-units = 1
+incremental = false
 
 ## So tests don't take ages.
 
@@ -108,3 +109,10 @@ opt-level = 2
 
 [profile.dev.package."test_vm"]
 opt-level = 2
+
+[profile.coverage]
+inherits = "test"
+incremental = false
+codegen-units = 1
+opt-level = 0
+overflow-checks = false

--- a/build.rs
+++ b/build.rs
@@ -27,8 +27,6 @@ const ACTORS: &[(&Package, &ID)] = &[
     ("verifreg", "verifiedregistry"),
 ];
 
-const WASM_FEATURES: &[&str] = &["+bulk-memory", "+crt-static"];
-
 const NETWORK_ENV: &str = "BUILD_FIL_NETWORK";
 
 /// Returns the configured network name, checking both the environment and feature flags.
@@ -104,10 +102,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("cargo:rerun-if-changed={}", file);
     }
 
-    let rustflags =
-        WASM_FEATURES.iter().flat_map(|flag| ["-Ctarget-feature=", *flag, " "]).collect::<String>()
-            + "-Clink-arg=--export-table";
-
     // Cargo build command for all actors at once.
     let mut cmd = Command::new(&cargo);
     cmd.arg("build")
@@ -117,7 +111,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         .arg("--locked")
         .arg("--features=fil-actor")
         .arg("--manifest-path=".to_owned() + manifest_path.to_str().unwrap())
-        .env("RUSTFLAGS", rustflags)
         .env(NETWORK_ENV, network_name)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
This can cause issues with caching. Unfortunately, we can only specify them per-target, not per-profile.