### PR TITLE
change hashmap/set to btreemap/set

### DIFF
--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -13,7 +13,7 @@ use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, SectorSize};
 use num_traits::Zero;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 pub fn check_state_invariants<BS: Blockstore>(
     policy: &Policy,
@@ -602,7 +602,7 @@ impl ExpirationQueueStateSummary {
         sector_size: SectorSize,
         acc: &MessageAccumulator,
     ) -> Self {
-        let mut seen_sectors: HashSet<SectorNumber> = HashSet::new();
+        let mut seen_sectors: BTreeSet<SectorNumber> = BTreeSet::new();
         let mut all_on_time: Vec<BitField> = Vec::new();
         let mut all_early: Vec<BitField> = Vec::new();
         let mut expiration_epochs: Vec<ChainEpoch> = Vec::new();
@@ -703,7 +703,7 @@ fn check_early_termination_queue<BS: Blockstore>(
     terminated: &BitField,
     acc: &MessageAccumulator,
 ) -> usize {
-    let mut seen: HashSet<u64> = HashSet::new();
+    let mut seen: BTreeSet<u64> = BTreeSet::new();
     let mut seen_bitfield = BitField::new();
 
     let iter_result = early_queue.amt.for_each(|epoch, bitfield| {
@@ -802,7 +802,7 @@ pub fn check_deadline_state_invariants<BS: Blockstore>(
     let mut partition_count = 0;
 
     // check partitions
-    let mut partitions_with_expirations: HashMap<ChainEpoch, Vec<u64>> = HashMap::new();
+    let mut partitions_with_expirations: BTreeMap<ChainEpoch, Vec<u64>> = BTreeMap::new();
     let mut partitions_with_early_terminations = BitField::new();
     partitions
         .for_each(|index, partition| {

--- a/actors/miner/tests/aggregate_prove_commit.rs
+++ b/actors/miner/tests/aggregate_prove_commit.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::iter::FromIterator;
 
 use fil_actor_miner::{
@@ -61,7 +61,7 @@ fn valid_precommits_then_aggregate_provecommit() {
     rt.set_balance(TokenAmount::from_whole(1000));
 
     let pcc = ProveCommitConfig {
-        deal_weights: HashMap::from_iter(
+        deal_weights: BTreeMap::from_iter(
             precommits.iter().map(|pc| (pc.info.sector_number, deal_weights.clone())),
         ),
         ..Default::default()
@@ -146,7 +146,7 @@ fn valid_precommits_then_aggregate_provecommit() {
     let quantized_expiration = quant.quantize_up(expiration);
 
     let d_queue = actor.collect_deadline_expirations(&rt, &deadline);
-    let mut expected_queue = HashMap::new();
+    let mut expected_queue = BTreeMap::new();
     expected_queue.insert(quantized_expiration, vec![p_idx]);
     assert_eq!(expected_queue, d_queue);
 

--- a/actors/miner/tests/batch_method_network_fees_test.rs
+++ b/actors/miner/tests/batch_method_network_fees_test.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use fil_actor_miner::{
     aggregate_pre_commit_network_fee, aggregate_prove_commit_network_fee,
@@ -105,7 +105,7 @@ fn insufficient_funds_for_batch_precommit_network_fee() {
     let state: State = rt.get_state();
     assert!(state.pre_commit_deposits.is_zero());
     let expirations = actor.collect_precommit_expirations(&rt, &state);
-    assert_eq!(HashMap::new(), expirations);
+    assert_eq!(BTreeMap::new(), expirations);
 
     expect_abort_contains_message(
         ExitCode::USR_INSUFFICIENT_FUNDS,
@@ -160,7 +160,7 @@ fn insufficient_funds_for_batch_precommit_in_combination_of_fee_debt_and_network
     let state: State = rt.get_state();
     assert!(state.pre_commit_deposits.is_zero());
     let expirations = actor.collect_precommit_expirations(&rt, &state);
-    assert_eq!(HashMap::new(), expirations);
+    assert_eq!(BTreeMap::new(), expirations);
 
     expect_abort_contains_message(
         ExitCode::USR_INSUFFICIENT_FUNDS,
@@ -220,7 +220,7 @@ fn enough_funds_for_fee_debt_and_network_fee_but_not_for_pcd() {
     let state: State = rt.get_state();
     assert!(state.pre_commit_deposits.is_zero());
     let expirations = actor.collect_precommit_expirations(&rt, &state);
-    assert_eq!(HashMap::new(), expirations);
+    assert_eq!(BTreeMap::new(), expirations);
 }
 
 #[test]

--- a/actors/miner/tests/deadline_state_test.rs
+++ b/actors/miner/tests/deadline_state_test.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use fil_actor_miner::testing::{check_deadline_state_invariants, DeadlineStateSummary};
 use fil_actor_miner::{
@@ -136,7 +136,7 @@ fn add_then_terminate(
         deadline,
         15,
         sectors.to_owned(),
-        HashMap::from([(0, bitfield_from_slice(&[1, 3])), (1, bitfield_from_slice(&[6]))]),
+        BTreeMap::from([(0, bitfield_from_slice(&[1, 3])), (1, bitfield_from_slice(&[6]))]),
     )
     .unwrap();
 
@@ -438,7 +438,7 @@ fn terminate_proven_and_faulty() {
         &mut deadline,
         15,
         sectors.to_owned(),
-        HashMap::from([(0, bitfield_from_slice(&[1, 3])), (1, bitfield_from_slice(&[6]))]),
+        BTreeMap::from([(0, bitfield_from_slice(&[1, 3])), (1, bitfield_from_slice(&[6]))]),
     )
     .unwrap();
 
@@ -466,7 +466,7 @@ fn terminate_sectors(
     deadline: &mut Deadline,
     epoch: ChainEpoch,
     sectors: Vec<SectorOnChainInfo>,
-    partition_sectors: HashMap<u64, BitField>,
+    partition_sectors: BTreeMap<u64, BitField>,
 ) -> anyhow::Result<PowerPair> {
     let store = rt.store();
     let sectors_array = sectors_arr(&store, sectors);
@@ -499,7 +499,7 @@ fn terminate_unproven_and_faulty() {
         &mut deadline,
         15,
         sectors.to_owned(),
-        HashMap::from([(0, bitfield_from_slice(&[1, 3])), (1, bitfield_from_slice(&[6]))]),
+        BTreeMap::from([(0, bitfield_from_slice(&[1, 3])), (1, bitfield_from_slice(&[6]))]),
     )
     .unwrap();
 
@@ -529,7 +529,7 @@ fn fails_to_terminate_missing_sector() {
         &mut deadline,
         15,
         sectors,
-        HashMap::from([(0, bitfield_from_slice(&[6]))]),
+        BTreeMap::from([(0, bitfield_from_slice(&[6]))]),
     );
 
     assert!(ret.is_err());
@@ -551,7 +551,7 @@ fn fails_to_terminate_missing_partition() {
         &mut deadline,
         15,
         sectors,
-        HashMap::from([(4, bitfield_from_slice(&[6]))]),
+        BTreeMap::from([(4, bitfield_from_slice(&[6]))]),
     );
 
     assert!(ret.is_err());
@@ -573,7 +573,7 @@ fn fails_to_terminate_already_terminated_sector() {
         &mut deadline,
         15,
         sectors,
-        HashMap::from([(0, bitfield_from_slice(&[1, 2]))]),
+        BTreeMap::from([(0, bitfield_from_slice(&[1, 2]))]),
     );
 
     assert!(ret.is_err());

--- a/actors/miner/tests/miner_actor_test_commitment.rs
+++ b/actors/miner/tests/miner_actor_test_commitment.rs
@@ -14,7 +14,7 @@ use fvm_shared::sector::{RegisteredSealProof, SectorNumber, MAX_SECTOR_NUMBER};
 
 use num_traits::Zero;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 mod util;
 use util::*;
@@ -78,7 +78,7 @@ fn assert_simple_pre_commit(sector_number: SectorNumber, deal_ids: &[DealID]) {
             + max_prove_commit_duration(&rt.policy, h.seal_proof_type).unwrap()
             + rt.policy.expired_pre_commit_clean_up_delay,
     );
-    assert_eq!(HashMap::from([(expected_precommit_expiration, vec![sector_number])]), expirations);
+    assert_eq!(BTreeMap::from([(expected_precommit_expiration, vec![sector_number])]), expirations);
 }
 
 mod miner_actor_test_commitment {

--- a/actors/miner/tests/miner_actor_test_precommit_batch.rs
+++ b/actors/miner/tests/miner_actor_test_precommit_batch.rs
@@ -14,7 +14,7 @@ use fvm_shared::sector::SectorNumber;
 use num_traits::Zero;
 
 use cid::Cid;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 mod util;
 use util::*;
@@ -139,7 +139,7 @@ fn assert_simple_batch(
             + max_prove_commit_duration(&rt.policy, h.seal_proof_type).unwrap()
             + rt.policy.expired_pre_commit_clean_up_delay,
     );
-    assert_eq!(HashMap::from([(expected_precommit_expiration, sector_no_as_uints)]), expirations);
+    assert_eq!(BTreeMap::from([(expected_precommit_expiration, sector_no_as_uints)]), expirations);
 }
 
 mod miner_actor_precommit_batch {

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -13,7 +13,7 @@ use fvm_shared::{
     sector::{StoragePower, MAX_SECTOR_NUMBER},
     smooth::FilterEstimate,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 mod util;
 
@@ -76,7 +76,7 @@ fn prove_single_sector() {
     rt.set_epoch(prove_commit_epoch);
     rt.balance.replace(TokenAmount::from_whole(1000));
     let pcc = ProveCommitConfig {
-        deal_weights: HashMap::from([(sector_no, deal_weight.clone())]),
+        deal_weights: BTreeMap::from([(sector_no, deal_weight.clone())]),
         ..Default::default()
     };
 
@@ -142,7 +142,7 @@ fn prove_single_sector() {
     let quantized_expiration = quant.quantize_up(precommit.info.expiration);
 
     let d_queue = h.collect_deadline_expirations(&rt, &deadline);
-    assert_eq!(HashMap::from([(quantized_expiration, vec![p_idx])]), d_queue);
+    assert_eq!(BTreeMap::from([(quantized_expiration, vec![p_idx])]), d_queue);
 
     assert_bitfield_equals(&partition.sectors, &[sector_no]);
     assert!(partition.faults.is_empty());
@@ -271,7 +271,7 @@ fn prove_sectors_from_batch_pre_commit() {
     {
         let precommit = &precommits[1];
         let pcc = ProveCommitConfig {
-            deal_weights: HashMap::from([(precommit.info.sector_number, deal_weights.clone())]),
+            deal_weights: BTreeMap::from([(precommit.info.sector_number, deal_weights.clone())]),
             ..Default::default()
         };
         let sector = h
@@ -300,7 +300,7 @@ fn prove_sectors_from_batch_pre_commit() {
     {
         let precommit = &precommits[2];
         let pcc = ProveCommitConfig {
-            deal_weights: HashMap::from([(precommit.info.sector_number, deal_weights)]),
+            deal_weights: BTreeMap::from([(precommit.info.sector_number, deal_weights)]),
             ..Default::default()
         };
         let sector = h
@@ -391,7 +391,7 @@ fn invalid_proof_rejected() {
 
     // Invalid deals (market ActivateDeals aborts)
     let verify_deals_exit =
-        HashMap::from([(precommit.info.sector_number, ExitCode::USR_ILLEGAL_ARGUMENT)]);
+        BTreeMap::from([(precommit.info.sector_number, ExitCode::USR_ILLEGAL_ARGUMENT)]);
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         h.prove_commit_sector_and_confirm(
@@ -529,7 +529,7 @@ fn drop_invalid_prove_commit_while_processing_valid_one() {
     h.prove_commit_sector(&mut rt, &pre_commit_b, h.make_prove_commit_params(sector_no_b)).unwrap();
 
     let conf = ProveCommitConfig {
-        verify_deals_exit: HashMap::from([(sector_no_a, ExitCode::USR_ILLEGAL_ARGUMENT)]),
+        verify_deals_exit: BTreeMap::from([(sector_no_a, ExitCode::USR_ILLEGAL_ARGUMENT)]),
         ..Default::default()
     };
     h.confirm_sector_proofs_valid(&mut rt, conf, vec![pre_commit_a, pre_commit_b]).unwrap();

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -75,7 +75,7 @@ use multihash::MultihashDigest;
 use fil_actor_miner::testing::{
     check_deadline_state_invariants, check_state_invariants, DeadlineStateSummary,
 };
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryInto;
 use std::ops::Neg;
 
@@ -1633,12 +1633,12 @@ impl ActorHarness {
         &self,
         rt: &MockRuntime,
         st: &State,
-    ) -> HashMap<ChainEpoch, Vec<u64>> {
+    ) -> BTreeMap<ChainEpoch, Vec<u64>> {
         let quant = st.quant_spec_every_deadline(&rt.policy);
         let queue = BitFieldQueue::new(&rt.store, &st.pre_committed_sectors_cleanup, quant)
             .map_err(|e| e.downcast_wrap("failed to load pre-commit clean up queue"))
             .unwrap();
-        let mut expirations: HashMap<ChainEpoch, Vec<u64>> = HashMap::new();
+        let mut expirations: BTreeMap<ChainEpoch, Vec<u64>> = BTreeMap::new();
         queue
             .amt
             .for_each(|epoch, bf| {
@@ -1748,10 +1748,10 @@ impl ActorHarness {
         &self,
         rt: &MockRuntime,
         deadline: &Deadline,
-    ) -> HashMap<ChainEpoch, Vec<u64>> {
+    ) -> BTreeMap<ChainEpoch, Vec<u64>> {
         let queue =
             BitFieldQueue::new(&rt.store, &deadline.expirations_epochs, NO_QUANTIZATION).unwrap();
-        let mut expirations = HashMap::new();
+        let mut expirations = BTreeMap::new();
         queue
             .amt
             .for_each(|epoch, bitfield| {
@@ -1767,10 +1767,10 @@ impl ActorHarness {
         &self,
         rt: &MockRuntime,
         partition: &Partition,
-    ) -> HashMap<ChainEpoch, ExpirationSet> {
+    ) -> BTreeMap<ChainEpoch, ExpirationSet> {
         let queue = ExpirationQueue::new(&rt.store, &partition.expirations_epochs, NO_QUANTIZATION)
             .unwrap();
-        let mut expirations = HashMap::new();
+        let mut expirations = BTreeMap::new();
         queue
             .amt
             .for_each(|epoch, set| {
@@ -2276,14 +2276,14 @@ impl PreCommitConfig {
 
 #[derive(Default, Clone)]
 pub struct ProveCommitConfig {
-    pub verify_deals_exit: HashMap<SectorNumber, ExitCode>,
-    pub deal_weights: HashMap<SectorNumber, DealWeights>,
+    pub verify_deals_exit: BTreeMap<SectorNumber, ExitCode>,
+    pub deal_weights: BTreeMap<SectorNumber, DealWeights>,
 }
 
 #[allow(dead_code)]
 impl ProveCommitConfig {
     pub fn empty() -> ProveCommitConfig {
-        ProveCommitConfig { verify_deals_exit: HashMap::new(), deal_weights: HashMap::new() }
+        ProveCommitConfig { verify_deals_exit: BTreeMap::new(), deal_weights: BTreeMap::new() }
     }
 }
 


### PR DESCRIPTION
change hashmaps and hashsets to btreemaps and btreesets, based on #51 . 

There's a remaining issue to change hashmaps/sets with Addresses as keys. 
I think Addresses in [fvm_shared](https://github.com/filecoin-project/ref-fvm/tree/master/shared) should implement Ord for that.