### PR TITLE
EVM: Refactor Interpreter dispatch

### DIFF
--- a/actors/evm/src/interpreter/bytecode.rs
+++ b/actors/evm/src/interpreter/bytecode.rs
@@ -12,7 +12,6 @@ impl Bytecode {
     pub fn new(bytecode: Vec<u8>) -> Self {
         // only jumps to those addresses are valid. This is a security
         // feature by EVM to disallow jumps to arbitary code addresses.
-        // todo: create the jumpdest table only once during initial contract deployment
         let mut jumpdest = vec![false; bytecode.len()];
         let mut i = 0;
         while i < bytecode.len() {

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -189,6 +189,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
 
     def_opcodes! {
         STOP: {=> Ok(ControlFlow::Exit)}
+
         ADD: {primop}
         MUL: {primop}
         SUB: {primop}
@@ -241,78 +242,21 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
         RETURNDATASIZE: {std}
         RETURNDATACOPY: {std}
         EXTCODEHASH: {std}
-
-        BLOCKHASH: {(m) => {
-            instructions::context::blockhash(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        COINBASE: {(m) => {
-            instructions::context::coinbase(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        TIMESTAMP: {(m) => {
-            instructions::context::timestamp(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        NUMBER: {(m) => {
-            instructions::context::block_number(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DIFFICULTY: {(m) => {
-            instructions::context::difficulty(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        GASLIMIT: {(m) => {
-            instructions::context::gas_limit(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        CHAINID: {(m) => {
-            instructions::context::chain_id(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SELFBALANCE: {(m) => {
-            instructions::state::selfbalance(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        BASEFEE: {(m) => {
-            instructions::context::base_fee(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
+        BLOCKHASH: {std}
+        COINBASE: {std}
+        TIMESTAMP: {std}
+        NUMBER: {std}
+        DIFFICULTY: {std}
+        GASLIMIT: {std}
+        CHAINID: {std}
+        BASEFEE: {std}
+        SELFBALANCE: {std}
         POP: {primop}
-
-        MLOAD: {(m) => {
-            instructions::memory::mload(m.state)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        MSTORE: {(m) => {
-            instructions::memory::mstore(m.state)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        MSTORE8: {(m) => {
-            instructions::memory::mstore8(m.state)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        SLOAD: {(m) => {
-            instructions::storage::sload(m.state, m.system)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        SSTORE: {(m) => {
-            instructions::storage::sstore(m.state, m.system)?;
-            Ok(ControlFlow::Continue)
-        }}
+        MLOAD: {std}
+        MSTORE: {std}
+        MSTORE8: {std}
+        SLOAD: {std}
+        SSTORE: {std}
 
         JUMP: {(m) => {
             m.pc = instructions::control::jump(&mut m.state.stack, m.bytecode)?;
@@ -333,15 +277,8 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             Ok(ControlFlow::Continue)
         }}
 
-        MSIZE: {(m) => {
-            instructions::memory::msize(m.state);
-            Ok(ControlFlow::Continue)
-        }}
-
-        GAS: {(m) => {
-            instructions::context::gas(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
+        MSIZE: {std}
+        GAS: {std}
 
         JUMPDEST: {=> Ok(ControlFlow::Continue)} // noop marker opcode for valid jumps addresses
 
@@ -412,30 +349,11 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
         SWAP15: {primop}
         SWAP16: {primop}
 
-        LOG0: {(m) => {
-            instructions::log::log(m.state, m.system, 0)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        LOG1: {(m) => {
-            instructions::log::log(m.state, m.system, 1)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        LOG2: {(m) => {
-            instructions::log::log(m.state, m.system, 2)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        LOG3: {(m) => {
-            instructions::log::log(m.state, m.system, 3)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        LOG4: {(m) => {
-            instructions::log::log(m.state, m.system, 4)?;
-            Ok(ControlFlow::Continue)
-        }}
+        LOG0: {std}
+        LOG1: {std}
+        LOG2: {std}
+        LOG3: {std}
+        LOG4: {std}
 
         CREATE: {(m) => {
             instructions::lifecycle::create(m.state, m.system)?;

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -91,6 +91,10 @@ macro_rules! def_ins {
         def_ins_primitive! { $ins }
     };
 
+    ($ins:ident {"push"}) => {
+        def_ins_push! { $ins }
+    };
+
     ($ins:ident {($arg:ident) $body:block}) => {
         def_ins_raw! { $ins ($arg) $body }
     };
@@ -112,6 +116,17 @@ macro_rules! def_ins_primitive {
         def_ins_raw!{
             $ins (m) {
                 instructions::$ins(&mut m.state.stack)?;
+                Ok(ControlFlow::Continue)
+            }
+        }
+    }
+}
+
+macro_rules! def_ins_push {
+    ($ins:ident) => {
+        def_ins_raw!{
+            $ins (m) {
+                m.pc += instructions::$ins(&mut m.state.stack, &m.bytecode[m.pc + 1..])?;
                 Ok(ControlFlow::Continue)
             }
         }
@@ -313,10 +328,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             Ok(ControlFlow::Continue)
         }}
 
-        POP: {(m) {
-            instructions::stack::pop(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
+        POP: {"primitive"}
 
         MLOAD: {(m) {
             instructions::memory::mload(m.state)?;
@@ -377,165 +389,38 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             Ok(ControlFlow::Continue)
         }}
 
-        PUSH1: {(m) {
-            m.pc += instructions::stack::push::<1>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH2: {(m) {
-            m.pc += instructions::stack::push::<2>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH3: {(m) {
-            m.pc += instructions::stack::push::<3>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH4: {(m) {
-            m.pc += instructions::stack::push::<4>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH5: {(m) {
-            m.pc += instructions::stack::push::<5>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH6: {(m) {
-            m.pc += instructions::stack::push::<6>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH7: {(m) {
-            m.pc += instructions::stack::push::<7>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH8: {(m) {
-            m.pc += instructions::stack::push::<8>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH9: {(m) {
-            m.pc += instructions::stack::push::<9>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH10: {(m) {
-            m.pc += instructions::stack::push::<10>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH11: {(m) {
-            m.pc += instructions::stack::push::<11>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH12: {(m) {
-            m.pc += instructions::stack::push::<12>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH13: {(m) {
-            m.pc += instructions::stack::push::<13>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH14: {(m) {
-            m.pc += instructions::stack::push::<14>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH15: {(m) {
-            m.pc += instructions::stack::push::<15>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH16: {(m) {
-            m.pc += instructions::stack::push::<16>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH17: {(m) {
-            m.pc += instructions::stack::push::<17>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH18: {(m) {
-            m.pc += instructions::stack::push::<18>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH19: {(m) {
-            m.pc += instructions::stack::push::<19>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH20: {(m) {
-            m.pc += instructions::stack::push::<20>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH21: {(m) {
-            m.pc += instructions::stack::push::<21>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH22: {(m) {
-            m.pc += instructions::stack::push::<22>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH23: {(m) {
-            m.pc += instructions::stack::push::<23>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH24: {(m) {
-            m.pc += instructions::stack::push::<24>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH25: {(m) {
-            m.pc += instructions::stack::push::<25>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH26: {(m) {
-            m.pc += instructions::stack::push::<26>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH27: {(m) {
-            m.pc += instructions::stack::push::<27>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH28: {(m) {
-            m.pc += instructions::stack::push::<28>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH29: {(m) {
-            m.pc += instructions::stack::push::<29>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH30: {(m) {
-            m.pc += instructions::stack::push::<30>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH31: {(m) {
-            m.pc += instructions::stack::push::<31>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
-
-        PUSH32: {(m) {
-            m.pc += instructions::stack::push::<32>(&mut m.state.stack, &m.bytecode[m.pc + 1..]);
-            Ok(ControlFlow::Continue)
-        }}
+        PUSH1: {"push"}
+        PUSH2: {"push"}
+        PUSH3: {"push"}
+        PUSH4: {"push"}
+        PUSH5: {"push"}
+        PUSH6: {"push"}
+        PUSH7: {"push"}
+        PUSH8: {"push"}
+        PUSH9: {"push"}
+        PUSH10: {"push"}
+        PUSH11: {"push"}
+        PUSH12: {"push"}
+        PUSH13: {"push"}
+        PUSH14: {"push"}
+        PUSH15: {"push"}
+        PUSH16: {"push"}
+        PUSH17: {"push"}
+        PUSH18: {"push"}
+        PUSH19: {"push"}
+        PUSH20: {"push"}
+        PUSH21: {"push"}
+        PUSH22: {"push"}
+        PUSH23: {"push"}
+        PUSH24: {"push"}
+        PUSH25: {"push"}
+        PUSH26: {"push"}
+        PUSH27: {"push"}
+        PUSH28: {"push"}
+        PUSH29: {"push"}
+        PUSH30: {"push"}
+        PUSH31: {"push"}
+        PUSH32: {"push"}
 
         DUP1: {"primitive"}
         DUP2: {"primitive"}

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -99,7 +99,7 @@ macro_rules! def_ins {
         def_ins_raw! { $ins (_m) { $expr } }
     };
 
-    ($ins:ident {($arg:ident) $body:block}) => {
+    ($ins:ident {($arg:ident) => $body:block}) => {
         def_ins_raw! { $ins ($arg) $body }
     };
 
@@ -200,169 +200,169 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
         SHR: {"primitive"}
         SAR: {"primitive"}
 
-        KECCAK256: {(m) {
+        KECCAK256: {(m) => {
             instructions::hash::keccak256(m.system, m.state)?;
             Ok(ControlFlow::Continue)
         }}
 
-        ADDRESS: {(m) {
+        ADDRESS: {(m) => {
             instructions::context::address(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        BALANCE: {(m) {
+        BALANCE: {(m) => {
             instructions::state::balance(m.state, m.system)?;
             Ok(ControlFlow::Continue)
         }}
 
-        ORIGIN: {(m) {
+        ORIGIN: {(m) => {
             instructions::context::origin(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        CALLER: {(m) {
+        CALLER: {(m) => {
             instructions::context::caller(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        CALLVALUE: {(m) {
+        CALLVALUE: {(m) => {
             instructions::context::call_value(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        CALLDATALOAD: {(m) {
+        CALLDATALOAD: {(m) => {
             instructions::call::calldataload(m.state);
             Ok(ControlFlow::Continue)
         }}
 
-        CALLDATASIZE: {(m) {
+        CALLDATASIZE: {(m) => {
             instructions::call::calldatasize(m.state);
             Ok(ControlFlow::Continue)
         }}
 
-        CALLDATACOPY: {(m) {
+        CALLDATACOPY: {(m) => {
             instructions::call::calldatacopy(m.state)?;
             Ok(ControlFlow::Continue)
         }}
 
-        CODESIZE: {(m) {
+        CODESIZE: {(m) => {
             instructions::call::codesize(&mut m.state.stack, m.bytecode.as_ref());
             Ok(ControlFlow::Continue)
         }}
 
-        CODECOPY: {(m) {
+        CODECOPY: {(m) => {
             instructions::call::codecopy(m.state, m.bytecode.as_ref())?;
             Ok(ControlFlow::Continue)
         }}
 
-        GASPRICE: {(m) {
+        GASPRICE: {(m) => {
             instructions::context::gas_price(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        EXTCODESIZE: {(m) {
+        EXTCODESIZE: {(m) => {
             instructions::ext::extcodesize(m.state, m.system)?;
             Ok(ControlFlow::Continue)
         }}
 
-        EXTCODECOPY: {(m) {
+        EXTCODECOPY: {(m) => {
             instructions::ext::extcodecopy(m.state, m.system)?;
             Ok(ControlFlow::Continue)
         }}
 
-        RETURNDATASIZE: {(m) {
+        RETURNDATASIZE: {(m) => {
             instructions::control::returndatasize(m.state);
             Ok(ControlFlow::Continue)
         }}
 
-        RETURNDATACOPY: {(m) {
+        RETURNDATACOPY: {(m) => {
             instructions::control::returndatacopy(m.state)?;
             Ok(ControlFlow::Continue)
         }}
 
-        EXTCODEHASH: {(m) {
+        EXTCODEHASH: {(m) => {
             instructions::ext::extcodehash(m.state, m.system)?;
             Ok(ControlFlow::Continue)
         }}
 
-        BLOCKHASH: {(m) {
+        BLOCKHASH: {(m) => {
             instructions::context::blockhash(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        COINBASE: {(m) {
+        COINBASE: {(m) => {
             instructions::context::coinbase(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        TIMESTAMP: {(m) {
+        TIMESTAMP: {(m) => {
             instructions::context::timestamp(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        NUMBER: {(m) {
+        NUMBER: {(m) => {
             instructions::context::block_number(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        DIFFICULTY: {(m) {
+        DIFFICULTY: {(m) => {
             instructions::context::difficulty(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        GASLIMIT: {(m) {
+        GASLIMIT: {(m) => {
             instructions::context::gas_limit(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        CHAINID: {(m) {
+        CHAINID: {(m) => {
             instructions::context::chain_id(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        SELFBALANCE: {(m) {
+        SELFBALANCE: {(m) => {
             instructions::state::selfbalance(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
-        BASEFEE: {(m) {
+        BASEFEE: {(m) => {
             instructions::context::base_fee(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
 
         POP: {"primitive"}
 
-        MLOAD: {(m) {
+        MLOAD: {(m) => {
             instructions::memory::mload(m.state)?;
             Ok(ControlFlow::Continue)
         }}
 
-        MSTORE: {(m) {
+        MSTORE: {(m) => {
             instructions::memory::mstore(m.state)?;
             Ok(ControlFlow::Continue)
         }}
 
-        MSTORE8: {(m) {
+        MSTORE8: {(m) => {
             instructions::memory::mstore8(m.state)?;
             Ok(ControlFlow::Continue)
         }}
 
-        SLOAD: {(m) {
+        SLOAD: {(m) => {
             instructions::storage::sload(m.state, m.system)?;
             Ok(ControlFlow::Continue)
         }}
 
-        SSTORE: {(m) {
+        SSTORE: {(m) => {
             instructions::storage::sstore(m.state, m.system)?;
             Ok(ControlFlow::Continue)
         }}
 
-        JUMP: {(m) {
+        JUMP: {(m) => {
             m.pc = instructions::control::jump(&mut m.state.stack, m.bytecode)?;
             Ok(ControlFlow::Jump)
         }}
 
-        JUMPI: {(m) {
+        JUMPI: {(m) => {
             if let Some(dest) = instructions::control::jumpi(&mut m.state.stack, m.bytecode)? {
                 m.pc = dest;
                 Ok(ControlFlow::Jump)
@@ -371,17 +371,17 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             }
         }}
 
-        PC: {(m) {
+        PC: {(m) => {
             instructions::control::pc(&mut m.state.stack, m.pc);
             Ok(ControlFlow::Continue)
         }}
 
-        MSIZE: {(m) {
+        MSIZE: {(m) => {
             instructions::memory::msize(m.state);
             Ok(ControlFlow::Continue)
         }}
 
-        GAS: {(m) {
+        GAS: {(m) => {
             instructions::context::gas(m.state, m.system);
             Ok(ControlFlow::Continue)
         }}
@@ -455,67 +455,67 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
         SWAP15: {"primitive"}
         SWAP16: {"primitive"}
 
-        LOG0: {(m) {
+        LOG0: {(m) => {
             instructions::log::log(m.state, m.system, 0)?;
             Ok(ControlFlow::Continue)
         }}
 
-        LOG1: {(m) {
+        LOG1: {(m) => {
             instructions::log::log(m.state, m.system, 1)?;
             Ok(ControlFlow::Continue)
         }}
 
-        LOG2: {(m) {
+        LOG2: {(m) => {
             instructions::log::log(m.state, m.system, 2)?;
             Ok(ControlFlow::Continue)
         }}
 
-        LOG3: {(m) {
+        LOG3: {(m) => {
             instructions::log::log(m.state, m.system, 3)?;
             Ok(ControlFlow::Continue)
         }}
 
-        LOG4: {(m) {
+        LOG4: {(m) => {
             instructions::log::log(m.state, m.system, 4)?;
             Ok(ControlFlow::Continue)
         }}
 
-        CREATE: {(m) {
+        CREATE: {(m) => {
             instructions::lifecycle::create(m.state, m.system)?;
             Ok(ControlFlow::Continue)
         }}
 
-        CALL: {(m) {
+        CALL: {(m) => {
             instructions::call::call(m.state, m.system, CallKind::Call)?;
             Ok(ControlFlow::Continue)
         }}
 
-        CALLCODE: {(m) {
+        CALLCODE: {(m) => {
             instructions::call::call(m.state, m.system, CallKind::CallCode)?;
             Ok(ControlFlow::Continue)
         }}
 
-        RETURN: {(m) {
+        RETURN: {(m) => {
             instructions::control::ret(m.state)?;
             Ok(ControlFlow::Exit)
         }}
 
-        DELEGATECALL: {(m) {
+        DELEGATECALL: {(m) => {
             instructions::call::call(m.state, m.system, CallKind::DelegateCall)?;
             Ok(ControlFlow::Continue)
         }}
 
-        CREATE2: {(m) {
+        CREATE2: {(m) => {
             instructions::lifecycle::create2(m.state, m.system)?;
             Ok(ControlFlow::Continue)
         }}
 
-        STATICCALL: {(m) {
+        STATICCALL: {(m) => {
             instructions::call::call(m.state, m.system, CallKind::StaticCall)?;
             Ok(ControlFlow::Continue)
         }}
 
-        REVERT: {(m) {
+        REVERT: {(m) => {
             instructions::control::ret(m.state)?;
             m.reverted = true;
             Ok(ControlFlow::Exit)
@@ -523,7 +523,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
 
         INVALID: {=> Err(StatusCode::InvalidInstruction)}
 
-        SELFDESTRUCT: {(m) {
+        SELFDESTRUCT: {(m) => {
             instructions::lifecycle::selfdestruct(m.state, m.system)?;
             Ok(ControlFlow::Exit) // selfdestruct halts the current context
         }}

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -95,9 +95,14 @@ macro_rules! def_ins {
         def_ins_push! { $ins }
     };
 
+    ($ins:ident {=> $expr:expr}) => {
+        def_ins_raw! { $ins (_m) { $expr } }
+    };
+
     ($ins:ident {($arg:ident) $body:block}) => {
         def_ins_raw! { $ins ($arg) $body }
     };
+
 }
 
 macro_rules! def_ins_raw {
@@ -168,10 +173,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
     }
 
     def_opcodes! {
-        STOP: {(_m) {
-            Ok(ControlFlow::Exit)
-        }}
-
+        STOP: {=> Ok(ControlFlow::Exit)}
         ADD: {"primitive"}
         MUL: {"primitive"}
         SUB: {"primitive"}
@@ -384,10 +386,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             Ok(ControlFlow::Continue)
         }}
 
-        JUMPDEST: {(_m) {
-            // marker opcode for valid jumps addresses
-            Ok(ControlFlow::Continue)
-        }}
+        JUMPDEST: {=> Ok(ControlFlow::Continue)} // noop marker opcode for valid jumps addresses
 
         PUSH1: {"push"}
         PUSH2: {"push"}
@@ -522,9 +521,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             Ok(ControlFlow::Exit)
         }}
 
-        INVALID: {(_m) {
-            Err(StatusCode::InvalidInstruction)
-        }}
+        INVALID: {=> Err(StatusCode::InvalidInstruction)}
 
         SELFDESTRUCT: {(m) {
             instructions::lifecycle::selfdestruct(m.state, m.system)?;

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -98,6 +98,10 @@ macro_rules! def_ins {
         def_ins_std! { $ins }
     };
 
+    ($ins:ident {code}) => {
+        def_ins_code! { $ins }
+    };
+
     ($ins:ident {=> $expr:expr}) => {
         def_ins_raw! { $ins (_m) { $expr } }
     };
@@ -146,6 +150,17 @@ macro_rules! def_ins_std {
         def_ins_raw!{
             $ins (m) {
                 instructions::$ins(m.state, m.system)?;
+                Ok(ControlFlow::Continue)
+            }
+        }
+    }
+}
+
+macro_rules! def_ins_code {
+    ($ins:ident) => {
+        def_ins_raw!{
+            $ins (m) {
+                instructions::$ins(m.state, m.system, m.bytecode.as_ref())?;
                 Ok(ControlFlow::Continue)
             }
         }
@@ -225,15 +240,8 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
         CALLDATASIZE: {std}
         CALLDATACOPY: {std}
 
-        CODESIZE: {(m) => {
-            instructions::call::codesize(&mut m.state.stack, m.bytecode.as_ref());
-            Ok(ControlFlow::Continue)
-        }}
-
-        CODECOPY: {(m) => {
-            instructions::call::codecopy(m.state, m.bytecode.as_ref())?;
-            Ok(ControlFlow::Continue)
-        }}
+        CODESIZE: {code}
+        CODECOPY: {code}
 
         GASPRICE: {std}
         EXTCODESIZE: {std}

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -87,8 +87,8 @@ macro_rules! def_jmptable {
 }
 
 macro_rules! def_ins {
-    ($ins:ident {"primop"}) => {
-        def_ins_primop! { $ins }
+    ($ins:ident {"primitive"}) => {
+        def_ins_primitive! { $ins }
     };
 
     ($ins:ident {($arg:ident) $body:block}) => {
@@ -107,7 +107,7 @@ macro_rules! def_ins_raw {
     };
 }
 
-macro_rules! def_ins_primop {
+macro_rules! def_ins_primitive {
     ($ins:ident) => {
         def_ins_raw!{
             $ins (m) {
@@ -157,31 +157,31 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             Ok(ControlFlow::Exit)
         }}
 
-        ADD: {"primop"}
-        MUL: {"primop"}
-        SUB: {"primop"}
-        DIV: {"primop"}
-        SDIV: {"primop"}
-        MOD: {"primop"}
-        SMOD: {"primop"}
-        ADDMOD: {"primop"}
-        MULMOD: {"primop"}
-        EXP: {"primop"}
-        SIGNEXTEND: {"primop"}
-        LT: {"primop"}
-        GT: {"primop"}
-        SLT: {"primop"}
-        SGT: {"primop"}
-        EQ: {"primop"}
-        ISZERO: {"primop"}
-        AND: {"primop"}
-        OR: {"primop"}
-        XOR: {"primop"}
-        NOT: {"primop"}
-        BYTE: {"primop"}
-        SHL: {"primop"}
-        SHR: {"primop"}
-        SAR: {"primop"}
+        ADD: {"primitive"}
+        MUL: {"primitive"}
+        SUB: {"primitive"}
+        DIV: {"primitive"}
+        SDIV: {"primitive"}
+        MOD: {"primitive"}
+        SMOD: {"primitive"}
+        ADDMOD: {"primitive"}
+        MULMOD: {"primitive"}
+        EXP: {"primitive"}
+        SIGNEXTEND: {"primitive"}
+        LT: {"primitive"}
+        GT: {"primitive"}
+        SLT: {"primitive"}
+        SGT: {"primitive"}
+        EQ: {"primitive"}
+        ISZERO: {"primitive"}
+        AND: {"primitive"}
+        OR: {"primitive"}
+        XOR: {"primitive"}
+        NOT: {"primitive"}
+        BYTE: {"primitive"}
+        SHL: {"primitive"}
+        SHR: {"primitive"}
+        SAR: {"primitive"}
 
         KECCAK256: {(m) {
             instructions::hash::keccak256(m.system, m.state)?;
@@ -537,165 +537,39 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             Ok(ControlFlow::Continue)
         }}
 
-        DUP1: {(m) {
-            instructions::stack::dup::<1>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
+        DUP1: {"primitive"}
+        DUP2: {"primitive"}
+        DUP3: {"primitive"}
+        DUP4: {"primitive"}
+        DUP5: {"primitive"}
+        DUP6: {"primitive"}
+        DUP7: {"primitive"}
+        DUP8: {"primitive"}
+        DUP9: {"primitive"}
+        DUP10: {"primitive"}
+        DUP11: {"primitive"}
+        DUP12: {"primitive"}
+        DUP13: {"primitive"}
+        DUP14: {"primitive"}
+        DUP15: {"primitive"}
+        DUP16: {"primitive"}
 
-        DUP2: {(m) {
-            instructions::stack::dup::<2>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP3: {(m) {
-            instructions::stack::dup::<3>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP4: {(m) {
-            instructions::stack::dup::<4>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP5: {(m) {
-            instructions::stack::dup::<5>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP6: {(m) {
-            instructions::stack::dup::<6>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP7: {(m) {
-            instructions::stack::dup::<7>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP8: {(m) {
-            instructions::stack::dup::<8>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP9: {(m) {
-            instructions::stack::dup::<9>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP10: {(m) {
-            instructions::stack::dup::<10>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP11: {(m) {
-            instructions::stack::dup::<11>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP12: {(m) {
-            instructions::stack::dup::<12>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP13: {(m) {
-            instructions::stack::dup::<13>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP14: {(m) {
-            instructions::stack::dup::<14>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP15: {(m) {
-            instructions::stack::dup::<15>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        DUP16: {(m) {
-            instructions::stack::dup::<16>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP1: {(m) {
-            instructions::stack::swap::<1>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP2: {(m) {
-            instructions::stack::swap::<2>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP3: {(m) {
-            instructions::stack::swap::<3>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP4: {(m) {
-            instructions::stack::swap::<4>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP5: {(m) {
-            instructions::stack::swap::<5>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP6: {(m) {
-            instructions::stack::swap::<6>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP7: {(m) {
-            instructions::stack::swap::<7>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP8: {(m) {
-            instructions::stack::swap::<8>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP9: {(m) {
-            instructions::stack::swap::<9>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP10: {(m) {
-            instructions::stack::swap::<10>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP11: {(m) {
-            instructions::stack::swap::<11>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP12: {(m) {
-            instructions::stack::swap::<12>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP13: {(m) {
-            instructions::stack::swap::<13>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP14: {(m) {
-            instructions::stack::swap::<14>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP15: {(m) {
-            instructions::stack::swap::<15>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
-
-        SWAP16: {(m) {
-            instructions::stack::swap::<16>(&mut m.state.stack);
-            Ok(ControlFlow::Continue)
-        }}
+        SWAP1: {"primitive"}
+        SWAP2: {"primitive"}
+        SWAP3: {"primitive"}
+        SWAP4: {"primitive"}
+        SWAP5: {"primitive"}
+        SWAP6: {"primitive"}
+        SWAP7: {"primitive"}
+        SWAP8: {"primitive"}
+        SWAP9: {"primitive"}
+        SWAP10: {"primitive"}
+        SWAP11: {"primitive"}
+        SWAP12: {"primitive"}
+        SWAP13: {"primitive"}
+        SWAP14: {"primitive"}
+        SWAP15: {"primitive"}
+        SWAP16: {"primitive"}
 
         LOG0: {(m) {
             instructions::log::log(m.state, m.system, 0)?;

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -223,11 +223,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
         CALLVALUE: (stdfun)
         CALLDATALOAD: (stdfun)
         CALLDATASIZE: (stdfun)
-
-        CALLDATACOPY: {(m) => {
-            instructions::call::calldatacopy(m.state)?;
-            Ok(ControlFlow::Continue)
-        }}
+        CALLDATACOPY: (stdfun)
 
         CODESIZE: {(m) => {
             instructions::call::codesize(&mut m.state.stack, m.bytecode.as_ref());

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -87,15 +87,15 @@ macro_rules! def_jmptable {
 }
 
 macro_rules! def_ins {
-    ($ins:ident (primitive)) => {
+    ($ins:ident {primitive}) => {
         def_ins_primitive! { $ins }
     };
 
-    ($ins:ident (push)) => {
+    ($ins:ident {push}) => {
         def_ins_push! { $ins }
     };
 
-    ($ins:ident (stdfun)) => {
+    ($ins:ident {stdfun}) => {
         def_ins_stdfun! { $ins }
     };
 
@@ -189,41 +189,41 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
 
     def_opcodes! {
         STOP: {=> Ok(ControlFlow::Exit)}
-        ADD: (primitive)
-        MUL: (primitive)
-        SUB: (primitive)
-        DIV: (primitive)
-        SDIV: (primitive)
-        MOD: (primitive)
-        SMOD: (primitive)
-        ADDMOD: (primitive)
-        MULMOD: (primitive)
-        EXP: (primitive)
-        SIGNEXTEND: (primitive)
-        LT: (primitive)
-        GT: (primitive)
-        SLT: (primitive)
-        SGT: (primitive)
-        EQ: (primitive)
-        ISZERO: (primitive)
-        AND: (primitive)
-        OR: (primitive)
-        XOR: (primitive)
-        NOT: (primitive)
-        BYTE: (primitive)
-        SHL: (primitive)
-        SHR: (primitive)
-        SAR: (primitive)
+        ADD: {primitive}
+        MUL: {primitive}
+        SUB: {primitive}
+        DIV: {primitive}
+        SDIV: {primitive}
+        MOD: {primitive}
+        SMOD: {primitive}
+        ADDMOD: {primitive}
+        MULMOD: {primitive}
+        EXP: {primitive}
+        SIGNEXTEND: {primitive}
+        LT: {primitive}
+        GT: {primitive}
+        SLT: {primitive}
+        SGT: {primitive}
+        EQ: {primitive}
+        ISZERO: {primitive}
+        AND: {primitive}
+        OR: {primitive}
+        XOR: {primitive}
+        NOT: {primitive}
+        BYTE: {primitive}
+        SHL: {primitive}
+        SHR: {primitive}
+        SAR: {primitive}
 
-        KECCAK256: (stdfun)
-        ADDRESS: (stdfun)
-        BALANCE: (stdfun)
-        ORIGIN: (stdfun)
-        CALLER: (stdfun)
-        CALLVALUE: (stdfun)
-        CALLDATALOAD: (stdfun)
-        CALLDATASIZE: (stdfun)
-        CALLDATACOPY: (stdfun)
+        KECCAK256: {stdfun}
+        ADDRESS: {stdfun}
+        BALANCE: {stdfun}
+        ORIGIN: {stdfun}
+        CALLER: {stdfun}
+        CALLVALUE: {stdfun}
+        CALLDATALOAD: {stdfun}
+        CALLDATASIZE: {stdfun}
+        CALLDATACOPY: {stdfun}
 
         CODESIZE: {(m) => {
             instructions::call::codesize(&mut m.state.stack, m.bytecode.as_ref());
@@ -310,7 +310,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             Ok(ControlFlow::Continue)
         }}
 
-        POP: (primitive)
+        POP: {primitive}
 
         MLOAD: {(m) => {
             instructions::memory::mload(m.state)?;
@@ -368,72 +368,72 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
 
         JUMPDEST: {=> Ok(ControlFlow::Continue)} // noop marker opcode for valid jumps addresses
 
-        PUSH1: (push)
-        PUSH2: (push)
-        PUSH3: (push)
-        PUSH4: (push)
-        PUSH5: (push)
-        PUSH6: (push)
-        PUSH7: (push)
-        PUSH8: (push)
-        PUSH9: (push)
-        PUSH10: (push)
-        PUSH11: (push)
-        PUSH12: (push)
-        PUSH13: (push)
-        PUSH14: (push)
-        PUSH15: (push)
-        PUSH16: (push)
-        PUSH17: (push)
-        PUSH18: (push)
-        PUSH19: (push)
-        PUSH20: (push)
-        PUSH21: (push)
-        PUSH22: (push)
-        PUSH23: (push)
-        PUSH24: (push)
-        PUSH25: (push)
-        PUSH26: (push)
-        PUSH27: (push)
-        PUSH28: (push)
-        PUSH29: (push)
-        PUSH30: (push)
-        PUSH31: (push)
-        PUSH32: (push)
+        PUSH1: {push}
+        PUSH2: {push}
+        PUSH3: {push}
+        PUSH4: {push}
+        PUSH5: {push}
+        PUSH6: {push}
+        PUSH7: {push}
+        PUSH8: {push}
+        PUSH9: {push}
+        PUSH10: {push}
+        PUSH11: {push}
+        PUSH12: {push}
+        PUSH13: {push}
+        PUSH14: {push}
+        PUSH15: {push}
+        PUSH16: {push}
+        PUSH17: {push}
+        PUSH18: {push}
+        PUSH19: {push}
+        PUSH20: {push}
+        PUSH21: {push}
+        PUSH22: {push}
+        PUSH23: {push}
+        PUSH24: {push}
+        PUSH25: {push}
+        PUSH26: {push}
+        PUSH27: {push}
+        PUSH28: {push}
+        PUSH29: {push}
+        PUSH30: {push}
+        PUSH31: {push}
+        PUSH32: {push}
 
-        DUP1: (primitive)
-        DUP2: (primitive)
-        DUP3: (primitive)
-        DUP4: (primitive)
-        DUP5: (primitive)
-        DUP6: (primitive)
-        DUP7: (primitive)
-        DUP8: (primitive)
-        DUP9: (primitive)
-        DUP10: (primitive)
-        DUP11: (primitive)
-        DUP12: (primitive)
-        DUP13: (primitive)
-        DUP14: (primitive)
-        DUP15: (primitive)
-        DUP16: (primitive)
+        DUP1: {primitive}
+        DUP2: {primitive}
+        DUP3: {primitive}
+        DUP4: {primitive}
+        DUP5: {primitive}
+        DUP6: {primitive}
+        DUP7: {primitive}
+        DUP8: {primitive}
+        DUP9: {primitive}
+        DUP10: {primitive}
+        DUP11: {primitive}
+        DUP12: {primitive}
+        DUP13: {primitive}
+        DUP14: {primitive}
+        DUP15: {primitive}
+        DUP16: {primitive}
 
-        SWAP1: (primitive)
-        SWAP2: (primitive)
-        SWAP3: (primitive)
-        SWAP4: (primitive)
-        SWAP5: (primitive)
-        SWAP6: (primitive)
-        SWAP7: (primitive)
-        SWAP8: (primitive)
-        SWAP9: (primitive)
-        SWAP10: (primitive)
-        SWAP11: (primitive)
-        SWAP12: (primitive)
-        SWAP13: (primitive)
-        SWAP14: (primitive)
-        SWAP15: (primitive)
-        SWAP16: (primitive)
+        SWAP1: {primitive}
+        SWAP2: {primitive}
+        SWAP3: {primitive}
+        SWAP4: {primitive}
+        SWAP5: {primitive}
+        SWAP6: {primitive}
+        SWAP7: {primitive}
+        SWAP8: {primitive}
+        SWAP9: {primitive}
+        SWAP10: {primitive}
+        SWAP11: {primitive}
+        SWAP12: {primitive}
+        SWAP13: {primitive}
+        SWAP14: {primitive}
+        SWAP15: {primitive}
+        SWAP16: {primitive}
 
         LOG0: {(m) => {
             instructions::log::log(m.state, m.system, 0)?;

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -87,7 +87,7 @@ macro_rules! def_jmptable {
 }
 
 macro_rules! def_ins {
-    ($ins:ident {primitive}) => {
+    ($ins:ident {primop}) => {
         def_ins_primitive! { $ins }
     };
 
@@ -95,8 +95,8 @@ macro_rules! def_ins {
         def_ins_push! { $ins }
     };
 
-    ($ins:ident {stdfun}) => {
-        def_ins_stdfun! { $ins }
+    ($ins:ident {std}) => {
+        def_ins_std! { $ins }
     };
 
     ($ins:ident {=> $expr:expr}) => {
@@ -142,7 +142,7 @@ macro_rules! def_ins_push {
     }
 }
 
-macro_rules! def_ins_stdfun {
+macro_rules! def_ins_std {
     ($ins:ident) => {
         def_ins_raw!{
             $ins (m) {
@@ -189,41 +189,41 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
 
     def_opcodes! {
         STOP: {=> Ok(ControlFlow::Exit)}
-        ADD: {primitive}
-        MUL: {primitive}
-        SUB: {primitive}
-        DIV: {primitive}
-        SDIV: {primitive}
-        MOD: {primitive}
-        SMOD: {primitive}
-        ADDMOD: {primitive}
-        MULMOD: {primitive}
-        EXP: {primitive}
-        SIGNEXTEND: {primitive}
-        LT: {primitive}
-        GT: {primitive}
-        SLT: {primitive}
-        SGT: {primitive}
-        EQ: {primitive}
-        ISZERO: {primitive}
-        AND: {primitive}
-        OR: {primitive}
-        XOR: {primitive}
-        NOT: {primitive}
-        BYTE: {primitive}
-        SHL: {primitive}
-        SHR: {primitive}
-        SAR: {primitive}
+        ADD: {primop}
+        MUL: {primop}
+        SUB: {primop}
+        DIV: {primop}
+        SDIV: {primop}
+        MOD: {primop}
+        SMOD: {primop}
+        ADDMOD: {primop}
+        MULMOD: {primop}
+        EXP: {primop}
+        SIGNEXTEND: {primop}
+        LT: {primop}
+        GT: {primop}
+        SLT: {primop}
+        SGT: {primop}
+        EQ: {primop}
+        ISZERO: {primop}
+        AND: {primop}
+        OR: {primop}
+        XOR: {primop}
+        NOT: {primop}
+        BYTE: {primop}
+        SHL: {primop}
+        SHR: {primop}
+        SAR: {primop}
 
-        KECCAK256: {stdfun}
-        ADDRESS: {stdfun}
-        BALANCE: {stdfun}
-        ORIGIN: {stdfun}
-        CALLER: {stdfun}
-        CALLVALUE: {stdfun}
-        CALLDATALOAD: {stdfun}
-        CALLDATASIZE: {stdfun}
-        CALLDATACOPY: {stdfun}
+        KECCAK256: {std}
+        ADDRESS: {std}
+        BALANCE: {std}
+        ORIGIN: {std}
+        CALLER: {std}
+        CALLVALUE: {std}
+        CALLDATALOAD: {std}
+        CALLDATASIZE: {std}
+        CALLDATACOPY: {std}
 
         CODESIZE: {(m) => {
             instructions::call::codesize(&mut m.state.stack, m.bytecode.as_ref());
@@ -235,35 +235,12 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             Ok(ControlFlow::Continue)
         }}
 
-        GASPRICE: {(m) => {
-            instructions::context::gas_price(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        EXTCODESIZE: {(m) => {
-            instructions::ext::extcodesize(m.state, m.system)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        EXTCODECOPY: {(m) => {
-            instructions::ext::extcodecopy(m.state, m.system)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        RETURNDATASIZE: {(m) => {
-            instructions::control::returndatasize(m.state);
-            Ok(ControlFlow::Continue)
-        }}
-
-        RETURNDATACOPY: {(m) => {
-            instructions::control::returndatacopy(m.state)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        EXTCODEHASH: {(m) => {
-            instructions::ext::extcodehash(m.state, m.system)?;
-            Ok(ControlFlow::Continue)
-        }}
+        GASPRICE: {std}
+        EXTCODESIZE: {std}
+        EXTCODECOPY: {std}
+        RETURNDATASIZE: {std}
+        RETURNDATACOPY: {std}
+        EXTCODEHASH: {std}
 
         BLOCKHASH: {(m) => {
             instructions::context::blockhash(m.state, m.system);
@@ -310,7 +287,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             Ok(ControlFlow::Continue)
         }}
 
-        POP: {primitive}
+        POP: {primop}
 
         MLOAD: {(m) => {
             instructions::memory::mload(m.state)?;
@@ -401,39 +378,39 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
         PUSH31: {push}
         PUSH32: {push}
 
-        DUP1: {primitive}
-        DUP2: {primitive}
-        DUP3: {primitive}
-        DUP4: {primitive}
-        DUP5: {primitive}
-        DUP6: {primitive}
-        DUP7: {primitive}
-        DUP8: {primitive}
-        DUP9: {primitive}
-        DUP10: {primitive}
-        DUP11: {primitive}
-        DUP12: {primitive}
-        DUP13: {primitive}
-        DUP14: {primitive}
-        DUP15: {primitive}
-        DUP16: {primitive}
+        DUP1: {primop}
+        DUP2: {primop}
+        DUP3: {primop}
+        DUP4: {primop}
+        DUP5: {primop}
+        DUP6: {primop}
+        DUP7: {primop}
+        DUP8: {primop}
+        DUP9: {primop}
+        DUP10: {primop}
+        DUP11: {primop}
+        DUP12: {primop}
+        DUP13: {primop}
+        DUP14: {primop}
+        DUP15: {primop}
+        DUP16: {primop}
 
-        SWAP1: {primitive}
-        SWAP2: {primitive}
-        SWAP3: {primitive}
-        SWAP4: {primitive}
-        SWAP5: {primitive}
-        SWAP6: {primitive}
-        SWAP7: {primitive}
-        SWAP8: {primitive}
-        SWAP9: {primitive}
-        SWAP10: {primitive}
-        SWAP11: {primitive}
-        SWAP12: {primitive}
-        SWAP13: {primitive}
-        SWAP14: {primitive}
-        SWAP15: {primitive}
-        SWAP16: {primitive}
+        SWAP1: {primop}
+        SWAP2: {primop}
+        SWAP3: {primop}
+        SWAP4: {primop}
+        SWAP5: {primop}
+        SWAP6: {primop}
+        SWAP7: {primop}
+        SWAP8: {primop}
+        SWAP9: {primop}
+        SWAP10: {primop}
+        SWAP11: {primop}
+        SWAP12: {primop}
+        SWAP13: {primop}
+        SWAP14: {primop}
+        SWAP15: {primop}
+        SWAP16: {primop}
 
         LOG0: {(m) => {
             instructions::log::log(m.state, m.system, 0)?;

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -362,10 +362,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
         LOG3: {std}
         LOG4: {std}
 
-        CREATE: {(m) => {
-            instructions::lifecycle::create(m.state, m.system)?;
-            Ok(ControlFlow::Continue)
-        }}
+        CREATE: {std}
 
         CALL: {std}
         CALLCODE: {std}
@@ -376,12 +373,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
         }}
 
         DELEGATECALL: {std}
-
-        CREATE2: {(m) => {
-            instructions::lifecycle::create2(m.state, m.system)?;
-            Ok(ControlFlow::Continue)
-        }}
-
+        CREATE2: {std}
         STATICCALL: {std}
 
         REVERT: {(m) => {

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -216,41 +216,13 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
         SAR: (primitive)
 
         KECCAK256: (stdfun)
-
-        ADDRESS: {(m) => {
-            instructions::context::address(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        BALANCE: {(m) => {
-            instructions::state::balance(m.state, m.system)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        ORIGIN: {(m) => {
-            instructions::context::origin(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        CALLER: {(m) => {
-            instructions::context::caller(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        CALLVALUE: {(m) => {
-            instructions::context::call_value(m.state, m.system);
-            Ok(ControlFlow::Continue)
-        }}
-
-        CALLDATALOAD: {(m) => {
-            instructions::call::calldataload(m.state);
-            Ok(ControlFlow::Continue)
-        }}
-
-        CALLDATASIZE: {(m) => {
-            instructions::call::calldatasize(m.state);
-            Ok(ControlFlow::Continue)
-        }}
+        ADDRESS: (stdfun)
+        BALANCE: (stdfun)
+        ORIGIN: (stdfun)
+        CALLER: (stdfun)
+        CALLVALUE: (stdfun)
+        CALLDATALOAD: (stdfun)
+        CALLDATASIZE: (stdfun)
 
         CALLDATACOPY: {(m) => {
             instructions::call::calldatacopy(m.state)?;

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -7,7 +7,6 @@ use {
     super::instructions,
     super::opcode::OpCode,
     super::StatusCode,
-    crate::interpreter::instructions::call::CallKind,
     crate::interpreter::memory::Memory,
     crate::interpreter::stack::Stack,
     crate::interpreter::{Bytecode, Output, System},
@@ -360,35 +359,22 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             Ok(ControlFlow::Continue)
         }}
 
-        CALL: {(m) => {
-            instructions::call::call(m.state, m.system, CallKind::Call)?;
-            Ok(ControlFlow::Continue)
-        }}
-
-        CALLCODE: {(m) => {
-            instructions::call::call(m.state, m.system, CallKind::CallCode)?;
-            Ok(ControlFlow::Continue)
-        }}
+        CALL: {std}
+        CALLCODE: {std}
 
         RETURN: {(m) => {
             instructions::control::ret(m.state)?;
             Ok(ControlFlow::Exit)
         }}
 
-        DELEGATECALL: {(m) => {
-            instructions::call::call(m.state, m.system, CallKind::DelegateCall)?;
-            Ok(ControlFlow::Continue)
-        }}
+        DELEGATECALL: {std}
 
         CREATE2: {(m) => {
             instructions::lifecycle::create2(m.state, m.system)?;
             Ok(ControlFlow::Continue)
         }}
 
-        STATICCALL: {(m) => {
-            instructions::call::call(m.state, m.system, CallKind::StaticCall)?;
-            Ok(ControlFlow::Continue)
-        }}
+        STATICCALL: {std}
 
         REVERT: {(m) => {
             instructions::control::ret(m.state)?;

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -87,7 +87,7 @@ macro_rules! def_jmptable {
 
 macro_rules! def_ins {
     ($ins:ident {primop}) => {
-        def_ins_primitive! { $ins }
+        def_ins_primop! { $ins }
     };
 
     ($ins:ident {push}) => {
@@ -119,7 +119,7 @@ macro_rules! def_ins_raw {
     };
 }
 
-macro_rules! def_ins_primitive {
+macro_rules! def_ins_primop {
     ($ins:ident) => {
         def_ins_raw!{
             $ins (m) {

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -87,12 +87,16 @@ macro_rules! def_jmptable {
 }
 
 macro_rules! def_ins {
-    ($ins:ident {"primitive"}) => {
+    ($ins:ident (primitive)) => {
         def_ins_primitive! { $ins }
     };
 
-    ($ins:ident {"push"}) => {
+    ($ins:ident (push)) => {
         def_ins_push! { $ins }
+    };
+
+    ($ins:ident (stdfun)) => {
+        def_ins_stdfun! { $ins }
     };
 
     ($ins:ident {=> $expr:expr}) => {
@@ -138,6 +142,17 @@ macro_rules! def_ins_push {
     }
 }
 
+macro_rules! def_ins_stdfun {
+    ($ins:ident) => {
+        def_ins_raw!{
+            $ins (m) {
+                instructions::$ins(m.state, m.system)?;
+                Ok(ControlFlow::Continue)
+            }
+        }
+    }
+}
+
 impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
     pub fn new(
         system: &'r mut System<'a, RT>,
@@ -174,36 +189,33 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
 
     def_opcodes! {
         STOP: {=> Ok(ControlFlow::Exit)}
-        ADD: {"primitive"}
-        MUL: {"primitive"}
-        SUB: {"primitive"}
-        DIV: {"primitive"}
-        SDIV: {"primitive"}
-        MOD: {"primitive"}
-        SMOD: {"primitive"}
-        ADDMOD: {"primitive"}
-        MULMOD: {"primitive"}
-        EXP: {"primitive"}
-        SIGNEXTEND: {"primitive"}
-        LT: {"primitive"}
-        GT: {"primitive"}
-        SLT: {"primitive"}
-        SGT: {"primitive"}
-        EQ: {"primitive"}
-        ISZERO: {"primitive"}
-        AND: {"primitive"}
-        OR: {"primitive"}
-        XOR: {"primitive"}
-        NOT: {"primitive"}
-        BYTE: {"primitive"}
-        SHL: {"primitive"}
-        SHR: {"primitive"}
-        SAR: {"primitive"}
+        ADD: (primitive)
+        MUL: (primitive)
+        SUB: (primitive)
+        DIV: (primitive)
+        SDIV: (primitive)
+        MOD: (primitive)
+        SMOD: (primitive)
+        ADDMOD: (primitive)
+        MULMOD: (primitive)
+        EXP: (primitive)
+        SIGNEXTEND: (primitive)
+        LT: (primitive)
+        GT: (primitive)
+        SLT: (primitive)
+        SGT: (primitive)
+        EQ: (primitive)
+        ISZERO: (primitive)
+        AND: (primitive)
+        OR: (primitive)
+        XOR: (primitive)
+        NOT: (primitive)
+        BYTE: (primitive)
+        SHL: (primitive)
+        SHR: (primitive)
+        SAR: (primitive)
 
-        KECCAK256: {(m) => {
-            instructions::hash::keccak256(m.system, m.state)?;
-            Ok(ControlFlow::Continue)
-        }}
+        KECCAK256: (stdfun)
 
         ADDRESS: {(m) => {
             instructions::context::address(m.state, m.system);
@@ -330,7 +342,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
             Ok(ControlFlow::Continue)
         }}
 
-        POP: {"primitive"}
+        POP: (primitive)
 
         MLOAD: {(m) => {
             instructions::memory::mload(m.state)?;
@@ -388,72 +400,72 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
 
         JUMPDEST: {=> Ok(ControlFlow::Continue)} // noop marker opcode for valid jumps addresses
 
-        PUSH1: {"push"}
-        PUSH2: {"push"}
-        PUSH3: {"push"}
-        PUSH4: {"push"}
-        PUSH5: {"push"}
-        PUSH6: {"push"}
-        PUSH7: {"push"}
-        PUSH8: {"push"}
-        PUSH9: {"push"}
-        PUSH10: {"push"}
-        PUSH11: {"push"}
-        PUSH12: {"push"}
-        PUSH13: {"push"}
-        PUSH14: {"push"}
-        PUSH15: {"push"}
-        PUSH16: {"push"}
-        PUSH17: {"push"}
-        PUSH18: {"push"}
-        PUSH19: {"push"}
-        PUSH20: {"push"}
-        PUSH21: {"push"}
-        PUSH22: {"push"}
-        PUSH23: {"push"}
-        PUSH24: {"push"}
-        PUSH25: {"push"}
-        PUSH26: {"push"}
-        PUSH27: {"push"}
-        PUSH28: {"push"}
-        PUSH29: {"push"}
-        PUSH30: {"push"}
-        PUSH31: {"push"}
-        PUSH32: {"push"}
+        PUSH1: (push)
+        PUSH2: (push)
+        PUSH3: (push)
+        PUSH4: (push)
+        PUSH5: (push)
+        PUSH6: (push)
+        PUSH7: (push)
+        PUSH8: (push)
+        PUSH9: (push)
+        PUSH10: (push)
+        PUSH11: (push)
+        PUSH12: (push)
+        PUSH13: (push)
+        PUSH14: (push)
+        PUSH15: (push)
+        PUSH16: (push)
+        PUSH17: (push)
+        PUSH18: (push)
+        PUSH19: (push)
+        PUSH20: (push)
+        PUSH21: (push)
+        PUSH22: (push)
+        PUSH23: (push)
+        PUSH24: (push)
+        PUSH25: (push)
+        PUSH26: (push)
+        PUSH27: (push)
+        PUSH28: (push)
+        PUSH29: (push)
+        PUSH30: (push)
+        PUSH31: (push)
+        PUSH32: (push)
 
-        DUP1: {"primitive"}
-        DUP2: {"primitive"}
-        DUP3: {"primitive"}
-        DUP4: {"primitive"}
-        DUP5: {"primitive"}
-        DUP6: {"primitive"}
-        DUP7: {"primitive"}
-        DUP8: {"primitive"}
-        DUP9: {"primitive"}
-        DUP10: {"primitive"}
-        DUP11: {"primitive"}
-        DUP12: {"primitive"}
-        DUP13: {"primitive"}
-        DUP14: {"primitive"}
-        DUP15: {"primitive"}
-        DUP16: {"primitive"}
+        DUP1: (primitive)
+        DUP2: (primitive)
+        DUP3: (primitive)
+        DUP4: (primitive)
+        DUP5: (primitive)
+        DUP6: (primitive)
+        DUP7: (primitive)
+        DUP8: (primitive)
+        DUP9: (primitive)
+        DUP10: (primitive)
+        DUP11: (primitive)
+        DUP12: (primitive)
+        DUP13: (primitive)
+        DUP14: (primitive)
+        DUP15: (primitive)
+        DUP16: (primitive)
 
-        SWAP1: {"primitive"}
-        SWAP2: {"primitive"}
-        SWAP3: {"primitive"}
-        SWAP4: {"primitive"}
-        SWAP5: {"primitive"}
-        SWAP6: {"primitive"}
-        SWAP7: {"primitive"}
-        SWAP8: {"primitive"}
-        SWAP9: {"primitive"}
-        SWAP10: {"primitive"}
-        SWAP11: {"primitive"}
-        SWAP12: {"primitive"}
-        SWAP13: {"primitive"}
-        SWAP14: {"primitive"}
-        SWAP15: {"primitive"}
-        SWAP16: {"primitive"}
+        SWAP1: (primitive)
+        SWAP2: (primitive)
+        SWAP3: (primitive)
+        SWAP4: (primitive)
+        SWAP5: (primitive)
+        SWAP6: (primitive)
+        SWAP7: (primitive)
+        SWAP8: (primitive)
+        SWAP9: (primitive)
+        SWAP10: (primitive)
+        SWAP11: (primitive)
+        SWAP12: (primitive)
+        SWAP13: (primitive)
+        SWAP14: (primitive)
+        SWAP15: (primitive)
+        SWAP16: (primitive)
 
         LOG0: {(m) => {
             instructions::log::log(m.state, m.system, 0)?;

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -109,7 +109,6 @@ macro_rules! def_ins {
     ($ins:ident {($arg:ident) => $body:block}) => {
         def_ins_raw! { $ins ($arg) $body }
     };
-
 }
 
 macro_rules! def_ins_raw {
@@ -125,46 +124,46 @@ macro_rules! def_ins_raw {
 
 macro_rules! def_ins_primop {
     ($ins:ident) => {
-        def_ins_raw!{
+        def_ins_raw! {
             $ins (m) {
                 instructions::$ins(&mut m.state.stack)?;
                 Ok(ControlFlow::Continue)
             }
         }
-    }
+    };
 }
 
 macro_rules! def_ins_push {
     ($ins:ident) => {
-        def_ins_raw!{
+        def_ins_raw! {
             $ins (m) {
                 m.pc += instructions::$ins(&mut m.state.stack, &m.bytecode[m.pc + 1..])?;
                 Ok(ControlFlow::Continue)
             }
         }
-    }
+    };
 }
 
 macro_rules! def_ins_std {
     ($ins:ident) => {
-        def_ins_raw!{
+        def_ins_raw! {
             $ins (m) {
                 instructions::$ins(m.state, m.system)?;
                 Ok(ControlFlow::Continue)
             }
         }
-    }
+    };
 }
 
 macro_rules! def_ins_code {
     ($ins:ident) => {
-        def_ins_raw!{
+        def_ins_raw! {
             $ins (m) {
                 instructions::$ins(m.state, m.system, m.bytecode.as_ref())?;
                 Ok(ControlFlow::Continue)
             }
         }
-    }
+    };
 }
 
 impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {

--- a/actors/evm/src/interpreter/instructions/arithmetic.rs
+++ b/actors/evm/src/interpreter/instructions/arithmetic.rs
@@ -75,7 +75,11 @@ pub fn signextend(a: U256, b: U256) -> U256 {
     if a < 32 {
         let bit_index = 8 * a.low_u32() + 7;
         let mask = U256::MAX >> (U256::BITS - bit_index);
-        if b.bit(bit_index as usize) { b | !mask } else { b & mask }
+        if b.bit(bit_index as usize) {
+            b | !mask
+        } else {
+            b & mask
+        }
     } else {
         b
     }
@@ -106,8 +110,8 @@ pub fn exp(mut base: U256, power: U256) -> U256 {
 
 #[cfg(test)]
 mod test {
-    use crate::interpreter::stack::Stack;
     use super::*;
+    use crate::interpreter::stack::Stack;
 
     mod basic {
         use crate::interpreter::{stack::Stack, U256};
@@ -122,11 +126,15 @@ mod test {
 
         fn expect_stack_value(s: &mut Stack, e: impl Into<U256>, comment: impl AsRef<str>) {
             let mut expected = Stack::new();
-            unsafe {expected.push(e.into());}
+            unsafe {
+                expected.push(e.into());
+            }
 
             // stacks should be _exactly_ the same
-            assert_eq!(unsafe {s.get(0)}, unsafe{expected.get(0)}, "{}", comment.as_ref());
-            unsafe {s.pop();}
+            assert_eq!(unsafe { s.get(0) }, unsafe { expected.get(0) }, "{}", comment.as_ref());
+            unsafe {
+                s.pop();
+            }
         }
 
         #[test]
@@ -267,7 +275,7 @@ mod test {
                 }
                 crate::interpreter::instructions::EXP(&mut stack).unwrap();
                 let res: U256 = ($result).into();
-                assert_eq!(res, unsafe{stack.pop()});
+                assert_eq!(res, unsafe { stack.pop() });
             };
         }
 

--- a/actors/evm/src/interpreter/instructions/bitwise.rs
+++ b/actors/evm/src/interpreter/instructions/bitwise.rs
@@ -58,6 +58,7 @@ pub fn sar(shift: U256, mut value: U256) -> U256 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::interpreter::stack::Stack;
 
     #[test]
     fn test_instruction_byte() {
@@ -65,29 +66,35 @@ mod tests {
 
         for i in 0u16..32 {
             let mut stack = Stack::new();
-            stack.push(value);
-            stack.push(U256::from(i));
+            unsafe {
+                stack.push(value);
+                stack.push(U256::from(i));
+            }
 
-            byte(&mut stack);
-            let result = stack.pop();
+            crate::interpreter::instructions::BYTE(&mut stack).unwrap();
+            let result = unsafe {stack.pop()};
 
             assert_eq!(result, U256::from(5 * (i + 1)));
         }
 
         let mut stack = Stack::new();
-        stack.push(value);
-        stack.push(U256::from(100u128));
+        unsafe {
+            stack.push(value);
+            stack.push(U256::from(100u128));
+        }
 
-        byte(&mut stack);
-        let result = stack.pop();
+        crate::interpreter::instructions::BYTE(&mut stack).unwrap();
+        let result = unsafe {stack.pop()};
         assert_eq!(result, U256::zero());
 
         let mut stack = Stack::new();
-        stack.push(value);
-        stack.push(U256::from_u128_words(1, 0));
+        unsafe {
+            stack.push(value);
+            stack.push(U256::from_u128_words(1, 0));
+        }
 
-        byte(&mut stack);
-        let result = stack.pop();
+        crate::interpreter::instructions::BYTE(&mut stack).unwrap();
+        let result = unsafe {stack.pop()};
         assert_eq!(result, U256::zero());
     }
 }

--- a/actors/evm/src/interpreter/instructions/bitwise.rs
+++ b/actors/evm/src/interpreter/instructions/bitwise.rs
@@ -1,52 +1,40 @@
-use {crate::interpreter::stack::Stack, crate::interpreter::U256};
+use {crate::interpreter::U256};
 
 #[inline]
-pub fn byte(stack: &mut Stack) {
-    let i = stack.pop();
-    let x = stack.get_mut(0);
-
+pub fn byte(i: U256, x: U256) -> U256 {
     if i >= 32 {
-        *x = U256::ZERO;
+        U256::ZERO
     } else {
-        *x = U256::from_u64(x.byte(31 - i.low_u64() as usize) as u64);
+        U256::from_u64(x.byte(31 - i.low_u64() as usize) as u64)
     }
 }
 
 #[inline]
-pub fn shl(stack: &mut Stack) {
-    let shift = stack.pop();
-    let value = stack.get_mut(0);
-
+pub fn shl(shift: U256, value: U256) -> U256 {
     if value.is_zero() || shift >= 256 {
-        *value = U256::ZERO;
+        U256::ZERO
     } else {
-        *value <<= shift
-    };
+        value << shift
+    }
 }
 
 #[inline]
-pub fn shr(stack: &mut Stack) {
-    let shift = stack.pop();
-    let value = stack.get_mut(0);
-
+pub fn shr(shift: U256, value: U256) -> U256 {
     if value.is_zero() || shift >= 256 {
-        *value = U256::ZERO;
+        U256::ZERO
     } else {
-        *value >>= shift
-    };
+        value >> shift
+    }
 }
 
 #[inline]
-pub fn sar(stack: &mut Stack) {
-    let shift = stack.pop();
-    let mut value = stack.pop();
-
+pub fn sar(shift: U256, mut value: U256) -> U256 {
     let negative = value.i256_is_negative();
     if negative {
         value = value.i256_neg();
     }
 
-    stack.push(if value.is_zero() || shift >= 256 {
+    if value.is_zero() || shift >= 256 {
         if negative {
             // value is < 0, pushing U256::MAX (== -1)
             U256::MAX
@@ -64,7 +52,7 @@ pub fn sar(stack: &mut Stack) {
         } else {
             value >> shift
         }
-    });
+    }
 }
 
 #[cfg(test)]

--- a/actors/evm/src/interpreter/instructions/bitwise.rs
+++ b/actors/evm/src/interpreter/instructions/bitwise.rs
@@ -1,4 +1,4 @@
-use {crate::interpreter::U256};
+use crate::interpreter::U256;
 
 #[inline]
 pub fn byte(i: U256, x: U256) -> U256 {
@@ -72,7 +72,7 @@ mod tests {
             }
 
             crate::interpreter::instructions::BYTE(&mut stack).unwrap();
-            let result = unsafe {stack.pop()};
+            let result = unsafe { stack.pop() };
 
             assert_eq!(result, U256::from(5 * (i + 1)));
         }
@@ -84,7 +84,7 @@ mod tests {
         }
 
         crate::interpreter::instructions::BYTE(&mut stack).unwrap();
-        let result = unsafe {stack.pop()};
+        let result = unsafe { stack.pop() };
         assert_eq!(result, U256::zero());
 
         let mut stack = Stack::new();
@@ -94,7 +94,7 @@ mod tests {
         }
 
         crate::interpreter::instructions::BYTE(&mut stack).unwrap();
-        let result = unsafe {stack.pop()};
+        let result = unsafe { stack.pop() };
         assert_eq!(result, U256::zero());
     }
 }

--- a/actors/evm/src/interpreter/instructions/boolean.rs
+++ b/actors/evm/src/interpreter/instructions/boolean.rs
@@ -1,7 +1,4 @@
-use {
-    crate::interpreter::uints::*, crate::interpreter::U256,
-    std::cmp::Ordering,
-};
+use {crate::interpreter::uints::*, crate::interpreter::U256, std::cmp::Ordering};
 
 #[inline]
 pub fn lt(a: U256, b: U256) -> U256 {

--- a/actors/evm/src/interpreter/instructions/boolean.rs
+++ b/actors/evm/src/interpreter/instructions/boolean.rs
@@ -1,77 +1,54 @@
 use {
-    crate::interpreter::stack::Stack, crate::interpreter::uints::*, crate::interpreter::U256,
+    crate::interpreter::uints::*, crate::interpreter::U256,
     std::cmp::Ordering,
 };
 
 #[inline]
-pub fn lt(stack: &mut Stack) {
-    let a = stack.pop();
-    let b = stack.get_mut(0);
-
-    *b = U256::from_u64((a < *b).into());
+pub fn lt(a: U256, b: U256) -> U256 {
+    U256::from_u64((a < b).into())
 }
 
 #[inline]
-pub fn gt(stack: &mut Stack) {
-    let a = stack.pop();
-    let b = stack.get_mut(0);
-
-    *b = U256::from_u64((a > *b).into());
+pub fn gt(a: U256, b: U256) -> U256 {
+    U256::from_u64((a > b).into())
 }
 
 #[inline]
-pub(crate) fn slt(stack: &mut Stack) {
-    let a = stack.pop();
-    let b = stack.get_mut(0);
-
-    *b = U256::from_u64((i256_cmp(a, *b) == Ordering::Less).into());
+pub(crate) fn slt(a: U256, b: U256) -> U256 {
+    U256::from_u64((i256_cmp(a, b) == Ordering::Less).into())
 }
 
 #[inline]
-pub(crate) fn sgt(stack: &mut Stack) {
-    let a = stack.pop();
-    let b = stack.get_mut(0);
-
-    *b = U256::from_u64((i256_cmp(a, *b) == Ordering::Greater).into());
+pub(crate) fn sgt(a: U256, b: U256) -> U256 {
+    U256::from_u64((i256_cmp(a, b) == Ordering::Greater).into())
 }
 
 #[inline]
-pub fn eq(stack: &mut Stack) {
-    let a = stack.pop();
-    let b = stack.get_mut(0);
-
-    *b = U256::from_u64((a == *b).into());
+pub fn eq(a: U256, b: U256) -> U256 {
+    U256::from_u64((a == b).into())
 }
 
 #[inline]
-pub fn iszero(stack: &mut Stack) {
-    let a = stack.get_mut(0);
-    *a = U256::from_u64(a.is_zero().into());
+pub fn iszero(a: U256) -> U256 {
+    U256::from_u64(a.is_zero().into())
 }
 
 #[inline]
-pub(crate) fn and(stack: &mut Stack) {
-    let a = stack.pop();
-    let b = stack.get_mut(0);
-    *b = a & *b;
+pub(crate) fn and(a: U256, b: U256) -> U256 {
+    a & b
 }
 
 #[inline]
-pub(crate) fn or(stack: &mut Stack) {
-    let a = stack.pop();
-    let b = stack.get_mut(0);
-    *b = a | *b;
+pub(crate) fn or(a: U256, b: U256) -> U256 {
+    a | b
 }
 
 #[inline]
-pub(crate) fn xor(stack: &mut Stack) {
-    let a = stack.pop();
-    let b = stack.get_mut(0);
-    *b = a ^ *b;
+pub(crate) fn xor(a: U256, b: U256) -> U256 {
+    a ^ b
 }
 
 #[inline]
-pub(crate) fn not(stack: &mut Stack) {
-    let v = stack.get_mut(0);
-    *v = !*v;
+pub(crate) fn not(v: U256) -> U256 {
+    !v
 }

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -29,7 +29,11 @@ pub enum CallKind {
     CallCode,
 }
 
-pub fn calldataload(state: &mut ExecutionState, _: &System<impl Runtime>, index: U256)  -> Result<U256, StatusCode> {
+pub fn calldataload(
+    state: &mut ExecutionState,
+    _: &System<impl Runtime>,
+    index: U256,
+) -> Result<U256, StatusCode> {
     let input_len = state.input_data.len();
     Ok(if index > U256::from(input_len) {
         U256::zero()
@@ -45,22 +49,42 @@ pub fn calldataload(state: &mut ExecutionState, _: &System<impl Runtime>, index:
 }
 
 #[inline]
-pub fn calldatasize(state: &mut ExecutionState, _: &System<impl Runtime>)  -> Result<U256, StatusCode> {
+pub fn calldatasize(
+    state: &mut ExecutionState,
+    _: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     Ok(u128::try_from(state.input_data.len()).unwrap().into())
 }
 
 #[inline]
-pub fn calldatacopy(state: &mut ExecutionState, _: &System<impl Runtime>, mem_index: U256, input_index: U256, size: U256) -> Result<(), StatusCode> {
+pub fn calldatacopy(
+    state: &mut ExecutionState,
+    _: &System<impl Runtime>,
+    mem_index: U256,
+    input_index: U256,
+    size: U256,
+) -> Result<(), StatusCode> {
     copy_to_memory(&mut state.memory, mem_index, size, input_index, &state.input_data, true)
 }
 
 #[inline]
-pub fn codesize(_state: &mut ExecutionState, _: &System<impl Runtime>, code: &[u8]) -> Result<U256, StatusCode> {
+pub fn codesize(
+    _state: &mut ExecutionState,
+    _: &System<impl Runtime>,
+    code: &[u8],
+) -> Result<U256, StatusCode> {
     Ok(U256::from(code.len()))
 }
 
 #[inline]
-pub fn codecopy(state: &mut ExecutionState, _: &System<impl Runtime>, code: &[u8], mem_index: U256, input_index: U256, size: U256) -> Result<(), StatusCode> {
+pub fn codecopy(
+    state: &mut ExecutionState,
+    _: &System<impl Runtime>,
+    code: &[u8],
+    mem_index: U256,
+    input_index: U256,
+    size: U256,
+) -> Result<(), StatusCode> {
     copy_to_memory(&mut state.memory, mem_index, size, input_index, code, true)
 }
 
@@ -76,7 +100,12 @@ pub fn call_call<RT: Runtime>(
     output_offset: U256,
     output_size: U256,
 ) -> Result<U256, StatusCode> {
-    call_generic(state, system, CallKind::Call, (gas, dst, value, input_offset, input_size, output_offset, output_size))
+    call_generic(
+        state,
+        system,
+        CallKind::Call,
+        (gas, dst, value, input_offset, input_size, output_offset, output_size),
+    )
 }
 
 #[inline]
@@ -91,7 +120,12 @@ pub fn call_callcode<RT: Runtime>(
     output_offset: U256,
     output_size: U256,
 ) -> Result<U256, StatusCode> {
-    call_generic(state, system, CallKind::CallCode, (gas, dst, value, input_offset, input_size, output_offset, output_size))
+    call_generic(
+        state,
+        system,
+        CallKind::CallCode,
+        (gas, dst, value, input_offset, input_size, output_offset, output_size),
+    )
 }
 
 #[inline]
@@ -105,7 +139,12 @@ pub fn call_delegatecall<RT: Runtime>(
     output_offset: U256,
     output_size: U256,
 ) -> Result<U256, StatusCode> {
-    call_generic(state, system, CallKind::DelegateCall, (gas, dst, U256::zero(), input_offset, input_size, output_offset, output_size))
+    call_generic(
+        state,
+        system,
+        CallKind::DelegateCall,
+        (gas, dst, U256::zero(), input_offset, input_size, output_offset, output_size),
+    )
 }
 
 #[inline]
@@ -119,7 +158,12 @@ pub fn call_staticcall<RT: Runtime>(
     output_offset: U256,
     output_size: U256,
 ) -> Result<U256, StatusCode> {
-    call_generic(state, system, CallKind::StaticCall, (gas, dst, U256::zero(), input_offset, input_size, output_offset, output_size))
+    call_generic(
+        state,
+        system,
+        CallKind::StaticCall,
+        (gas, dst, U256::zero(), input_offset, input_size, output_offset, output_size),
+    )
 }
 
 pub fn call_generic<RT: Runtime>(

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -50,11 +50,7 @@ pub fn calldatasize(state: &mut ExecutionState, _: &System<impl Runtime>)  -> Re
     Ok(u128::try_from(state.input_data.len()).unwrap().into())
 }
 
-pub fn calldatacopy(state: &mut ExecutionState) -> Result<(), StatusCode> {
-    let mem_index = state.stack.pop();
-    let input_index = state.stack.pop();
-    let size = state.stack.pop();
-
+pub fn calldatacopy(state: &mut ExecutionState, _: &System<impl Runtime>, mem_index: U256, input_index: U256, size: U256) -> Result<(), StatusCode> {
     copy_to_memory(&mut state.memory, mem_index, size, input_index, &state.input_data, true)
 }
 

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -9,7 +9,6 @@ use {
     crate::interpreter::instructions::memory::MemoryRegion,
     crate::interpreter::output::StatusCode,
     crate::interpreter::precompiles,
-    crate::interpreter::stack::Stack,
     crate::interpreter::ExecutionState,
     crate::interpreter::System,
     crate::interpreter::U256,
@@ -50,20 +49,18 @@ pub fn calldatasize(state: &mut ExecutionState, _: &System<impl Runtime>)  -> Re
     Ok(u128::try_from(state.input_data.len()).unwrap().into())
 }
 
+#[inline]
 pub fn calldatacopy(state: &mut ExecutionState, _: &System<impl Runtime>, mem_index: U256, input_index: U256, size: U256) -> Result<(), StatusCode> {
     copy_to_memory(&mut state.memory, mem_index, size, input_index, &state.input_data, true)
 }
 
 #[inline]
-pub fn codesize(stack: &mut Stack, code: &[u8]) {
-    stack.push(U256::from(code.len()))
+pub fn codesize(_state: &mut ExecutionState, _: &System<impl Runtime>, code: &[u8]) -> Result<U256, StatusCode> {
+    Ok(U256::from(code.len()))
 }
 
-pub fn codecopy(state: &mut ExecutionState, code: &[u8]) -> Result<(), StatusCode> {
-    let mem_index = state.stack.pop();
-    let input_index = state.stack.pop();
-    let size = state.stack.pop();
-
+#[inline]
+pub fn codecopy(state: &mut ExecutionState, _: &System<impl Runtime>, code: &[u8], mem_index: U256, input_index: U256, size: U256) -> Result<(), StatusCode> {
     copy_to_memory(&mut state.memory, mem_index, size, input_index, code, true)
 }
 

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -14,7 +14,7 @@ use {
     crate::interpreter::System,
     crate::interpreter::U256,
     crate::RawBytes,
-    crate::{DelegateCallParams, Method, EVM_CONTRACT_EXECUTION_ERROR, EVM_CONTRACT_REVERTED},
+    crate::{DelegateCallParams, Method, EVM_CONTRACT_EXECUTION_ERROR},
     fil_actors_runtime::runtime::builtins::Type,
     fil_actors_runtime::runtime::Runtime,
     fil_actors_runtime::ActorError,
@@ -67,36 +67,75 @@ pub fn codecopy(state: &mut ExecutionState, code: &[u8]) -> Result<(), StatusCod
     copy_to_memory(&mut state.memory, mem_index, size, input_index, code, true)
 }
 
-pub fn call<RT: Runtime>(
+#[inline]
+pub fn call_call<RT: Runtime>(
+    state: &mut ExecutionState,
+    system: &mut System<RT>,
+    gas: U256,
+    dst: U256,
+    value: U256,
+    input_offset: U256,
+    input_size: U256,
+    output_offset: U256,
+    output_size: U256,
+) -> Result<U256, StatusCode> {
+    call_generic(state, system, CallKind::Call, (gas, dst, value, input_offset, input_size, output_offset, output_size))
+}
+
+#[inline]
+pub fn call_callcode<RT: Runtime>(
+    state: &mut ExecutionState,
+    system: &mut System<RT>,
+    gas: U256,
+    dst: U256,
+    value: U256,
+    input_offset: U256,
+    input_size: U256,
+    output_offset: U256,
+    output_size: U256,
+) -> Result<U256, StatusCode> {
+    call_generic(state, system, CallKind::CallCode, (gas, dst, value, input_offset, input_size, output_offset, output_size))
+}
+
+#[inline]
+pub fn call_delegatecall<RT: Runtime>(
+    state: &mut ExecutionState,
+    system: &mut System<RT>,
+    gas: U256,
+    dst: U256,
+    input_offset: U256,
+    input_size: U256,
+    output_offset: U256,
+    output_size: U256,
+) -> Result<U256, StatusCode> {
+    call_generic(state, system, CallKind::DelegateCall, (gas, dst, U256::zero(), input_offset, input_size, output_offset, output_size))
+}
+
+#[inline]
+pub fn call_staticcall<RT: Runtime>(
+    state: &mut ExecutionState,
+    system: &mut System<RT>,
+    gas: U256,
+    dst: U256,
+    input_offset: U256,
+    input_size: U256,
+    output_offset: U256,
+    output_size: U256,
+) -> Result<U256, StatusCode> {
+    call_generic(state, system, CallKind::StaticCall, (gas, dst, U256::zero(), input_offset, input_size, output_offset, output_size))
+}
+
+pub fn call_generic<RT: Runtime>(
     state: &mut ExecutionState,
     system: &mut System<RT>,
     kind: CallKind,
-) -> Result<(), StatusCode> {
-    let ExecutionState { stack, memory, .. } = state;
+    params: (U256, U256, U256, U256, U256, U256, U256),
+) -> Result<U256, StatusCode> {
+    let ExecutionState { stack: _, memory, .. } = state;
 
     // NOTE gas is currently ignored as FVM's send doesn't allow the caller to specify a gas
     //      limit (external invocation gas limit applies). This may changed in the future.
-    let (gas, dst, value, input_offset, input_size, output_offset, output_size) = match kind {
-        CallKind::Call | CallKind::CallCode => (
-            stack.pop(),
-            stack.pop(),
-            stack.pop(),
-            stack.pop(),
-            stack.pop(),
-            stack.pop(),
-            stack.pop(),
-        ),
-
-        CallKind::DelegateCall | CallKind::StaticCall => (
-            stack.pop(),
-            stack.pop(),
-            U256::from(0),
-            stack.pop(),
-            stack.pop(),
-            stack.pop(),
-            stack.pop(),
-        ),
-    };
+    let (gas, dst, value, input_offset, input_size, output_offset, output_size) = params;
 
     if system.readonly && value > U256::zero() {
         // non-zero sends are side-effects and hence a static mode violation
@@ -225,71 +264,5 @@ pub fn call<RT: Runtime>(
     // copy return data to output region if it is non-zero
     copy_to_memory(memory, output_offset, output_size, U256::zero(), &state.return_data, false)?;
 
-    stack.push(U256::from(call_result));
-    Ok(())
-}
-
-pub fn callactor(
-    state: &mut ExecutionState,
-    system: &System<impl Runtime>,
-) -> Result<(), StatusCode> {
-    let ExecutionState { stack, memory, .. } = state;
-    let rt = &*system.rt; // as immutable reference
-
-    // TODO Until we support readonly (static) calls at the fvm level, we disallow callactor
-    //      when in static mode as it is sticky and there are no guarantee of preserving the
-    //      static invariant
-    if system.readonly {
-        return Err(StatusCode::StaticModeViolation);
-    }
-
-    // stack: GAS DEST VALUE METHODNUM INPUT-OFFSET INPUT-SIZE
-    // NOTE: we don't need output-offset/output-size (which the CALL instructions have)
-    //       becase these are kinda useless; we can just use RETURNDATA anyway.
-    // NOTE: gas is currently ignored
-    let _gas = stack.pop();
-    let dst = stack.pop();
-    let value = stack.pop();
-    let method = stack.pop();
-    let input_offset = stack.pop();
-    let input_size = stack.pop();
-
-    let input_region = get_memory_region(memory, input_offset, input_size)
-        .map_err(|_| StatusCode::InvalidMemoryAccess)?;
-
-    let result = {
-        // TODO: this is wrong https://github.com/filecoin-project/ref-fvm/issues/1018
-        let dst_addr: EthAddress = dst.into();
-        let dst_addr: Address = dst_addr.try_into()?;
-
-        if method.bits() > 64 {
-            return Err(StatusCode::ArgumentOutOfRange(format!("bad method number: {}", method)));
-        }
-        let methodnum = method.as_u64();
-
-        let input_data = if let Some(MemoryRegion { offset, size }) = input_region {
-            &memory[offset..][..size.get()]
-        } else {
-            &[]
-        }
-        .to_vec();
-        rt.send(&dst_addr, methodnum, RawBytes::from(input_data), TokenAmount::from(&value))
-    };
-
-    if let Err(ae) = result {
-        return if ae.exit_code() == EVM_CONTRACT_REVERTED {
-            // reverted -- we don't have return data yet
-            // push failure
-            stack.push(U256::zero());
-            Ok(())
-        } else {
-            Err(StatusCode::from(ae))
-        };
-    }
-
-    // save return_data
-    state.return_data = result.unwrap().to_vec().into();
-    // push success
-    stack.push(U256::from(1));
-    Ok(())
+    Ok(U256::from(call_result))
 }

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use fvm_ipld_encoding::{BytesDe, BytesSer};
 use fvm_shared::{address::Address, METHOD_SEND};
 

--- a/actors/evm/src/interpreter/instructions/context.rs
+++ b/actors/evm/src/interpreter/instructions/context.rs
@@ -1,7 +1,7 @@
 use fvm_shared::clock::ChainEpoch;
 
 use {
-    crate::interpreter::{ExecutionState, System, U256},
+    crate::interpreter::{ExecutionState, System, U256, StatusCode},
     fil_actors_runtime::runtime::chainid,
     fil_actors_runtime::runtime::Runtime,
 };
@@ -33,26 +33,26 @@ pub fn blockhash(state: &mut ExecutionState, system: &System<impl Runtime>) {
 }
 
 #[inline]
-pub fn caller(state: &mut ExecutionState, _: &System<impl Runtime>) {
-    state.stack.push(state.caller.as_evm_word())
+pub fn caller(state: &mut ExecutionState, _: &System<impl Runtime>)  -> Result<U256, StatusCode>  {
+    Ok(state.caller.as_evm_word())
 }
 
 #[inline]
-pub fn address(state: &mut ExecutionState, _system: &System<impl Runtime>) {
-    state.stack.push(state.receiver.as_evm_word())
+pub fn address(state: &mut ExecutionState, _system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+    Ok(state.receiver.as_evm_word())
 }
 
 #[inline]
-pub fn origin(state: &mut ExecutionState, system: &System<impl Runtime>) {
+pub fn origin(_state: &mut ExecutionState, system: &System<impl Runtime>)  -> Result<U256, StatusCode> {
     let origin_addr = system
         .resolve_ethereum_address(&system.rt.message().origin())
         .expect("failed to resolve origin address");
-    state.stack.push(origin_addr.as_evm_word())
+    Ok(origin_addr.as_evm_word())
 }
 
 #[inline]
-pub fn call_value(state: &mut ExecutionState, system: &System<impl Runtime>) {
-    state.stack.push(U256::from(&system.rt.message().value_received()));
+pub fn call_value(_state: &mut ExecutionState, system: &System<impl Runtime>)   -> Result<U256, StatusCode> {
+    Ok(U256::from(&system.rt.message().value_received()))
 }
 
 #[inline]

--- a/actors/evm/src/interpreter/instructions/context.rs
+++ b/actors/evm/src/interpreter/instructions/context.rs
@@ -62,9 +62,9 @@ pub fn coinbase(state: &mut ExecutionState, _system: &System<impl Runtime>) {
 }
 
 #[inline]
-pub fn gas_price(state: &mut ExecutionState, system: &System<impl Runtime>) {
+pub fn gas_price(_state: &mut ExecutionState, system: &System<impl Runtime>) -> Result<U256, StatusCode> {
     let effective_price = system.rt.base_fee() + system.rt.message().gas_premium();
-    state.stack.push(U256::from(&effective_price));
+    Ok(U256::from(&effective_price))
 }
 
 #[inline]

--- a/actors/evm/src/interpreter/instructions/context.rs
+++ b/actors/evm/src/interpreter/instructions/context.rs
@@ -1,13 +1,17 @@
 use fvm_shared::clock::ChainEpoch;
 
 use {
-    crate::interpreter::{ExecutionState, System, U256, StatusCode},
+    crate::interpreter::{ExecutionState, StatusCode, System, U256},
     fil_actors_runtime::runtime::chainid,
     fil_actors_runtime::runtime::Runtime,
 };
 
 #[inline]
-pub fn blockhash(_state: &mut ExecutionState, system: &System<impl Runtime>, bn: U256) -> Result<U256, StatusCode> {
+pub fn blockhash(
+    _state: &mut ExecutionState,
+    system: &System<impl Runtime>,
+    bn: U256,
+) -> Result<U256, StatusCode> {
     let result = bn
         .try_into()
         .ok()
@@ -32,17 +36,23 @@ pub fn blockhash(_state: &mut ExecutionState, system: &System<impl Runtime>, bn:
 }
 
 #[inline]
-pub fn caller(state: &mut ExecutionState, _: &System<impl Runtime>)  -> Result<U256, StatusCode>  {
+pub fn caller(state: &mut ExecutionState, _: &System<impl Runtime>) -> Result<U256, StatusCode> {
     Ok(state.caller.as_evm_word())
 }
 
 #[inline]
-pub fn address(state: &mut ExecutionState, _system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+pub fn address(
+    state: &mut ExecutionState,
+    _system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     Ok(state.receiver.as_evm_word())
 }
 
 #[inline]
-pub fn origin(_state: &mut ExecutionState, system: &System<impl Runtime>)  -> Result<U256, StatusCode> {
+pub fn origin(
+    _state: &mut ExecutionState,
+    system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     let origin_addr = system
         .resolve_ethereum_address(&system.rt.message().origin())
         .expect("failed to resolve origin address");
@@ -50,18 +60,27 @@ pub fn origin(_state: &mut ExecutionState, system: &System<impl Runtime>)  -> Re
 }
 
 #[inline]
-pub fn call_value(_state: &mut ExecutionState, system: &System<impl Runtime>)   -> Result<U256, StatusCode> {
+pub fn call_value(
+    _state: &mut ExecutionState,
+    system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     Ok(U256::from(&system.rt.message().value_received()))
 }
 
 #[inline]
-pub fn coinbase(_state: &mut ExecutionState, _system: &System<impl Runtime>)    -> Result<U256, StatusCode> {
+pub fn coinbase(
+    _state: &mut ExecutionState,
+    _system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     // TODO do we want to return the zero ID address, or just a plain 0?
     Ok(U256::zero())
 }
 
 #[inline]
-pub fn gas_price(_state: &mut ExecutionState, system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+pub fn gas_price(
+    _state: &mut ExecutionState,
+    system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     let effective_price = system.rt.base_fee() + system.rt.message().gas_premium();
     Ok(U256::from(&effective_price))
 }
@@ -72,32 +91,50 @@ pub fn gas(_state: &mut ExecutionState, system: &System<impl Runtime>) -> Result
 }
 
 #[inline]
-pub fn timestamp(_state: &mut ExecutionState, system: &System<impl Runtime>)  -> Result<U256, StatusCode> {
+pub fn timestamp(
+    _state: &mut ExecutionState,
+    system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     Ok(U256::from(system.rt.tipset_timestamp()))
 }
 
 #[inline]
-pub fn block_number(_state: &mut ExecutionState, system: &System<impl Runtime>)  -> Result<U256, StatusCode> {
+pub fn block_number(
+    _state: &mut ExecutionState,
+    system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     Ok(U256::from(system.rt.curr_epoch()))
 }
 
 #[inline]
-pub fn difficulty(_state: &mut ExecutionState, _system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+pub fn difficulty(
+    _state: &mut ExecutionState,
+    _system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     Ok(U256::zero())
 }
 
 #[inline]
-pub fn gas_limit(_state: &mut ExecutionState, _system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+pub fn gas_limit(
+    _state: &mut ExecutionState,
+    _system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     const BLOCK_GAS_LIMIT: u64 = 10_000_000_000u64;
     Ok(U256::from(BLOCK_GAS_LIMIT))
 }
 
 #[inline]
-pub fn chain_id(_state: &mut ExecutionState, _system: &System<impl Runtime>)  -> Result<U256, StatusCode> {
+pub fn chain_id(
+    _state: &mut ExecutionState,
+    _system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     Ok(U256::from(chainid::CHAINID))
 }
 
 #[inline]
-pub fn base_fee(_state: &mut ExecutionState, system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+pub fn base_fee(
+    _state: &mut ExecutionState,
+    system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     Ok(U256::from(&system.rt.base_fee()))
 }

--- a/actors/evm/src/interpreter/instructions/context.rs
+++ b/actors/evm/src/interpreter/instructions/context.rs
@@ -7,8 +7,7 @@ use {
 };
 
 #[inline]
-pub fn blockhash(state: &mut ExecutionState, system: &System<impl Runtime>) {
-    let bn = state.stack.pop();
+pub fn blockhash(_state: &mut ExecutionState, system: &System<impl Runtime>, bn: U256) -> Result<U256, StatusCode> {
     let result = bn
         .try_into()
         .ok()
@@ -29,7 +28,7 @@ pub fn blockhash(state: &mut ExecutionState, system: &System<impl Runtime>) {
             U256::from_big_endian(hash)
         })
         .unwrap_or_default();
-    state.stack.push(result);
+    Ok(result)
 }
 
 #[inline]
@@ -56,9 +55,9 @@ pub fn call_value(_state: &mut ExecutionState, system: &System<impl Runtime>)   
 }
 
 #[inline]
-pub fn coinbase(state: &mut ExecutionState, _system: &System<impl Runtime>) {
+pub fn coinbase(_state: &mut ExecutionState, _system: &System<impl Runtime>)    -> Result<U256, StatusCode> {
     // TODO do we want to return the zero ID address, or just a plain 0?
-    state.stack.push(U256::zero())
+    Ok(U256::zero())
 }
 
 #[inline]
@@ -68,37 +67,37 @@ pub fn gas_price(_state: &mut ExecutionState, system: &System<impl Runtime>) -> 
 }
 
 #[inline]
-pub fn gas(state: &mut ExecutionState, system: &System<impl Runtime>) {
-    state.stack.push(U256::from(system.rt.gas_available()));
+pub fn gas(_state: &mut ExecutionState, system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+    Ok(U256::from(system.rt.gas_available()))
 }
 
 #[inline]
-pub fn timestamp(state: &mut ExecutionState, system: &System<impl Runtime>) {
-    state.stack.push(U256::from(system.rt.tipset_timestamp()));
+pub fn timestamp(_state: &mut ExecutionState, system: &System<impl Runtime>)  -> Result<U256, StatusCode> {
+    Ok(U256::from(system.rt.tipset_timestamp()))
 }
 
 #[inline]
-pub fn block_number(state: &mut ExecutionState, system: &System<impl Runtime>) {
-    state.stack.push(U256::from(system.rt.curr_epoch()));
+pub fn block_number(_state: &mut ExecutionState, system: &System<impl Runtime>)  -> Result<U256, StatusCode> {
+    Ok(U256::from(system.rt.curr_epoch()))
 }
 
 #[inline]
-pub fn difficulty(state: &mut ExecutionState, _system: &System<impl Runtime>) {
-    state.stack.push(U256::zero());
+pub fn difficulty(_state: &mut ExecutionState, _system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+    Ok(U256::zero())
 }
 
 #[inline]
-pub fn gas_limit(state: &mut ExecutionState, _system: &System<impl Runtime>) {
+pub fn gas_limit(_state: &mut ExecutionState, _system: &System<impl Runtime>) -> Result<U256, StatusCode> {
     const BLOCK_GAS_LIMIT: u64 = 10_000_000_000u64;
-    state.stack.push(U256::from(BLOCK_GAS_LIMIT));
+    Ok(U256::from(BLOCK_GAS_LIMIT))
 }
 
 #[inline]
-pub fn chain_id(state: &mut ExecutionState, _system: &System<impl Runtime>) {
-    state.stack.push(U256::from(chainid::CHAINID));
+pub fn chain_id(_state: &mut ExecutionState, _system: &System<impl Runtime>)  -> Result<U256, StatusCode> {
+    Ok(U256::from(chainid::CHAINID))
 }
 
 #[inline]
-pub fn base_fee(state: &mut ExecutionState, system: &System<impl Runtime>) {
-    state.stack.push(U256::from(&system.rt.base_fee()))
+pub fn base_fee(_state: &mut ExecutionState, system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+    Ok(U256::from(&system.rt.base_fee()))
 }

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -1,12 +1,18 @@
 use {
-    super::memory::get_memory_region, crate::interpreter::output::StatusCode,
+    super::memory::get_memory_region,
+    crate::interpreter::output::StatusCode,
     crate::interpreter::Bytecode,
     crate::interpreter::{ExecutionState, System, U256},
     fil_actors_runtime::runtime::Runtime,
 };
 
 #[inline]
-pub fn output(state: &mut ExecutionState, _system: &System<impl Runtime>, offset: U256, size: U256) -> Result<(), StatusCode> {
+pub fn output(
+    state: &mut ExecutionState,
+    _system: &System<impl Runtime>,
+    offset: U256,
+    size: U256,
+) -> Result<(), StatusCode> {
     if let Some(region) = super::memory::get_memory_region(&mut state.memory, offset, size)
         .map_err(|_| StatusCode::InvalidMemoryAccess)?
     {
@@ -18,12 +24,21 @@ pub fn output(state: &mut ExecutionState, _system: &System<impl Runtime>, offset
 }
 
 #[inline]
-pub fn returndatasize(state: &mut ExecutionState, _system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+pub fn returndatasize(
+    state: &mut ExecutionState,
+    _system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     Ok(U256::from(state.return_data.len()))
 }
 
 #[inline]
-pub fn returndatacopy(state: &mut ExecutionState, _system: &System<impl Runtime>, mem_index: U256, input_index: U256, size: U256) -> Result<(), StatusCode> {
+pub fn returndatacopy(
+    state: &mut ExecutionState,
+    _system: &System<impl Runtime>,
+    mem_index: U256,
+    input_index: U256,
+    size: U256,
+) -> Result<(), StatusCode> {
     let region = get_memory_region(&mut state.memory, mem_index, size)
         .map_err(|_| StatusCode::InvalidMemoryAccess)?;
 

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -1,6 +1,6 @@
 use {
     super::memory::get_memory_region, crate::interpreter::output::StatusCode,
-    crate::interpreter::stack::Stack, crate::interpreter::Bytecode,
+    crate::interpreter::Bytecode,
     crate::interpreter::{ExecutionState, System, U256},
     fil_actors_runtime::runtime::Runtime,
 };
@@ -42,11 +42,6 @@ pub fn returndatacopy(state: &mut ExecutionState, _system: &System<impl Runtime>
     }
 
     Ok(())
-}
-
-#[inline]
-pub fn pc(stack: &mut Stack, pc: usize) {
-    stack.push(U256::from(pc))
 }
 
 #[inline]

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -1,7 +1,8 @@
 use {
     super::memory::get_memory_region, crate::interpreter::output::StatusCode,
     crate::interpreter::stack::Stack, crate::interpreter::Bytecode,
-    crate::interpreter::ExecutionState, crate::interpreter::U256,
+    crate::interpreter::{ExecutionState, System, U256},
+    fil_actors_runtime::runtime::Runtime,
 };
 
 #[inline]
@@ -20,16 +21,12 @@ pub fn ret(state: &mut ExecutionState) -> Result<(), StatusCode> {
 }
 
 #[inline]
-pub fn returndatasize(state: &mut ExecutionState) {
-    state.stack.push(U256::from(state.return_data.len()));
+pub fn returndatasize(state: &mut ExecutionState, _system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+    Ok(U256::from(state.return_data.len()))
 }
 
 #[inline]
-pub fn returndatacopy(state: &mut ExecutionState) -> Result<(), StatusCode> {
-    let mem_index = state.stack.pop();
-    let input_index = state.stack.pop();
-    let size = state.stack.pop();
-
+pub fn returndatacopy(state: &mut ExecutionState, _system: &System<impl Runtime>, mem_index: U256, input_index: U256, size: U256) -> Result<(), StatusCode> {
     let region = get_memory_region(&mut state.memory, mem_index, size)
         .map_err(|_| StatusCode::InvalidMemoryAccess)?;
 

--- a/actors/evm/src/interpreter/instructions/hash.rs
+++ b/actors/evm/src/interpreter/instructions/hash.rs
@@ -6,12 +6,11 @@ use {
 };
 
 pub fn keccak256(
-    system: &System<impl Runtime>,
     state: &mut ExecutionState,
-) -> Result<(), StatusCode> {
-    let index = state.stack.pop();
-    let size = state.stack.pop();
-
+    system: &System<impl Runtime>,
+    index: U256,
+    size: U256,
+) -> Result<U256, StatusCode> {
     let region = get_memory_region(&mut state.memory, index, size) //
         .map_err(|_| StatusCode::InvalidMemoryAccess)?;
 
@@ -24,7 +23,5 @@ pub fn keccak256(
         },
     );
 
-    state.stack.push(U256::from_big_endian(&buf[..size]));
-
-    Ok(())
+    Ok(U256::from_big_endian(&buf[..size]))
 }

--- a/actors/evm/src/interpreter/instructions/lifecycle.rs
+++ b/actors/evm/src/interpreter/instructions/lifecycle.rs
@@ -146,11 +146,12 @@ fn create_init(
 pub fn selfdestruct(
     state: &mut ExecutionState,
     system: &mut System<impl Runtime>,
+    beneficiary: U256,
 ) -> Result<(), StatusCode> {
     if system.readonly {
         return Err(StatusCode::StaticModeViolation);
     }
-    let beneficiary_addr: EthAddress = state.stack.pop().into();
+    let beneficiary_addr: EthAddress = beneficiary.into();
     // TODO: how do we handle errors here? Just ignore them?
     state.selfdestroyed = beneficiary_addr.try_into().ok();
     Ok(())

--- a/actors/evm/src/interpreter/instructions/lifecycle.rs
+++ b/actors/evm/src/interpreter/instructions/lifecycle.rs
@@ -5,7 +5,6 @@ use fvm_shared::MethodNum;
 use fvm_shared::{address::Address, econ::TokenAmount};
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
-use crate::interpreter::stack::Stack;
 use crate::interpreter::{address::EthAddress, U256};
 
 use super::memory::{get_memory_region, MemoryRegion};
@@ -42,15 +41,15 @@ pub struct EamReturn {
 pub fn create(
     state: &mut ExecutionState,
     system: &mut System<impl Runtime>,
-) -> Result<(), StatusCode> {
+    value: U256,
+    offset: U256,
+    size: U256,
+) -> Result<U256, StatusCode> {
     if system.readonly {
         return Err(StatusCode::StaticModeViolation);
     }
 
-    let ExecutionState { stack, memory, .. } = state;
-
-    let value = stack.pop();
-    let (offset, size) = (stack.pop(), stack.pop());
+    let ExecutionState { stack: _, memory, .. } = state;
 
     let value = TokenAmount::from(&value);
     let input_region =
@@ -66,25 +65,24 @@ pub fn create(
 
     let nonce = system.increment_nonce();
     let params = CreateParams { code: input_data.to_vec(), nonce };
-    create_init(stack, system, RawBytes::serialize(&params)?, CREATE_METHOD_NUM, value)
+    create_init(system, RawBytes::serialize(&params)?, CREATE_METHOD_NUM, value)
 }
 
 pub fn create2(
     state: &mut ExecutionState,
     system: &mut System<impl Runtime>,
-) -> Result<(), StatusCode> {
+    endowment: U256,
+    offset: U256,
+    size: U256,
+    salt: U256,
+) -> Result<U256, StatusCode> {
     if system.readonly {
         return Err(StatusCode::StaticModeViolation);
     }
 
-    let ExecutionState { stack, memory, .. } = state;
+    let ExecutionState { stack: _, memory, .. } = state;
 
     // see `create()` overall TODOs
-
-    let endowment = stack.pop();
-    let (offset, size) = (stack.pop(), stack.pop());
-    let salt = stack.pop();
-
     let endowment = TokenAmount::from(&endowment);
     let input_region =
         get_memory_region(memory, offset, size).map_err(|_| StatusCode::InvalidMemoryAccess)?;
@@ -102,17 +100,17 @@ pub fn create2(
     let params = Create2Params { code: input_data.to_vec(), salt };
 
     system.increment_nonce();
-    create_init(stack, system, RawBytes::serialize(&params)?, CREATE2_METHOD_NUM, endowment)
+    create_init(system, RawBytes::serialize(&params)?, CREATE2_METHOD_NUM, endowment)
 }
 
 /// call into Ethereum Address Manager to make the new account
+#[inline]
 fn create_init(
-    stack: &mut Stack,
     system: &mut System<impl Runtime>,
     params: RawBytes,
     method: MethodNum,
     value: TokenAmount,
-) -> Result<(), StatusCode> {
+) -> Result<U256, StatusCode> {
     // send bytecode & params to EAM to generate the address and contract
     let ret = system.send(&EAM_ACTOR_ADDR, method, params, value);
 
@@ -135,16 +133,13 @@ fn create_init(
     // TODO Exit with revert if sys out of gas when subcall gas limits are introduced
     // https://github.com/filecoin-project/ref-fvm/issues/966
 
-    let word = match ret {
+    Ok(match ret {
         Ok(eam_ret) => {
             let ret: EamReturn = eam_ret.deserialize()?;
             ret.eth_address.as_evm_word()
         }
         Err(_) => U256::zero(),
-    };
-
-    stack.push(word);
-    Ok(())
+    })
 }
 
 #[inline]

--- a/actors/evm/src/interpreter/instructions/memory.rs
+++ b/actors/evm/src/interpreter/instructions/memory.rs
@@ -2,9 +2,9 @@
 
 use {
     crate::interpreter::memory::Memory,
-    crate::interpreter::{ExecutionState, System, StatusCode, U256},
-    std::num::NonZeroUsize,
+    crate::interpreter::{ExecutionState, StatusCode, System, U256},
     fil_actors_runtime::runtime::Runtime,
+    std::num::NonZeroUsize,
 };
 
 /// The size of the EVM 256-bit word in bytes.
@@ -107,7 +107,11 @@ pub fn copy_to_memory(
 }
 
 #[inline]
-pub fn mload(state: &mut ExecutionState, _system: &System<impl Runtime>, index: U256) -> Result<U256, StatusCode> {
+pub fn mload(
+    state: &mut ExecutionState,
+    _system: &System<impl Runtime>,
+    index: U256,
+) -> Result<U256, StatusCode> {
     let region =
         get_memory_region_u64(&mut state.memory, index, NonZeroUsize::new(WORD_SIZE).unwrap())
             .map_err(|_| StatusCode::InvalidMemoryAccess)?;
@@ -118,7 +122,12 @@ pub fn mload(state: &mut ExecutionState, _system: &System<impl Runtime>, index: 
 }
 
 #[inline]
-pub fn mstore(state: &mut ExecutionState, _system: &System<impl Runtime>, index: U256, value: U256) -> Result<(), StatusCode> {
+pub fn mstore(
+    state: &mut ExecutionState,
+    _system: &System<impl Runtime>,
+    index: U256,
+    value: U256,
+) -> Result<(), StatusCode> {
     let region =
         get_memory_region_u64(&mut state.memory, index, NonZeroUsize::new(WORD_SIZE).unwrap())
             .map_err(|_| StatusCode::InvalidMemoryAccess)?;
@@ -131,7 +140,12 @@ pub fn mstore(state: &mut ExecutionState, _system: &System<impl Runtime>, index:
 }
 
 #[inline]
-pub fn mstore8(state: &mut ExecutionState, _system: &System<impl Runtime>, index: U256, value: U256) -> Result<(), StatusCode> {
+pub fn mstore8(
+    state: &mut ExecutionState,
+    _system: &System<impl Runtime>,
+    index: U256,
+    value: U256,
+) -> Result<(), StatusCode> {
     let region = get_memory_region_u64(&mut state.memory, index, NonZeroUsize::new(1).unwrap())
         .map_err(|_| StatusCode::InvalidMemoryAccess)?;
 
@@ -142,7 +156,10 @@ pub fn mstore8(state: &mut ExecutionState, _system: &System<impl Runtime>, index
 }
 
 #[inline]
-pub fn msize(state: &mut ExecutionState,  _system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+pub fn msize(
+    state: &mut ExecutionState,
+    _system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     Ok(u64::try_from(state.memory.len()).unwrap().into())
 }
 

--- a/actors/evm/src/interpreter/instructions/memory.rs
+++ b/actors/evm/src/interpreter/instructions/memory.rs
@@ -2,8 +2,9 @@
 
 use {
     crate::interpreter::memory::Memory,
-    crate::interpreter::{ExecutionState, StatusCode, U256},
+    crate::interpreter::{ExecutionState, System, StatusCode, U256},
     std::num::NonZeroUsize,
+    fil_actors_runtime::runtime::Runtime,
 };
 
 /// The size of the EVM 256-bit word in bytes.
@@ -106,25 +107,18 @@ pub fn copy_to_memory(
 }
 
 #[inline]
-pub fn mload(state: &mut ExecutionState) -> Result<(), StatusCode> {
-    let index = state.stack.pop();
-
+pub fn mload(state: &mut ExecutionState, _system: &System<impl Runtime>, index: U256) -> Result<U256, StatusCode> {
     let region =
         get_memory_region_u64(&mut state.memory, index, NonZeroUsize::new(WORD_SIZE).unwrap())
             .map_err(|_| StatusCode::InvalidMemoryAccess)?;
     let value =
         U256::from_big_endian(&state.memory[region.offset..region.offset + region.size.get()]);
 
-    state.stack.push(value);
-
-    Ok(())
+    Ok(value)
 }
 
 #[inline]
-pub fn mstore(state: &mut ExecutionState) -> Result<(), StatusCode> {
-    let index = state.stack.pop();
-    let value = state.stack.pop();
-
+pub fn mstore(state: &mut ExecutionState, _system: &System<impl Runtime>, index: U256, value: U256) -> Result<(), StatusCode> {
     let region =
         get_memory_region_u64(&mut state.memory, index, NonZeroUsize::new(WORD_SIZE).unwrap())
             .map_err(|_| StatusCode::InvalidMemoryAccess)?;
@@ -137,23 +131,19 @@ pub fn mstore(state: &mut ExecutionState) -> Result<(), StatusCode> {
 }
 
 #[inline]
-pub fn mstore8(state: &mut ExecutionState) -> Result<(), StatusCode> {
-    let index = state.stack.pop();
-    let value = state.stack.pop();
-
+pub fn mstore8(state: &mut ExecutionState, _system: &System<impl Runtime>, index: U256, value: U256) -> Result<(), StatusCode> {
     let region = get_memory_region_u64(&mut state.memory, index, NonZeroUsize::new(1).unwrap())
         .map_err(|_| StatusCode::InvalidMemoryAccess)?;
 
     let value = (value.low_u32() & 0xff) as u8;
-
     state.memory[region.offset] = value;
 
     Ok(())
 }
 
 #[inline]
-pub fn msize(state: &mut ExecutionState) {
-    state.stack.push(u64::try_from(state.memory.len()).unwrap().into());
+pub fn msize(state: &mut ExecutionState,  _system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+    Ok(u64::try_from(state.memory.len()).unwrap().into())
 }
 
 #[cfg(test)]

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -27,9 +27,9 @@ macro_rules! def_primop {
         pub fn $op(sk: &mut Stack) -> Result<(), StatusCode> {
             check_arity!($op, ($($arg),*));
             check_stack!($op, sk);
-            $(let $arg = sk.pop();)*
+            $(let $arg = unsafe {sk.pop()};)*
             let result = $impl($($arg),*);
-            sk.push(result);
+            unsafe {sk.push(result);}
             Ok(())
         }
     }
@@ -41,7 +41,7 @@ macro_rules! def_stackop {
         #[allow(non_snake_case)]
         pub fn $op(sk: &mut Stack) -> Result<(), StatusCode> {
             check_stack!($op, sk);
-            $impl(sk);
+            unsafe{$impl(sk);}
             Ok(())
         }
     }
@@ -54,7 +54,7 @@ macro_rules! def_push {
         #[allow(non_snake_case)]
         pub fn $op(sk: &mut Stack, code: &[u8]) -> Result<usize, StatusCode> {
             check_stack!($op, sk);
-            let off = $impl(sk, code);
+            let off = unsafe {$impl(sk, code)};
             Ok(off)
         }
     }
@@ -68,9 +68,9 @@ macro_rules! def_stdfun {
         pub fn $op(state: &mut ExecutionState, system: &mut System<impl Runtime>) -> Result<(), StatusCode> {
             check_arity!($op, ($($arg),*));
             check_stack!($op, state.stack);
-            $(let $arg = state.stack.pop();)*
+            $(let $arg = unsafe {state.stack.pop()};)*
             let result = $impl(state, system, $($arg),*)?;
-            state.stack.push(result);
+            unsafe {state.stack.push(result);}
             Ok(())
         }
     }
@@ -83,7 +83,7 @@ macro_rules! def_stdproc {
         pub fn $op(state: &mut ExecutionState, system: &mut System<impl Runtime>) -> Result<(), StatusCode> {
             check_arity!($op, ($($arg),*));
             check_stack!($op, state.stack);
-            $(let $arg = state.stack.pop();)*
+            $(let $arg = unsafe {state.stack.pop()};)*
             $impl(state, system, $($arg),*)?;
             Ok(())
         }
@@ -97,9 +97,9 @@ macro_rules! def_stdfun_code {
         pub fn $op(state: &mut ExecutionState, system: &mut System<impl Runtime>, code: &[u8]) -> Result<(), StatusCode> {
             check_arity!($op, ($($arg),*));
             check_stack!($op, state.stack);
-            $(let $arg = state.stack.pop();)*
+            $(let $arg = unsafe {state.stack.pop()};)*
             let result = $impl(state, system, code, $($arg),*)?;
-            state.stack.push(result);
+            unsafe {state.stack.push(result);}
             Ok(())
         }
     }
@@ -111,7 +111,7 @@ macro_rules! def_stdproc_code {
         pub fn $op(state: &mut ExecutionState, system: &mut System<impl Runtime>, code: &[u8]) -> Result<(), StatusCode> {
             check_arity!($op, ($($arg),*));
             check_stack!($op, state.stack);
-            $(let $arg = state.stack.pop();)*
+            $(let $arg = unsafe {state.stack.pop()};)*
             $impl(state, system, code, $($arg),*)?;
             Ok(())
         }
@@ -124,9 +124,9 @@ macro_rules! def_stdlog {
         #[allow(non_snake_case)]
         pub fn $op(state: &mut ExecutionState, system: &System<impl Runtime>) -> Result<(), StatusCode> {
             check_stack!($op, state.stack);
-            let a = state.stack.pop();
-            let b = state.stack.pop();
-            $(let $topic = state.stack.pop();)*
+            let a = unsafe {state.stack.pop()};
+            let b = unsafe {state.stack.pop()};
+            $(let $topic = unsafe {state.stack.pop()};)*
             log::log(state, system, $ntopics, a, b, &[$($topic),*])
         }
     }
@@ -139,7 +139,7 @@ macro_rules! def_jmp {
         pub fn $op(sk: &mut Stack, bytecode: &Bytecode) -> Result<Option<usize>, StatusCode> {
             check_arity!($op, ($($arg),*));
             check_stack!($op, sk);
-            $(let $arg = sk.pop();)*
+            $(let $arg = unsafe {sk.pop()};)*
             $impl(bytecode, $($arg),*)
         }
     }
@@ -153,7 +153,7 @@ macro_rules! def_special {
         pub fn $op(sk: &mut Stack, $($arg:$t),*) -> Result<(), StatusCode> {
             check_stack!($op, sk);
             let result = $value;
-            sk.push(result);
+            unsafe {sk.push(result)};
             Ok(())
         }
     }

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -141,6 +141,9 @@ macro_rules! arg_count {
     ($arg:ident, $arg2:ident) => {2};
     ($arg:ident, $arg2:ident, $arg3:ident) => {3};
     ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident) => {4};
+    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident) => {5};
+    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident, $arg6:ident) => {6};
+    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident, $arg6:ident, $arg7:ident) => {7};
     // can't use this coz we need a literal number
     //($arg: ident, $($rest:ident),*) => { 1 + arg_count!($($rest),*) };
 }
@@ -281,3 +284,7 @@ def_stdlog!{ LOG1(1, (topic1)) }
 def_stdlog!{ LOG2(2, (topic1, topic2)) }
 def_stdlog!{ LOG3(3, (topic1, topic2, topic3)) }
 def_stdlog!{ LOG4(4, (topic1, topic2, topic3, topic4)) }
+def_stdfun!{ CALL(gas, dst, value, ioff, isz, ooff, osz) => call::call_call }
+def_stdfun!{ CALLCODE(gas, dst, value, ioff, isz, ooff, osz) => call::call_callcode }
+def_stdfun!{ DELEGATECALL(gas, dst, ioff, isz, ooff, osz) => call::call_delegatecall }
+def_stdfun!{ STATICCALL(gas, dst, ioff, isz, ooff, osz) => call::call_staticcall }

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -318,3 +318,5 @@ def_stdfun!{ DELEGATECALL(gas, dst, ioff, isz, ooff, osz) => call::call_delegate
 def_stdfun!{ STATICCALL(gas, dst, ioff, isz, ooff, osz) => call::call_staticcall }
 def_stdfun_code!{ CODESIZE() => call::codesize }
 def_stdproc_code!{ CODECOPY(a, b, c) => call::codecopy }
+def_stdfun!{ CREATE(a, b, c) => lifecycle::create }
+def_stdfun!{ CREATE2(a, b, c, d) => lifecycle::create2 }

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -186,38 +186,15 @@ macro_rules! check_arity {
             const SPEC: StackSpec = OpCode::$op.spec();
             // the error message is super ugly, but this static asserts we got the
             // arity of the primop right.
-            const _: [();(arg_count!($($arg),*)) - SPEC.required as usize] = [];
+            const _: [();(arg_count!($($arg)*)) - SPEC.required as usize] = [];
         }
         checkargs();
     }}
 }
 
 macro_rules! arg_count {
-    () => {
-        0
-    };
-    ($arg:ident) => {
-        1
-    };
-    ($arg:ident, $arg2:ident) => {
-        2
-    };
-    ($arg:ident, $arg2:ident, $arg3:ident) => {
-        3
-    };
-    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident) => {
-        4
-    };
-    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident) => {
-        5
-    };
-    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident, $arg6:ident) => {
-        6
-    };
-    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident, $arg6:ident, $arg7:ident) => {
-        7
-    }; // can't use this coz we need a literal number
-       //($arg: ident, $($rest:ident),*) => { 1 + arg_count!($($rest),*) };
+    () => { 0 };
+    ($arg:ident $($rest:ident)*) => { 1 + arg_count!($($rest)*) };
 }
 
 // IMPLEMENTATION

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -125,6 +125,7 @@ macro_rules! arg_count {
     ($arg:ident) => {1};
     ($arg:ident, $arg2:ident) => {2};
     ($arg:ident, $arg2:ident, $arg3:ident) => {3};
+    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident) => {4};
     // can't use this coz we need a literal number
     //($arg: ident, $($rest:ident),*) => { 1 + arg_count!($($rest),*) };
 }
@@ -228,7 +229,7 @@ def_push!{ PUSH29 => stack::push::<29> }
 def_push!{ PUSH30 => stack::push::<30> }
 def_push!{ PUSH31 => stack::push::<31> }
 def_push!{ PUSH32 => stack::push::<32> }
-// stdfuns
+// functionoids
 def_stdfun!{ KECCAK256(a, b) => hash::keccak256 }
 def_stdfun!{ ADDRESS() => context::address }
 def_stdfun!{ BALANCE(a) => state::balance }
@@ -238,3 +239,11 @@ def_stdfun!{ CALLVALUE() => context::call_value }
 def_stdfun!{ CALLDATALOAD(a) => call::calldataload }
 def_stdfun!{ CALLDATASIZE() => call::calldatasize }
 def_stdproc!{ CALLDATACOPY(a, b, c) => call::calldatacopy }
+def_stdfun!{ GASPRICE() => context::gas_price }
+def_stdfun!{ EXTCODESIZE(a) => ext::extcodesize }
+def_stdproc!{ EXTCODECOPY(a, b, c, d) => ext::extcodecopy }
+def_stdfun!{ EXTCODEHASH(a) => ext::extcodehash }
+def_stdfun!{ RETURNDATASIZE() => control::returndatasize }
+def_stdproc!{ RETURNDATACOPY(a, b, c) => control::returndatacopy }
+// CODESIZE
+// COPDECOPY

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -107,6 +107,7 @@ macro_rules! check_arity {
 }
 
 macro_rules! arg_count {
+    () => {0};
     ($arg:ident) => {1};
     ($arg:ident, $arg2:ident) => {2};
     ($arg:ident, $arg2:ident, $arg3:ident) => {3};
@@ -215,3 +216,10 @@ def_push!{ PUSH31 => stack::push::<31> }
 def_push!{ PUSH32 => stack::push::<32> }
 // stdfuns
 def_stdfun!{ KECCAK256(a, b) => hash::keccak256 }
+def_stdfun!{ ADDRESS() => context::address }
+def_stdfun!{ BALANCE(a) => state::balance }
+def_stdfun!{ ORIGIN() => context::origin }
+def_stdfun!{ CALLER() => context::caller }
+def_stdfun!{ CALLVALUE() => context::call_value }
+def_stdfun!{ CALLDATALOAD(a) => call::calldataload }
+def_stdfun!{ CALLDATASIZE() => call::calldatasize }

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -76,6 +76,20 @@ macro_rules! def_stdfun {
     }
 }
 
+// stdproc: like stdfun, but returns no value
+macro_rules! def_stdproc {
+    ($op:ident ($($arg:ident),*) => $impl:path) => {
+        #[allow(non_snake_case)]
+        pub fn $op(state: &mut ExecutionState, system: &System<impl Runtime>) -> Result<(), StatusCode> {
+            check_arity!($op, ($($arg),*));
+            check_stack!($op, state.stack);
+            $(let $arg = state.stack.pop();)*
+            $impl(state, system, $($arg),*)?;
+            Ok(())
+        }
+    }
+}
+
 // auxiliary macros
 macro_rules! check_stack {
     ($op:ident, $sk:expr) => {{
@@ -223,3 +237,4 @@ def_stdfun!{ CALLER() => context::caller }
 def_stdfun!{ CALLVALUE() => context::call_value }
 def_stdfun!{ CALLDATALOAD(a) => call::calldataload }
 def_stdfun!{ CALLDATASIZE() => call::calldatasize }
+def_stdproc!{ CALLDATACOPY(a, b, c) => call::calldatacopy }

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -12,3 +12,49 @@ pub mod memory;
 pub mod stack;
 pub mod state;
 pub mod storage;
+
+use crate::interpreter::stack::Stack;
+use crate::interpreter::output::StatusCode;
+
+// macros
+macro_rules! def_primop {
+    ($op:ident ($($arg:ident),*) => $impl:path) => {
+        #[allow(non_snake_case)]
+        pub fn $op(sk: &mut Stack) -> Result<(), StatusCode> {
+            $(let $arg = sk.pop();)*
+            let result = $impl($($arg),*);
+            sk.push(result);
+            Ok(())
+        }
+    }
+}
+
+// CHECK+DISPATCH
+// arithmetic
+def_primop!{ ADD(a, b) => arithmetic::add }
+def_primop!{ MUL(a, b) => arithmetic::mul }
+def_primop!{ SUB(a, b) => arithmetic::sub }
+def_primop!{ DIV(a, b) => arithmetic::div }
+def_primop!{ SDIV(a, b) => arithmetic::sdiv }
+def_primop!{ MOD(a, b) => arithmetic::modulo }
+def_primop!{ SMOD(a, b) => arithmetic::smod }
+def_primop!{ ADDMOD(a, b, c) => arithmetic::addmod }
+def_primop!{ MULMOD(a, b, c) => arithmetic::mulmod }
+def_primop!{ EXP(a, b) => arithmetic::exp }
+def_primop!{ SIGNEXTEND(a, b) => arithmetic::signextend }
+// boolean
+def_primop!{ LT(a, b) => boolean::lt }
+def_primop!{ GT(a, b) => boolean::gt }
+def_primop!{ SLT(a, b) => boolean::slt }
+def_primop!{ SGT(a, b) => boolean::sgt }
+def_primop!{ EQ(a, b) => boolean::eq }
+def_primop!{ ISZERO(a) => boolean::iszero }
+def_primop!{ AND(a, b) => boolean::and }
+def_primop!{ OR(a, b) => boolean::or }
+def_primop!{ XOR(a, b) => boolean::xor }
+def_primop!{ NOT(a) => boolean::not }
+// bitwise
+def_primop!{ BYTE(a, b) => bitwise::byte }
+def_primop!{ SHL(a, b) => bitwise::shl }
+def_primop!{ SHR(a, b) => bitwise::shr }
+def_primop!{ SAR(a, b) => bitwise::sar }

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -13,10 +13,10 @@ pub mod stack;
 pub mod state;
 pub mod storage;
 
-use crate::interpreter::stack::Stack;
+use crate::interpreter::opcode::{OpCode, StackSpec};
 use crate::interpreter::output::StatusCode;
-use crate::interpreter::opcode::{OpCode,StackSpec};
-use crate::interpreter::{ExecutionState, System, Bytecode, U256};
+use crate::interpreter::stack::Stack;
+use crate::interpreter::{Bytecode, ExecutionState, System, U256};
 use fil_actors_runtime::runtime::Runtime;
 
 // macros for the instruction zoo:
@@ -41,10 +41,12 @@ macro_rules! def_stackop {
         #[allow(non_snake_case)]
         pub fn $op(sk: &mut Stack) -> Result<(), StatusCode> {
             check_stack!($op, sk);
-            unsafe{$impl(sk);}
+            unsafe {
+                $impl(sk);
+            }
             Ok(())
         }
-    }
+    };
 }
 
 // pushops: push stuff on the stack given input bytecode; the kind of thing that makes you want
@@ -54,10 +56,10 @@ macro_rules! def_push {
         #[allow(non_snake_case)]
         pub fn $op(sk: &mut Stack, code: &[u8]) -> Result<usize, StatusCode> {
             check_stack!($op, sk);
-            let off = unsafe {$impl(sk, code)};
+            let off = unsafe { $impl(sk, code) };
             Ok(off)
         }
-    }
+    };
 }
 
 // stdfuns: take state and system as first args, and args from the stack and return a result value
@@ -160,7 +162,6 @@ macro_rules! def_special {
 
 }
 
-
 // auxiliary macros
 macro_rules! check_stack {
     ($op:ident, $sk:expr) => {{
@@ -192,165 +193,179 @@ macro_rules! check_arity {
 }
 
 macro_rules! arg_count {
-    () => {0};
-    ($arg:ident) => {1};
-    ($arg:ident, $arg2:ident) => {2};
-    ($arg:ident, $arg2:ident, $arg3:ident) => {3};
-    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident) => {4};
-    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident) => {5};
-    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident, $arg6:ident) => {6};
-    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident, $arg6:ident, $arg7:ident) => {7};
-    // can't use this coz we need a literal number
-    //($arg: ident, $($rest:ident),*) => { 1 + arg_count!($($rest),*) };
+    () => {
+        0
+    };
+    ($arg:ident) => {
+        1
+    };
+    ($arg:ident, $arg2:ident) => {
+        2
+    };
+    ($arg:ident, $arg2:ident, $arg3:ident) => {
+        3
+    };
+    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident) => {
+        4
+    };
+    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident) => {
+        5
+    };
+    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident, $arg6:ident) => {
+        6
+    };
+    ($arg:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident, $arg6:ident, $arg7:ident) => {
+        7
+    }; // can't use this coz we need a literal number
+       //($arg: ident, $($rest:ident),*) => { 1 + arg_count!($($rest),*) };
 }
-
 
 // IMPLEMENTATION
 // arithmetic
-def_primop!{ ADD(a, b) => arithmetic::add }
-def_primop!{ MUL(a, b) => arithmetic::mul }
-def_primop!{ SUB(a, b) => arithmetic::sub }
-def_primop!{ DIV(a, b) => arithmetic::div }
-def_primop!{ SDIV(a, b) => arithmetic::sdiv }
-def_primop!{ MOD(a, b) => arithmetic::modulo }
-def_primop!{ SMOD(a, b) => arithmetic::smod }
-def_primop!{ ADDMOD(a, b, c) => arithmetic::addmod }
-def_primop!{ MULMOD(a, b, c) => arithmetic::mulmod }
-def_primop!{ EXP(a, b) => arithmetic::exp }
-def_primop!{ SIGNEXTEND(a, b) => arithmetic::signextend }
+def_primop! { ADD(a, b) => arithmetic::add }
+def_primop! { MUL(a, b) => arithmetic::mul }
+def_primop! { SUB(a, b) => arithmetic::sub }
+def_primop! { DIV(a, b) => arithmetic::div }
+def_primop! { SDIV(a, b) => arithmetic::sdiv }
+def_primop! { MOD(a, b) => arithmetic::modulo }
+def_primop! { SMOD(a, b) => arithmetic::smod }
+def_primop! { ADDMOD(a, b, c) => arithmetic::addmod }
+def_primop! { MULMOD(a, b, c) => arithmetic::mulmod }
+def_primop! { EXP(a, b) => arithmetic::exp }
+def_primop! { SIGNEXTEND(a, b) => arithmetic::signextend }
 // boolean
-def_primop!{ LT(a, b) => boolean::lt }
-def_primop!{ GT(a, b) => boolean::gt }
-def_primop!{ SLT(a, b) => boolean::slt }
-def_primop!{ SGT(a, b) => boolean::sgt }
-def_primop!{ EQ(a, b) => boolean::eq }
-def_primop!{ ISZERO(a) => boolean::iszero }
-def_primop!{ AND(a, b) => boolean::and }
-def_primop!{ OR(a, b) => boolean::or }
-def_primop!{ XOR(a, b) => boolean::xor }
-def_primop!{ NOT(a) => boolean::not }
+def_primop! { LT(a, b) => boolean::lt }
+def_primop! { GT(a, b) => boolean::gt }
+def_primop! { SLT(a, b) => boolean::slt }
+def_primop! { SGT(a, b) => boolean::sgt }
+def_primop! { EQ(a, b) => boolean::eq }
+def_primop! { ISZERO(a) => boolean::iszero }
+def_primop! { AND(a, b) => boolean::and }
+def_primop! { OR(a, b) => boolean::or }
+def_primop! { XOR(a, b) => boolean::xor }
+def_primop! { NOT(a) => boolean::not }
 // bitwise
-def_primop!{ BYTE(a, b) => bitwise::byte }
-def_primop!{ SHL(a, b) => bitwise::shl }
-def_primop!{ SHR(a, b) => bitwise::shr }
-def_primop!{ SAR(a, b) => bitwise::sar }
+def_primop! { BYTE(a, b) => bitwise::byte }
+def_primop! { SHL(a, b) => bitwise::shl }
+def_primop! { SHR(a, b) => bitwise::shr }
+def_primop! { SAR(a, b) => bitwise::sar }
 // dup
-def_stackop!{ DUP1 => stack::dup::<1> }
-def_stackop!{ DUP2 => stack::dup::<2> }
-def_stackop!{ DUP3 => stack::dup::<3> }
-def_stackop!{ DUP4 => stack::dup::<4> }
-def_stackop!{ DUP5 => stack::dup::<5> }
-def_stackop!{ DUP6 => stack::dup::<6> }
-def_stackop!{ DUP7 => stack::dup::<7> }
-def_stackop!{ DUP8 => stack::dup::<8> }
-def_stackop!{ DUP9 => stack::dup::<9> }
-def_stackop!{ DUP10 => stack::dup::<10> }
-def_stackop!{ DUP11 => stack::dup::<11> }
-def_stackop!{ DUP12 => stack::dup::<12> }
-def_stackop!{ DUP13 => stack::dup::<13> }
-def_stackop!{ DUP14 => stack::dup::<14> }
-def_stackop!{ DUP15 => stack::dup::<15> }
-def_stackop!{ DUP16 => stack::dup::<16> }
+def_stackop! { DUP1 => stack::dup::<1> }
+def_stackop! { DUP2 => stack::dup::<2> }
+def_stackop! { DUP3 => stack::dup::<3> }
+def_stackop! { DUP4 => stack::dup::<4> }
+def_stackop! { DUP5 => stack::dup::<5> }
+def_stackop! { DUP6 => stack::dup::<6> }
+def_stackop! { DUP7 => stack::dup::<7> }
+def_stackop! { DUP8 => stack::dup::<8> }
+def_stackop! { DUP9 => stack::dup::<9> }
+def_stackop! { DUP10 => stack::dup::<10> }
+def_stackop! { DUP11 => stack::dup::<11> }
+def_stackop! { DUP12 => stack::dup::<12> }
+def_stackop! { DUP13 => stack::dup::<13> }
+def_stackop! { DUP14 => stack::dup::<14> }
+def_stackop! { DUP15 => stack::dup::<15> }
+def_stackop! { DUP16 => stack::dup::<16> }
 // swap
-def_stackop!{ SWAP1 => stack::swap::<1> }
-def_stackop!{ SWAP2 => stack::swap::<2> }
-def_stackop!{ SWAP3 => stack::swap::<3> }
-def_stackop!{ SWAP4 => stack::swap::<4> }
-def_stackop!{ SWAP5 => stack::swap::<5> }
-def_stackop!{ SWAP6 => stack::swap::<6> }
-def_stackop!{ SWAP7 => stack::swap::<7> }
-def_stackop!{ SWAP8 => stack::swap::<8> }
-def_stackop!{ SWAP9 => stack::swap::<9> }
-def_stackop!{ SWAP10 => stack::swap::<10> }
-def_stackop!{ SWAP11 => stack::swap::<11> }
-def_stackop!{ SWAP12 => stack::swap::<12> }
-def_stackop!{ SWAP13 => stack::swap::<13> }
-def_stackop!{ SWAP14 => stack::swap::<14> }
-def_stackop!{ SWAP15 => stack::swap::<15> }
-def_stackop!{ SWAP16 => stack::swap::<16> }
+def_stackop! { SWAP1 => stack::swap::<1> }
+def_stackop! { SWAP2 => stack::swap::<2> }
+def_stackop! { SWAP3 => stack::swap::<3> }
+def_stackop! { SWAP4 => stack::swap::<4> }
+def_stackop! { SWAP5 => stack::swap::<5> }
+def_stackop! { SWAP6 => stack::swap::<6> }
+def_stackop! { SWAP7 => stack::swap::<7> }
+def_stackop! { SWAP8 => stack::swap::<8> }
+def_stackop! { SWAP9 => stack::swap::<9> }
+def_stackop! { SWAP10 => stack::swap::<10> }
+def_stackop! { SWAP11 => stack::swap::<11> }
+def_stackop! { SWAP12 => stack::swap::<12> }
+def_stackop! { SWAP13 => stack::swap::<13> }
+def_stackop! { SWAP14 => stack::swap::<14> }
+def_stackop! { SWAP15 => stack::swap::<15> }
+def_stackop! { SWAP16 => stack::swap::<16> }
 // pop
-def_stackop!{ POP => stack::pop }
+def_stackop! { POP => stack::pop }
 // push
-def_push!{ PUSH1 => stack::push::<1> }
-def_push!{ PUSH2 => stack::push::<2> }
-def_push!{ PUSH3 => stack::push::<3> }
-def_push!{ PUSH4 => stack::push::<4> }
-def_push!{ PUSH5 => stack::push::<5> }
-def_push!{ PUSH6 => stack::push::<6> }
-def_push!{ PUSH7 => stack::push::<7> }
-def_push!{ PUSH8 => stack::push::<8> }
-def_push!{ PUSH9 => stack::push::<9> }
-def_push!{ PUSH10 => stack::push::<10> }
-def_push!{ PUSH11 => stack::push::<11> }
-def_push!{ PUSH12 => stack::push::<12> }
-def_push!{ PUSH13 => stack::push::<13> }
-def_push!{ PUSH14 => stack::push::<14> }
-def_push!{ PUSH15 => stack::push::<15> }
-def_push!{ PUSH16 => stack::push::<16> }
-def_push!{ PUSH17 => stack::push::<17> }
-def_push!{ PUSH18 => stack::push::<18> }
-def_push!{ PUSH19 => stack::push::<19> }
-def_push!{ PUSH20 => stack::push::<20> }
-def_push!{ PUSH21 => stack::push::<21> }
-def_push!{ PUSH22 => stack::push::<22> }
-def_push!{ PUSH23 => stack::push::<23> }
-def_push!{ PUSH24 => stack::push::<24> }
-def_push!{ PUSH25 => stack::push::<25> }
-def_push!{ PUSH26 => stack::push::<26> }
-def_push!{ PUSH27 => stack::push::<27> }
-def_push!{ PUSH28 => stack::push::<28> }
-def_push!{ PUSH29 => stack::push::<29> }
-def_push!{ PUSH30 => stack::push::<30> }
-def_push!{ PUSH31 => stack::push::<31> }
-def_push!{ PUSH32 => stack::push::<32> }
+def_push! { PUSH1 => stack::push::<1> }
+def_push! { PUSH2 => stack::push::<2> }
+def_push! { PUSH3 => stack::push::<3> }
+def_push! { PUSH4 => stack::push::<4> }
+def_push! { PUSH5 => stack::push::<5> }
+def_push! { PUSH6 => stack::push::<6> }
+def_push! { PUSH7 => stack::push::<7> }
+def_push! { PUSH8 => stack::push::<8> }
+def_push! { PUSH9 => stack::push::<9> }
+def_push! { PUSH10 => stack::push::<10> }
+def_push! { PUSH11 => stack::push::<11> }
+def_push! { PUSH12 => stack::push::<12> }
+def_push! { PUSH13 => stack::push::<13> }
+def_push! { PUSH14 => stack::push::<14> }
+def_push! { PUSH15 => stack::push::<15> }
+def_push! { PUSH16 => stack::push::<16> }
+def_push! { PUSH17 => stack::push::<17> }
+def_push! { PUSH18 => stack::push::<18> }
+def_push! { PUSH19 => stack::push::<19> }
+def_push! { PUSH20 => stack::push::<20> }
+def_push! { PUSH21 => stack::push::<21> }
+def_push! { PUSH22 => stack::push::<22> }
+def_push! { PUSH23 => stack::push::<23> }
+def_push! { PUSH24 => stack::push::<24> }
+def_push! { PUSH25 => stack::push::<25> }
+def_push! { PUSH26 => stack::push::<26> }
+def_push! { PUSH27 => stack::push::<27> }
+def_push! { PUSH28 => stack::push::<28> }
+def_push! { PUSH29 => stack::push::<29> }
+def_push! { PUSH30 => stack::push::<30> }
+def_push! { PUSH31 => stack::push::<31> }
+def_push! { PUSH32 => stack::push::<32> }
 // functionoids
-def_stdfun!{ KECCAK256(a, b) => hash::keccak256 }
-def_stdfun!{ ADDRESS() => context::address }
-def_stdfun!{ BALANCE(a) => state::balance }
-def_stdfun!{ ORIGIN() => context::origin }
-def_stdfun!{ CALLER() => context::caller }
-def_stdfun!{ CALLVALUE() => context::call_value }
-def_stdfun!{ CALLDATALOAD(a) => call::calldataload }
-def_stdfun!{ CALLDATASIZE() => call::calldatasize }
-def_stdproc!{ CALLDATACOPY(a, b, c) => call::calldatacopy }
-def_stdfun!{ GASPRICE() => context::gas_price }
-def_stdfun!{ EXTCODESIZE(a) => ext::extcodesize }
-def_stdproc!{ EXTCODECOPY(a, b, c, d) => ext::extcodecopy }
-def_stdfun!{ EXTCODEHASH(a) => ext::extcodehash }
-def_stdfun!{ RETURNDATASIZE() => control::returndatasize }
-def_stdproc!{ RETURNDATACOPY(a, b, c) => control::returndatacopy }
-def_stdfun!{ BLOCKHASH(a) => context::blockhash }
-def_stdfun!{ COINBASE() => context::coinbase }
-def_stdfun!{ TIMESTAMP() => context::timestamp }
-def_stdfun!{ NUMBER() => context::block_number }
-def_stdfun!{ DIFFICULTY() => context::difficulty }
-def_stdfun!{ GASLIMIT() => context::gas_limit }
-def_stdfun!{ CHAINID() => context::chain_id }
-def_stdfun!{ BASEFEE() => context::base_fee }
-def_stdfun!{ SELFBALANCE() => state::selfbalance }
-def_stdfun!{ MLOAD(a) => memory::mload }
-def_stdproc!{ MSTORE(a, b) => memory::mstore }
-def_stdproc!{ MSTORE8(a, b) => memory::mstore8 }
-def_stdfun!{ SLOAD(a) => storage::sload }
-def_stdproc!{ SSTORE(a, b) => storage::sstore }
-def_stdfun!{ MSIZE() => memory::msize }
-def_stdfun!{ GAS() => context::gas }
-def_stdlog!{ LOG0(0, ()) }
-def_stdlog!{ LOG1(1, (topic1)) }
-def_stdlog!{ LOG2(2, (topic1, topic2)) }
-def_stdlog!{ LOG3(3, (topic1, topic2, topic3)) }
-def_stdlog!{ LOG4(4, (topic1, topic2, topic3, topic4)) }
-def_stdfun!{ CALL(gas, dst, value, ioff, isz, ooff, osz) => call::call_call }
-def_stdfun!{ CALLCODE(gas, dst, value, ioff, isz, ooff, osz) => call::call_callcode }
-def_stdfun!{ DELEGATECALL(gas, dst, ioff, isz, ooff, osz) => call::call_delegatecall }
-def_stdfun!{ STATICCALL(gas, dst, ioff, isz, ooff, osz) => call::call_staticcall }
-def_stdfun_code!{ CODESIZE() => call::codesize }
-def_stdproc_code!{ CODECOPY(a, b, c) => call::codecopy }
-def_stdfun!{ CREATE(a, b, c) => lifecycle::create }
-def_stdfun!{ CREATE2(a, b, c, d) => lifecycle::create2 }
-def_stdproc!{ RETURN(a, b) => control::output }
-def_stdproc!{ REVERT(a, b) => control::output }
-def_stdproc!{ SELFDESTRUCT(a) => lifecycle::selfdestruct }
-def_jmp!{ JUMP(a) => control::jump }
-def_jmp!{ JUMPI(a, b) => control::jumpi }
-def_special!{ PC(pc: usize) => U256::from(pc) }
+def_stdfun! { KECCAK256(a, b) => hash::keccak256 }
+def_stdfun! { ADDRESS() => context::address }
+def_stdfun! { BALANCE(a) => state::balance }
+def_stdfun! { ORIGIN() => context::origin }
+def_stdfun! { CALLER() => context::caller }
+def_stdfun! { CALLVALUE() => context::call_value }
+def_stdfun! { CALLDATALOAD(a) => call::calldataload }
+def_stdfun! { CALLDATASIZE() => call::calldatasize }
+def_stdproc! { CALLDATACOPY(a, b, c) => call::calldatacopy }
+def_stdfun! { GASPRICE() => context::gas_price }
+def_stdfun! { EXTCODESIZE(a) => ext::extcodesize }
+def_stdproc! { EXTCODECOPY(a, b, c, d) => ext::extcodecopy }
+def_stdfun! { EXTCODEHASH(a) => ext::extcodehash }
+def_stdfun! { RETURNDATASIZE() => control::returndatasize }
+def_stdproc! { RETURNDATACOPY(a, b, c) => control::returndatacopy }
+def_stdfun! { BLOCKHASH(a) => context::blockhash }
+def_stdfun! { COINBASE() => context::coinbase }
+def_stdfun! { TIMESTAMP() => context::timestamp }
+def_stdfun! { NUMBER() => context::block_number }
+def_stdfun! { DIFFICULTY() => context::difficulty }
+def_stdfun! { GASLIMIT() => context::gas_limit }
+def_stdfun! { CHAINID() => context::chain_id }
+def_stdfun! { BASEFEE() => context::base_fee }
+def_stdfun! { SELFBALANCE() => state::selfbalance }
+def_stdfun! { MLOAD(a) => memory::mload }
+def_stdproc! { MSTORE(a, b) => memory::mstore }
+def_stdproc! { MSTORE8(a, b) => memory::mstore8 }
+def_stdfun! { SLOAD(a) => storage::sload }
+def_stdproc! { SSTORE(a, b) => storage::sstore }
+def_stdfun! { MSIZE() => memory::msize }
+def_stdfun! { GAS() => context::gas }
+def_stdlog! { LOG0(0, ()) }
+def_stdlog! { LOG1(1, (topic1)) }
+def_stdlog! { LOG2(2, (topic1, topic2)) }
+def_stdlog! { LOG3(3, (topic1, topic2, topic3)) }
+def_stdlog! { LOG4(4, (topic1, topic2, topic3, topic4)) }
+def_stdfun! { CALL(gas, dst, value, ioff, isz, ooff, osz) => call::call_call }
+def_stdfun! { CALLCODE(gas, dst, value, ioff, isz, ooff, osz) => call::call_callcode }
+def_stdfun! { DELEGATECALL(gas, dst, ioff, isz, ooff, osz) => call::call_delegatecall }
+def_stdfun! { STATICCALL(gas, dst, ioff, isz, ooff, osz) => call::call_staticcall }
+def_stdfun_code! { CODESIZE() => call::codesize }
+def_stdproc_code! { CODECOPY(a, b, c) => call::codecopy }
+def_stdfun! { CREATE(a, b, c) => lifecycle::create }
+def_stdfun! { CREATE2(a, b, c, d) => lifecycle::create2 }
+def_stdproc! { RETURN(a, b) => control::output }
+def_stdproc! { REVERT(a, b) => control::output }
+def_stdproc! { SELFDESTRUCT(a) => lifecycle::selfdestruct }
+def_jmp! { JUMP(a) => control::jump }
+def_jmp! { JUMPI(a, b) => control::jumpi }
+def_special! { PC(pc: usize) => U256::from(pc) }

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -17,7 +17,8 @@ use crate::interpreter::stack::Stack;
 use crate::interpreter::output::StatusCode;
 use crate::interpreter::opcode::{OpCode,StackSpec};
 
-// macros
+// macros for the instruction zoo:
+// primops: take values of the stack and return a result value to be pushed on the stack
 macro_rules! def_primop {
     ($op:ident ($($arg:ident),*) => $impl:path) => {
         #[allow(non_snake_case)]
@@ -32,6 +33,19 @@ macro_rules! def_primop {
     }
 }
 
+// stackops: operate directly on the stack
+macro_rules! def_stackop {
+    ($op:ident => $impl:path) => {
+        #[allow(non_snake_case)]
+        pub fn $op(sk: &mut Stack) -> Result<(), StatusCode> {
+            check_stack!($op, sk);
+            $impl(sk);
+            Ok(())
+        }
+    }
+}
+
+// auxiliary macros
 macro_rules! check_stack {
     ($op:ident, $sk:ident) => {{
         const SPEC: StackSpec = OpCode::$op.spec();
@@ -70,7 +84,7 @@ macro_rules! arg_count {
 }
 
 
-// CHECK+DISPATCH
+// IMPLEMENTATION
 // arithmetic
 def_primop!{ ADD(a, b) => arithmetic::add }
 def_primop!{ MUL(a, b) => arithmetic::mul }
@@ -99,3 +113,37 @@ def_primop!{ BYTE(a, b) => bitwise::byte }
 def_primop!{ SHL(a, b) => bitwise::shl }
 def_primop!{ SHR(a, b) => bitwise::shr }
 def_primop!{ SAR(a, b) => bitwise::sar }
+// dup
+def_stackop!{ DUP1 => stack::dup::<1> }
+def_stackop!{ DUP2 => stack::dup::<2> }
+def_stackop!{ DUP3 => stack::dup::<3> }
+def_stackop!{ DUP4 => stack::dup::<4> }
+def_stackop!{ DUP5 => stack::dup::<5> }
+def_stackop!{ DUP6 => stack::dup::<6> }
+def_stackop!{ DUP7 => stack::dup::<7> }
+def_stackop!{ DUP8 => stack::dup::<8> }
+def_stackop!{ DUP9 => stack::dup::<9> }
+def_stackop!{ DUP10 => stack::dup::<10> }
+def_stackop!{ DUP11 => stack::dup::<11> }
+def_stackop!{ DUP12 => stack::dup::<12> }
+def_stackop!{ DUP13 => stack::dup::<13> }
+def_stackop!{ DUP14 => stack::dup::<14> }
+def_stackop!{ DUP15 => stack::dup::<15> }
+def_stackop!{ DUP16 => stack::dup::<16> }
+// swap
+def_stackop!{ SWAP1 => stack::swap::<1> }
+def_stackop!{ SWAP2 => stack::swap::<2> }
+def_stackop!{ SWAP3 => stack::swap::<3> }
+def_stackop!{ SWAP4 => stack::swap::<4> }
+def_stackop!{ SWAP5 => stack::swap::<5> }
+def_stackop!{ SWAP6 => stack::swap::<6> }
+def_stackop!{ SWAP7 => stack::swap::<7> }
+def_stackop!{ SWAP8 => stack::swap::<8> }
+def_stackop!{ SWAP9 => stack::swap::<9> }
+def_stackop!{ SWAP10 => stack::swap::<10> }
+def_stackop!{ SWAP11 => stack::swap::<11> }
+def_stackop!{ SWAP12 => stack::swap::<12> }
+def_stackop!{ SWAP13 => stack::swap::<13> }
+def_stackop!{ SWAP14 => stack::swap::<14> }
+def_stackop!{ SWAP15 => stack::swap::<15> }
+def_stackop!{ SWAP16 => stack::swap::<16> }

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -45,6 +45,19 @@ macro_rules! def_stackop {
     }
 }
 
+// pushops: push stuff on the stack given input bytecode; the kind of thing that makes you want
+// to cry because it really is a stack op.
+macro_rules! def_push {
+    ($op:ident => $impl:path) => {
+        #[allow(non_snake_case)]
+        pub fn $op(sk: &mut Stack, code: &[u8]) -> Result<usize, StatusCode> {
+            check_stack!($op, sk);
+            let off = $impl(sk, code);
+            Ok(off)
+        }
+    }
+}
+
 // auxiliary macros
 macro_rules! check_stack {
     ($op:ident, $sk:ident) => {{
@@ -147,3 +160,38 @@ def_stackop!{ SWAP13 => stack::swap::<13> }
 def_stackop!{ SWAP14 => stack::swap::<14> }
 def_stackop!{ SWAP15 => stack::swap::<15> }
 def_stackop!{ SWAP16 => stack::swap::<16> }
+// pop
+def_stackop!{ POP => stack::pop }
+// push
+def_push!{ PUSH1 => stack::push::<1> }
+def_push!{ PUSH2 => stack::push::<2> }
+def_push!{ PUSH3 => stack::push::<3> }
+def_push!{ PUSH4 => stack::push::<4> }
+def_push!{ PUSH5 => stack::push::<5> }
+def_push!{ PUSH6 => stack::push::<6> }
+def_push!{ PUSH7 => stack::push::<7> }
+def_push!{ PUSH8 => stack::push::<8> }
+def_push!{ PUSH9 => stack::push::<9> }
+def_push!{ PUSH10 => stack::push::<10> }
+def_push!{ PUSH11 => stack::push::<11> }
+def_push!{ PUSH12 => stack::push::<12> }
+def_push!{ PUSH13 => stack::push::<13> }
+def_push!{ PUSH14 => stack::push::<14> }
+def_push!{ PUSH15 => stack::push::<15> }
+def_push!{ PUSH16 => stack::push::<16> }
+def_push!{ PUSH17 => stack::push::<17> }
+def_push!{ PUSH18 => stack::push::<18> }
+def_push!{ PUSH19 => stack::push::<19> }
+def_push!{ PUSH20 => stack::push::<20> }
+def_push!{ PUSH21 => stack::push::<21> }
+def_push!{ PUSH22 => stack::push::<22> }
+def_push!{ PUSH23 => stack::push::<23> }
+def_push!{ PUSH24 => stack::push::<24> }
+def_push!{ PUSH25 => stack::push::<25> }
+def_push!{ PUSH26 => stack::push::<26> }
+def_push!{ PUSH27 => stack::push::<27> }
+def_push!{ PUSH28 => stack::push::<28> }
+def_push!{ PUSH29 => stack::push::<29> }
+def_push!{ PUSH30 => stack::push::<30> }
+def_push!{ PUSH31 => stack::push::<31> }
+def_push!{ PUSH32 => stack::push::<32> }

--- a/actors/evm/src/interpreter/instructions/stack.rs
+++ b/actors/evm/src/interpreter/instructions/stack.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_safety_doc)]
 use {crate::interpreter::stack::Stack, crate::interpreter::U256};
 
 #[inline]

--- a/actors/evm/src/interpreter/instructions/stack.rs
+++ b/actors/evm/src/interpreter/instructions/stack.rs
@@ -1,7 +1,7 @@
 use {crate::interpreter::stack::Stack, crate::interpreter::U256};
 
 #[inline]
-pub(crate) fn push<const LEN: usize>(stack: &mut Stack, code: &[u8]) -> usize {
+pub(crate) unsafe fn push<const LEN: usize>(stack: &mut Stack, code: &[u8]) -> usize {
     let pushval = &code[..LEN];
     stack.push(match pushval.len() {
         0 => U256::zero(),
@@ -16,16 +16,16 @@ pub(crate) fn push<const LEN: usize>(stack: &mut Stack, code: &[u8]) -> usize {
 }
 
 #[inline]
-pub(crate) fn dup<const HEIGHT: usize>(stack: &mut Stack) {
+pub(crate) unsafe fn dup<const HEIGHT: usize>(stack: &mut Stack) {
     stack.push(*stack.get(HEIGHT - 1));
 }
 
 #[inline]
-pub(crate) fn swap<const HEIGHT: usize>(stack: &mut Stack) {
+pub(crate) unsafe fn swap<const HEIGHT: usize>(stack: &mut Stack) {
     stack.swap_top(HEIGHT);
 }
 
 #[inline]
-pub(crate) fn pop(stack: &mut Stack) {
+pub(crate) unsafe fn pop(stack: &mut Stack) {
     stack.pop();
 }

--- a/actors/evm/src/interpreter/instructions/state.rs
+++ b/actors/evm/src/interpreter/instructions/state.rs
@@ -26,7 +26,10 @@ pub fn balance(
 }
 
 #[inline]
-pub fn selfbalance(_state: &mut ExecutionState, system: &System<impl Runtime>)  -> Result<U256, StatusCode> {
+pub fn selfbalance(
+    _state: &mut ExecutionState,
+    system: &System<impl Runtime>,
+) -> Result<U256, StatusCode> {
     // Returns native FIL balance of the receiver. Value precision is identical to Ethereum, so
     // no conversion needed (atto, 1e18).
     Ok(U256::from(&system.rt.current_balance()))

--- a/actors/evm/src/interpreter/instructions/state.rs
+++ b/actors/evm/src/interpreter/instructions/state.rs
@@ -9,10 +9,11 @@ use {
 
 #[inline]
 pub fn balance(
-    state: &mut ExecutionState,
+    _state: &mut ExecutionState,
     system: &System<impl Runtime>,
-) -> Result<(), StatusCode> {
-    let actor: EthAddress = state.stack.pop().into();
+    actor: U256,
+) -> Result<U256, StatusCode> {
+    let actor: EthAddress = actor.into();
 
     let balance = actor
         .try_into()
@@ -21,8 +22,7 @@ pub fn balance(
         .and_then(|id| system.rt.actor_balance(id).as_ref().map(U256::from))
         .unwrap_or_default();
 
-    state.stack.push(balance);
-    Ok(())
+    Ok(balance)
 }
 
 #[inline]

--- a/actors/evm/src/interpreter/instructions/state.rs
+++ b/actors/evm/src/interpreter/instructions/state.rs
@@ -26,8 +26,8 @@ pub fn balance(
 }
 
 #[inline]
-pub fn selfbalance(state: &mut ExecutionState, system: &System<impl Runtime>) {
+pub fn selfbalance(_state: &mut ExecutionState, system: &System<impl Runtime>)  -> Result<U256, StatusCode> {
     // Returns native FIL balance of the receiver. Value precision is identical to Ethereum, so
     // no conversion needed (atto, 1e18).
-    state.stack.push(U256::from(&system.rt.current_balance()))
+    Ok(U256::from(&system.rt.current_balance()))
 }

--- a/actors/evm/src/interpreter/instructions/storage.rs
+++ b/actors/evm/src/interpreter/instructions/storage.rs
@@ -1,33 +1,28 @@
 use {
-    crate::interpreter::{ExecutionState, StatusCode, System},
+    crate::interpreter::{ExecutionState, StatusCode, System, U256},
     fil_actors_runtime::runtime::Runtime,
 };
 
 #[inline]
 pub fn sload(
-    state: &mut ExecutionState,
+    _state: &mut ExecutionState,
     system: &mut System<impl Runtime>,
-) -> Result<(), StatusCode> {
-    // where?
-    let location = state.stack.pop();
-
+    location: U256,
+) -> Result<U256, StatusCode> {
     // get from storage and place on stack
-    state.stack.push(system.get_storage(location)?);
-    Ok(())
+    system.get_storage(location)
 }
 
 #[inline]
 pub fn sstore(
-    state: &mut ExecutionState,
+    _state: &mut ExecutionState,
     system: &mut System<impl Runtime>,
+    key: U256,
+    value: U256,
 ) -> Result<(), StatusCode> {
     if system.readonly {
         return Err(StatusCode::StaticModeViolation);
     }
 
-    let key = state.stack.pop();
-    let value = state.stack.pop();
-
-    system.set_storage(key, value)?;
-    Ok(())
+    system.set_storage(key, value)
 }

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -1,62 +1,78 @@
 #![allow(dead_code)]
 
-use {crate::interpreter::U256, arrayvec::ArrayVec, serde::Serialize};
+use crate::interpreter::U256;
 
 /// Ethereum Yellow Paper (9.1)
-pub const MAX_STACK_SIZE: usize = 1024;
+pub const STACK_SIZE: usize = 1024;
 
 /// EVM stack.
-#[derive(Clone, Debug, Default, Serialize)]
-pub struct Stack(pub ArrayVec<U256, MAX_STACK_SIZE>);
+#[derive(Clone, Debug)]
+pub struct Stack {
+    sk: [U256; STACK_SIZE],
+    d: usize,
+}
 
 impl Stack {
     #[inline]
-    pub const fn new() -> Self {
-        Self(ArrayVec::new_const())
+    pub fn new() -> Self {
+        Stack { sk: [U256::zero(); STACK_SIZE], d: 0 }
     }
 
     #[inline]
-    const fn get_pos(&self, pos: usize) -> usize {
-        self.len() - 1 - pos
+    pub fn require(&self, required: usize) -> bool {
+        required <= self.d
     }
 
     #[inline]
-    pub fn get(&self, pos: usize) -> &U256 {
-        let pos = self.get_pos(pos);
-        self.0.get(pos).unwrap()
+    pub fn ensure(&self, space: usize) -> bool {
+        self.d + space <= STACK_SIZE
     }
 
     #[inline]
-    pub fn get_mut(&mut self, pos: usize) -> &mut U256 {
-        let pos = self.get_pos(pos);
-        self.0.get_mut(pos).unwrap()
+    pub fn get(&self, i: usize) -> &U256 {
+        let pos = self.d - i - 1;
+        unsafe { self.sk.get_unchecked(pos) }
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, i: usize) -> &mut U256 {
+        let pos = self.d - i - 1;
+        unsafe { self.sk.get_unchecked_mut(pos) }
     }
 
     #[inline(always)]
     pub const fn len(&self) -> usize {
-        self.0.len()
+        self.d
     }
 
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.d == 0
     }
 
     #[inline]
     pub fn push(&mut self, v: U256) {
-        self.0.push(v)
+        unsafe {
+            *self.sk.get_unchecked_mut(self.d) = v;
+        }
+        self.d += 1;
     }
 
     #[inline]
     pub fn pop(&mut self) -> U256 {
-        self.0.pop().unwrap()
+        self.d -= 1;
+        unsafe { *self.sk.get_unchecked(self.d) }
     }
 
     #[inline]
-    pub fn swap_top(&mut self, pos: usize) {
-        let top = self.0.len() - 1;
-        let pos = self.get_pos(pos);
-        self.0.swap(top, pos);
+    pub fn swap_top(&mut self, i: usize) {
+        let top = self.d - 1;
+        let pos = self.d - i - 1;
+        unsafe {
+            let tmp = *self.sk.get_unchecked(top);
+            *self.sk.get_unchecked_mut(top) = *self.sk.get_unchecked(pos);
+            *self.sk.get_unchecked_mut(pos) = tmp;
+        }
     }
 }
 
@@ -66,7 +82,7 @@ mod tests {
 
     #[test]
     fn stack() {
-        let mut stack = Stack::default();
+        let mut stack = Stack::new();
 
         let items: [u128; 4] = [0xde, 0xad, 0xbe, 0xef];
 

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -34,9 +34,9 @@ impl Stack {
                 return false;
             }
 
-            // Note: this breaks if space > current stack size (initial: 32), but there is
-            //       no instruction that does that.
-            self.sk.resize(2 * self.sk.len(), U256::zero());
+            while required > self.sk.len() {
+                self.sk.resize(2 * self.sk.len(), U256::zero());
+            }
         }
         true
     }

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -32,7 +32,7 @@ impl Stack {
             return false;
         }
 
-        if self.d + space >= self.sk.len() {
+        if self.d + space > self.sk.len() {
             self.sk.resize(max(2 * self.sk.len(), self.d + space), U256::zero());
         }
         true

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
 use crate::interpreter::U256;
-use std::cmp::max;
 
 /// Ethereum Yellow Paper (9.1)
 pub const STACK_SIZE: usize = 1024;
@@ -28,12 +27,16 @@ impl Stack {
 
     #[inline]
     pub fn ensure(&mut self, space: usize) -> bool {
-        if self.d + space > STACK_SIZE {
-            return false;
-        }
+        let required = self.d + space;
 
-        if self.d + space > self.sk.len() {
-            self.sk.resize(max(2 * self.sk.len(), self.d + space), U256::zero());
+        if required > self.sk.len() {
+            if required > STACK_SIZE {
+                return false;
+            }
+
+            // Note: this breaks if space > current stack size (initial: 32), but there is
+            //       no instruction that does that.
+            self.sk.resize(2 * self.sk.len(), U256::zero());
         }
         true
     }

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -41,20 +41,8 @@ impl Stack {
         true
     }
 
-    #[inline]
-    pub fn get(&self, i: usize) -> &U256 {
-        let pos = self.d - i - 1;
-        unsafe { self.sk.get_unchecked(pos) }
-    }
-
-    #[inline]
-    pub fn get_mut(&mut self, i: usize) -> &mut U256 {
-        let pos = self.d - i - 1;
-        unsafe { self.sk.get_unchecked_mut(pos) }
-    }
-
     #[inline(always)]
-    pub const fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.d
     }
 
@@ -64,28 +52,36 @@ impl Stack {
     }
 
     #[inline]
-    pub fn push(&mut self, v: U256) {
-        unsafe {
-            *self.sk.get_unchecked_mut(self.d) = v;
-        }
+    pub unsafe fn get(&self, i: usize) -> &U256 {
+        let pos = self.d - i - 1;
+        self.sk.get_unchecked(pos)
+    }
+
+    #[inline]
+    pub unsafe fn get_mut(&mut self, i: usize) -> &mut U256 {
+        let pos = self.d - i - 1;
+        self.sk.get_unchecked_mut(pos)
+    }
+
+    #[inline]
+    pub unsafe fn push(&mut self, v: U256) {
+        *self.sk.get_unchecked_mut(self.d) = v;
         self.d += 1;
     }
 
     #[inline]
-    pub fn pop(&mut self) -> U256 {
+    pub unsafe fn pop(&mut self) -> U256 {
         self.d -= 1;
-        unsafe { *self.sk.get_unchecked(self.d) }
+        *self.sk.get_unchecked(self.d)
     }
 
     #[inline]
-    pub fn swap_top(&mut self, i: usize) {
+    pub unsafe fn swap_top(&mut self, i: usize) {
         let top = self.d - 1;
         let pos = self.d - i - 1;
-        unsafe {
-            let tmp = *self.sk.get_unchecked(top);
-            *self.sk.get_unchecked_mut(top) = *self.sk.get_unchecked(pos);
-            *self.sk.get_unchecked_mut(pos) = tmp;
-        }
+        let tmp = *self.sk.get_unchecked(top);
+        *self.sk.get_unchecked_mut(top) = *self.sk.get_unchecked(pos);
+        *self.sk.get_unchecked_mut(pos) = tmp;
     }
 }
 

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -86,6 +86,12 @@ impl Stack {
     }
 }
 
+impl Default for Stack {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -102,12 +102,12 @@ mod tests {
         let items: [u128; 4] = [0xde, 0xad, 0xbe, 0xef];
 
         for (i, item) in items.iter().copied().enumerate() {
-            unsafe{stack.push(item.into())};
+            unsafe { stack.push(item.into()) };
             assert_eq!(stack.len(), i + 1);
         }
 
-        assert_eq!(unsafe{*stack.get(2)}, U256::from(0xad));
-        assert_eq!(unsafe{stack.pop()}, U256::from(0xef));
-        assert_eq!(unsafe{*stack.get(2)}, U256::from(0xde));
+        assert_eq!(unsafe { *stack.get(2) }, U256::from(0xad));
+        assert_eq!(unsafe { stack.pop() }, U256::from(0xef));
+        assert_eq!(unsafe { *stack.get(2) }, U256::from(0xde));
     }
 }

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, clippy::missing_safety_doc)]
 
 use crate::interpreter::U256;
 

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -1,21 +1,24 @@
 #![allow(dead_code)]
 
 use crate::interpreter::U256;
+use std::cmp::max;
 
 /// Ethereum Yellow Paper (9.1)
 pub const STACK_SIZE: usize = 1024;
 
+const INITIAL_STACK_SIZE: usize = 32;
+
 /// EVM stack.
 #[derive(Clone, Debug)]
 pub struct Stack {
-    sk: [U256; STACK_SIZE],
+    sk: Vec<U256>,
     d: usize,
 }
 
 impl Stack {
     #[inline]
     pub fn new() -> Self {
-        Stack { sk: [U256::zero(); STACK_SIZE], d: 0 }
+        Stack { sk: Vec::from([U256::zero(); INITIAL_STACK_SIZE]), d: 0 }
     }
 
     #[inline]
@@ -24,8 +27,15 @@ impl Stack {
     }
 
     #[inline]
-    pub fn ensure(&self, space: usize) -> bool {
-        self.d + space <= STACK_SIZE
+    pub fn ensure(&mut self, space: usize) -> bool {
+        if self.d + space > STACK_SIZE {
+            return false;
+        }
+
+        if self.d + space >= self.sk.len() {
+            self.sk.resize(max(2 * self.sk.len(), self.d + space), U256::zero());
+        }
+        true
     }
 
     #[inline]

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -102,12 +102,12 @@ mod tests {
         let items: [u128; 4] = [0xde, 0xad, 0xbe, 0xef];
 
         for (i, item) in items.iter().copied().enumerate() {
-            stack.push(item.into());
+            unsafe{stack.push(item.into())};
             assert_eq!(stack.len(), i + 1);
         }
 
-        assert_eq!(*stack.get(2), U256::from(0xad));
-        assert_eq!(stack.pop(), U256::from(0xef));
-        assert_eq!(*stack.get(2), U256::from(0xde));
+        assert_eq!(unsafe{*stack.get(2)}, U256::from(0xad));
+        assert_eq!(unsafe{stack.pop()}, U256::from(0xef));
+        assert_eq!(unsafe{*stack.get(2)}, U256::from(0xde));
     }
 }


### PR DESCRIPTION
Refactors dispatch logic so that:
- Do stack checks upfront, which allows us to remove bounds checks from stack ops
- Mechanize stack checks according to spec, so that programmer can't mess it up.
- Use a growable stack.
- Uniformize the instruction zoo.

TBD: 
- [ ] benchmarks/finetuning
