### PR TITLE
feat: add an embryo actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actor_embryo"
+version = "10.0.0-alpha.1"
+dependencies = [
+ "fvm_sdk",
+ "fvm_shared",
+]
+
+[[package]]
 name = "fil_actor_evm"
 version = "10.0.0-alpha.1"
 dependencies = [
@@ -929,6 +937,7 @@ dependencies = [
  "fil_actor_account",
  "fil_actor_bundler",
  "fil_actor_cron",
+ "fil_actor_embryo",
  "fil_actor_evm",
  "fil_actor_init",
  "fil_actor_market",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ fil_actor_miner = { version = "10.0.0-alpha.1", path = "./actors/miner", feature
 fil_actor_reward = { version = "10.0.0-alpha.1", path = "./actors/reward", features = ["fil-actor"] }
 fil_actor_system = { version = "10.0.0-alpha.1", path = "./actors/system", features = ["fil-actor"] }
 fil_actor_init = { version = "10.0.0-alpha.1", path = "./actors/init", features = ["fil-actor"] }
+fil_actor_embryo = { version = "10.0.0-alpha.1", path = "./actors/embryo", features = ["fil-actor"] }
 fil_actor_evm = { version = "10.0.0-alpha.1", path = "./actors/evm", features = ["fil-actor"] }
 
 [build-dependencies]

--- a/actors/embryo/Cargo.toml
+++ b/actors/embryo/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "fil_actor_embryo"
+description = "Builtin embryo actor for Filecoin"
+version = "10.0.0-alpha.1"
+license = "MIT OR Apache-2.0"
+authors = ["Protocol Labs", "Filecoin Core Devs"]
+edition = "2021"
+keywords = ["filecoin", "web3", "wasm"]
+
+[lib]
+## lib is necessary for integration tests
+## cdylib is necessary for Wasm build
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+fvm_sdk = { version = "3.0.0-alpha.2", optional = true }
+fvm_shared = { version = "3.0.0-alpha.1", optional = true }
+
+[features]
+fil-actor = ["fvm_sdk", "fvm_shared"]

--- a/actors/embryo/src/lib.rs
+++ b/actors/embryo/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(feature = "fil-actor")]
+#[no_mangle]
+pub extern "C" fn invoke(_: u32) -> u32 {
+    fvm_sdk::vm::abort(
+        fvm_shared::error::ExitCode::USR_UNHANDLED_MESSAGE.value(),
+        Some("embryo actors may only receive messages on method 0"),
+    )
+}

--- a/build.rs
+++ b/build.rs
@@ -25,6 +25,7 @@ const ACTORS: &[(&Package, &ID)] = &[
     ("multisig", "multisig"),
     ("reward", "reward"),
     ("verifreg", "verifiedregistry"),
+    ("embryo", "embryo"),
     ("evm", "evm"),
 ];
 

--- a/runtime/src/runtime/builtins.rs
+++ b/runtime/src/runtime/builtins.rs
@@ -19,7 +19,8 @@ pub enum Type {
     Multisig = 9,
     Reward = 10,
     VerifiedRegistry = 11,
-    EVM = 12,
+    Embryo = 12,
+    EVM = 13,
 }
 
 impl Type {
@@ -36,6 +37,7 @@ impl Type {
             Type::Multisig => "multisig",
             Type::Reward => "reward",
             Type::VerifiedRegistry => "verifiedregistry",
+            Type::Embryo => "embryo",
             Type::EVM => "evm",
         }
     }

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -57,6 +57,7 @@ lazy_static::lazy_static! {
     pub static ref MULTISIG_ACTOR_CODE_ID: Cid = make_builtin(b"fil/test/multisig");
     pub static ref REWARD_ACTOR_CODE_ID: Cid = make_builtin(b"fil/test/reward");
     pub static ref VERIFREG_ACTOR_CODE_ID: Cid = make_builtin(b"fil/test/verifiedregistry");
+    pub static ref EMBRYO_ACTOR_CODE_ID: Cid = make_builtin(b"fil/test/embryo");
     pub static ref EVM_ACTOR_CODE_ID: Cid = make_builtin(b"fil/test/evm");
     pub static ref ACTOR_TYPES: BTreeMap<Cid, Type> = {
         let mut map = BTreeMap::new();
@@ -71,6 +72,7 @@ lazy_static::lazy_static! {
         map.insert(*MULTISIG_ACTOR_CODE_ID, Type::Multisig);
         map.insert(*REWARD_ACTOR_CODE_ID, Type::Reward);
         map.insert(*VERIFREG_ACTOR_CODE_ID, Type::VerifiedRegistry);
+        map.insert(*EMBRYO_ACTOR_CODE_ID, Type::EVM);
         map.insert(*EVM_ACTOR_CODE_ID, Type::EVM);
         map
     };
@@ -86,6 +88,8 @@ lazy_static::lazy_static! {
         (Type::Multisig, *MULTISIG_ACTOR_CODE_ID),
         (Type::Reward, *REWARD_ACTOR_CODE_ID),
         (Type::VerifiedRegistry, *VERIFREG_ACTOR_CODE_ID),
+        (Type::Embryo, *EMBRYO_ACTOR_CODE_ID),
+        (Type::EVM, *EVM_ACTOR_CODE_ID),
     ]
     .into_iter()
     .collect();
@@ -95,6 +99,8 @@ lazy_static::lazy_static! {
         map.insert(*PAYCH_ACTOR_CODE_ID, ());
         map.insert(*MULTISIG_ACTOR_CODE_ID, ());
         map.insert(*MINER_ACTOR_CODE_ID, ());
+        map.insert(*EMBRYO_ACTOR_CODE_ID, ());
+        map.insert(*EVM_ACTOR_CODE_ID, ());
         map
     };
 }

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -204,6 +204,7 @@ pub fn check_state_invariants<'a, BS: Blockstore + Debug>(
                 acc.with_prefix("verifreg: ").add_all(&msgs);
                 verifreg_summary = Some(summary);
             }
+            Some(Type::Embryo) => {}
             Some(Type::EVM) => {}
             None => {
                 bail!("unexpected actor code CID {} for address {}", actor.code, key);

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -661,6 +661,9 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
             Type::Power => PowerActor::invoke_method(self, self.msg.method, &params),
             Type::PaymentChannel => PaychActor::invoke_method(self, self.msg.method, &params),
             Type::VerifiedRegistry => VerifregActor::invoke_method(self, self.msg.method, &params),
+            Type::Embryo => {
+                Err(ActorError::unhandled_message("embryo actors only handle method 0".into()))
+            }
             Type::EVM => EvmContractActor::invoke_method(self, self.msg.method, &params),
         };
         if res.is_err() {


### PR DESCRIPTION
The embryo actor:

- Has no constructor (the system is expected to simply "set" the embryo code CID, not construct it).
- Immediately aborts when called with a non-zero method.

We could, alternatively, use some well-known "id" address. But it's nice to make this actual valid wasm.