### PR TITLE
chore: update fvm_sdk and fvm_shared

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1846,7 +1846,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.4.2"
-source = "git+https://github.com/filecoin-project/ref-fvm#19ad768ce45c1408c1e1695b92305ac2e9a745d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d09e5aa7de45452676d18fcb70b750acd65faae7a4fe18fe784b4c85f869fb"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1862,7 +1863,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.3"
-source = "git+https://github.com/filecoin-project/ref-fvm#19ad768ce45c1408c1e1695b92305ac2e9a745d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97dfb38431e301bf063a412f870a3d9ebb541d581d1884f95e921f5ea823d29d"
 dependencies = [
  "cs_serde_bytes",
  "fvm_ipld_encoding",
@@ -1874,7 +1876,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
-source = "git+https://github.com/filecoin-project/ref-fvm#19ad768ce45c1408c1e1695b92305ac2e9a745d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688239a96199577f6705a3f9689abfd795f867f91f5847bc7e236017cc672df7"
 dependencies = [
  "anyhow",
  "cid",
@@ -1899,7 +1902,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.2.2"
-source = "git+https://github.com/filecoin-project/ref-fvm#19ad768ce45c1408c1e1695b92305ac2e9a745d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9cfcb4ae444801009182fded790dd56aff9c9a567e54510e2ccf14fb9daf8e"
 dependencies = [
  "anyhow",
  "cid",
@@ -1916,7 +1920,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.5.1"
-source = "git+https://github.com/filecoin-project/ref-fvm#19ad768ce45c1408c1e1695b92305ac2e9a745d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65b5c939897aa1bfd63e7cb9c458ba10689371af3278ff20d66c6f8ca152c6c0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1935,8 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.2"
-source = "git+https://github.com/filecoin-project/ref-fvm#19ad768ce45c1408c1e1695b92305ac2e9a745d6"
+version = "3.0.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab114165b001c7ff18de384d56c05992b636a29180f704c1bb09e28fe57e6a3"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -1949,8 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0-alpha.2"
-source = "git+https://github.com/filecoin-project/ref-fvm#19ad768ce45c1408c1e1695b92305ac2e9a745d6"
+version = "3.0.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f383d7556da494339f507766bc1caa0cf612fa1986cc94bb76509e05ad7037d7"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -2342,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "libipld-core"
@@ -3519,9 +3526,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3784,9 +3791,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,14 +55,14 @@ members = [
      "test_vm",
 ]
 
-[patch.crates-io]
-fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm"  }
-fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm" }
+#[patch.crates-io]
+#fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm"  }
+#fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm" }
 
 ## Uncomment when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/embryo/Cargo.toml
+++ b/actors/embryo/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fvm_sdk = { version = "3.0.0-alpha.2", optional = true }
-fvm_shared = { version = "3.0.0-alpha.2", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.3", optional = true }
+fvm_shared = { version = "3.0.0-alpha.3", optional = true }
 
 [features]
 fil-actor = ["fvm_sdk", "fvm_shared"]

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5"

--- a/actors/evm/src/interpreter/instructions/state.rs
+++ b/actors/evm/src/interpreter/instructions/state.rs
@@ -13,11 +13,11 @@ pub fn balance<'r, BS: Blockstore, RT: Runtime<BS>>(
 ) -> Result<(), StatusCode> {
     let actor = state.stack.pop();
 
-    let balance = if let Some(id) = EthAddress::try_from(actor).ok().and_then(|addr| addr.as_id()) {
-        U256::from(&platform.rt.actor_balance(id))
-    } else {
-        U256::zero()
-    };
+    let balance = EthAddress::try_from(actor)
+        .ok()
+        .and_then(|addr| addr.as_id())
+        .and_then(|id| platform.rt.actor_balance(id).as_ref().map(U256::from))
+        .unwrap_or_default();
 
     state.stack.push(balance);
     Ok(())

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
 fvm_ipld_hamt = "0.5.1"
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 fvm_ipld_bitfield = "0.5.2"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
 fvm_ipld_hamt = "0.5.1"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 fvm_ipld_encoding = "0.2.2"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 [dependencies]
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -34,7 +34,7 @@ paste = "1.0.9"
 sha2 = "0.10"
 
 # fil-actor
-fvm_sdk = { version = "3.0.0-alpha.2", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.3", optional = true }
 
 # test_util
 rand = { version = "0.8.5", default-features = false, optional = true }

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -166,7 +166,7 @@ where
         fvm::sself::current_balance()
     }
 
-    fn actor_balance(&self, id: ActorID) -> TokenAmount {
+    fn actor_balance(&self, id: ActorID) -> Option<TokenAmount> {
         fvm::actor::balance_of(id)
     }
 
@@ -408,7 +408,7 @@ where
     }
 
     fn tipset_cid(&self, epoch: i64) -> Option<Cid> {
-        fvm::network::tipset_cid(epoch)
+        fvm::network::tipset_cid(epoch).ok()
     }
 }
 

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -67,7 +67,7 @@ pub trait Runtime<BS: Blockstore>: Primitives + Verifier + RuntimePolicy {
     fn current_balance(&self) -> TokenAmount;
 
     /// The balance of an actor.
-    fn actor_balance(&self, id: ActorID) -> TokenAmount;
+    fn actor_balance(&self, id: ActorID) -> Option<TokenAmount>;
 
     /// Resolves an address of any protocol to an ID address (via the Init actor's table).
     /// This allows resolution of externally-provided SECP, BLS, or actor addresses to the canonical form.

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -823,9 +823,9 @@ impl<BS: Blockstore> Runtime<Rc<BS>> for MockRuntime<BS> {
         self.balance.borrow().clone()
     }
 
-    fn actor_balance(&self, id: ActorID) -> TokenAmount {
+    fn actor_balance(&self, id: ActorID) -> Option<TokenAmount> {
         self.require_in_call();
-        self.actor_balances.get(&id).cloned().unwrap_or_default()
+        self.actor_balances.get(&id).cloned()
     }
 
     fn resolve_address(&self, address: &Address) -> Option<ActorID> {

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -26,7 +26,7 @@ fil_actor_reward = { version = "10.0.0-alpha.1", path = "../actors/reward"}
 fil_actor_system = { version = "10.0.0-alpha.1", path = "../actors/system"}
 fil_actor_init = { version = "10.0.0-alpha.1", path = "../actors/init"}
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../runtime"}
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 fvm_ipld_encoding = "0.2.2"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -26,7 +26,7 @@ fil_actor_verifreg = { version = "10.0.0-alpha.1", path = "../actors/verifreg" }
 fil_actor_miner = { version = "10.0.0-alpha.1", path = "../actors/miner" }
 fil_actor_evm = { version = "10.0.0-alpha.1", path = "../actors/evm" }
 lazy_static = "1.4.0"
-fvm_shared = { version = "3.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.3", default-features = false }
 fvm_ipld_encoding = { version = "0.2.2", default-features = false }
 fvm_ipld_blockstore = { version = "0.1.1", default-features = false }
 fvm_ipld_bitfield = "0.5.2"

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -930,7 +930,7 @@ impl<'invocation, 'bs> Runtime<&'bs MemoryBlockstore> for InvocationCtx<'invocat
         TokenAmount::zero()
     }
 
-    fn actor_balance(&self, _id: ActorID) -> TokenAmount {
+    fn actor_balance(&self, _id: ActorID) -> Option<TokenAmount> {
         todo!()
     }
 


### PR DESCRIPTION
This updates fvm_sdk and fvm_shared to the latest released version ahead of some f4 changes (so we can atomically back out of those changes).