### PR TITLE
Optimization for #636 | Perform SHA256 hashes natively via a syscall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "aes"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +44,12 @@ name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -191,10 +208,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bellperson"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b6d7cc52a57ea764d8e9175c6684c6fe8e5d560db78f0f50ccd4ceac3857eb"
+dependencies = [
+ "bincode",
+ "bitvec 0.22.3",
+ "blake2s_simd 0.5.11",
+ "blstrs",
+ "byteorder",
+ "crossbeam-channel",
+ "digest 0.9.0",
+ "ec-gpu",
+ "ec-gpu-gen",
+ "ff",
+ "group",
+ "itertools 0.10.3",
+ "lazy_static",
+ "log",
+ "memmap",
+ "num_cpus",
+ "pairing",
+ "rand",
+ "rand_core",
+ "rayon",
+ "rustversion",
+ "serde",
+ "sha2 0.9.9",
+ "thiserror",
+ "yastl",
+]
+
+[[package]]
 name = "bimap"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -203,13 +262,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+dependencies = [
+ "funty 1.2.0",
+ "radium 0.6.2",
+ "tap",
+ "wyz 0.4.0",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty 2.0.0",
+ "radium 0.7.0",
+ "tap",
+ "wyz 0.5.0",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.7.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
  "constant_time_eq",
 ]
 
@@ -220,7 +314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.7.2",
  "constant_time_eq",
 ]
 
@@ -231,7 +325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.7.2",
  "cc",
  "cfg-if",
  "constant_time_eq",
