### PR TITLE
Claim verifreg allocations from miner actor

### DIFF
--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -538,9 +538,7 @@ impl Actor {
 
         Ok(VerifyDealsForActivationReturn { sectors: sectors_data })
     }
-    /// Activate a set of deals, returning the combined deal weights.
-    /// The weight is defined as the sum, over all deals in the set, of the product of deal size
-    /// and duration.
+    /// Activate a set of deals, returning the combined deal space and extra info for verified deals.
     fn activate_deals<BS, RT>(
         rt: &mut RT,
         params: ActivateDealsParams,
@@ -571,6 +569,7 @@ impl Actor {
         };
 
         // Update deal states
+        let mut verified_infos = Vec::new();
         rt.transaction(|st: &mut State, rt| {
             let mut msm = st.mutator(rt.store());
             msm.with_deal_states(Permission::Write)
@@ -639,7 +638,17 @@ impl Actor {
                     .delete(&deal_id_key(deal_id))
                     .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
                         format!("failed to remove allocation id for deal {}", deal_id)
-                    })?;
+                    })?
+                    .unwrap_or((BytesKey(vec![]), NO_ALLOCATION_ID))
+                    .1;
+                if allocation != NO_ALLOCATION_ID {
+                    verified_infos.push(VerifiedDealInfo {
+                        client: proposal.client.id().unwrap(),
+                        allocation_id: allocation,
+                        data: proposal.piece_cid,
+                        size: proposal.piece_size,
+                    })
+                }
                 msm.deal_states
                     .as_mut()
                     .unwrap()
@@ -649,9 +658,7 @@ impl Actor {
                             sector_start_epoch: curr_epoch,
                             last_updated_epoch: EPOCH_UNDEFINED,
                             slash_epoch: EPOCH_UNDEFINED,
-                            verified_claim: allocation
-                                .unwrap_or((BytesKey(vec![]), NO_ALLOCATION_ID))
-                                .1,
+                            verified_claim: allocation,
                         },
                     )
                     .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
@@ -663,7 +670,7 @@ impl Actor {
             Ok(())
         })?;
 
-        Ok(ActivateDealsResult { spaces: deal_spaces })
+        Ok(ActivateDealsResult { nonverified_deal_space: deal_spaces.deal_space, verified_infos })
     }
 
     /// Terminate a set of deals in response to their containing sector being terminated.

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use super::ext::verifreg::AllocationID;
 use cid::Cid;
 use fil_actors_runtime::Array;
 use fvm_ipld_bitfield::BitField;
@@ -11,6 +12,9 @@ use fvm_shared::bigint::{bigint_ser, BigInt};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
+use fvm_shared::piece::PaddedPieceSize;
+use fvm_shared::ActorID;
+
 use fvm_shared::sector::RegisteredSealProof;
 
 use super::deal::{ClientDealProposal, DealProposal, DealState};
