### PR TITLE
Implement state checks for allocs/claims and between verified registry and datacap.

### DIFF
--- a/actors/datacap/src/testing.rs
+++ b/actors/datacap/src/testing.rs
@@ -1,11 +1,19 @@
+use frc46_token::token::state::decode_actor_id;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::address::Protocol;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::ActorID;
+use std::collections::HashMap;
 
 use fil_actors_runtime::MessageAccumulator;
 
 use crate::State;
 
-pub struct StateSummary {}
+pub struct StateSummary {
+    pub balances: HashMap<ActorID, TokenAmount>,
+    pub allowances: HashMap<ActorID, HashMap<ActorID, TokenAmount>>,
+    pub total_supply: TokenAmount,
+}
 
 /// Checks internal invariants of data cap token actor state.
 pub fn check_state_invariants<BS: Blockstore>(
@@ -13,11 +21,62 @@ pub fn check_state_invariants<BS: Blockstore>(
     store: &BS,
 ) -> (StateSummary, MessageAccumulator) {
     let acc = MessageAccumulator::default();
-    acc.require(state.governor.protocol() == Protocol::ID, "registry must be ID address");
+    acc.require(state.governor.protocol() == Protocol::ID, "governor must be ID address");
     let r = state.token.check_invariants(store);
+
+    // TODO: replace this with the state summary returned by the token library
+    // after that's implemented (expected in 1.2.0)
+    let mut summary = StateSummary {
+        balances: HashMap::new(),
+        allowances: HashMap::new(),
+        total_supply: state.token.supply.clone(),
+    };
+    match state.token.get_balance_map(store) {
+        Ok(balance_map) => {
+            balance_map
+                .for_each(|owner, v| {
+                    // Unwrapping decode here because the token library should have checked it.
+                    let owner = decode_actor_id(owner).unwrap();
+                    summary.balances.insert(owner, v.clone());
+                    Ok(())
+                })
+                .unwrap();
+        }
+        Err(e) => acc.add(format!("error loading balances {e}")),
+    }
+    match state.token.get_allowances_map(store) {
+        Ok(allowances_map) => {
+            allowances_map
+                .for_each(|owner, _| {
+                    let owner = decode_actor_id(owner).unwrap();
+                    let mut allowances = HashMap::<ActorID, TokenAmount>::new();
+                    match state.token.get_owner_allowance_map(store, owner) {
+                        Ok(allowance_map) => {
+                            if let Some(allowance_map) = allowance_map {
+                                allowance_map
+                                    .for_each(|operator, v| {
+                                        let operator = decode_actor_id(operator).unwrap();
+                                        allowances.insert(operator, v.clone());
+                                        Ok(())
+                                    })
+                                    .unwrap();
+                            } else {
+                                acc.add(format!("missing allowance map for {owner}"));
+                            }
+                        }
+                        Err(e) => acc.add(format!("error loading allowances for {owner} {e}")),
+                    }
+                    summary.allowances.insert(owner, allowances);
+                    Ok(())
+                })
+                .unwrap();
+        }
+        Err(e) => acc.add(format!("error loading allowances {e}")),
+    }
+
     if let Err(e) = r {
         acc.add(e.to_string());
     }
 
-    (StateSummary {}, acc)
+    (summary, acc)
 }

--- a/actors/datacap/tests/datacap_actor_test.rs
+++ b/actors/datacap/tests/datacap_actor_test.rs
@@ -62,7 +62,7 @@ mod mint {
 
     #[test]
     fn requires_verifreg_caller() {
-        let (mut rt, _) = make_harness();
+        let (mut rt, h) = make_harness();
         let amt = TokenAmount::from_whole(1);
         let params = MintParams { to: *ALICE, amount: amt, operators: vec![] };
 
@@ -73,6 +73,7 @@ mod mint {
             "caller address",
             rt.call::<Actor>(Method::Mint as MethodNum, &serialize(&params, "params").unwrap()),
         );
+        h.check_state(&rt);
     }
 
     #[test]
@@ -84,6 +85,7 @@ mod mint {
             "must be a multiple of 1000000000000000000",
             h.mint(&mut rt, &*ALICE, &amt, vec![]),
         );
+        h.check_state(&rt);
     }
 }
 

--- a/actors/verifreg/src/testing.rs
+++ b/actors/verifreg/src/testing.rs
@@ -1,25 +1,38 @@
+use frc46_token::token::state::decode_actor_id;
 use std::collections::HashMap;
 
