### PR TITLE
chore: switch to rust 2021 edition & resolver 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ testing = []
 testing-fake-proofs = []
 
 [workspace]
+resolver = "2"
 members = [
      "actors/*",
      "state",

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -4,7 +4,7 @@ description = "Builtin account actor for Filecoin"
 version = "10.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -4,7 +4,7 @@ description = "Builtin cron actor for Filecoin"
 version = "10.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -4,7 +4,7 @@ description = "Builtin init actor for Filecoin"
 version = "10.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -4,7 +4,7 @@ description = "Builtin market actor for Filecoin"
 version = "10.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -4,7 +4,7 @@ description = "Builtin miner actor for Filecoin"
 version = "10.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -4,7 +4,7 @@ description = "Builtin multisig actor for Filecoin"
 version = "10.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -4,7 +4,7 @@ description = "Builtin paych actor for Filecoin"
 version = "10.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -4,7 +4,7 @@ description = "Builtin power actor for Filecoin"
 version = "10.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -4,7 +4,7 @@ description = "Builtin reward actor for Filecoin"
 version = "10.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -4,7 +4,7 @@ description = "Builtin system actor for Filecoin"
 version = "10.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -4,7 +4,7 @@ description = "Builtin verifreg actor for Filecoin"
 version = "10.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -4,7 +4,7 @@ description = "Builtin Actor state utils for Filecoin"
 version = "10.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 


### PR DESCRIPTION
- The v2 feature resolver will ensure that features don't get unified across test and non-test dependencies.
- Rust 2021 will allow some new idioms.