### PR TITLE
fix: keep the embryo balance on deploy

### DIFF
--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -691,9 +691,12 @@ impl<'invocation, 'bs> Runtime<&'bs MemoryBlockstore> for InvocationCtx<'invocat
             }
         }
         let addr = Address::new_id(actor_id);
-        match self.v.get_actor(addr) {
-            Some(act) if act.code == *EMBRYO_ACTOR_CODE_ID => (),
-            None => (),
+        let actor = match self.v.get_actor(addr) {
+            Some(mut act) if act.code == *EMBRYO_ACTOR_CODE_ID => {
+                act.code = code_id;
+                act
+            }
+            None => actor(code_id, EMPTY_ARR_CID, 0, TokenAmount::zero()),
             _ => {
                 // can happen if an actor is deployed to an f4 address.
                 return Err(ActorError::unchecked(
@@ -701,9 +704,8 @@ impl<'invocation, 'bs> Runtime<&'bs MemoryBlockstore> for InvocationCtx<'invocat
                     "attempt to create new actor at existing address".to_string(),
                 ));
             }
-        }
-        let a = actor(code_id, EMPTY_ARR_CID, 0, TokenAmount::zero());
-        self.v.set_actor(addr, a);
+        };
+        self.v.set_actor(addr, actor);
         Ok(())
     }
 

--- a/test_vm/tests/init_test.rs
+++ b/test_vm/tests/init_test.rs
@@ -47,6 +47,9 @@ fn embryo_deploy() {
     let expect_id_addr = Address::new_id(FIRST_TEST_USER_ADDR);
     assert_embryo_actor(TokenAmount::from_atto(42u8), &v, expect_id_addr);
 
+    // Make sure we assigned the right f4 address.
+    assert_eq!(v.normalize_address(&addr).unwrap(), expect_id_addr);
+
     // Deploy a multisig to the embryo.
     let msig_ctor_params = serialize(
         &fil_actor_multisig::ConstructorParams {
@@ -82,6 +85,9 @@ fn embryo_deploy() {
         expect_id_addr, msig_ctor_ret.id_address,
         "expected actor to be deployed over embryo"
     );
+
+    // Make sure we kept the balance.
+    assert_eq!(v.get_actor(expect_id_addr).unwrap().balance, TokenAmount::from_atto(42u8));
 
     // Try to overwrite it.
     let msig_ctor_res = deploy();


### PR DESCRIPTION
create_actor was overwriting the actor when deploying over an embryo, instead of just changing the code id.