-use fil_actors_runtime::{Map, MessageAccumulator};
+use fil_actors_runtime::runtime::policy_constants::{
+    MAXIMUM_VERIFIED_ALLOCATION_EXPIRATION, MAXIMUM_VERIFIED_ALLOCATION_TERM,
+    MINIMUM_VERIFIED_ALLOCATION_SIZE, MINIMUM_VERIFIED_ALLOCATION_TERM,
+};
+use fil_actors_runtime::shared::HAMT_BIT_WIDTH;
+use fil_actors_runtime::{
+    make_map_with_root_and_bitwidth, parse_uint_key, Map, MessageAccumulator,
+};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::address::{Address, Protocol};
 use fvm_shared::bigint::bigint_ser::BigIntDe;
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::ActorID;
 use num_traits::Signed;
 
-use crate::{DataCap, State};
+use crate::{Allocation, AllocationID, Claim, ClaimID, DataCap, State};
 
 pub struct StateSummary {
     pub verifiers: HashMap<Address, DataCap>,
+    pub allocations: HashMap<AllocationID, Allocation>,
+    pub claims: HashMap<ClaimID, Claim>,
 }
 
 /// Checks internal invariants of verified registry state.
 pub fn check_state_invariants<BS: Blockstore>(
     state: &State,
     store: &BS,
+    prior_epoch: ChainEpoch,
 ) -> (StateSummary, MessageAccumulator) {
     let acc = MessageAccumulator::default();
 
-    // check verifiers
+    // Load and check verifiers
     let mut all_verifiers = HashMap::new();
     match Map::<_, BigIntDe>::load(&state.verifiers, store) {
         Ok(verifiers) => {
@@ -44,5 +57,157 @@ pub fn check_state_invariants<BS: Blockstore>(
         Err(e) => acc.add(format!("error loading verifiers {e}")),
     }
 
-    (StateSummary { verifiers: all_verifiers }, acc)
+    // Load and check allocations
+    let mut all_allocations = HashMap::new();
+    match make_map_with_root_and_bitwidth(&state.allocations, store, HAMT_BIT_WIDTH) {
+        Ok(allocations) => {
+            let ret = allocations.for_each(|client_key, inner_root| {
+                let client_id = decode_actor_id(client_key).unwrap();
+                match make_map_with_root_and_bitwidth(inner_root, store, HAMT_BIT_WIDTH) {
+                    Ok(allocations) => {
+                        let ret = allocations.for_each(|alloc_id_key, allocation: &Allocation| {
+                            let allocation_id = parse_uint_key(alloc_id_key).unwrap();
+                            check_allocation_state(
+                                allocation_id,
+                                allocation,
+                                client_id,
+                                state.next_allocation_id,
+                                prior_epoch,
+                                &acc,
+                            );
+
+                            all_allocations.insert(allocation_id, allocation.clone());
+                            Ok(())
+                        });
+                        acc.require_no_error(
+                            ret,
+                            format!("error iterating allocations inner for {client_id}"),
+                        );
+                    }
+                    Err(e) => acc.add(format!("error loading allocations {e}")),
+                }
+                Ok(())
+            });
+
+            acc.require_no_error(ret, "error iterating allocations outer");
+        }
+        Err(e) => acc.add(format!("error loading allocations from {e}")),
+    }
+
+    let mut all_claims = HashMap::new();
+    match make_map_with_root_and_bitwidth(&state.claims, store, HAMT_BIT_WIDTH) {
+        Ok(claims) => {
+            let ret = claims.for_each(|provider_key, inner_root| {
+                let provider_id = decode_actor_id(provider_key).unwrap();
+                match make_map_with_root_and_bitwidth(inner_root, store, HAMT_BIT_WIDTH) {
+                    Ok(claims) => {
+                        let ret = claims.for_each(|claim_id_key, claim: &Claim| {
+                            let claim_id = parse_uint_key(claim_id_key).unwrap();
+                            check_claim_state(
+                                claim_id,
+                                claim,
+                                provider_id,
+                                state.next_allocation_id,
+                                prior_epoch,
+                                &acc,
+                            );
+                            all_claims.insert(claim_id, claim.clone());
+                            Ok(())
+                        });
+                        acc.require_no_error(
+                            ret,
+                            format!("error iterating allocations inner for {provider_id}"),
+                        );
+                    }
+                    Err(e) => acc.add(format!("error loading allocations {e}")),
+                }
+                Ok(())
+            });
+
+            acc.require_no_error(ret, "error iterating allocations outer");
+        }
+        Err(e) => acc.add(format!("error loading claims {e}")),
+    }
+
+    (
+        StateSummary { verifiers: all_verifiers, allocations: all_allocations, claims: all_claims },
+        acc,
+    )
+}
+
+fn check_allocation_state(
+    id: u64,
+    alloc: &Allocation,
+    client: ActorID,
+    next_alloc_id: u64,
+    prior_epoch: ChainEpoch,
+    acc: &MessageAccumulator,
+) {
+    acc.require(id < next_alloc_id, format!("allocation id {} exceeds next {}", id, next_alloc_id));
+    acc.require(
+        alloc.client == client,
+        format!("allocation {} client {} doesn't match key {}", id, alloc.client, client),
+    );
+    acc.require(
+        alloc.size.0 >= MINIMUM_VERIFIED_ALLOCATION_SIZE as u64,
+        format!("allocation {} size {} too small", id, alloc.size.0),
+    );
+    acc.require(
+        alloc.term_min >= MINIMUM_VERIFIED_ALLOCATION_TERM,
+        format!("allocation {} term min {} too small", id, alloc.term_min),
+    );
+    acc.require(
+        alloc.term_max <= MAXIMUM_VERIFIED_ALLOCATION_TERM,
+        format!("allocation {} term max {} too large ", id, alloc.term_max),
+    );
+    acc.require(
+        alloc.term_min <= alloc.term_max,
+        format!("allocation {} term min {} exceeds max {}", id, alloc.term_min, alloc.term_max),
+    );
+    acc.require(
+        alloc.expiration <= prior_epoch + MAXIMUM_VERIFIED_ALLOCATION_EXPIRATION,
+        format!(
+            "allocation {} expiration {} too far from now {}",
+            id, alloc.expiration, prior_epoch
+        ),
+    )
+}
+
+fn check_claim_state(
+    id: u64,
+    claim: &Claim,
+    provider: ActorID,
+    next_alloc_id: u64,
+    prior_epoch: ChainEpoch,
+    acc: &MessageAccumulator,
+) {
+    acc.require(id < next_alloc_id, format!("claim id {} exceeds next {}", id, next_alloc_id));
+    acc.require(
+        claim.provider == provider,
+        format!("claim {} provider {} doesn't match key {}", id, claim.provider, provider),
+    );
+    acc.require(
+        claim.size.0 >= MINIMUM_VERIFIED_ALLOCATION_SIZE as u64,
+        format!(
+            "claim {} size {} below minimum {}",
+            id, claim.size.0, MINIMUM_VERIFIED_ALLOCATION_SIZE
+        ),
+    );
+    acc.require(
+        claim.term_min >= MINIMUM_VERIFIED_ALLOCATION_TERM,
+        format!(
+            "claim {} term min {} below minimum {}",
+            id, claim.term_min, MINIMUM_VERIFIED_ALLOCATION_TERM
+        ),
+    );
+    // The maximum term is not limited because it can be extended
+    // arbitrarily long by a client spending new datacap.
+    acc.require(
+        claim.term_min <= claim.term_max,
+        format!("claim {} term min {} exceeds max {}", id, claim.term_min, claim.term_max),
+    );
+    acc.require(
+        claim.term_start <= prior_epoch,
+        format!("claim {} term start {} after now {}", id, claim.term_start, prior_epoch),
+    );
 }

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -198,7 +198,7 @@ impl Harness {
     }
 
     pub fn check_state(&self, rt: &MockRuntime) {
-        let (_, acc) = check_state_invariants(&rt.get_state(), rt.store());
+        let (_, acc) = check_state_invariants(&rt.get_state(), rt.store(), rt.epoch);
         acc.assert_empty();
     }
 
@@ -439,8 +439,8 @@ pub fn make_alloc(data_id: &str, client: ActorID, provider: ActorID, size: u64) 
         provider,
         data: make_piece_cid(data_id.as_bytes()),
         size: PaddedPieceSize(size),
-        term_min: 1000,
-        term_max: 2000,
+        term_min: MINIMUM_VERIFIED_ALLOCATION_TERM,
+        term_max: MINIMUM_VERIFIED_ALLOCATION_TERM * 2,
         expiration: 100,
     }
 }


### PR DESCRIPTION
This addresses a large part of #537. I've checked off the items there that I think are done.