### PR TITLE
Store/lookup predictable addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.3"
+version = "3.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab114165b001c7ff18de384d56c05992b636a29180f704c1bb09e28fe57e6a3"
+checksum = "52916d828994181d1e61b01ad254d3502291869e92892ddd0624dd49951e47cc"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -1955,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0-alpha.3"
+version = "3.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f383d7556da494339f507766bc1caa0cf612fa1986cc94bb76509e05ad7037d7"
+checksum = "6806b52893ee4da415d47136ffb3c495af82c6e830fcb803a325a3b573b4893b"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/embryo/Cargo.toml
+++ b/actors/embryo/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fvm_sdk = { version = "3.0.0-alpha.3", optional = true }
-fvm_shared = { version = "3.0.0-alpha.3", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.4", optional = true }
+fvm_shared = { version = "3.0.0-alpha.4", optional = true }
 
 [features]
 fil-actor = ["fvm_sdk", "fvm_shared"]

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5"

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -93,7 +93,7 @@ impl Actor {
         })?;
 
         // Create an empty actor
-        rt.create_actor(params.code_cid, id_address)?;
+        rt.create_actor(params.code_cid, id_address, None)?;
 
         // Invoke constructor
         rt.send(
@@ -144,7 +144,7 @@ impl Actor {
         })?;
 
         // Create an empty actor
-        rt.create_actor(params.code_cid, id_address)?;
+        rt.create_actor(params.code_cid, id_address, Some(delegated_address))?;
 
         // Invoke constructor
         rt.send(

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -67,7 +67,7 @@ fn repeated_robust_address() {
         // Next id
         let expected_id = 100;
         let expected_id_addr = Address::new_id(expected_id);
-        rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id);
+        rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id, None);
 
         // Expect a send to the multisig actor constructor
         rt.expect_send(
@@ -125,7 +125,7 @@ fn create_2_payment_channels() {
 
         let expected_id = 100 + n;
         let expected_id_addr = Address::new_id(expected_id);
-        rt.expect_create_actor(*PAYCH_ACTOR_CODE_ID, expected_id);
+        rt.expect_create_actor(*PAYCH_ACTOR_CODE_ID, expected_id, None);
 
         let fake_params = ConstructorParams { network_name: String::from("fake_param") };
 
@@ -169,7 +169,7 @@ fn create_storage_miner() {
 
     let expected_id = 100;
     let expected_id_addr = Address::new_id(expected_id);
-    rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id);
+    rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id, None);
 
     let fake_params = ConstructorParams { network_name: String::from("fake_param") };
 
@@ -218,7 +218,7 @@ fn create_multisig_actor() {
     // Next id
     let expected_id = 100;
     let expected_id_addr = Address::new_id(expected_id);
-    rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id);
+    rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id, None);
 
     let fake_params = ConstructorParams { network_name: String::from("fake_param") };
     // Expect a send to the multisig actor constructor
@@ -253,7 +253,7 @@ fn sending_constructor_failure() {
     // Create the next id address
     let expected_id = 100;
     let expected_id_addr = Address::new_id(expected_id);
-    rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id);
+    rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id, None);
 
     let fake_params = ConstructorParams { network_name: String::from("fake_param") };
     rt.expect_send(
@@ -292,10 +292,14 @@ fn call_exec4() {
     let unique_address = Address::new_actor(b"test");
     rt.new_actor_addr = Some(unique_address);
 
+    // Make the f4 addr
+    let subaddr = b"foobar";
+    let f4_addr = Address::new_delegated(EAM_ACTOR_ID, subaddr).unwrap();
+
     // Next id
     let expected_id = 100;
     let expected_id_addr = Address::new_id(expected_id);
-    rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id);
+    rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id, Some(f4_addr));
 
     let fake_params = ConstructorParams { network_name: String::from("fake_param") };
     // Expect a send to the multisig actor constructor
@@ -307,9 +311,6 @@ fn call_exec4() {
         RawBytes::default(),
         ExitCode::OK,
     );