@@ -95,11 +99,20 @@ pub struct ActivateDealsParams {
     pub sector_expiry: ChainEpoch,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct ActivateDealsResult {
-    pub spaces: DealSpaces,
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+pub struct VerifiedDealInfo {
+    pub client: ActorID,
+    pub allocation_id: AllocationID,
+    pub data: Cid,
+    pub size: PaddedPieceSize,
 }
 
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct ActivateDealsResult {
+    #[serde(with = "bigint_ser")]
+    pub nonverified_deal_space: BigInt,
+    pub verified_infos: Vec<VerifiedDealInfo>,
+}
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Default)]
 pub struct DealSpaces {
     #[serde(with = "bigint_ser")]

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -38,9 +38,30 @@ pub mod market {
         pub sector_expiry: ChainEpoch,
     }
 
+    #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+    pub struct VerifiedDealInfo {
+        pub client: ActorID,
+        pub allocation_id: u64,
+        pub data: Cid,
+        pub size: PaddedPieceSize,
+    }
+
+    impl Default for VerifiedDealInfo {
+        fn default() -> VerifiedDealInfo {
+            VerifiedDealInfo {
+                size: PaddedPieceSize(0),
+                client: 0,
+                allocation_id: 0,
+                data: Default::default(),
+            }
+        }
+    }
+
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct ActivateDealsResult {
-        pub spaces: DealSpaces,
+        #[serde(with = "bigint_ser")]
+        pub nonverified_deal_space: BigInt,
+        pub verified_infos: Vec<VerifiedDealInfo>,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone, Default)]
@@ -138,8 +159,11 @@ pub mod verifreg {
     use super::*;
 
     pub const GET_CLAIMS_METHOD: u64 = 10;
+    pub const CLAIM_ALLOCATIONS_METHOD: u64 = 9;
 
     pub type ClaimID = u64;
+    pub type AllocationID = u64;
+
     #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug, PartialEq, Eq)]
     pub struct Claim {
         // The provider storing the data (from allocation).
@@ -169,5 +193,27 @@ pub mod verifreg {
     pub struct GetClaimsReturn {
         pub batch_info: BatchReturn,
         pub claims: Vec<Claim>,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+    pub struct SectorAllocationClaim {
+        pub client: ActorID,
+        pub allocation_id: AllocationID,
+        pub data: Cid,
+        pub size: PaddedPieceSize,
+        pub sector: SectorNumber,
+        pub sector_expiry: ChainEpoch,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+    pub struct ClaimAllocationsParams {
+        pub sectors: Vec<SectorAllocationClaim>,
+        pub all_or_nothing: bool,
+    }
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+    pub struct ClaimAllocationsReturn {
+        pub batch_info: BatchReturn,
+        #[serde(with = "bigint_ser")]
+        pub claimed_space: BigInt,
     }
 }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1052,25 +1052,20 @@ impl Actor {
                 continue;
             }
 
-            let res = rt.send(
-                &STORAGE_MARKET_ACTOR_ADDR,
-                ext::market::ACTIVATE_DEALS_METHOD,
-                RawBytes::serialize(ext::market::ActivateDealsParams {
-                    deal_ids: update.deals.clone(),
-                    sector_expiry: sector_info.expiration,
-                })?,
-                TokenAmount::zero(),
-            );
-            let deal_spaces = if let Ok(res) = res {
-                // Erroring in this case as it means something went really wrong
-                let activate_ret: ext::market::ActivateDealsResult = res.deserialize()?;
-                activate_ret.spaces
-            } else {
-                info!(
-                    "failed to activate deals on sector {0}, skipping sector {0}",
-                    update.sector_number,
-                );
-                continue;
+            let deal_spaces = match activate_deals_and_claim_allocations(
+                rt,
+                update.deals.clone(),
+                sector_info.expiration,
+                sector_info.sector_number,
+            )? {
+                Some(deal_spaces) => deal_spaces,
+                None => {
+                    info!(
+                        "failed to activate deals on sector {}, skipping from replica update set",
+                        update.sector_number
+                    );
+                    continue;
+                }
             };
 
             let expiration = sector_info.expiration;
@@ -4787,35 +4782,21 @@ where
     let mut valid_pre_commits = Vec::default();
 
     for pre_commit in pre_commits {
-        let deal_spaces = if !pre_commit.info.deal_ids.is_empty() {
-            // Check (and activate) storage deals associated to sector. Abort if checks failed.
-            let res = rt.send(
-                &STORAGE_MARKET_ACTOR_ADDR,
-                ext::market::ACTIVATE_DEALS_METHOD,
-                RawBytes::serialize(ext::market::ActivateDealsParams {
-                    deal_ids: pre_commit.info.deal_ids.clone(),
-                    sector_expiry: pre_commit.info.expiration,
-                })?,
-                TokenAmount::zero(),
-            );
-            match res {
-                Ok(res) => {
-                    let activate_res: ext::market::ActivateDealsResult = res.deserialize()?;
-                    activate_res.spaces
-                }
-                Err(e) => {
-                    info!(
-                        "failed to activate deals on sector {}, dropping from prove commit set: {}",
-                        pre_commit.info.sector_number,
-                        e.msg()
-                    );
-                    continue;
-                }
+        match activate_deals_and_claim_allocations(
+            rt,
+            pre_commit.clone().info.deal_ids,
+            pre_commit.info.expiration,
+            pre_commit.info.sector_number,
+        )? {
+            None => {
+                info!(
+                    "failed to activate deals on sector {}, dropping from prove commit set",
+                    pre_commit.info.sector_number,
+                );
+                continue;
             }
-        } else {
-            ext::market::DealSpaces::default()
+            Some(deal_spaces) => valid_pre_commits.push((pre_commit, deal_spaces)),
         };
-        valid_pre_commits.push((pre_commit, deal_spaces));
     }
 
     // When all prove commits have failed abort early
@@ -4962,6 +4943,79 @@ where
     notify_pledge_changed(rt, &(total_pledge - newly_vested))?;
 
     Ok(())
+}
+
+// activate deals with builtin market and claim allocations with verified registry actor
+// returns an error in case of a fatal programmer error
+// returns Ok(None) in case deal activation or verified allocation claim fails
+fn activate_deals_and_claim_allocations<RT, BS>(
+    rt: &mut RT,
+    deal_ids: Vec<DealID>,
+    sector_expiry: ChainEpoch,
+    sector_number: SectorNumber,
+) -> Result<Option<crate::ext::market::DealSpaces>, ActorError>
+where
+    BS: Blockstore,
+    RT: Runtime<BS>,
+{
+    if deal_ids.is_empty() {
+        return Ok(Some(ext::market::DealSpaces::default()));
+    }
+    // Check (and activate) storage deals associated to sector. Abort if checks failed.
+    let activate_raw = rt.send(
+        &STORAGE_MARKET_ACTOR_ADDR,
+        ext::market::ACTIVATE_DEALS_METHOD,
+        RawBytes::serialize(ext::market::ActivateDealsParams { deal_ids, sector_expiry })?,
+        TokenAmount::zero(),
+    );
+    let activate_res: ext::market::ActivateDealsResult = match activate_raw {
+        Ok(res) => res.deserialize()?,
+        Err(e) => {
+            info!("error activating deals on sector {}: {}", sector_number, e.msg());
+            return Ok(None);
+        }
+    };
+
+    // If deal activation includes verified deals claim allocations
+    if activate_res.verified_infos.is_empty() {
+        return Ok(Some(ext::market::DealSpaces {
+            deal_space: activate_res.nonverified_deal_space,
+            ..Default::default()
+        }));
+    }
+    let sector_claims = activate_res
+        .verified_infos
+        .iter()
+        .map(|info| ext::verifreg::SectorAllocationClaim {
+            client: info.client,
+            allocation_id: info.allocation_id,
+            data: info.data,
+            size: info.size,
+            sector: sector_number,
+            sector_expiry,
+        })
+        .collect();
+
+    let claim_raw = rt.send(
+        &VERIFIED_REGISTRY_ACTOR_ADDR,
+        ext::verifreg::CLAIM_ALLOCATIONS_METHOD,
+        RawBytes::serialize(ext::verifreg::ClaimAllocationsParams {
+            sectors: sector_claims,
+            all_or_nothing: true,
+        })?,
+        TokenAmount::zero(),
+    );
+    let claim_res: ext::verifreg::ClaimAllocationsReturn = match claim_raw {
+        Ok(res) => res.deserialize()?,
+        Err(e) => {
+            info!("error claiming allocation on sector {}: {}", sector_number, e.msg());
+            return Ok(None);
+        }
+    };
+    Ok(Some(ext::market::DealSpaces {
+        deal_space: activate_res.nonverified_deal_space,
+        verified_deal_space: claim_res.claimed_space,
+    }))
 }
 
 // XXX: probably better to push this one level down into state

--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -1,4 +1,4 @@
-use fil_actor_market::DealSpaces;
+use fil_actor_market::VerifiedDealInfo;
 use fil_actor_miner::ext::verifreg::Claim as FILPlusClaim;
 use fil_actor_miner::{
     power_for_sector, seal_proof_sector_maximum_lifetime, ExpirationExtension,
@@ -13,13 +13,11 @@ use fil_actors_runtime::{
 use fvm_ipld_bitfield::BitField;
 use fvm_shared::{
     address::Address,
-    bigint::BigInt,
     clock::ChainEpoch,
     error::ExitCode,
     sector::{RegisteredSealProof, SectorNumber},
     ActorID,
 };
-use fvm_shared::{bigint::Zero, piece::PaddedPieceSize};
 use std::collections::HashMap;
 
 mod util;
@@ -363,26 +361,16 @@ fn supports_extensions_off_deadline_boundary() {
     h.check_state(&rt);
 }
 
-struct TestVerifiedDeal {
-    pub space: PaddedPieceSize,
-}
-
 fn commit_sector_verified_deals(
-    verified_deals: &Vec<TestVerifiedDeal>,
+    verified_deals: &Vec<VerifiedDealInfo>,
     h: &mut ActorHarness,
     rt: &mut MockRuntime,
 ) -> SectorOnChainInfo {
     h.construct_and_verify(rt);
     assert!(!verified_deals.is_empty());
-    let mut sector_space = 0;
-    for d in verified_deals {
-        sector_space += d.space.0;
-    }
-    let mut prove_commit_spaces = HashMap::new();
-    prove_commit_spaces.insert(
-        h.next_sector_no,
-        DealSpaces { deal_space: BigInt::zero(), verified_deal_space: BigInt::from(sector_space) },
-    );
+
+    let mut pcc = ProveCommitConfig::empty();
+    pcc.add_verified_deals(h.next_sector_no, verified_deals.clone());
 
     let sector_info = &h.commit_and_prove_sectors_with_cfgs(
         rt,
@@ -390,7 +378,7 @@ fn commit_sector_verified_deals(
         DEFAULT_SECTOR_EXPIRATION as u64,
         vec![vec![42]],
         true,
-        ProveCommitConfig { verify_deals_exit: HashMap::new(), deal_spaces: prove_commit_spaces },
+        pcc,
     )[0];
 
     sector_info.clone()
@@ -429,14 +417,14 @@ fn make_claim(
     client: ActorID,
     provider: ActorID,
     new_expiration: ChainEpoch,
-    deal: &TestVerifiedDeal,
+    deal: &VerifiedDealInfo,
     term_min: ChainEpoch,
 ) -> FILPlusClaim {
     FILPlusClaim {
         provider,
         client,
         data: make_piece_cid(format!("piece for claim {}", claim_id).as_bytes()),
-        size: deal.space,
+        size: deal.size,
         term_min,
         term_max: new_expiration - sector.activation,
         term_start: sector.activation,
@@ -449,8 +437,8 @@ fn update_expiration_multiple_claims() {
     let (mut h, mut rt) = setup();
     // add in verified deal
     let verified_deals = vec![
-        TestVerifiedDeal { space: PaddedPieceSize(h.sector_size as u64 / 2) },
-        TestVerifiedDeal { space: PaddedPieceSize(h.sector_size as u64 / 2) },
+        test_verified_deal(h.sector_size as u64 / 2),
+        test_verified_deal(h.sector_size as u64 / 2),
     ];
     let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &mut rt);
     h.advance_and_submit_posts(&mut rt, &vec![old_sector.clone()]);
@@ -520,8 +508,8 @@ fn update_expiration2_failure_cases() {
     let (mut h, mut rt) = setup();
     // add in verified deal
     let verified_deals = vec![
-        TestVerifiedDeal { space: PaddedPieceSize(h.sector_size as u64 / 2) },
-        TestVerifiedDeal { space: PaddedPieceSize(h.sector_size as u64 / 2) },
+        test_verified_deal(h.sector_size as u64 / 2),
+        test_verified_deal(h.sector_size as u64 / 2),
     ];
     let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &mut rt);
     h.advance_and_submit_posts(&mut rt, &vec![old_sector.clone()]);

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -6,7 +6,7 @@ use fil_actors_runtime::BatchReturn;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
+use fvm_shared::bigint::{bigint_ser, BigInt};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::piece::PaddedPieceSize;
@@ -131,10 +131,18 @@ impl Cbor for SectorAllocationClaim {}
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ClaimAllocationsParams {
     pub sectors: Vec<SectorAllocationClaim>,
+    pub all_or_nothing: bool,
 }
 impl Cbor for ClaimAllocationsParams {}
 
-pub type ClaimAllocationsReturn = BatchReturn;
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct ClaimAllocationsReturn {
+    pub batch_info: BatchReturn,
+    #[serde(with = "bigint_ser")]
+    pub claimed_space: BigInt,
+}
+
+impl Cbor for ClaimAllocationsReturn {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ClaimTerm {

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -238,6 +238,7 @@ impl Harness {
         provider: ActorID,
         claim_allocs: Vec<SectorAllocationClaim>,
         datacap_burnt: u64,
+        all_or_nothing: bool,
     ) -> Result<ClaimAllocationsReturn, ActorError> {
         rt.expect_validate_caller_type(vec![Type::Miner]);
         rt.set_caller(*MINER_ACTOR_CODE_ID, Address::new_id(provider));
@@ -254,7 +255,7 @@ impl Harness {
             ExitCode::OK,
         );
 
-        let params = ClaimAllocationsParams { sectors: claim_allocs };
+        let params = ClaimAllocationsParams { sectors: claim_allocs, all_or_nothing };
         let ret = rt
             .call::<VerifregActor>(
                 Method::ClaimAllocations as MethodNum,

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -422,6 +422,7 @@ mod clients {
 }
 
 mod claims {
+    use fvm_shared::bigint::BigInt;
     use fvm_shared::error::ExitCode;
     use fvm_shared::ActorID;
     use num_traits::Zero;
@@ -562,10 +563,12 @@ mod claims {
                     make_claim_req(3, &alloc3, sector, 1500),
                 ],
                 size * 3,
+                false,
             )
             .unwrap();
 
-        assert_eq!(ret.codes(), vec![ExitCode::OK, ExitCode::OK, ExitCode::OK]);
+        assert_eq!(ret.batch_info.codes(), vec![ExitCode::OK, ExitCode::OK, ExitCode::OK]);
+        assert_eq!(ret.claimed_space, BigInt::from(3 * size));
 
         // check that state is as expected
         let st: State = rt.get_state();


### PR DESCRIPTION
Closes #596

- [x] change market actor deal activation return value
- [x] call verifreg from miner actor
- [x] fix unit and itests
- [x] come to a decision about partial failures and corresponding restructuring of verifreg claim allocations
