### PR TITLE
Legacy sector tests

### DIFF
--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -729,7 +729,7 @@ fn extend_expiration2_drop_claims() {
 }
 
 #[test]
-fn update_expiration_legacy_fails_on_new_sector_with_deals_fails() {
+fn update_expiration_legacy_fails_on_new_sector_with_deals() {
     let (mut h, mut rt) = setup();
     // add in verified deal
     let verified_deals = vec![

--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -729,6 +729,50 @@ fn extend_expiration2_drop_claims() {
 }
 
 #[test]
+fn update_expiration_legacy_fails_on_new_sector_with_deals_fails() {
+    let (mut h, mut rt) = setup();
+    // add in verified deal
+    let verified_deals = vec![
+        test_verified_deal(h.sector_size as u64 / 2),
+        test_verified_deal(h.sector_size as u64 / 2),
+    ];
+    let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &mut rt);
+    h.advance_and_submit_posts(&mut rt, &vec![old_sector.clone()]);
+
+    let state: State = rt.get_state();
+
+    let (deadline_index, partition_index) =
+        state.find_sector(rt.policy(), rt.store(), old_sector.sector_number).unwrap();
+
+    let extension = 42 * rt.policy().wpost_proving_period;
+    let new_expiration = old_sector.expiration + extension;
+
+    let params = ExtendSectorExpirationParams {
+        extensions: vec![ExpirationExtension {
+            deadline: deadline_index,
+            partition: partition_index,
+            sectors: make_bitfield(&[old_sector.sector_number]),
+            new_expiration,
+        }],
+    };
+
+    // legacy extend_sectors will fail to extend newly created sectors with deals
+    expect_abort_contains_message(
+        ExitCode::USR_FORBIDDEN,
+        "cannot use legacy sector extension for simple qa power with deal weight",
+        h.extend_sectors(&mut rt, params),
+    );
+    check_for_expiration(
+        &mut h,
+        &mut rt,
+        old_sector.expiration,
+        old_sector.sector_number,
+        deadline_index,
+        partition_index,
+    );
+}
+
+#[test]
 fn update_expiration2_drop_claims_failure_cases() {
     let (mut h, mut rt) = setup();
     let policy = Policy::default();

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -35,6 +35,7 @@ fn extend2_legacy_sector_with_deals() {
     extend_legacy_sector_with_deals_inner(true);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn extend1(
     v: &VM,
     worker: Address,
@@ -45,17 +46,17 @@ fn extend1(
     new_expiration: ChainEpoch,
     power_update_params: RawBytes,
 ) {
-    let mut extension_params = ExtendSectorExpirationParams {
+    let extension_params = ExtendSectorExpirationParams {
         extensions: vec![ExpirationExtension {
             deadline: deadline_index,
             partition: partition_index,
             sectors: BitField::try_from_bits([sector_number].iter().copied()).unwrap(),
-            new_expiration: new_expiration,
+            new_expiration,
         }],
     };
 
     apply_ok(
-        &v,
+        v,
         worker,
         maddr,
         TokenAmount::zero(),
@@ -77,6 +78,7 @@ fn extend1(
     .matches(v.take_invocations().last().unwrap());
 }
 
+#[allow(clippy::too_many_arguments)]
 fn extend2(
     v: &VM,
     worker: Address,
@@ -87,18 +89,18 @@ fn extend2(
     new_expiration: ChainEpoch,
     power_update_params: RawBytes,
 ) {
-    let mut extension_params = ExtendSectorExpiration2Params {
+    let extension_params = ExtendSectorExpiration2Params {
         extensions: vec![ExpirationExtension2 {
             deadline: deadline_index,
             partition: partition_index,
             sectors: BitField::try_from_bits([sector_number].iter().copied()).unwrap(),
-            new_expiration: new_expiration,
+            new_expiration,
             sectors_with_claims: vec![],
         }],
     };
 
     apply_ok(
-        &v,
+        v,
         worker,
         maddr,
         TokenAmount::zero(),

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -1,6 +1,7 @@
 use fil_actor_miner::{
-    max_prove_commit_duration, ExpirationExtension, ExtendSectorExpirationParams,
-    Method as MinerMethod, PowerPair, Sectors, State as MinerState,
+    max_prove_commit_duration, ExpirationExtension, ExpirationExtension2,
+    ExtendSectorExpiration2Params, ExtendSectorExpirationParams, Method as MinerMethod, PowerPair,
+    Sectors, State as MinerState,
 };
 use fil_actor_power::{Method as PowerMethod, UpdateClaimedPowerParams};
 use fil_actors_runtime::cbor::serialize;
@@ -8,7 +9,10 @@ use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{DealWeight, EPOCHS_IN_DAY, STORAGE_POWER_ACTOR_ADDR};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
+use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
@@ -22,7 +26,100 @@ use test_vm::util::{
 use test_vm::{ExpectInvocation, VM};
 
 #[test]
-fn extend_sector_with_deals() {
+fn extend_legacy_sector_with_deals() {
+    extend_legacy_sector_with_deals_inner(false);
+}
+
+#[test]
+fn extend2_legacy_sector_with_deals() {
+    extend_legacy_sector_with_deals_inner(true);
+}
+
+fn extend1(
+    v: &VM,
+    worker: Address,
+    maddr: Address,
+    deadline_index: u64,
+    partition_index: u64,
+    sector_number: SectorNumber,
+    new_expiration: ChainEpoch,
+    power_update_params: RawBytes,
+) {
+    let mut extension_params = ExtendSectorExpirationParams {
+        extensions: vec![ExpirationExtension {
+            deadline: deadline_index,
+            partition: partition_index,
+            sectors: BitField::try_from_bits([sector_number].iter().copied()).unwrap(),
+            new_expiration: new_expiration,
+        }],
+    };
+
+    apply_ok(
+        &v,
+        worker,
+        maddr,
+        TokenAmount::zero(),
+        MinerMethod::ExtendSectorExpiration as u64,
+        extension_params,
+    );
+
+    ExpectInvocation {
+        to: maddr,
+        method: MinerMethod::ExtendSectorExpiration as u64,
+        subinvocs: Some(vec![ExpectInvocation {
+            to: STORAGE_POWER_ACTOR_ADDR,
+            method: PowerMethod::UpdateClaimedPower as u64,
+            params: Some(power_update_params),
+            ..Default::default()
+        }]),
+        ..Default::default()
+    }
+    .matches(v.take_invocations().last().unwrap());
+}
+
+fn extend2(
+    v: &VM,
+    worker: Address,
+    maddr: Address,
+    deadline_index: u64,
+    partition_index: u64,
+    sector_number: SectorNumber,
+    new_expiration: ChainEpoch,
+    power_update_params: RawBytes,
+) {
+    let mut extension_params = ExtendSectorExpiration2Params {
+        extensions: vec![ExpirationExtension2 {
+            deadline: deadline_index,
+            partition: partition_index,
+            sectors: BitField::try_from_bits([sector_number].iter().copied()).unwrap(),
+            new_expiration: new_expiration,
+            sectors_with_claims: vec![],
+        }],
+    };
+
+    apply_ok(
+        &v,
+        worker,
+        maddr,
+        TokenAmount::zero(),
+        MinerMethod::ExtendSectorExpiration2 as u64,
+        extension_params,
+    );
+    ExpectInvocation {
+        to: maddr,
+        method: MinerMethod::ExtendSectorExpiration2 as u64,
+        subinvocs: Some(vec![ExpectInvocation {
+            to: STORAGE_POWER_ACTOR_ADDR,
+            method: PowerMethod::UpdateClaimedPower as u64,
+            params: Some(power_update_params),
+            ..Default::default()
+        }]),
+        ..Default::default()
+    }
+    .matches(v.take_invocations().last().unwrap());
+}
+
+fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     let store = MemoryBlockstore::new();
     let mut v = VM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
@@ -154,23 +251,8 @@ fn extend_sector_with_deals() {
         deal_start + 90 * EPOCHS_IN_DAY,
     );
 
-    let mut extension_params = ExtendSectorExpirationParams {
-        extensions: vec![ExpirationExtension {
-            deadline: deadline_info.index,
-            partition: partition_index,
-            sectors: BitField::try_from_bits([sector_number].iter().copied()).unwrap(),
-            new_expiration: deal_start + 2 * 180 * EPOCHS_IN_DAY,
-        }],
-    };
+    let new_expiration = deal_start + 2 * 180 * EPOCHS_IN_DAY;
 
-    apply_ok(
-        &v,
-        worker,
-        miner_id,
-        TokenAmount::zero(),
-        MinerMethod::ExtendSectorExpiration as u64,
-        extension_params,
-    );
     let mut expected_update_claimed_power_params = UpdateClaimedPowerParams {
         raw_byte_delta: StoragePower::zero(),
         quality_adjusted_delta: StoragePower::from(-675 * (32i64 << 30) / 100),
@@ -178,18 +260,29 @@ fn extend_sector_with_deals() {
     let mut expected_update_claimed_power_params_ser =
         serialize(&expected_update_claimed_power_params, "update_claimed_power params").unwrap();
 
-    ExpectInvocation {
-        to: miner_id,
-        method: MinerMethod::ExtendSectorExpiration as u64,
-        subinvocs: Some(vec![ExpectInvocation {
-            to: STORAGE_POWER_ACTOR_ADDR,
-            method: PowerMethod::UpdateClaimedPower as u64,
-            params: Some(expected_update_claimed_power_params_ser),
-            ..Default::default()
-        }]),
-        ..Default::default()
+    if do_extend2 {
+        extend2(
+            &v,
+            worker,
+            miner_id,
+            deadline_info.index,
+            partition_index,
+            sector_number,
+            new_expiration,
+            expected_update_claimed_power_params_ser,
+        );
+    } else {
+        extend1(
+            &v,
+            worker,
+            miner_id,
+            deadline_info.index,
+            partition_index,
+            sector_number,
+            new_expiration,
+            expected_update_claimed_power_params_ser,
+        );
     }
-    .matches(v.take_invocations().last().unwrap());
 
     // advance to 6 months (original expiration) and extend another 6 months
     // verified deal weight /= 2
@@ -204,24 +297,7 @@ fn extend_sector_with_deals() {
         deal_start + 180 * EPOCHS_IN_DAY,
     );
 
-    extension_params = ExtendSectorExpirationParams {
-        extensions: vec![ExpirationExtension {
-            deadline: deadline_info.index,
-            partition: partition_index,
-            sectors: BitField::try_from_bits([sector_number].iter().copied()).unwrap(),
-            new_expiration: deal_start + 3 * 180 * EPOCHS_IN_DAY,
-        }],
-    };
-
-    apply_ok(
-        &v,
-        worker,
-        miner_id,
-        TokenAmount::zero(),
-        MinerMethod::ExtendSectorExpiration as u64,
-        extension_params,
-    );
-
+    let new_expiration = deal_start + 3 * 180 * EPOCHS_IN_DAY;
     expected_update_claimed_power_params = UpdateClaimedPowerParams {
         raw_byte_delta: StoragePower::zero(),
         quality_adjusted_delta: StoragePower::from(-15 * (32i64 << 30) / 10),
@@ -229,18 +305,29 @@ fn extend_sector_with_deals() {
     expected_update_claimed_power_params_ser =
         serialize(&expected_update_claimed_power_params, "update_claimed_power params").unwrap();
 
-    ExpectInvocation {
-        to: miner_id,
-        method: MinerMethod::ExtendSectorExpiration as u64,
-        subinvocs: Some(vec![ExpectInvocation {
-            to: STORAGE_POWER_ACTOR_ADDR,
-            method: PowerMethod::UpdateClaimedPower as u64,
-            params: Some(expected_update_claimed_power_params_ser),
-            ..Default::default()
-        }]),
-        ..Default::default()
+    if do_extend2 {
+        extend2(
+            &v,
+            worker,
+            miner_id,
+            deadline_info.index,
+            partition_index,
+            sector_number,
+            new_expiration,
+            expected_update_claimed_power_params_ser,
+        );
+    } else {
+        extend1(
+            &v,
+            worker,
+            miner_id,
+            deadline_info.index,
+            partition_index,
+            sector_number,
+            new_expiration,
+            expected_update_claimed_power_params_ser,
+        );
     }
-    .matches(v.take_invocations().last().unwrap());
 
     miner_state = v.get_state::<MinerState>(miner_id).unwrap();
     sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();


### PR DESCRIPTION
Add a test that the old extend method will fail when attempting to extend a new (simple qap) sector with deals and inversely test that the new extend method will succeed when extending a legacy (non simple qp) sector with deals.