-
-    let subaddr = b"foobar";
-    let f4_addr = Address::new_delegated(EAM_ACTOR_ID, subaddr).unwrap();
 
     // Return should have been successful. Check the returned addresses
     let exec_ret =

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_ipld_hamt = "0.5.1"
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 fvm_ipld_bitfield = "0.5.2"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
 fvm_ipld_hamt = "0.5.1"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 fvm_ipld_encoding = "0.2.2"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 [dependencies]
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -34,7 +34,7 @@ paste = "1.0.9"
 sha2 = "0.10"
 
 # fil-actor
-fvm_sdk = { version = "3.0.0-alpha.3", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.4", optional = true }
 
 # test_util
 rand = { version = "0.8.5", default-features = false, optional = true }

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -363,13 +363,18 @@ where
         Ok(fvm::actor::new_actor_address())
     }
 
-    fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {
+    fn create_actor(
+        &mut self,
+        code_id: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) -> Result<(), ActorError> {
         if self.in_transaction {
             return Err(
                 actor_error!(assertion_failed; "create_actor is not allowed during transaction"),
             );
         }
-        fvm::actor::create_actor(actor_id, &code_id).map_err(|e| match e {
+        fvm::actor::create_actor(actor_id, &code_id, predictable_address).map_err(|e| match e {
             ErrorNumber::IllegalArgument => {
                 ActorError::illegal_argument("failed to create actor".into())
             }

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -140,9 +140,14 @@ pub trait Runtime<BS: Blockstore>: Primitives + Verifier + RuntimePolicy {
     /// Always an ActorExec address.
     fn new_actor_address(&mut self) -> Result<Address, ActorError>;
 
-    /// Creates an actor with code `codeID` and address `address`, with empty state.
+    /// Creates an actor with code `codeID`, an empty state, id `actor_id`, and an optional predictable address.
     /// May only be called by Init actor.
-    fn create_actor(&mut self, code_id: Cid, address: ActorID) -> Result<(), ActorError>;
+    fn create_actor(
+        &mut self,
+        code_id: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) -> Result<(), ActorError>;
 
     /// Deletes the executing actor from the state tree, transferring any balance to beneficiary.
     /// Aborts if the beneficiary does not exist.

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -317,10 +317,11 @@ impl<BS> MockRuntime<BS> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct ExpectCreateActor {
     pub code_id: Cid,
     pub actor_id: ActorID,
+    pub predictable_address: Option<Address>,
 }
 
 #[derive(Clone, Debug)]
@@ -595,8 +596,13 @@ impl<BS: Blockstore> MockRuntime<BS> {
     }
 
     #[allow(dead_code)]
-    pub fn expect_create_actor(&mut self, code_id: Cid, actor_id: ActorID) {
-        let a = ExpectCreateActor { code_id, actor_id };
+    pub fn expect_create_actor(
+        &mut self,
+        code_id: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) {
+        let a = ExpectCreateActor { code_id, actor_id, predictable_address };
         self.expectations.borrow_mut().expect_create_actor = Some(a);
     }
 
@@ -1015,7 +1021,12 @@ impl<BS: Blockstore> Runtime<Rc<BS>> for MockRuntime<BS> {
         Ok(ret)
     }
 
-    fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {
+    fn create_actor(
+        &mut self,
+        code_id: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) -> Result<(), ActorError> {
         self.require_in_call();
         if self.in_transaction {
             return Err(actor_error!(assertion_failed; "side-effect within transaction"));
@@ -1027,7 +1038,11 @@ impl<BS: Blockstore> Runtime<Rc<BS>> for MockRuntime<BS> {
             .take()
             .expect("unexpected call to create actor");
 
-        assert!(expect_create_actor.code_id == code_id && expect_create_actor.actor_id == actor_id, "unexpected actor being created, expected code: {:?} address: {:?}, actual code: {:?} address: {:?}", expect_create_actor.code_id, expect_create_actor.actor_id, code_id, actor_id);
+        assert_eq!(
+            expect_create_actor,
+            ExpectCreateActor { code_id, actor_id, predictable_address },
+            "unexpected actor being created"
+        );
         Ok(())
     }
 

--- a/runtime/src/util/chaos/mod.rs
+++ b/runtime/src/util/chaos/mod.rs
@@ -123,7 +123,7 @@ impl Actor {
 
         let actor_address = arg.actor_id;
 
-        rt.create_actor(actor_cid, actor_address)
+        rt.create_actor(actor_cid, actor_address, None)
     }
 
     /// Resolves address, and returns the resolved address (defaulting to 0 ID) and success boolean.

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -26,7 +26,7 @@ fil_actor_reward = { version = "10.0.0-alpha.1", path = "../actors/reward"}
 fil_actor_system = { version = "10.0.0-alpha.1", path = "../actors/system"}
 fil_actor_init = { version = "10.0.0-alpha.1", path = "../actors/init"}
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../runtime"}
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 fvm_ipld_encoding = "0.2.2"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -60,6 +60,10 @@ pub struct Actor {
     pub call_seq_num: u64,
     /// Token balance of the actor
     pub balance: TokenAmount,
+    /// The actor's "predictable" address, if assigned.
+    ///
+    /// This field is set on actor creation and never modified.
+    pub address: Option<Address>,
 }
 
 /// A specialization of a map of ID-addresses to actor heads.

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -26,7 +26,7 @@ fil_actor_verifreg = { version = "10.0.0-alpha.1", path = "../actors/verifreg" }
 fil_actor_miner = { version = "10.0.0-alpha.1", path = "../actors/miner" }
 fil_actor_evm = { version = "10.0.0-alpha.1", path = "../actors/evm" }
 lazy_static = "1.4.0"
-fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.4", default-features = false }
 fvm_ipld_encoding = { version = "0.2.2", default-features = false }
 fvm_ipld_blockstore = { version = "0.1.1", default-features = false }
 fvm_ipld_bitfield = "0.5.2"

--- a/test_vm/tests/init_test.rs
+++ b/test_vm/tests/init_test.rs
@@ -26,7 +26,7 @@ fn embryo_deploy() {
     // Create a "fake" eam.
     v.set_actor(
         EAM_ACTOR_ADDR,
-        actor(*ACCOUNT_ACTOR_CODE_ID, EMPTY_ARR_CID, 0, TokenAmount::zero()),
+        actor(*ACCOUNT_ACTOR_CODE_ID, EMPTY_ARR_CID, 0, TokenAmount::zero(), None),
     );
 
     // Create an embryo.

--- a/test_vm/tests/test_vm_test.rs
+++ b/test_vm/tests/test_vm_test.rs
@@ -21,14 +21,25 @@ fn state_control() {
     let addr2 = Address::new_id(2222);
 
     // set actor
-    let a1 =
-        actor(*ACCOUNT_ACTOR_CODE_ID, make_builtin(b"a1-head"), 42, TokenAmount::from_atto(10u8));
+    let a1 = actor(
+        *ACCOUNT_ACTOR_CODE_ID,
+        make_builtin(b"a1-head"),
+        42,
+        TokenAmount::from_atto(10u8),
+        None,
+    );
     v.set_actor(addr1, a1.clone());
     let out = v.get_actor(addr1).unwrap();
     assert_eq!(out, a1);
     let check = v.checkpoint();
 
-    let a2 = actor(*PAYCH_ACTOR_CODE_ID, make_builtin(b"a2-head"), 88, TokenAmount::from_atto(1u8));
+    let a2 = actor(
+        *PAYCH_ACTOR_CODE_ID,
+        make_builtin(b"a2-head"),
+        88,
+        TokenAmount::from_atto(1u8),
+        None,
+    );
     v.set_actor(addr2, a2.clone());
     assert_eq!(v.get_actor(addr2).unwrap(), a2);
     // rollback removes a2 but not a1


### PR DESCRIPTION
Store predictable (f1/f3/f4 addresses) in state (implementing https://github.com/filecoin-project/FIPs/discussions/477). This will allow the EVM to perform reverse-lookups on EVM addresses.