### PR TITLE
fix: make the empty array CID const and export it

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,7 +14,7 @@ fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
-lazy_static = "1.4.0"
+lazy_static = { version = "1.4.0", optional = true }
 unsigned-varint = "0.7.1"
 integer-encoding = { version = "3.0.3", default-features = false }
 byteorder = "1.4.3"
@@ -78,4 +78,4 @@ no-provider-deal-collateral = []
 # fake proofs (for testing)
 fake-proofs = []
 
-test_utils = ["hex", "multihash/sha2"]
+test_utils = ["hex", "multihash/sha2", "lazy_static"]

--- a/runtime/src/runtime/empty.rs
+++ b/runtime/src/runtime/empty.rs
@@ -1,0 +1,37 @@
+use std::mem;
+
+use cid::multihash::Multihash;
+use cid::Cid;
+use fvm_ipld_encoding::DAG_CBOR;
+use fvm_shared::crypto::hash::SupportedHashes;
+
+const fn const_unwrap<T: Copy, E>(r: Result<T, E>) -> T {
+    let v = match r {
+        Ok(r) => r,
+        Err(_) => panic!(),
+    };
+    mem::forget(r);
+    v
+}
+
+// 45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0
+const EMPTY_ARR_HASH_DIGEST: &[u8] = &[
+    0x45, 0xb0, 0xcf, 0xc2, 0x20, 0xce, 0xec, 0x5b, 0x7c, 0x1c, 0x62, 0xc4, 0xd4, 0x19, 0x3d, 0x38,
+    0xe4, 0xeb, 0xa4, 0x8e, 0x88, 0x15, 0x72, 0x9c, 0xe7, 0x5f, 0x9c, 0x0a, 0xb0, 0xe4, 0xc1, 0xc0,
+];
+
+// bafy2bzacebc3bt6cedhoyw34drrmjvazhu4oj25er2ebk4u445pzycvq4ta4a
+pub const EMPTY_ARR_CID: Cid = Cid::new_v1(
+    DAG_CBOR,
+    const_unwrap(Multihash::wrap(SupportedHashes::Blake2b256 as u64, EMPTY_ARR_HASH_DIGEST)),
+);
+
+#[test]
+fn test_empty_arr_cid() {
+    use cid::multihash::{Code, MultihashDigest};
+    use fvm_ipld_encoding::to_vec;
+
+    let empty = to_vec::<[(); 0]>(&[]).unwrap();
+    let expected = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));
+    assert_eq!(EMPTY_ARR_CID, expected);
+}

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, Error};
-use cid::multihash::{Code, MultihashDigest};
+use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::{to_vec, Cbor, CborStore, RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::{Cbor, CborStore, RawBytes, DAG_CBOR};
 use fvm_sdk as fvm;
 use fvm_sdk::NO_DATA_BLOCK_ID;
 use fvm_shared::address::Address;
@@ -30,13 +30,7 @@ use crate::runtime::{
 };
 use crate::{actor_error, ActorError, Runtime};
 
-lazy_static::lazy_static! {
-    /// Cid of the empty array Cbor bytes (`EMPTY_ARR_BYTES`).
-    pub static ref EMPTY_ARR_CID: Cid = {
-        let empty = to_vec::<[(); 0]>(&[]).unwrap();
-        Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty))
-    };
-}
+use super::EMPTY_ARR_CID;
 
 /// A runtime that bridges to the FVM environment through the FVM SDK.
 pub struct FvmRuntime<B = ActorBlockstore> {
@@ -231,7 +225,7 @@ where
 
     fn create<C: Cbor>(&mut self, obj: &C) -> Result<(), ActorError> {
         let root = fvm::sself::root()?;
-        if root != *EMPTY_ARR_CID {
+        if root != EMPTY_ARR_CID {
             return Err(
                 actor_error!(illegal_state; "failed to create state; expected empty array CID, got: {}", root),
             );

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -34,6 +34,9 @@ mod actor_blockstore;
 #[cfg(feature = "fil-actor")]
 pub mod fvm;
 
+pub(crate) mod empty;
+pub use empty::EMPTY_ARR_CID;
+
 /// Runtime is the VM's internal runtime object.
 /// this is everything that is accessible to actors, beyond parameters.
 pub trait Runtime<BS: Blockstore>: Primitives + Verifier + RuntimePolicy {


### PR DESCRIPTION
Otherwise, we'll perform a hash in WASM when we first dereference (max once per call) which is just wasteful.

This also fixes the integration tests to use the "correct" empty object. Previously, they were using `()` which mapped to null, not `[]`.