### PR TITLE
EVM: Fix Precompile Failure Modes & Implement Remaining Precompile Tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "arrayref"
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.20"
+version = "3.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
+checksum = "1ed5341b2301a26ab80be5cbdced622e80ed808483c52e45e3310a877d3b37d7"
 dependencies = [
  "atty",
  "bitflags",
@@ -1116,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_bitfield"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1587207c7455ea70a762d4360f502b6728ea6e2dfbec2b66b6d4d943ee29ae"
+checksum = "97dfb38431e301bf063a412f870a3d9ebb541d581d1884f95e921f5ea823d29d"
 dependencies = [
  "cs_serde_bytes",
  "fvm_ipld_encoding",
@@ -1349,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
 dependencies = [
  "either",
 ]
@@ -1364,9 +1364,9 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1646,9 +1646,9 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "pest"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
+checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1656,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905708f7f674518498c1f8d644481440f476d39ca6ecae83319bba7c6c12da91"
+checksum = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1666,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5803d8284a629cc999094ecd630f55e91b561a1d1ba75e233b00ae13b91a69ad"
+checksum = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1679,13 +1679,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1538eb784f07615c6d9a8ab061089c6c54a344c5b4301db51990ca1c241e8c04"
+checksum = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6"
 dependencies = [
  "once_cell",
  "pest",
- "sha-1",
+ "sha1",
 ]
 
 [[package]]
@@ -1874,9 +1874,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -1972,10 +1972,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.0"
+name = "sha1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2097,8 +2097,7 @@ dependencies = [
 [[package]]
 name = "substrate-bn"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+source = "git+https://github.com/mriise/bn.git?branch=err-eq#b7775153f29bc1fcb2fe909d7bf89fdd12fbd3ce"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -2194,18 +2193,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
+checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
+checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2247,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-xid"
@@ -2293,9 +2292,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2303,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -2318,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2330,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2340,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2353,15 +2352,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "impl-serde",
+ "lazy_static",
  "log",
  "multihash",
  "near-blake2",
@@ -1796,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -2253,9 +2254,9 @@ checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsigned-varint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,7 +2097,8 @@ dependencies = [
 [[package]]
 name = "substrate-bn"
 version = "0.6.0"
-source = "git+https://github.com/mriise/bn.git?branch=err-eq#b7775153f29bc1fcb2fe909d7bf89fdd12fbd3ce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
 dependencies = [
  "byteorder",
  "crunchy",

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -38,6 +38,7 @@ fixed-hash = { version = "0.7.0", default-features = false }
 impl-serde = { version = "0.3.2", default-features = false }
 arrayvec = { version = "0.7.2", features = ["serde"] }
 hex = "0.4.3"
+hex-literal = "0.3.4"
 substrate-bn = { version = "0.6.0", default-features = false } 
 near-blake2 = { version = "0.9.1", git = "https://github.com/filecoin-project/near-blake2.git" }
 lazy_static = "1.4.0"
@@ -45,7 +46,6 @@ lazy_static = "1.4.0"
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
 etk-asm = "^0.2.1"
-hex-literal = "0.3.4"
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -38,7 +38,8 @@ fixed-hash = { version = "0.7.0", default-features = false }
 impl-serde = { version = "0.3.2", default-features = false }
 arrayvec = { version = "0.7.2", features = ["serde"] }
 hex = "0.4.3"
-substrate-bn = { version = "0.6.0", default-features = false }
+# TODO check this. needed Eq for errors, looked unmaintained 
+substrate-bn = { version = "0.6.0", default-features = false, git = "https://github.com/mriise/bn.git", branch = "err-eq"} 
 near-blake2 = { version = "0.9.1", git = "https://github.com/filecoin-project/near-blake2.git" }
 
 [dev-dependencies]

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -40,11 +40,12 @@ arrayvec = { version = "0.7.2", features = ["serde"] }
 hex = "0.4.3"
 substrate-bn = { version = "0.6.0", default-features = false } 
 near-blake2 = { version = "0.9.1", git = "https://github.com/filecoin-project/near-blake2.git" }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
-hex-literal = "0.3.4"
 etk-asm = "^0.2.1"
+hex-literal = "0.3.4"
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -39,7 +39,7 @@ impl-serde = { version = "0.3.2", default-features = false }
 arrayvec = { version = "0.7.2", features = ["serde"] }
 hex = "0.4.3"
 hex-literal = "0.3.4"
-substrate-bn = { version = "0.6.0", default-features = false } 
+substrate-bn = { version = "0.6.0", default-features = false }
 near-blake2 = { version = "0.9.1", git = "https://github.com/filecoin-project/near-blake2.git" }
 lazy_static = "1.4.0"
 

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -38,8 +38,7 @@ fixed-hash = { version = "0.7.0", default-features = false }
 impl-serde = { version = "0.3.2", default-features = false }
 arrayvec = { version = "0.7.2", features = ["serde"] }
 hex = "0.4.3"
-# TODO check this. needed Eq for errors, looked unmaintained 
-substrate-bn = { version = "0.6.0", default-features = false, git = "https://github.com/mriise/bn.git", branch = "err-eq"} 
+substrate-bn = { version = "0.6.0", default-features = false } 
 near-blake2 = { version = "0.9.1", git = "https://github.com/filecoin-project/near-blake2.git" }
 
 [dev-dependencies]

--- a/actors/evm/src/interpreter/precompiles.rs
+++ b/actors/evm/src/interpreter/precompiles.rs
@@ -86,12 +86,10 @@ impl<BS: Blockstore, RT: Runtime<BS>> Precompiles<BS, RT> {
 fn read_right_pad<'a>(input: impl Into<Cow<'a, [u8]>>, len: usize) -> Cow<'a, [u8]> {
     let mut input: Cow<[u8]> = input.into();
     let input_len = input.len();
-    if len <= input_len {
-        input
-    } else {
+    if len > input_len {
         input.to_mut().resize(len, 0);
-        input
-    }
+    } 
+    input
 }
 
 /// https://github.com/ethereum/go-ethereum/blob/25b35c97289a8db4753cdf5ab7f2b306ec71794d/core/vm/common.go#L54
@@ -244,7 +242,7 @@ fn ec_mul<RT: Primitives>(_: &RT, input: &[u8]) -> PrecompileResult {
         Fr::new_mul_factor(data.into())
     };
 
-    Ok(curve_to_vec(point.mul(scalar)))
+    Ok(curve_to_vec(point * scalar))
 }
 
 // https://github.com/ethereum/go-ethereum/blob/25b35c97289a8db4753cdf5ab7f2b306ec71794d/core/vm/contracts.go#L504

--- a/actors/evm/src/interpreter/precompiles.rs
+++ b/actors/evm/src/interpreter/precompiles.rs
@@ -649,7 +649,7 @@ mod tests {
                 12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
             )
             .unwrap();
-            
+
             let expected =
                 hex::decode("0000000000000000000000000000000000000000000000000000000000000001")
                     .unwrap();

--- a/actors/evm/src/interpreter/precompiles.rs
+++ b/actors/evm/src/interpreter/precompiles.rs
@@ -16,6 +16,10 @@ use uint::byteorder::{ByteOrder, LE};
 
 pub use substrate_bn::{CurveError, FieldError, GroupError};
 
+lazy_static::lazy_static! {
+    pub(crate) static ref SECP256K1: BigUint = BigUint::from_bytes_be(&hex::decode("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141").unwrap());
+}
+
 #[derive(Debug)]
 pub enum PrecompileError {
     EcErr(CurveError),
@@ -122,13 +126,7 @@ fn ec_recover<RT: Primitives>(rt: &RT, input: &[u8]) -> PrecompileResult {
     let valid = if r <= BigUint::one() || s <= BigUint::one() {
         false
     } else {
-        let secp256k1_n = BigUint::parse_bytes(
-            b"fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
-            16,
-        )
-        .unwrap();
-
-        r <= secp256k1_n && s <= secp256k1_n && (v == 0 || v == 1)
+        r <= *SECP256K1 && s <= *SECP256K1 && (v == 0 || v == 1)
     };
 
     if !valid {

--- a/actors/evm/src/interpreter/precompiles.rs
+++ b/actors/evm/src/interpreter/precompiles.rs
@@ -89,7 +89,7 @@ fn read_right_pad<'a>(input: impl Into<Cow<'a, [u8]>>, len: usize) -> Cow<'a, [u
     if len <= input_len {
         input
     } else {
-        input.to_mut().splice(..0, std::iter::repeat(0).take(len - input_len));
+        input.to_mut().resize(len, 0);
         input
     }
 }
@@ -373,6 +373,27 @@ mod tests {
     use super::*;
     use fil_actors_runtime::test_utils::MockRuntime;
     use hex_literal::hex;
+
+    #[test]
+    fn padding() {
+        let input = b"foo bar boxy";
+        let mut input = Vec::from(*input);
+        for i in 12..64 {
+            let mut expected = input.clone();
+            expected.resize(i, 0);
+
+            let res = read_right_pad(&input, i);
+            assert_eq!(&*res, &expected);
+
+            let res = get_data(&input, 0, i);
+            assert_eq!(&*res, &expected);
+
+            let res = get_data(&input, i + i, i);
+            assert_eq!(&*res, &vec![0; i]);
+
+            input.push(0);
+        }
+    }
 
     #[test]
     fn bn_recover() {

--- a/actors/evm/src/interpreter/precompiles.rs
+++ b/actors/evm/src/interpreter/precompiles.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, convert::TryInto, marker::PhantomData, ops::Mul};
+use std::{borrow::Cow, convert::TryInto, marker::PhantomData};
 
 use super::U256;
 use fil_actors_runtime::runtime::{Primitives, Runtime};
@@ -88,7 +88,7 @@ fn read_right_pad<'a>(input: impl Into<Cow<'a, [u8]>>, len: usize) -> Cow<'a, [u
     let input_len = input.len();
     if len > input_len {
         input.to_mut().resize(len, 0);
-    } 
+    }
     input
 }
 

--- a/actors/evm/src/interpreter/precompiles.rs
+++ b/actors/evm/src/interpreter/precompiles.rs
@@ -171,9 +171,9 @@ fn identity<RT: Primitives>(_: &RT, input: &[u8]) -> PrecompileResult {
 /// modulus exponent a number
 fn modexp<RT: Primitives>(_: &RT, input: &[u8]) -> PrecompileResult {
     let len_buf = read_right_pad(input, 96);
-    let base_len = U256::from_big_endian(&len_buf[..32]).as_usize();
-    let exponent_len = U256::from_big_endian(&len_buf[32..64]).as_usize();
-    let mod_len = U256::from_big_endian(&len_buf[64..96]).as_usize();
+    let base_len = U256::from_big_endian(&len_buf[..32]).low_u64() as usize;
+    let exponent_len = U256::from_big_endian(&len_buf[32..64]).low_u64() as usize;
+    let mod_len = U256::from_big_endian(&len_buf[64..96]).low_u64() as usize;
 
     let input = if input.len() > 96 { &input[96..] } else { &[] };
 

--- a/actors/evm/src/interpreter/precompiles.rs
+++ b/actors/evm/src/interpreter/precompiles.rs
@@ -71,7 +71,7 @@ fn read_u256_infalliable(buf: &[u8], start: usize) -> U256 {
 }
 
 fn ec_recover<RT: Primitives>(rt: &RT, input: &[u8]) -> PrecompileResult {
-    if input.len() != 128 {
+    if input.len() < 128 {
         return Err(PrecompileError::IncorrectInputSize);
     }
     let mut hash = [0u8; SECP_SIG_MESSAGE_HASH_SIZE];

--- a/actors/evm/src/interpreter/precompiles.rs
+++ b/actors/evm/src/interpreter/precompiles.rs
@@ -16,7 +16,7 @@ use uint::byteorder::{ByteOrder, LE};
 
 pub use substrate_bn::{CurveError, FieldError, GroupError};
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub enum PrecompileError {
     EcErr(CurveError),
     EcGroupErr(GroupError),
@@ -704,7 +704,7 @@ mod tests {
             )
             .unwrap();
             let res = ec_pairing(&rt, &input);
-            assert_eq!(res, Err(PrecompileError::IncorrectInputSize));
+            assert!(matches!(res, Err(PrecompileError::IncorrectInputSize)));
         }
     }
 
@@ -734,7 +734,7 @@ mod tests {
         // }
 
         // T0 invalid input len
-        assert_eq!(blake2f(&rt, &[]), Err(PrecompileError::IncorrectInputSize));
+        assert!(matches!(blake2f(&rt, &[]), Err(PrecompileError::IncorrectInputSize)));
 
         // T1 too small
         let input = &hex!(
@@ -745,7 +745,7 @@ mod tests {
             "0000000000000000"
             "02"
         );
-        assert_eq!(blake2f(&rt, input), Err(PrecompileError::IncorrectInputSize));
+        assert!(matches!(blake2f(&rt, input), Err(PrecompileError::IncorrectInputSize)));
 
         // T2 too large
         let input = &hex!(
@@ -756,7 +756,7 @@ mod tests {
             "0000000000000000"
             "02"
         );
-        assert_eq!(blake2f(&rt, input), Err(PrecompileError::IncorrectInputSize));
+        assert!(matches!(blake2f(&rt, input), Err(PrecompileError::IncorrectInputSize)));
 
         // T3 final block indicator invalid
         let input = &hex!(
@@ -767,12 +767,12 @@ mod tests {
             "0000000000000000"
             "02"
         );
-        assert_eq!(blake2f(&rt, input), Err(PrecompileError::IncorrectInputSize));
+        assert!(matches!(blake2f(&rt, input), Err(PrecompileError::IncorrectInputSize)));
 
         // outputs
 
         // T4
-        let expected = &hex!("08c9bcf367e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d282e6ad7f520e511f6c3e2b8c68059b9442be0454267ce079217e1319cde05b");
+        let expected = hex!("08c9bcf367e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d282e6ad7f520e511f6c3e2b8c68059b9442be0454267ce079217e1319cde05b");
         let input = &hex!(
             "00000000"
             "48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b"
@@ -781,7 +781,7 @@ mod tests {
             "0000000000000000"
             "01"
         );
-        assert_eq!(blake2f(&rt, input), Ok(expected.to_vec()));
+        assert!(matches!(blake2f(&rt, input), Ok(v) if v == expected));
 
         // T5
         let expected = &hex!("ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d17d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923");
@@ -793,7 +793,7 @@ mod tests {
             "0000000000000000"
             "01"
         );
-        assert_eq!(blake2f(&rt, input), Ok(expected.to_vec()));
+        assert!(matches!(blake2f(&rt, input), Ok(v) if v == expected));
 
         // T6
         let expected = &hex!("75ab69d3190a562c51aef8d88f1c2775876944407270c42c9844252c26d2875298743e7f6d5ea2f2d3e8d226039cd31b4e426ac4f2d3d666a610c2116fde4735");
@@ -805,7 +805,7 @@ mod tests {
             "0000000000000000"
             "00"
         );
-        assert_eq!(blake2f(&rt, input), Ok(expected.to_vec()));
+        assert!(matches!(blake2f(&rt, input), Ok(v) if v == expected));
 
         // T7
         let expected = &hex!("b63a380cb2897d521994a85234ee2c181b5f844d2c624c002677e9703449d2fba551b3a8333bcdf5f2f7e08993d53923de3d64fcc68c034e717b9293fed7a421");
@@ -817,7 +817,7 @@ mod tests {
             "0000000000000000"
             "01"
         );
-        assert_eq!(blake2f(&rt, input), Ok(expected.to_vec()));
+        assert!(matches!(blake2f(&rt, input), Ok(v) if v == expected));
 
         // T8
         // NOTE:
@@ -834,6 +834,6 @@ mod tests {
             "0000000000000000"
             "01"
         );
-        assert_eq!(blake2f(&rt, input), Ok(expected.to_vec()));
+        assert!(matches!(blake2f(&rt, input), Ok(v) if v == expected));
     }
 }

--- a/actors/evm/src/interpreter/precompiles.rs
+++ b/actors/evm/src/interpreter/precompiles.rs
@@ -17,7 +17,7 @@ use uint::byteorder::{ByteOrder, LE};
 pub use substrate_bn::{CurveError, FieldError, GroupError};
 
 lazy_static::lazy_static! {
-    pub(crate) static ref SECP256K1: BigUint = BigUint::from_bytes_be(&hex::decode("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141").unwrap());
+    pub(crate) static ref SECP256K1: BigUint = BigUint::from_bytes_be(&hex_literal::hex!("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"));
 }
 
 #[derive(Debug)]

--- a/actors/evm/src/interpreter/precompiles.rs
+++ b/actors/evm/src/interpreter/precompiles.rs
@@ -93,7 +93,6 @@ impl<'a> Data<'a> {
     }
 
     /// https://github.com/ethereum/go-ethereum/blob/25b35c97289a8db4753cdf5ab7f2b306ec71794d/common/bytes.go#L108
-    /// Return type is kept Vec since the upper scope needs to own it.
     fn read_right_pad(input: &'a [u8], len: usize) -> Self {
         if len <= input.len() {
             Self::Slice(input)

--- a/actors/evm/src/interpreter/precompiles.rs
+++ b/actors/evm/src/interpreter/precompiles.rs
@@ -89,7 +89,7 @@ fn read_right_pad<'a>(input: impl Into<Cow<'a, [u8]>>, len: usize) -> Cow<'a, [u
     if len <= input_len {
         input
     } else {
-        input.to_mut().splice(..0, core::iter::repeat(0).take(len - input_len));
+        input.to_mut().splice(..0, std::iter::repeat(0).take(len - input_len));
         input
     }
 }
@@ -144,8 +144,7 @@ fn ec_recover<RT: Primitives>(rt: &RT, input: &[u8]) -> PrecompileResult {
     };
 
     let mut address = rt.hash(SupportedHashes::Keccak256, &pubkey[1..]);
-    address.drain(..12); // TODO
-                         // address[..12].copy_from_slice(&[0u8; 12]);  // TODO left padding, do we care about alignment in precompiles really?
+    address[..12].copy_from_slice(&[0u8; 12]);
 
     Ok(address)
 }
@@ -195,7 +194,7 @@ fn modexp<RT: Primitives>(_: &RT, input: &[u8]) -> PrecompileResult {
 
     if output.len() < mod_len {
         let mut ret = Vec::with_capacity(mod_len);
-        ret.extend(core::iter::repeat(0).take(mod_len - output.len())); // left padding
+        ret.extend(std::iter::repeat(0).take(mod_len - output.len())); // left padding
         ret.extend_from_slice(&output);
         output = ret;
     }
@@ -387,7 +386,7 @@ mod tests {
             "4f8ae3bd7535248d0bd448298cc2e2071e56992d0774dc340c368ae950852ada" // s
         );
 
-        let expected = hex!("7156526fbd7a3c72969b54f64e42c10fbb768c8a");
+        let expected = hex!("0000000000000000000000007156526fbd7a3c72969b54f64e42c10fbb768c8a");
         let res = ec_recover(&rt, input).unwrap();
         assert_eq!(&res, &expected);
 

--- a/actors/evm/src/interpreter/uints.rs
+++ b/actors/evm/src/interpreter/uints.rs
@@ -20,9 +20,9 @@ impl From<&TokenAmount> for U256 {
     }
 }
 
-impl Into<arith::U256> for U256 {
-    fn into(self) -> arith::U256 {
-        arith::U256::from(self.0)
+impl From<U256> for arith::U256 {
+    fn from(src: U256) -> arith::U256 {
+        arith::U256::from(src.0)
     }
 }
 

--- a/actors/evm/src/interpreter/uints.rs
+++ b/actors/evm/src/interpreter/uints.rs
@@ -3,6 +3,8 @@
 // see https://github.com/paritytech/parity-common/issues/660
 #![allow(clippy::ptr_offset_with_cast, clippy::assign_op_pattern)]
 
+use substrate_bn::arith;
+
 use {
     fvm_shared::bigint::BigInt, fvm_shared::econ::TokenAmount, impl_serde::impl_uint_serde,
     std::cmp::Ordering, uint::construct_uint,
@@ -15,6 +17,12 @@ impl From<&TokenAmount> for U256 {
     fn from(amount: &TokenAmount) -> U256 {
         let (_, bytes) = amount.atto().to_bytes_be();
         U256::from(bytes.as_slice())
+    }
+}
+
+impl Into<arith::U256> for U256 {
+    fn into(self) -> arith::U256 {
+        arith::U256::from(self.0)
     }
 }
 


### PR DESCRIPTION
Fixes broken ec_recover implementation.
Fixes precompiles that were failing improperly. 
Adds cow for adding padding as needed.

Adds remaining tests
- ec_recover
- modexp
- ec_pair