### PR TITLE
demo: refactor blockstore into associated type

### DIFF
--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{actor_error, ActorContext, ActorError};
-use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::address::Address;
 use fvm_shared::ActorID;
 use fvm_shared::METHOD_SEND;
@@ -20,11 +19,10 @@ pub const CALLER_TYPES_SIGNABLE: &[Type] = &[Type::Account, Type::Multisig];
 /// ResolveToActorID resolves the given address to it's actor ID.
 /// If an actor ID for the given address dosen't exist yet, it tries to create one by sending
 /// a zero balance to the given address.
-pub fn resolve_to_actor_id<BS, RT>(rt: &mut RT, address: &Address) -> Result<ActorID, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+pub fn resolve_to_actor_id<BS, RT>(
+    rt: &mut impl Runtime,
+    address: &Address,
+) -> Result<ActorID, ActorError> {
     // if we are able to resolve it to an ID address, return the resolved address
     if let Some(id) = rt.resolve_address(address) {
         return Ok(id);

--- a/runtime/src/runtime/actor_code.rs
+++ b/runtime/src/runtime/actor_code.rs
@@ -11,7 +11,7 @@ use crate::{ActorError, Runtime};
 pub trait ActorCode {
     /// Invokes method with runtime on the actor's code. Method number will match one
     /// defined by the Actor, and parameters will be serialized and used in execution
-    fn invoke_method<BS, RT>(
+    fn invoke_method<RT>(
         rt: &mut RT,
         method: MethodNum,
         params: &RawBytes,
@@ -20,6 +20,6 @@ pub trait ActorCode {
         // TODO: remove the clone requirement on the blockstore when we fix "replica update" to not
         // hold onto state between transactions.
         // https://github.com/filecoin-project/builtin-actors/issues/133
-        BS: Blockstore + Clone,
-        RT: Runtime<BS>;
+        RT: Runtime,
+        RT::Blockstore: Blockstore + Clone;
 }

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -95,10 +95,12 @@ impl MessageInfo for FvmMessage {
     }
 }
 
-impl<B> Runtime<B> for FvmRuntime<B>
+impl<B> Runtime for FvmRuntime<B>
 where
     B: Blockstore,
 {
+    type Blockstore = B;
+
     fn network_version(&self) -> NetworkVersion {
         fvm::network::version()
     }

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -36,7 +36,9 @@ pub mod fvm;
 
 /// Runtime is the VM's internal runtime object.
 /// this is everything that is accessible to actors, beyond parameters.
-pub trait Runtime<BS: Blockstore>: Primitives + Verifier + RuntimePolicy {
+pub trait Runtime: Primitives + Verifier + RuntimePolicy {
+    type Blockstore: Blockstore;
+
     /// The network protocol version number at the current epoch.
     fn network_version(&self) -> NetworkVersion;
 
@@ -108,7 +110,7 @@ pub trait Runtime<BS: Blockstore>: Primitives + Verifier + RuntimePolicy {
         F: FnOnce(&mut C, &mut Self) -> Result<RT, ActorError>;
 
     /// Returns reference to blockstore
-    fn store(&self) -> &BS;
+    fn store(&self) -> &Self::Blockstore;
 
     /// Sends a message to another actor, returning the exit code and return value envelope.
     /// If the invoked method does not return successfully, its state changes


### PR DESCRIPTION
And use `impl Runtime` where possible. We don't use this in `invoke_method` so implementers can name the runtime if desired.

I'm making this PR for demo purposes this is something think we should change. However, it's a pretty invasive change.