@@ -256,6 +350,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,10 +373,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "bls-signatures"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6567c1a0c5578465c7d0d543d615a9fa05319556fa14e20d874e3ed4885bdd"
+dependencies = [
+ "blst",
+ "blstrs",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c521c26a784d5c4bcd98d483a7d3518376e9ff1efbcfa9e2d456ab8183752303"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "which",
+ "zeroize",
+]
+
+[[package]]
+name = "blstrs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ffb24e55817127673bd14f6874ce54b91b338cd0c7d3e4b0da2545f466c459"
+dependencies = [
+ "blst",
+ "byte-slice-cast",
+ "ec-gpu",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "serde",
+ "subtle",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c5fdd0166095e1d463fc6cc01aa8ce547ad77a4e84d42eb6762b084e28067e"
 
 [[package]]
 name = "byteorder"
@@ -295,6 +450,15 @@ name = "cache-padded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cbor4ii"
@@ -329,6 +493,16 @@ dependencies = [
  "serde",
  "serde_bytes",
  "unsigned-varint",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -380,6 +554,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ad70579325f1a38ea4c13412b82241c5900700a69785d73e2736bd65a33f86"
+dependencies = [
+ "async-trait",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +595,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "once_cell",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -570,6 +817,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +846,37 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "ec-gpu"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f1e64cf7ee95dacc8c739e0bf0b06583edaa8e0cee45b27ee2c08ae9343a2e"
+
+[[package]]
+name = "ec-gpu-gen"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1a11b4bfc7a0e48bb2b202a4d3dd2c31cfc9835062229ad332130105f34f82"
+dependencies = [
+ "bitvec 0.22.3",
+ "blstrs",
+ "crossbeam-channel",
+ "ec-gpu",
+ "execute",
+ "ff",
+ "group",
+ "hex",
+ "log",
+ "num_cpus",
+ "once_cell",
+ "pairing",
+ "rayon",
+ "sha2 0.10.5",
+ "temp-env",
+ "thiserror",
+ "yastl",
+]
 
 [[package]]
 name = "either"
@@ -622,12 +906,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "execute"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313431b1c5e3a6ec9b864333defee57d2ddb50de77abab419e4baedb6cdff292"
+dependencies = [
+ "execute-command-macro",
+ "execute-command-tokens",
+ "generic-array",
+]
+
+[[package]]
+name = "execute-command-macro"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5fbc65a0cf735106743f4c38c9a3671c1e734b5c2c20d21a3c93c696daa3157"
+dependencies = [
+ "execute-command-macro-impl",
+]
+
+[[package]]
+name = "execute-command-macro-impl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5109f6bc9cd57feda665da326f3f6c57e0498c8fe9f7d12d7b8abc96719ca91b"
+dependencies = [
+ "execute-command-tokens",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "execute-command-tokens"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba569491c70ec8471e34aa7e9c0b9e82bb5d2464c0398442d17d3c4af814e5a"
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fdlimit"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4c9e43643f5a3be4ca5b67d26b98031ff9db6806c3440ae32e02e3ceac3f1b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
+dependencies = [
+ "bitvec 1.0.1",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -681,7 +1028,7 @@ name = "fil_actor_evm"
 version = "10.0.0-alpha.1"
 dependencies = [
  "anyhow",
- "arrayvec",
+ "arrayvec 0.7.2",
  "bytes",
  "cid",
  "derive_more",
@@ -743,7 +1090,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
- "itertools",
+ "itertools 0.10.3",
  "libipld-core",
  "log",
  "multihash",
@@ -771,7 +1118,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
- "itertools",
+ "itertools 0.10.3",
  "lazy_static",
  "log",
  "multihash",
@@ -902,7 +1249,7 @@ dependencies = [
  "fvm_sdk",
  "fvm_shared",
  "hex",
- "itertools",
+ "itertools 0.10.3",
  "lazy_static",
  "libsecp256k1",
  "log",
@@ -969,6 +1316,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "filecoin-hashers"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22043e76604b4fe353a66a002b149e2ace3f8a0f8a1bb2ad5b01501ff805a221"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "blstrs",
+ "ff",
+ "generic-array",
+ "hex",
+ "lazy_static",
+ "merkletree",
+ "neptune",
+ "rand",
+ "serde",
+ "sha2 0.10.5",
+]
+
+[[package]]
+name = "filecoin-proofs"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1252bda62b0389976108642edb613eca3abafd712342d64dccee404fe78ff3d"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "bincode",
+ "blake2b_simd",
+ "blstrs",
+ "filecoin-hashers",
+ "fr32",
+ "generic-array",
+ "hex",
+ "lazy_static",
+ "log",
+ "memmap",
+ "merkletree",
+ "once_cell",
+ "rand",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha2 0.10.5",
+ "storage-proofs-core",
+ "storage-proofs-porep",
+ "storage-proofs-post",
+ "storage-proofs-update",
+ "typenum",
+]
+
+[[package]]
+name = "filecoin-proofs-api"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5cae97f440f20aa8f4838f521c857d36163e958d96ba7cb18f4822d07c87f06"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "bincode",
+ "blstrs",
+ "filecoin-hashers",
+ "filecoin-proofs",
+ "fr32",
+ "lazy_static",
+ "serde",
+ "storage-proofs-core",
+ "storage-proofs-porep",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,20 +1396,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "spin 0.9.4",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "forest_hash_utils"
-version = "0.1.0"
+name = "fr32"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb061ad769411763a5d6ae39d596696657472b25a66387fbb0ba8c133bb6575"
+checksum = "2a708283c98a2736ae1f4237e0515b1e8f31467bb148d88368087a4d9af7b817"
 dependencies = [
- "cs_serde_bytes",
- "serde",
+ "anyhow",
+ "blstrs",
+ "byte-slice-cast",
+ "byteorder",
+ "ff",
+ "thiserror",
 ]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "funty"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1100,15 +1553,13 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d09e5aa7de45452676d18fcb70b750acd65faae7a4fe18fe784b4c85f869fb"
 dependencies = [
  "ahash",
  "anyhow",
  "cid",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "itertools",
+ "itertools 0.10.3",
  "once_cell",
  "serde",
  "thiserror",
@@ -1116,9 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_bitfield"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1587207c7455ea70a762d4360f502b6728ea6e2dfbec2b66b6d4d943ee29ae"
+version = "0.5.3"
 dependencies = [
  "cs_serde_bytes",
  "fvm_ipld_encoding",
@@ -1130,8 +1579,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688239a96199577f6705a3f9689abfd795f867f91f5847bc7e236017cc672df7"
 dependencies = [
  "anyhow",
  "cid",
@@ -1156,8 +1603,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9cfcb4ae444801009182fded790dd56aff9c9a567e54510e2ccf14fb9daf8e"
 dependencies = [
  "anyhow",
  "cid",
@@ -1174,16 +1619,15 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b5c939897aa1bfd63e7cb9c458ba10689371af3278ff20d66c6f8ca152c6c0"
 dependencies = [
  "anyhow",
  "byteorder",
  "cid",
  "cs_serde_bytes",
- "forest_hash_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
+ "fvm_shared",
+ "lazy_static",
  "libipld-core",
  "multihash",
  "once_cell",
@@ -1195,8 +1639,6 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.0.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f90eee234e07d5879e174167700a14bfcf2b87965fdacf94e98871a37126db"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -1209,20 +1651,21 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261314c3de2e9d6d479977dfba985d38e05cacf59de1dc412e92aab6ccd61d51"
+version = "3.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "blake2b_simd",
+ "bls-signatures",
  "byteorder",
  "cid",
  "cs_serde_bytes",
  "data-encoding",
  "data-encoding-macro",
+ "filecoin-proofs-api",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "lazy_static",
+ "libsecp256k1",
  "log",
  "multihash",
  "num-bigint",
@@ -1258,6 +1701,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1716,20 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
+dependencies = [
+ "byteorder",
+ "ff",
+ "rand",
+ "rand_core",
+ "rand_xorshift",
+ "subtle",
 ]
 
 [[package]]
@@ -1303,6 +1766,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array",
+ "hmac",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1813,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1839,15 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 dependencies = [
  "async-trait",
  "futures-util",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1392,7 +1895,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -1425,12 +1928,14 @@ dependencies = [
  "arrayref",
  "base64",
  "digest 0.9.0",
+ "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand",
  "serde",
  "sha2 0.9.9",
+ "typenum",
 ]
 
 [[package]]
@@ -1463,6 +1968,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,10 +1988,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "mapr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a28a55dbc005b2f6f123c4058933d57add373d362f6fd3a76aab4fe6973500"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "merkletree"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d348b5b0d1707be1c8a727b7078daa08e2a3051d63b35715a19c35a324d2aaac"
+dependencies = [
+ "anyhow",
+ "arrayref",
+ "log",
+ "memmap2",
+ "positioned-io",
+ "rayon",
+ "serde",
+ "tempfile",
+ "typenum",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "multibase"
@@ -1496,7 +2072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
  "blake2b_simd",
- "blake2s_simd",
+ "blake2s_simd 1.0.0",
  "blake3",
  "core2",
  "digest 0.10.3",
@@ -1531,6 +2107,37 @@ dependencies = [
  "crypto-mac",
  "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "neptune"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f084020da67b848b63d8f8983be641c83c8fe40b8c81f30018212c9900add81"
+dependencies = [
+ "bellperson",
+ "blake2s_simd 0.5.11",
+ "blstrs",
+ "byteorder",
+ "execute",
+ "ff",
+ "generic-array",
+ "hex",
+ "itertools 0.8.2",
+ "lazy_static",
+ "log",
+ "pasta_curves",
+ "sha2 0.9.9",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1621,6 +2228,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,10 +2256,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "pairing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+dependencies = [
+ "group",
+]
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
+name = "pasta_curves"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369d7785168ad7ff0cbe467d968ca3e19a927d8536b11ef9c21b4e454b15ba42"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pest"
@@ -1715,10 +2371,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "positioned-io"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173e3686d2cec75681bebc1d84d8ed1e22a0336ccde102ac1d2d134679173ad8"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -1774,6 +2453,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,6 +2495,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,6 +2552,15 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "ripemd"
@@ -2004,6 +2746,31 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.3",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf27176fb5d15398e3a479c652c20459d9dac830dedd1fa55b42a77dbcdbfcea"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "sha2raw"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab959e1821a9d2978fbf115214d882f9e7464f4717b0a579d62b6ac598f8ae4"
+dependencies = [
+ "byteorder",
+ "cpufeatures",
+ "digest 0.10.3",
+ "fake-simd",
+ "lazy_static",
+ "opaque-debug",
+ "sha2-asm",
 ]
 
 [[package]]
@@ -2064,10 +2831,139 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "storage-proofs-core"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e041abad726ba8ee539de94a3b721dc91bae121a77566e817d55ef37d0a86d2c"
+dependencies = [
+ "aes",
+ "anyhow",
+ "bellperson",
+ "blake2b_simd",
+ "blstrs",
+ "byteorder",
+ "cbc",
+ "config",
+ "ff",
+ "filecoin-hashers",
+ "fr32",
+ "fs2",
+ "generic-array",
+ "itertools 0.10.3",
+ "lazy_static",
+ "log",
+ "memmap",
+ "merkletree",
+ "num_cpus",
+ "rand",
+ "rand_chacha",
+ "rayon",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2 0.10.5",
+ "thiserror",
+]
+
+[[package]]
+name = "storage-proofs-porep"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da8ba79e585224937a22678aa6d240bf64cc4605f5dc6a5f38663b444b9414d6"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "bincode",
+ "blstrs",
+ "byte-slice-cast",
+ "byteorder",
+ "crossbeam",
+ "fdlimit",
+ "ff",
+ "filecoin-hashers",
+ "fr32",
+ "generic-array",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "mapr",
+ "merkletree",
+ "neptune",
+ "num-bigint",
+ "num-traits",
+ "num_cpus",
+ "pretty_assertions",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha2 0.10.5",
+ "sha2raw",
+ "storage-proofs-core",
+ "yastl",
+]
+
+[[package]]
+name = "storage-proofs-post"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06b7da2ac5f7803aa11e214c27839dff8c713f91b976a7e35e87e5081714b80"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "blake2b_simd",
+ "blstrs",
+ "byteorder",
+ "ff",
+ "filecoin-hashers",
+ "fr32",
+ "generic-array",
+ "hex",
+ "log",
+ "rayon",
+ "serde",
+ "sha2 0.10.5",
+ "storage-proofs-core",
+]
+
+[[package]]
+name = "storage-proofs-update"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ea43ecc885405d75a81e8988ce332b53f105e9f1a494753288e2efb4a2f1458"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "blstrs",
+ "ff",
+ "filecoin-hashers",
+ "fr32",
+ "generic-array",
+ "lazy_static",
+ "log",
+ "memmap",
+ "merkletree",
+ "neptune",
+ "rayon",
+ "serde",
+ "storage-proofs-core",
+ "storage-proofs-porep",
+]
 
 [[package]]
 name = "strsim"
@@ -2134,6 +3030,35 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "temp-env"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45107136c2ddf8c4b87453c02294fd0adf41751796e81e8ba3f7fd951977ab57"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -2210,6 +3135,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -2377,6 +3311,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2406,3 +3351,58 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yastl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca6c5a4d66c1a9ea261811cf4773c27343de7e5033e1b75ea3f297dc7db3c1a"
+dependencies = [
+ "flume",
+ "scopeguard",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,26 +54,27 @@ members = [
      "test_vm",
 ]
 
-#[patch.crates-io]
-#fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm" }
+# [patch.crates-io]
+# fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm" }
+# fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm" }
+# fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm" }
+# fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm" }
+# fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm" }
+# fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm" }
+# fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm" }
 
 ## Uncomment when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
 ## (Valid while FVM modules aren't published to crates.io)
-#[patch."https://github.com/filecoin-project/ref-fvm"]
-#fvm_shared = { path = "../ref-fvm/shared" }
-#fvm_sdk = { path = "../ref-fvm/sdk" }
-#fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
-#fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
-#fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
-#fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
-#fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
+# [patch."https://github.com/filecoin-project/ref-fvm"]
+[patch.crates-io]
+fvm_shared = { path = "../ref-fvm/shared" }
+fvm_sdk = { path = "../ref-fvm/sdk" }
+fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
+fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
+fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
+fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
+fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
 
 ## Uncomment entries below when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.

--- a/actors/evm/src/interpreter/uints.rs
+++ b/actors/evm/src/interpreter/uints.rs
@@ -5,7 +5,7 @@
 
 use {
     fvm_shared::bigint::BigInt, fvm_shared::econ::TokenAmount, impl_serde::impl_uint_serde,
-    std::cmp::Ordering, uint::construct_uint,
+    std::cmp::Ordering, std::hash::Hasher, uint::construct_uint,
 };
 
 construct_uint! { pub struct U256(4); } // ethereum word size
@@ -35,7 +35,7 @@ impl_uint_serde!(U512, 8);
 macro_rules! impl_hamt_hash {
     ($type:ident) => {
         impl fvm_ipld_hamt::Hash for $type {
-            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            fn hash(&self, state: &mut dyn Hasher) {
                 self.0.hash(state);
             }
         }

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -14,7 +14,7 @@ use {
     fvm_ipld_blockstore::Blockstore,
     fvm_ipld_encoding::tuple::*,
     fvm_ipld_encoding::RawBytes,
-    fvm_ipld_hamt::Hamt,
+    fvm_ipld_hamt::{Hamt},
     fvm_shared::error::*,
     fvm_shared::{MethodNum, METHOD_CONSTRUCTOR},
     num_derive::FromPrimitive,
@@ -112,7 +112,10 @@ impl EvmContractActor {
         } else if let StatusCode::ActorError(e) = exec_status.status_code {
             Err(e)
         } else {
-            Err(ActorError::unspecified("EVM constructor failed".to_string()))
+            Err(ActorError::unspecified(format!(
+                "EVM constructor failed: {}",
+                exec_status.status_code
+            )))
         }
     }
 

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -87,7 +87,7 @@ impl Actor {
         // Allocate an ID for this actor.
         // Store mapping of pubkey or actor address to actor ID
         let id_address: ActorID = rt.transaction(|s: &mut State, rt| {
-            s.map_address_to_new_id(rt.store(), &robust_address).map_err(|e| {
+            s.map_address_to_new_id(rt.store(), &robust_address, rt).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to allocate ID address")
             })
         })?;

--- a/actors/init/src/state.rs
+++ b/actors/init/src/state.rs
@@ -13,6 +13,7 @@ use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 #[cfg(feature = "m2-native")]
 use fvm_ipld_encoding::CborStore;
+use fvm_ipld_hamt::HashAlgorithm;
 use fvm_shared::address::{Address, Protocol};
 use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
 
@@ -50,12 +51,13 @@ impl State {
         &mut self,
         store: &BS,
         addr: &Address,
+        hash_algo: &dyn HashAlgorithm,
     ) -> anyhow::Result<ActorID> {
         let id = self.next_id;
         self.next_id += 1;
 
         let mut map = make_map_with_root_and_bitwidth(&self.address_map, store, HAMT_BIT_WIDTH)?;
-        let is_new = map.set_if_absent(addr.to_bytes().into(), id)?;
+        let is_new = map.set_if_absent(addr.to_bytes().into(), id, hash_algo)?;
         if !is_new {
             // this is impossible today as the robust address is a hash of unique inputs
             // but in close future predictable address generation will make this possible
@@ -84,6 +86,7 @@ impl State {
         &self,
         store: &BS,
         addr: &Address,
+        hash_algo: &dyn HashAlgorithm,
     ) -> anyhow::Result<Option<Address>> {
         if addr.protocol() == Protocol::ID {
             return Ok(Some(*addr));
@@ -91,7 +94,7 @@ impl State {
 
         let map = make_map_with_root_and_bitwidth(&self.address_map, store, HAMT_BIT_WIDTH)?;
 
-        Ok(map.get(&addr.to_bytes())?.copied().map(Address::new_id))
+        Ok(map.get(&addr.to_bytes(), hash_algo)?.copied().map(Address::new_id))
     }
 
     /// Check to see if an actor is already installed

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -148,7 +148,7 @@ fn create_2_payment_channels() {
 
         let state: State = rt.get_state();
         let returned_address = state
-            .resolve_address(&rt.store, &unique_address)
+            .resolve_address(&rt.store, &unique_address, &rt)
             .expect("Resolve should not error")
             .expect("Address should be able to be resolved");
 
@@ -192,7 +192,7 @@ fn create_storage_miner() {
     // Address should be resolved
     let state: State = rt.get_state();
     let returned_address = state
-        .resolve_address(&rt.store, &unique_address)
+        .resolve_address(&rt.store, &unique_address, &rt)
         .expect("Resolve should not error")
         .expect("Address should be able to be resolved");
     assert_eq!(expected_id_addr, returned_address);
@@ -200,7 +200,7 @@ fn create_storage_miner() {
     // Should return error since the address of flurbo is unknown
     let unknown_addr = Address::new_actor(b"flurbo");
 
-    let returned_address = state.resolve_address(&rt.store, &unknown_addr).unwrap();
+    let returned_address = state.resolve_address(&rt.store, &unknown_addr, &rt).unwrap();
     assert_eq!(returned_address, None, "Addresses should have not been found");
     check_state(&rt);
 }
@@ -282,7 +282,7 @@ fn sending_constructor_failure() {
 
     let state: State = rt.get_state();
 
-    let returned_address = state.resolve_address(&rt.store, &unique_address).unwrap();
+    let returned_address = state.resolve_address(&rt.store, &unique_address, &rt).unwrap();
     assert_eq!(returned_address, None, "Addresses should have not been found");
     check_state(&rt);
 }

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -43,7 +43,7 @@ fn test_remove_all_error() {
     let market_actor = Address::new_id(100);
     let rt = MockRuntime { receiver: market_actor, ..Default::default() };
 
-    SetMultimap::new(&rt.store()).remove_all(42).expect("expected no error");
+    SetMultimap::new(&rt.store()).remove_all(42, &rt).expect("expected no error");
 }
 
 // TODO add array stuff
@@ -607,15 +607,15 @@ fn deal_starts_on_day_boundary() {
     let store = &rt.store;
     let dobe = SetMultimap::from_root(store, &st.deal_ops_by_epoch).unwrap();
     for e in deal_updates_interval..(2 * deal_updates_interval) {
-        assert_n_good_deals(&dobe, e, 3);
+        assert_n_good_deals(&rt, &dobe, e, 3);
     }
 
     // DOBE has no deals scheduled in the previous or next day
     for e in 0..deal_updates_interval {
-        assert_n_good_deals(&dobe, e, 0);
+        assert_n_good_deals(&rt, &dobe, e, 0);
     }
     for e in (2 * deal_updates_interval)..(3 * deal_updates_interval) {
-        assert_n_good_deals(&dobe, e, 0);
+        assert_n_good_deals(&rt, &dobe, e, 0);
     }
 }
 
@@ -646,11 +646,11 @@ fn deal_starts_partway_through_day() {
     let store = &rt.store;
     let dobe = SetMultimap::from_root(store, &st.deal_ops_by_epoch).unwrap();
     for e in 2880..(2880 + start_epoch) {
-        assert_n_good_deals(&dobe, e, 1);
+        assert_n_good_deals(&rt, &dobe, e, 1);
     }
     // Nothing scheduled between 0 and 2880
     for e in 0..2880 {
-        assert_n_good_deals(&dobe, e, 0);
+        assert_n_good_deals(&rt, &dobe, e, 0);
     }
 
     // Now add another 500 deals
@@ -671,7 +671,7 @@ fn deal_starts_partway_through_day() {
     let store = &rt.store;
     let dobe = SetMultimap::from_root(store, &st.deal_ops_by_epoch).unwrap();
     for e in start_epoch..(start_epoch + 500) {
-        assert_n_good_deals(&dobe, e, 1);
+        assert_n_good_deals(&rt, &dobe, e, 1);
     }
 }
 

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -704,7 +704,7 @@ impl Actor {
         )?;
         let store = rt.store();
         let precommits =
-            state.get_all_precommitted_sectors(store, sector_numbers).map_err(|e| {
+            state.get_all_precommitted_sectors(store, sector_numbers, rt).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get precommits")
             })?;
 
@@ -1755,7 +1755,7 @@ impl Actor {
                 .map_err(|e|
                     e.wrap("failed to allocate sector numbers")
                 )?;
-            state.put_precommitted_sectors(store, chain_infos)
+            state.put_precommitted_sectors(store, chain_infos, rt)
                 .map_err(|e|
                     e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to write pre-committed sectors")
                 )?;
@@ -1803,7 +1803,7 @@ impl Actor {
 
         let st: State = rt.state()?;
         let precommit = st
-            .get_precommitted_sector(rt.store(), sector_number)
+            .get_precommitted_sector(rt.store(), sector_number, rt)
             .map_err(|e| {
                 e.downcast_default(
                     ExitCode::USR_ILLEGAL_STATE,
@@ -1895,7 +1895,7 @@ impl Actor {
         let store = rt.store();
         // This skips missing pre-commits.
         let precommited_sectors =
-            st.find_precommitted_sectors(store, &params.sectors).map_err(|e| {
+            st.find_precommitted_sectors(store, &params.sectors, rt).map_err(|e| {
                 e.downcast_default(
                     ExitCode::USR_ILLEGAL_STATE,
                     "failed to load pre-committed sectors",
@@ -3394,7 +3394,7 @@ where
         process_pending_worker(&mut info, rt, state)?;
 
         let deposit_to_burn = state
-            .cleanup_expired_pre_commits(policy, rt.store(), rt.curr_epoch())
+            .cleanup_expired_pre_commits(policy, rt.store(), rt.curr_epoch(), rt)
             .map_err(|e| {
                 e.downcast_default(
                     ExitCode::USR_ILLEGAL_STATE,
@@ -4356,7 +4356,7 @@ where
             e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to put new sectors")
         })?;
 
-        state.delete_precommitted_sectors(store, &new_sector_numbers).map_err(|e| {
+        state.delete_precommitted_sectors(store, &new_sector_numbers, rt).map_err(|e| {
             e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to delete precommited sectors")
         })?;
 

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -17,7 +17,7 @@ use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{serde_bytes, BytesDe, Cbor, CborStore};
-use fvm_ipld_hamt::Error as HamtError;
+use fvm_ipld_hamt::{Error as HamtError, HashAlgorithm};
 use fvm_shared::address::Address;
 
 use fvm_shared::clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED};
@@ -288,13 +288,14 @@ impl State {
         &mut self,
         store: &BS,
         precommits: Vec<SectorPreCommitOnChainInfo>,
+        hash_algo: &dyn HashAlgorithm,
     ) -> anyhow::Result<()> {
         let mut precommitted =
             make_map_with_root_and_bitwidth(&self.pre_committed_sectors, store, HAMT_BIT_WIDTH)?;
         for precommit in precommits.into_iter() {
             let sector_no = precommit.info.sector_number;
             let modified = precommitted
-                .set_if_absent(u64_key(precommit.info.sector_number), precommit)
+                .set_if_absent(u64_key(precommit.info.sector_number), precommit, hash_algo)
                 .map_err(|e| {
                     e.downcast_wrap(format!("failed to store precommitment for {:?}", sector_no,))
                 })?;
@@ -311,10 +312,11 @@ impl State {
         &self,
         store: &BS,
         sector_num: SectorNumber,
+        hash_algo: &dyn HashAlgorithm,
     ) -> Result<Option<SectorPreCommitOnChainInfo>, HamtError> {
         let precommitted =
             make_map_with_root_and_bitwidth(&self.pre_committed_sectors, store, HAMT_BIT_WIDTH)?;
-        Ok(precommitted.get(&u64_key(sector_num))?.cloned())
+        Ok(precommitted.get(&u64_key(sector_num), hash_algo)?.cloned())
     }
 
     /// Gets and returns the requested pre-committed sectors, skipping missing sectors.
@@ -322,6 +324,7 @@ impl State {
         &self,
         store: &BS,
         sector_numbers: &[SectorNumber],
+        hash_algo: &dyn HashAlgorithm,
     ) -> anyhow::Result<Vec<SectorPreCommitOnChainInfo>> {
         let precommitted = make_map_with_root_and_bitwidth::<_, SectorPreCommitOnChainInfo>(
             &self.pre_committed_sectors,
@@ -331,7 +334,7 @@ impl State {
         let mut result = Vec::with_capacity(sector_numbers.len());
 
         for &sector_number in sector_numbers {
-            let info = match precommitted.get(&u64_key(sector_number)).map_err(|e| {
+            let info = match precommitted.get(&u64_key(sector_number), hash_algo).map_err(|e| {
                 e.downcast_wrap(format!("failed to load precommitment for {}", sector_number))
             })? {
                 Some(info) => info.clone(),
@@ -348,6 +351,7 @@ impl State {
         &mut self,
         store: &BS,
         sector_nums: &[SectorNumber],
+        hash_algo: &dyn HashAlgorithm,
     ) -> Result<(), HamtError> {
         let mut precommitted = make_map_with_root_and_bitwidth::<_, SectorPreCommitOnChainInfo>(
             &self.pre_committed_sectors,
@@ -356,7 +360,7 @@ impl State {
         )?;
 
         for &sector_num in sector_nums {
-            let prev_entry = precommitted.delete(&u64_key(sector_num))?;
+            let prev_entry = precommitted.delete(&u64_key(sector_num), hash_algo)?;
             if prev_entry.is_none() {
                 return Err(format!("sector {} doesn't exist", sector_num).into());
             }
@@ -1035,6 +1039,7 @@ impl State {
         policy: &Policy,
         store: &BS,
         current_epoch: ChainEpoch,
+        hash_algo: &dyn HashAlgorithm,
     ) -> anyhow::Result<TokenAmount> {
         let mut deposit_to_burn = TokenAmount::zero();
 
@@ -1056,7 +1061,7 @@ impl State {
         for i in sectors.iter() {
             let sector_number = i as SectorNumber;
 
-            let sector = match self.get_precommitted_sector(store, sector_number)? {
+            let sector = match self.get_precommitted_sector(store, sector_number, hash_algo)? {
                 Some(sector) => sector,
                 // already committed/deleted
                 None => continue,
@@ -1071,7 +1076,7 @@ impl State {
 
         // Actually delete it.
         if !precommits_to_delete.is_empty() {
-            self.delete_precommitted_sectors(store, &precommits_to_delete)?;
+            self.delete_precommitted_sectors(store, &precommits_to_delete, hash_algo)?;
         }
 
         self.pre_commit_deposits -= &deposit_to_burn;
@@ -1173,6 +1178,7 @@ impl State {
         &self,
         store: &BS,
         sector_nos: &BitField,
+        hash_algo: &dyn HashAlgorithm,
     ) -> anyhow::Result<Vec<SectorPreCommitOnChainInfo>> {
         let mut precommits = Vec::new();
         let precommitted =
@@ -1183,10 +1189,9 @@ impl State {
                     actor_error!(illegal_argument; "sector number greater than maximum").into()
                 );
             }
-            let info: &SectorPreCommitOnChainInfo =
-                precommitted
-                    .get(&u64_key(sector_no as u64))?
-                    .ok_or_else(|| actor_error!(not_found, "sector {} not found", sector_no))?;
+            let info: &SectorPreCommitOnChainInfo = precommitted
+                .get(&u64_key(sector_no as u64), hash_algo)?
+                .ok_or_else(|| actor_error!(not_found, "sector {} not found", sector_no))?;
             precommits.push(info.clone());
         }
         Ok(precommits)

--- a/actors/miner/tests/precommitted_sector_stores.rs
+++ b/actors/miner/tests/precommitted_sector_stores.rs
@@ -15,56 +15,61 @@ use state_harness::*;
 fn put_get_and_delete() {
     let mut h = StateHarness::new(0);
 
+    let rt = h.new_runtime();
+
     let pc1 =
         new_pre_commit_on_chain(1, make_sealed_cid("1".as_bytes()), TokenAmount::from_atto(1), 1);
-    h.put_precommitted_sectors(vec![pc1.clone()]).unwrap();
-    assert_eq!(pc1, h.get_precommit(1));
+    h.put_precommitted_sectors(&rt, vec![pc1.clone()]).unwrap();
+    assert_eq!(pc1, h.get_precommit(&rt, 1));
 
     let pc2 =
         new_pre_commit_on_chain(2, make_sealed_cid("2".as_bytes()), TokenAmount::from_atto(1), 1);
-    h.put_precommitted_sectors(vec![pc2.clone()]).unwrap();
-    assert_eq!(pc2, h.get_precommit(2));
+    h.put_precommitted_sectors(&rt, vec![pc2.clone()]).unwrap();
+    assert_eq!(pc2, h.get_precommit(&rt, 2));
 
     let pc3 =
         new_pre_commit_on_chain(3, make_sealed_cid("2".as_bytes()), TokenAmount::from_atto(1), 1);
     let pc4 =
         new_pre_commit_on_chain(4, make_sealed_cid("2".as_bytes()), TokenAmount::from_atto(1), 1);
-    h.put_precommitted_sectors(vec![pc3.clone(), pc4.clone()]).unwrap();
-    assert_eq!(pc3, h.get_precommit(3));
-    assert_eq!(pc4, h.get_precommit(4));
+    h.put_precommitted_sectors(&rt, vec![pc3.clone(), pc4.clone()]).unwrap();
+    assert_eq!(pc3, h.get_precommit(&rt, 3));
+    assert_eq!(pc4, h.get_precommit(&rt, 4));
 
-    h.delete_precommitted_sectors(&[1]).unwrap();
-    assert!(!h.has_precommit(1));
-    assert!(h.has_precommit(2));
+    h.delete_precommitted_sectors(&rt, &[1]).unwrap();
+    assert!(!h.has_precommit(&rt, 1));
+    assert!(h.has_precommit(&rt, 2));
 }
 
 #[test]
 fn delete_nonexistent_value_returns_an_error() {
     let mut h = StateHarness::new(0);
-    assert!(h.delete_precommitted_sectors(&[1]).is_err());
+    let rt = h.new_runtime();
+    assert!(h.delete_precommitted_sectors(&rt, &[1]).is_err());
 }
 
 #[test]
 fn has_nonexistent_value_returns_false() {
     let h = StateHarness::new(0);
-    assert!(!h.has_precommit(1));
+    let rt = h.new_runtime();
+    assert!(!h.has_precommit(&rt, 1));
 }
 
 #[test]
 fn duplicate_put_rejected() {
     let mut h = StateHarness::new(0);
+    let rt = h.new_runtime();
 
     let pc1 =
         new_pre_commit_on_chain(1, make_sealed_cid("1".as_bytes()), TokenAmount::from_atto(1), 1);
 
     // In sequence
-    assert!(h.put_precommitted_sectors(vec![pc1.clone()]).is_ok());
-    assert!(h.put_precommitted_sectors(vec![pc1]).is_err());
+    assert!(h.put_precommitted_sectors(&rt, vec![pc1.clone()]).is_ok());
+    assert!(h.put_precommitted_sectors(&rt, vec![pc1]).is_err());
 
     // In batch
     let pc2 =
         new_pre_commit_on_chain(2, make_sealed_cid("2".as_bytes()), TokenAmount::from_atto(1), 1);
-    assert!(h.put_precommitted_sectors(vec![pc2.clone(), pc2]).is_err());
+    assert!(h.put_precommitted_sectors(&rt, vec![pc2.clone(), pc2]).is_err());
 }
 
 fn new_pre_commit_on_chain(

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -107,7 +107,7 @@ fn prove_single_sector() {
 
     // expect precommit to have been removed
     let st = h.get_state(&rt);
-    let found = st.get_precommitted_sector(&rt.store, sector_no).unwrap();
+    let found = st.get_precommitted_sector(&rt.store, sector_no, &rt).unwrap();
     assert!(found.is_none());
 
     // expect deposit to have been transferred to initial pledges

--- a/actors/miner/tests/state_harness.rs
+++ b/actors/miner/tests/state_harness.rs
@@ -61,27 +61,33 @@ impl StateHarness {
     #[allow(dead_code)]
     pub fn put_precommitted_sectors(
         &mut self,
+        rt: &MockRuntime,
         precommits: Vec<SectorPreCommitOnChainInfo>,
     ) -> anyhow::Result<()> {
-        self.st.put_precommitted_sectors(&self.store, precommits)
+        self.st.put_precommitted_sectors(&self.store, precommits, rt)
     }
 
     #[allow(dead_code)]
     pub fn delete_precommitted_sectors(
         &mut self,
+        rt: &MockRuntime,
         sector_nums: &[SectorNumber],
     ) -> Result<(), HamtError> {
-        self.st.delete_precommitted_sectors(&self.store, sector_nums)
+        self.st.delete_precommitted_sectors(&self.store, sector_nums, rt)
     }
 
     #[allow(dead_code)]
-    pub fn get_precommit(&self, sector_number: SectorNumber) -> SectorPreCommitOnChainInfo {
-        self.st.get_precommitted_sector(&self.store, sector_number).unwrap().unwrap()
+    pub fn get_precommit(
+        &self,
+        rt: &MockRuntime,
+        sector_number: SectorNumber,
+    ) -> SectorPreCommitOnChainInfo {
+        self.st.get_precommitted_sector(&self.store, sector_number, rt).unwrap().unwrap()
     }
 
     #[allow(dead_code)]
-    pub fn has_precommit(&self, sector_number: SectorNumber) -> bool {
-        self.st.get_precommitted_sector(&self.store, sector_number).unwrap().is_some()
+    pub fn has_precommit(&self, rt: &MockRuntime, sector_number: SectorNumber) -> bool {
+        self.st.get_precommitted_sector(&self.store, sector_number, rt).unwrap().is_some()
     }
 
     #[allow(dead_code)]

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -653,7 +653,7 @@ impl ActorHarness {
 
     pub fn has_precommit(&self, rt: &MockRuntime, sector_number: SectorNumber) -> bool {
         let state = self.get_state(rt);
-        state.get_precommitted_sector(&rt.store, sector_number).unwrap().is_some()
+        state.get_precommitted_sector(&rt.store, sector_number, rt).unwrap().is_some()
     }
 
     pub fn get_precommit(
@@ -662,7 +662,7 @@ impl ActorHarness {
         sector_number: SectorNumber,
     ) -> SectorPreCommitOnChainInfo {
         let state = self.get_state(rt);
-        state.get_precommitted_sector(&rt.store, sector_number).unwrap().unwrap()
+        state.get_precommitted_sector(&rt.store, sector_number, rt).unwrap().unwrap()
     }
 
     pub fn expect_query_network_info(&self, rt: &mut MockRuntime) {

--- a/actors/multisig/src/state.rs
+++ b/actors/multisig/src/state.rs
@@ -6,6 +6,7 @@ use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
+use fvm_ipld_hamt::HashAlgorithm;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::bigint::Integer;
@@ -75,6 +76,7 @@ impl State {
         &mut self,
         store: &BS,
         addr: &Address,
+        hash_algo: &dyn HashAlgorithm,
     ) -> anyhow::Result<()> {
         let mut txns = make_map_with_root(&self.pending_txs, store)?;
 
@@ -94,9 +96,9 @@ impl State {
             txn.approved.retain(|approver| approver != addr);
 
             if !txn.approved.is_empty() {
-                txns.set(tx_id.into(), txn)?;
+                txns.set(tx_id.into(), txn, hash_algo)?;
             } else {
-                txns.delete(&tx_id)?;
+                txns.delete(&tx_id, hash_algo)?;
             }
         }
 

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -222,7 +222,7 @@ impl Harness {
         let st: State = rt.get_state();
         let claims =
             make_map_with_root_and_bitwidth(&st.claims, rt.store(), HAMT_BIT_WIDTH).unwrap();
-        claims.get(&miner.to_bytes()).unwrap().cloned()
+        claims.get(&miner.to_bytes(), rt).unwrap().cloned()
     }
 
     pub fn delete_claim(&mut self, rt: &mut MockRuntime, miner: &Address) {
@@ -231,7 +231,7 @@ impl Harness {
         let mut claims =
             make_map_with_root_and_bitwidth::<_, Claim>(&state.claims, rt.store(), HAMT_BIT_WIDTH)
                 .unwrap();
-        claims.delete(&miner.to_bytes()).expect("Failed to delete claim");
+        claims.delete(&miner.to_bytes(), rt).expect("Failed to delete claim");
         state.claims = claims.flush().unwrap();
 
         rt.replace_state(&state);
@@ -268,10 +268,14 @@ impl Harness {
 
         let mut events: Vec<CronEvent> = Vec::new();
         events_map
-            .for_each::<_, CronEvent>(&epoch_key(epoch), |_, v| {
-                events.push(v.to_owned());
-                Ok(())
-            })
+            .for_each::<_, CronEvent>(
+                &epoch_key(epoch),
+                |_, v| {
+                    events.push(v.to_owned());
+                    Ok(())
+                },
+                rt,
+            )
             .unwrap();
 
         events

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -1343,7 +1343,7 @@ mod submit_porep_for_bulk_verify_tests {
             PROOF_VALIDATION_BATCH_AMT_BITWIDTH,
         )
         .unwrap();
-        let arr = mmap.get::<SealVerifyInfo>(&MINER.to_bytes()).unwrap();
+        let arr = mmap.get::<SealVerifyInfo>(&MINER.to_bytes(), &rt).unwrap();
         let found = arr.unwrap();
         assert_eq!(1_u64, found.count());
         let sealed_cid = found.get(0).unwrap().unwrap().sealed_cid;

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -111,14 +111,14 @@ impl Harness {
 
     pub fn get_verifier_allowance(&self, rt: &MockRuntime, verifier: &Address) -> DataCap {
         let verifiers = load_verifiers(rt);
-        let BigIntDe(allowance) = verifiers.get(&verifier.to_bytes()).unwrap().unwrap();
+        let BigIntDe(allowance) = verifiers.get(&verifier.to_bytes(), rt).unwrap().unwrap();
         allowance.clone()
     }
 
     pub fn assert_verifier_removed(&self, rt: &MockRuntime, verifier: &Address) {
         let verifier_id_addr = rt.get_id_address(verifier).unwrap();
         let verifiers = load_verifiers(rt);
-        assert!(!verifiers.contains_key(&verifier_id_addr.to_bytes()).unwrap())
+        assert!(!verifiers.contains_key(&verifier_id_addr.to_bytes(), rt).unwrap())
     }
 
     pub fn add_client(
@@ -151,14 +151,14 @@ impl Harness {
 
     pub fn get_client_allowance(&self, rt: &MockRuntime, client: &Address) -> DataCap {
         let clients = load_clients(rt);
-        let BigIntDe(allowance) = clients.get(&client.to_bytes()).unwrap().unwrap();
+        let BigIntDe(allowance) = clients.get(&client.to_bytes(), rt).unwrap().unwrap();
         allowance.clone()
     }
 
     pub fn assert_client_removed(&self, rt: &MockRuntime, client: &Address) {
         let client_id_addr = rt.get_id_address(client).unwrap();
         let clients = load_clients(rt);
-        assert!(!clients.contains_key(&client_id_addr.to_bytes()).unwrap())
+        assert!(!clients.contains_key(&client_id_addr.to_bytes(), rt).unwrap())
     }
 
     pub fn add_verifier_and_client(

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -36,7 +36,7 @@ sha2 = "0.10"
 fvm_sdk = { version = "3.0.0-alpha.2", optional = true }
 
 # test_util
-rand = { version = "0.8.5", default-features = false, optional = true }
+rand = { version = "0.8.5", default-features = false, features = ["std_rng"], optional = true }
 hex = { version = "0.4.3", optional = true }
 blake2b_simd = { version = "1.0", optional = true }
 

--- a/runtime/src/runtime/hash_algorithm.rs
+++ b/runtime/src/runtime/hash_algorithm.rs
@@ -1,0 +1,15 @@
+use std::hash::Hasher;
+
+#[derive(Default)]
+pub struct RuntimeHasherWrapper(pub Vec<u8>);
+
+impl Hasher for RuntimeHasherWrapper {
+    fn finish(&self) -> u64 {
+        // u64 hash not used in hamt
+        0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.extend_from_slice(bytes);
+    }
+}

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -4,6 +4,7 @@
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_hamt::HashAlgorithm;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
@@ -37,9 +38,11 @@ mod actor_blockstore;
 #[cfg(feature = "fil-actor")]
 pub mod fvm;
 
+pub mod hash_algorithm;
+
 /// Runtime is the VM's internal runtime object.
 /// this is everything that is accessible to actors, beyond parameters.
-pub trait Runtime<BS: Blockstore>: Primitives + Verifier + RuntimePolicy {
+pub trait Runtime<BS: Blockstore>: Primitives + Verifier + RuntimePolicy + HashAlgorithm {
     /// The network protocol version number at the current epoch.
     fn network_version(&self) -> NetworkVersion;
 

--- a/runtime/src/util/set.rs
+++ b/runtime/src/util/set.rs
@@ -3,7 +3,7 @@
 
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_hamt::Error;
+use fvm_ipld_hamt::{Error, HashAlgorithm};
 use fvm_shared::HAMT_BIT_WIDTH;
 
 use crate::{make_empty_map, make_map_with_root, BytesKey, Map};
@@ -45,22 +45,26 @@ where
 
     /// Adds key to the set.
     #[inline]
-    pub fn put(&mut self, key: BytesKey) -> Result<(), Error> {
+    pub fn put(&mut self, key: BytesKey, hash_algo: &dyn HashAlgorithm) -> Result<(), Error> {
         // Set hamt node to array root
-        self.0.set(key, ())?;
+        self.0.set(key, (), hash_algo)?;
         Ok(())
     }
 
     /// Checks if key exists in the set.
     #[inline]
-    pub fn has(&self, key: &[u8]) -> Result<bool, Error> {
-        self.0.contains_key(key)
+    pub fn has(&self, key: &[u8], hash_algo: &dyn HashAlgorithm) -> Result<bool, Error> {
+        self.0.contains_key(key, hash_algo)
     }
 
     /// Deletes key from set.
     #[inline]
-    pub fn delete(&mut self, key: &[u8]) -> Result<Option<()>, Error> {
-        match self.0.delete(key)? {
+    pub fn delete(
+        &mut self,
+        key: &[u8],
+        hash_algo: &dyn HashAlgorithm,
+    ) -> Result<Option<()>, Error> {
+        match self.0.delete(key, hash_algo)? {
             Some(_) => Ok(Some(())),
             None => Ok(None),
         }

--- a/runtime/src/util/set_multimap.rs
+++ b/runtime/src/util/set_multimap.rs
@@ -5,7 +5,7 @@ use std::borrow::Borrow;
 
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_hamt::Error;
+use fvm_ipld_hamt::{Error, HashAlgorithm};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::HAMT_BIT_WIDTH;
@@ -38,41 +38,55 @@ where
     }
 
     /// Puts the DealID in the hash set of the key.
-    pub fn put(&mut self, key: ChainEpoch, value: DealID) -> Result<(), Error> {
+    pub fn put(
+        &mut self,
+        key: ChainEpoch,
+        value: DealID,
+        hash_algo: &dyn HashAlgorithm,
+    ) -> Result<(), Error> {
         // Get construct amt from retrieved cid or create new
-        let mut set = self.get(key)?.unwrap_or_else(|| Set::new(self.0.store()));
+        let mut set = self.get(key, hash_algo)?.unwrap_or_else(|| Set::new(self.0.store()));
 
-        set.put(u64_key(value))?;
+        set.put(u64_key(value), hash_algo)?;
 
         // Save and calculate new root
         let new_root = set.root()?;
 
         // Set hamt node to set new root
-        self.0.set(u64_key(key as u64), new_root)?;
+        self.0.set(u64_key(key as u64), new_root, hash_algo)?;
         Ok(())
     }
 
     /// Puts slice of DealIDs in the hash set of the key.
-    pub fn put_many(&mut self, key: ChainEpoch, values: &[DealID]) -> Result<(), Error> {
+    pub fn put_many(
+        &mut self,
+        key: ChainEpoch,
+        values: &[DealID],
+        hash_algo: &dyn HashAlgorithm,
+    ) -> Result<(), Error> {
         // Get construct amt from retrieved cid or create new
-        let mut set = self.get(key)?.unwrap_or_else(|| Set::new(self.0.store()));
+        let mut set = self.get(key, hash_algo)?.unwrap_or_else(|| Set::new(self.0.store()));
 
         for &v in values {
-            set.put(u64_key(v))?;
+            set.put(u64_key(v), hash_algo)?;
         }
 
         // Save and calculate new root
         let new_root = set.root()?;
 
         // Set hamt node to set new root
-        self.0.set(u64_key(key as u64), new_root)?;
+        self.0.set(u64_key(key as u64), new_root, hash_algo)?;
         Ok(())
     }
 
     /// Gets the set at the given index of the `SetMultimap`
     #[inline]
-    pub fn get(&self, key: ChainEpoch) -> Result<Option<Set<'a, BS>>, Error> {
-        match self.0.get(&u64_key(key as u64))? {
+    pub fn get(
+        &self,
+        key: ChainEpoch,
+        hash_algo: &dyn HashAlgorithm,
+    ) -> Result<Option<Set<'a, BS>>, Error> {
+        match self.0.get::<_>(&u64_key(key as u64), hash_algo)? {
             Some(cid) => Ok(Some(Set::from_root(*self.0.store(), cid)?)),
             None => Ok(None),
         }
@@ -80,37 +94,51 @@ where
 
     /// Removes a DealID from a key hash set.
     #[inline]
-    pub fn remove(&mut self, key: ChainEpoch, v: DealID) -> Result<(), Error> {
+    pub fn remove(
+        &mut self,
+        key: ChainEpoch,
+        v: DealID,
+        hash_algo: &dyn HashAlgorithm,
+    ) -> Result<(), Error> {
         // Get construct amt from retrieved cid and return if no set exists
-        let mut set = match self.get(key)? {
+        let mut set = match self.get(key, hash_algo)? {
             Some(s) => s,
             None => return Ok(()),
         };
 
-        set.delete(u64_key(v).borrow())?;
+        set.delete(u64_key(v).borrow(), hash_algo)?;
 
         // Save and calculate new root
         let new_root = set.root()?;
-        self.0.set(u64_key(key as u64), new_root)?;
+        self.0.set(u64_key(key as u64), new_root, hash_algo)?;
         Ok(())
     }
 
     /// Removes set at index.
     #[inline]
-    pub fn remove_all(&mut self, key: ChainEpoch) -> Result<(), Error> {
+    pub fn remove_all(
+        &mut self,
+        key: ChainEpoch,
+        hash_algo: &dyn HashAlgorithm,
+    ) -> Result<(), Error> {
         // Remove entry from table
-        self.0.delete(&u64_key(key as u64))?;
+        self.0.delete::<_>(&u64_key(key as u64), hash_algo)?;
 
         Ok(())
     }
 
     /// Iterates through keys and converts them to a DealID to call a function on each.
-    pub fn for_each<F>(&self, key: ChainEpoch, mut f: F) -> Result<(), Error>
+    pub fn for_each<F>(
+        &self,
+        key: ChainEpoch,
+        mut f: F,
+        hash_algo: &dyn HashAlgorithm,
+    ) -> Result<(), Error>
     where
         F: FnMut(DealID) -> Result<(), Error>,
     {
         // Get construct amt from retrieved cid and return if no set exists
-        let set = match self.get(key)? {
+        let set = match self.get(key, hash_algo)? {
             Some(s) => s,
             None => return Ok(()),
         };


### PR DESCRIPTION
Hello @Stebalien & @fvm-team,

Tried to refactor the code to optimize for [#636](https://github.com/filecoin-project/ref-fvm/issues/636),

Have taken implementation approach of ...

* Passing the context specific hash function as `HashAlgorithm` trait object to following methods ...

```
Hamt::set()
Hamt::set_if_absent()
Hamt::get()
Hamt::contains_key()
Hamt::delete()
```

* Verified the changes with existing unit test app. All are passed except one.

* Hit with one Unit test failure error, checking the cause for it in-progress.

![](https://i.imgur.com/OtOHk4z.png)

* Observed some regression on bench results, not sure about the cause,  suspecting HW configuration of my machine, investigation in-progress.

![](https://i.imgur.com/6kIBbQk.png)

* Code is ready for review.