### PR TITLE
fix: remove input_data from EVM constructor

### DIFF
--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -68,10 +68,7 @@ impl EvmContractActor {
         })?;
 
         // create a new execution context
-        let mut exec_state = ExecutionState::new(
-            Method::Constructor as u64,
-            Bytes::copy_from_slice(&params.input_data),
-        );
+        let mut exec_state = ExecutionState::new(Method::Constructor as u64, Bytes::new());
 
         // identify bytecode valid jump destinations
         let bytecode = Bytecode::new(&params.bytecode)
@@ -266,7 +263,6 @@ impl ActorCode for EvmContractActor {
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ConstructorParams {
     pub bytecode: RawBytes,
-    pub input_data: RawBytes,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/evm/tests/basic.rs
+++ b/actors/evm/tests/basic.rs
@@ -17,7 +17,6 @@ fn basic_contract_construction_and_invocation() {
 
     let params = evm::ConstructorParams {
         bytecode: hex::decode(include_str!("simplecoin.hex")).unwrap().into(),
-        input_data: RawBytes::default(),
     };
 
     // invoke constructor
@@ -99,8 +98,7 @@ return
     let mut rt = MockRuntime::default();
 
     rt.expect_validate_caller_any();
-    let params =
-        evm::ConstructorParams { bytecode: init_code.into(), input_data: RawBytes::default() };
+    let params = evm::ConstructorParams { bytecode: init_code.into() };
     let result = rt
         .call::<evm::EvmContractActor>(
             evm::Method::Constructor as u64,
@@ -140,8 +138,7 @@ sstore";
     let mut rt = MockRuntime::default();
 
     rt.expect_validate_caller_any();
-    let params =
-        evm::ConstructorParams { bytecode: init_code.into(), input_data: RawBytes::default() };
+    let params = evm::ConstructorParams { bytecode: init_code.into() };
     let result = rt
         .call::<evm::EvmContractActor>(
             evm::Method::Constructor as u64,

--- a/actors/evm/tests/calc.rs
+++ b/actors/evm/tests/calc.rs
@@ -75,8 +75,7 @@ fn test_magic_calc() {
     // invoke constructor
     rt.expect_validate_caller_any();
 
-    let params =
-        evm::ConstructorParams { bytecode: contract.into(), input_data: RawBytes::default() };
+    let params = evm::ConstructorParams { bytecode: contract.into() };
 
     let result = rt
         .call::<evm::EvmContractActor>(

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -63,8 +63,7 @@ fn test_call() {
     // construct the proxy
     let contract = call_proxy_contract();
     rt.expect_validate_caller_any();
-    let params =
-        evm::ConstructorParams { bytecode: contract.into(), input_data: RawBytes::default() };
+    let params = evm::ConstructorParams { bytecode: contract.into() };
     let result = rt
         .call::<evm::EvmContractActor>(
             evm::Method::Constructor as u64,
@@ -131,8 +130,7 @@ fn test_methodnum() {
 
     let contract = methodnum_contract();
     rt.expect_validate_caller_any();
-    let params =
-        evm::ConstructorParams { bytecode: contract.into(), input_data: RawBytes::default() };
+    let params = evm::ConstructorParams { bytecode: contract.into() };
     let result = rt
         .call::<evm::EvmContractActor>(
             evm::Method::Constructor as u64,
@@ -204,8 +202,7 @@ fn test_callactor() {
     // construct the proxy
     let contract = callactor_proxy_contract();
     rt.expect_validate_caller_any();
-    let params =
-        evm::ConstructorParams { bytecode: contract.into(), input_data: RawBytes::default() };
+    let params = evm::ConstructorParams { bytecode: contract.into() };
     let result = rt
         .call::<evm::EvmContractActor>(
             evm::Method::Constructor as u64,

--- a/actors/evm/tests/ext_opcodes.rs
+++ b/actors/evm/tests/ext_opcodes.rs
@@ -34,7 +34,7 @@ fn test_extcodesize() {
 
     let mut rt = MockRuntime::default();
     rt.expect_validate_caller_any();
-    let params = evm::ConstructorParams { bytecode, input_data: RawBytes::default() };
+    let params = evm::ConstructorParams { bytecode };
     let result = rt
         .call::<evm::EvmContractActor>(
             evm::Method::Constructor as u64,
@@ -93,7 +93,7 @@ fn test_extcodehash() {
 
     let mut rt = MockRuntime::default();
     rt.expect_validate_caller_any();
-    let params = evm::ConstructorParams { bytecode, input_data: RawBytes::default() };
+    let params = evm::ConstructorParams { bytecode };
     let result = rt
         .call::<evm::EvmContractActor>(
             evm::Method::Constructor as u64,
@@ -150,7 +150,7 @@ fn test_extcodecopy() {
 
     let mut rt = MockRuntime::default();
     rt.expect_validate_caller_any();
-    let params = evm::ConstructorParams { bytecode, input_data: RawBytes::default() };
+    let params = evm::ConstructorParams { bytecode };
     let result = rt
         .call::<evm::EvmContractActor>(
             evm::Method::Constructor as u64,

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -45,8 +45,7 @@ fn test_precompile_hash() {
     // invoke constructor
     rt.expect_validate_caller_any();
 
-    let params =
-        evm::ConstructorParams { bytecode: contract.into(), input_data: RawBytes::default() };
+    let params = evm::ConstructorParams { bytecode: contract.into() };
 
     let result = rt
         .call::<evm::EvmContractActor>(

--- a/actors/evm/tests/selfdestruct.rs
+++ b/actors/evm/tests/selfdestruct.rs
@@ -12,7 +12,6 @@ fn test_selfdestruct() {
 
     let params = evm::ConstructorParams {
         bytecode: hex::decode(include_str!("selfdestruct.hex")).unwrap().into(),
-        input_data: RawBytes::default(),
     };
 
     // invoke constructor


### PR DESCRIPTION
EVM contracts don't take parameters on construction.