### PR TITLE
EVM runtime: fix BALANCE behaviour to match EVM

### DIFF
--- a/actors/evm/src/interpreter/address.rs
+++ b/actors/evm/src/interpreter/address.rs
@@ -100,6 +100,11 @@ mod tests {
                     $expectation
                 );
 
+                assert_eq!(
+                    evm_addr.as_id(),
+                    $expectation.map(|addr: FilecoinAddress| addr.id().unwrap())
+                );
+
                 // test inverse conversion, if a valid ID address was supplied
                 if let Some(fil_addr) = $expectation {
                     assert_eq!(EthAddress::from_id_address(&fil_addr), Some(evm_addr));

--- a/actors/evm/src/interpreter/address.rs
+++ b/actors/evm/src/interpreter/address.rs
@@ -1,6 +1,7 @@
 use crate::StatusCode;
 use crate::U256;
 use fvm_shared::address::Address as FilecoinAddress;
+use fvm_shared::ActorID;
 
 /// A Filecoin address as represented in the FEVM runtime (also called EVM-form).
 ///
@@ -44,8 +45,8 @@ impl EthAddress {
         EthAddress(bytes)
     }
 
-    /// Interpret the hash as an ID address in EVM-form, and return a Filecoin ID address if that's
-    /// the case.
+    /// Interpret the EVM word as an ID address in EVM-form, and return a Filecoin ID address if
+    /// that's the case.
     ///
     /// An ID address starts with 0xff (msb), and contains the u64 in the last 8 bytes.
     /// We assert that everything in between are 0x00, otherwise we've gotten an illegal address.
@@ -57,6 +58,11 @@ impl EthAddress {
             return None;
         }
         Some(FilecoinAddress::new_id(u64::from_be_bytes(self.0[12..].try_into().unwrap())))
+    }
+
+    /// Same as as_id_address, but go the extra mile and return the ActorID.
+    pub fn as_id(&self) -> Option<ActorID> {
+        self.as_id_address().and_then(|id| id.id().ok())
     }
 
     /// Returns this Address as an EVM word.

--- a/actors/evm/src/interpreter/instructions/state.rs
+++ b/actors/evm/src/interpreter/instructions/state.rs
@@ -13,17 +13,13 @@ pub fn balance<'r, BS: Blockstore, RT: Runtime<BS>>(
 ) -> Result<(), StatusCode> {
     let actor = state.stack.pop();
 
-    let maybe_actor_addr = EthAddress::try_from(actor);
-    if maybe_actor_addr.is_err() {
-        state.stack.push(U256::zero());
-        return Ok(());
-    }
-
-    if let Some(actor_addr) = maybe_actor_addr.unwrap().as_id_address() {
-        state.stack.push(U256::from(&platform.rt.actor_balance(actor_addr.id().unwrap())));
+    let balance = if let Some(id) = EthAddress::try_from(actor).ok().and_then(|addr| addr.as_id()) {
+        U256::from(&platform.rt.actor_balance(id))
     } else {
-        state.stack.push(U256::zero());
-    }
+        U256::zero()
+    };
+
+    state.stack.push(balance);
     Ok(())
 }
 

--- a/actors/evm/tests/misc.rs
+++ b/actors/evm/tests/misc.rs
@@ -152,6 +152,57 @@ return
 }
 
 #[test]
+fn test_balance_bogus() {
+    let contract = asm::new_contract(
+        "balance",
+        "",
+        r#"
+push1 0x20
+push1 0x00
+push1 0x00
+calldatacopy
+push1 0x00
+mload
+balance
+push1 0x00
+mstore
+push1 0x20
+push1 0x00
+return
+"#,
+    )
+    .unwrap();
+
+    let mut rt = util::construct_and_verify(contract);
+    let mut input_data = vec![0u8; 32];
+    input_data[31] = 123;
+    let result = util::invoke_contract(&mut rt, RawBytes::from(input_data));
+    assert_eq!(U256::from_big_endian(&result), U256::from(0));
+}
+
+#[test]
+fn test_balance0() {
+    let contract = asm::new_contract(
+        "balance",
+        "",
+        r#"
+push1 0x00
+balance
+push1 0x00
+mstore
+push1 0x20
+push1 0x00
+return
+"#,
+    )
+    .unwrap();
+
+    let mut rt = util::construct_and_verify(contract);
+    let result = util::invoke_contract(&mut rt, RawBytes::default());
+    assert_eq!(U256::from_big_endian(&result), U256::from(0));
+}
+
+#[test]
 fn test_gas() {
     let contract = asm::new_contract(
         "gas",


### PR DESCRIPTION
turns out balance 0 is a valid call and bogus addresses shouldn't bomb.