### PR TITLE
Implement verified claim term extension by client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
+ "itertools",
  "lazy_static",
  "log",
  "num-derive",

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -23,6 +23,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.2"
 fvm_ipld_hamt = "0.5.1"
 fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+itertools = "0.10.3"
 lazy_static = "1.4.0"
 log = "0.4.14"
 num-derive = "0.3.3"

--- a/actors/verifreg/src/state.rs
+++ b/actors/verifreg/src/state.rs
@@ -240,3 +240,29 @@ pub struct Allocation {
 }
 
 impl Cbor for State {}
+
+pub fn get_allocation<'a, BS>(
+    allocations: &'a mut MapMap<BS, Allocation, ActorID, AllocationID>,
+    client: ActorID,
+    id: AllocationID,
+) -> Result<Option<&'a Allocation>, ActorError>
+where
+    BS: Blockstore,
+{
+    allocations
+        .get(client, id)
+        .context_code(ExitCode::USR_ILLEGAL_STATE, "HAMT lookup failure getting allocation")
+}
+
+pub fn get_claim<'a, BS>(
+    claims: &'a mut MapMap<BS, Claim, ActorID, ClaimID>,
+    provider: ActorID,
+    id: ClaimID,
+) -> Result<Option<&'a Claim>, ActorError>
+where
+    BS: Blockstore,
+{
+    claims
+        .get(provider, id)
+        .context_code(ExitCode::USR_ILLEGAL_STATE, "HAMT lookup failure getting claim")
+}

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -125,15 +125,15 @@ pub type ClaimAllocationsReturn = BatchReturn;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ClaimTerm {
-    provider: ActorID,
-    claim_id: ClaimID,
-    term_max: ChainEpoch,
+    pub provider: ActorID,
+    pub claim_id: ClaimID,
+    pub term_max: ChainEpoch,
 }
 impl Cbor for ClaimTerm {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ExtendClaimTermsParams {
-    pub claims: Vec<ClaimTerm>,
+    pub terms: Vec<ClaimTerm>,
 }
 impl Cbor for ExtendClaimTermsParams {}
 


### PR DESCRIPTION
This was fairly straightforward.

One possibly controversial decision was to allow extension of claims that have already expired. I couldn't find a good reason to deny it. I think this will harmonise with my intentions to (in the future) allow re-committing a verified piece if the original sector fails within a claim's lifetime. The "failure" in the case I've implemented is the client forgetting to extend their claim term in time, so the sector was forced to drop it and the provider will need to re-seal.

Closes #550.