### PR TITLE
build: optimize bitfield operations in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,9 @@ incremental = false
 
 ## So tests don't take ages.
 
+[profile.dev.package."fvm_ipld_bitfield"]
+opt-level = 2
+
 [profile.dev.package."num-bigint"]
 opt-level = 2
 


### PR DESCRIPTION
This isn't as big of an issue as hashing, but it still matters for tests.