### PR TITLE
Remove all expired allocations for a client when none specified

### DIFF
--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -97,12 +97,25 @@ impl AddrPairKey {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct RemoveExpiredAllocationsParams {
+    // Client for which to remove expired allocations.
     pub client: ActorID,
+    // Optional list of allocation IDs to attempt to remove.
+    // Empty means remove all eligible expired allocations.
     pub allocation_ids: Vec<AllocationID>,
 }
 impl Cbor for RemoveExpiredAllocationsParams {}
 
-pub type RemoveExpiredAllocationsReturn = BatchReturn;
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct RemoveExpiredAllocationsReturn {
+    // Ids of the allocations that were either specified by the caller or discovered to be expired.
+    pub considered: Vec<AllocationID>,
+    // Results for each processed allocation.
+    pub results: BatchReturn,
+    // The amount of datacap reclaimed for the client.
+    #[serde(with = "bigint_ser")]
+    pub datacap_recovered: DataCap,
+}
+impl Cbor for RemoveExpiredAllocationsReturn {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct SectorAllocationClaim {

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -230,10 +230,7 @@ impl Harness {
         id: AllocationID,
     ) -> Option<Allocation> {
         let st: State = rt.get_state();
-        let mut allocs =
-            MapMap::from_root(rt.store(), &st.allocations, HAMT_BIT_WIDTH, HAMT_BIT_WIDTH)
-                .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load allocations table")
-                .unwrap();
+        let mut allocs = st.load_allocs(rt.store()).unwrap();
         allocs.get(client.id().unwrap(), id).unwrap().cloned()
     }
 

--- a/runtime/src/util/batch_return.rs
+++ b/runtime/src/util/batch_return.rs
@@ -60,7 +60,7 @@ impl BatchReturnGen {
     }
 
     pub fn gen(&self) -> BatchReturn {
-        assert_eq!(self.expect_count, self.success_count + self.fail_codes.len(), "programmer error, mismatched batch size {} and processed coutn {} batch return must include success/fail for all inputs", self.expect_count, self.success_count + self.fail_codes.len());
+        assert_eq!(self.expect_count, self.success_count + self.fail_codes.len(), "programmer error, mismatched batch size {} and processed count {} batch return must include success/fail for all inputs", self.expect_count, self.success_count + self.fail_codes.len());
         BatchReturn { success_count: self.success_count, fail_codes: self.fail_codes.clone() }
     }
 }

--- a/runtime/src/util/mapmap.rs
+++ b/runtime/src/util/mapmap.rs
@@ -102,6 +102,18 @@ where
         in_map.get(&inside_k.key())
     }
 
+    // Runs a function over all values for one outer key.
+    pub fn for_each<F>(&mut self, outside_k: K1, f: F) -> Result<(), Error>
+    where
+        F: FnMut(&BytesKey, &V) -> anyhow::Result<()>,
+    {
+        let (is_empty, in_map) = self.load_inner_map(outside_k)?;
+        if is_empty {
+            return Ok(());
+        }
+        in_map.for_each(f)
+    }
+
     // Puts a key value pair in the MapMap if it is not already set.  Returns true
     // if key is newly set, false if it was already set.
     pub fn put_if_absent(&mut self, outside_k: K1, inside_k: K2, value: V) -> Result<bool, Error> {


### PR DESCRIPTION
This raises a bit of a question about the return value when no allocation IDs were specified. If this were a separate method, maybe we'd return the list of removed IDs. In either case maybe we'd like to return the total datacap reclaimed. I've taken the simplest possible path here of returning nothing.

We could merge these into a return value that includes all these, like:
```
{
	specified_allocations: BatchReturn // only non-empty when specified
    found_allocations: Vec<AllocationID> // only non-empty when none specified
    datacap: DataCap
}
```

What do you think @ZenGround0 ?

Closes #606.