### PR TITLE
EVM: save/restore state before/after send

### DIFF
--- a/actors/evm/src/interpreter/bytecode.rs
+++ b/actors/evm/src/interpreter/bytecode.rs
@@ -1,14 +1,15 @@
 #![allow(dead_code)]
 
-use {super::opcode::OpCode, crate::interpreter::output::StatusCode, std::ops::Deref};
+use {super::opcode::OpCode, std::ops::Deref};
 
-pub struct Bytecode<'c> {
-    code: &'c [u8],
+#[derive(Clone, Debug)]
+pub struct Bytecode {
+    code: Vec<u8>,
     jumpdest: Vec<bool>,
 }
 
-impl<'c> Bytecode<'c> {
-    pub fn new(bytecode: &'c [u8]) -> Result<Self, StatusCode> {
+impl Bytecode {
+    pub fn new(bytecode: Vec<u8>) -> Self {
         // only jumps to those addresses are valid. This is a security
         // feature by EVM to disallow jumps to arbitary code addresses.
         // todo: create the jumpdest table only once during initial contract deployment
@@ -25,7 +26,7 @@ impl<'c> Bytecode<'c> {
             }
         }
 
-        Ok(Self { code: bytecode, jumpdest })
+        Self { code: bytecode, jumpdest }
     }
 
     /// Checks if the EVM is allowed to jump to this location.
@@ -37,16 +38,16 @@ impl<'c> Bytecode<'c> {
     }
 }
 
-impl<'c> Deref for Bytecode<'c> {
+impl Deref for Bytecode {
     type Target = [u8];
 
-    fn deref(&self) -> &'c Self::Target {
-        self.code
+    fn deref(&self) -> &Self::Target {
+        &self.code
     }
 }
 
-impl<'c> AsRef<[u8]> for Bytecode<'c> {
-    fn as_ref(&self) -> &'c [u8] {
-        self.code
+impl AsRef<[u8]> for Bytecode {
+    fn as_ref(&self) -> &[u8] {
+        &self.code
     }
 }

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -107,9 +107,9 @@ pub fn codecopy(state: &mut ExecutionState, code: &[u8]) -> Result<(), StatusCod
     Ok(())
 }
 
-pub fn call<'a, 'r, BS: Blockstore, RT: Runtime<BS>>(
+pub fn call<BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    platform: &'a mut System<'r, BS, RT>,
+    platform: &mut System<BS, RT>,
     kind: CallKind,
 ) -> Result<(), StatusCode> {
     let ExecutionState { stack, memory, .. } = state;
@@ -203,9 +203,9 @@ pub fn call<'a, 'r, BS: Blockstore, RT: Runtime<BS>>(
     Ok(())
 }
 
-pub fn callactor<'r, BS: Blockstore, RT: Runtime<BS>>(
+pub fn callactor<BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    platform: &'r System<'r, BS, RT>,
+    platform: &System<BS, RT>,
 ) -> Result<(), StatusCode> {
     let ExecutionState { stack, memory, .. } = state;
     let rt = &*platform.rt; // as immutable reference

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -107,13 +107,12 @@ pub fn codecopy(state: &mut ExecutionState, code: &[u8]) -> Result<(), StatusCod
     Ok(())
 }
 
-pub fn call<'r, BS: Blockstore, RT: Runtime<BS>>(
+pub fn call<'a, 'r, BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    platform: &'r System<'r, BS, RT>,
+    platform: &'a mut System<'r, BS, RT>,
     kind: CallKind,
 ) -> Result<(), StatusCode> {
     let ExecutionState { stack, memory, .. } = state;
-    let rt = &*platform.rt; // as immutable reference
 
     // NOTE gas is currently ignored as FVM's send doesn't allow the caller to specify a gas
     //      limit (external invocation gas limit applies). This may changed in the future.
@@ -151,7 +150,7 @@ pub fn call<'r, BS: Blockstore, RT: Runtime<BS>>(
         };
 
         if precompiles::Precompiles::<BS, RT>::is_precompile(&dst) {
-            precompiles::Precompiles::call_precompile(rt, dst, input_data)
+            precompiles::Precompiles::call_precompile(platform.rt, dst, input_data)
                 .map_err(|_| StatusCode::PrecompileFailure)?
         } else {
             let dst_addr = EthAddress::try_from(dst)?
@@ -159,7 +158,7 @@ pub fn call<'r, BS: Blockstore, RT: Runtime<BS>>(
                 .ok_or_else(|| StatusCode::BadAddress("not an actor id address".to_string()))?;
 
             let call_result = match kind {
-                CallKind::Call => rt.send(
+                CallKind::Call => platform.send(
                     &dst_addr,
                     Method::InvokeContract as u64,
                     // TODO: support IPLD codecs #758

--- a/actors/evm/src/interpreter/instructions/lifecycle.rs
+++ b/actors/evm/src/interpreter/instructions/lifecycle.rs
@@ -41,9 +41,9 @@ pub struct EamReturn {
 }
 
 #[inline]
-pub fn create<'r, BS: Blockstore, RT: Runtime<BS>>(
+pub fn create<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    platform: &'r mut System<'r, BS, RT>,
+    platform: &'r mut System<'a, BS, RT>,
 ) -> Result<(), StatusCode> {
     let ExecutionState { stack, memory, .. } = state;
 
@@ -75,9 +75,9 @@ pub fn create<'r, BS: Blockstore, RT: Runtime<BS>>(
     create_init(stack, platform, RawBytes::serialize(&params)?, CREATE_METHOD_NUM, value)
 }
 
-pub fn create2<'r, BS: Blockstore, RT: Runtime<BS>>(
+pub fn create2<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    platform: &'r mut System<'r, BS, RT>,
+    platform: &'r mut System<'a, BS, RT>,
 ) -> Result<(), StatusCode> {
     let ExecutionState { stack, memory, .. } = state;
 
@@ -113,9 +113,9 @@ pub fn create2<'r, BS: Blockstore, RT: Runtime<BS>>(
 }
 
 /// call into Ethereum Address Manager to make the new account
-fn create_init<'r, BS: Blockstore, RT: Runtime<BS>>(
+fn create_init<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
     stack: &mut Stack,
-    platform: &'r mut System<'r, BS, RT>,
+    platform: &'a mut System<'r, BS, RT>,
     params: RawBytes,
     method: MethodNum,
     value: TokenAmount,
@@ -155,9 +155,9 @@ fn create_init<'r, BS: Blockstore, RT: Runtime<BS>>(
 }
 
 #[inline]
-pub fn selfdestruct<'r, BS: Blockstore, RT: Runtime<BS>>(
+pub fn selfdestruct<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    _system: &'r mut System<'r, BS, RT>,
+    _system: &'r mut System<'a, BS, RT>,
 ) -> Result<(), StatusCode> {
     let beneficiary_addr = EthAddress::try_from(state.stack.pop())?;
     let id_addr = beneficiary_addr.as_id_address().expect("no support for non-ID addresses yet");

--- a/actors/evm/src/interpreter/instructions/lifecycle.rs
+++ b/actors/evm/src/interpreter/instructions/lifecycle.rs
@@ -40,9 +40,9 @@ pub struct EamReturn {
 }
 
 #[inline]
-pub fn create<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
+pub fn create<BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    platform: &'r mut System<'a, BS, RT>,
+    platform: &mut System<BS, RT>,
 ) -> Result<(), StatusCode> {
     let ExecutionState { stack, memory, .. } = state;
 
@@ -66,9 +66,9 @@ pub fn create<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
     create_init(stack, platform, RawBytes::serialize(&params)?, CREATE_METHOD_NUM, value)
 }
 
-pub fn create2<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
+pub fn create2<BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    platform: &'r mut System<'a, BS, RT>,
+    platform: &mut System<BS, RT>,
 ) -> Result<(), StatusCode> {
     let ExecutionState { stack, memory, .. } = state;
 
@@ -99,9 +99,9 @@ pub fn create2<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
 }
 
 /// call into Ethereum Address Manager to make the new account
-fn create_init<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
+fn create_init<BS: Blockstore, RT: Runtime<BS>>(
     stack: &mut Stack,
-    platform: &'a mut System<'r, BS, RT>,
+    platform: &mut System<BS, RT>,
     params: RawBytes,
     method: MethodNum,
     value: TokenAmount,
@@ -141,9 +141,9 @@ fn create_init<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
 }
 
 #[inline]
-pub fn selfdestruct<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
+pub fn selfdestruct<BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    _system: &'r mut System<'a, BS, RT>,
+    _system: &mut System<BS, RT>,
 ) -> Result<(), StatusCode> {
     let beneficiary_addr = EthAddress::try_from(state.stack.pop())?;
     let id_addr = beneficiary_addr.as_id_address().expect("no support for non-ID addresses yet");

--- a/actors/evm/src/interpreter/instructions/storage.rs
+++ b/actors/evm/src/interpreter/instructions/storage.rs
@@ -5,9 +5,9 @@ use {
 };
 
 #[inline]
-pub fn sload<'r, BS: Blockstore, RT: Runtime<BS>>(
+pub fn sload<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    platform: &'r mut System<'r, BS, RT>,
+    platform: &'r mut System<'a, BS, RT>,
 ) -> Result<(), StatusCode> {
     // where?
     let location = state.stack.pop();
@@ -22,9 +22,9 @@ pub fn sload<'r, BS: Blockstore, RT: Runtime<BS>>(
 }
 
 #[inline]
-pub fn sstore<'r, BS: Blockstore, RT: Runtime<BS>>(
+pub fn sstore<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    platform: &'r mut System<'r, BS, RT>,
+    platform: &'r mut System<'a, BS, RT>,
 ) -> Result<(), StatusCode> {
     let location = state.stack.pop();
     let value = state.stack.pop();

--- a/actors/evm/src/interpreter/instructions/storage.rs
+++ b/actors/evm/src/interpreter/instructions/storage.rs
@@ -5,9 +5,9 @@ use {
 };
 
 #[inline]
-pub fn sload<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
+pub fn sload<BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    platform: &'r mut System<'a, BS, RT>,
+    platform: &mut System<BS, RT>,
 ) -> Result<(), StatusCode> {
     // where?
     let location = state.stack.pop();
@@ -22,9 +22,9 @@ pub fn sload<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
 }
 
 #[inline]
-pub fn sstore<'r, 'a, BS: Blockstore, RT: Runtime<BS>>(
+pub fn sstore<BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
-    platform: &'r mut System<'a, BS, RT>,
+    platform: &mut System<BS, RT>,
 ) -> Result<(), StatusCode> {
     let location = state.stack.pop();
     let value = state.stack.pop();

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -42,9 +42,13 @@ pub enum StorageStatus {
 pub struct System<'r, BS: Blockstore, RT: Runtime<BS>> {
     pub rt: &'r mut RT,
 
+    /// The current bytecode. This is usually only "none" when the actor is first constructed.
     bytecode: Option<Cid>,
+    /// The contract's EVM storage slots.
     slots: Hamt<BS, U256, U256>,
+    /// The contracts "nonce" (incremented when creating new actors).
     nonce: u64,
+    /// The last saved state root. None if the current state hasn't been saved yet.
     saved_state_root: Option<Cid>,
 }
 

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -37,8 +37,6 @@ pub enum StorageStatus {
     Deleted,
 }
 
-struct SystemState {}
-
 /// Platform Abstraction Layer
 /// that bridges the FVM world to EVM world
 pub struct System<'r, BS: Blockstore, RT: Runtime<BS>> {

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -92,6 +92,14 @@ impl<'r, BS: Blockstore, RT: Runtime<BS>> System<'r, BS, RT> {
         })
     }
 
+    pub fn increment_nonce(&mut self) -> u64 {
+        self.saved_state_root = None;
+        let nonce = self.nonce;
+        self.nonce = self.nonce.checked_add(1).unwrap();
+        nonce
+    }
+
+    /// Send a message, saving and reloading state as necessary.
     pub fn send(
         &mut self,
         to: &Address,

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -1,9 +1,19 @@
 #![allow(dead_code)]
 
-use fil_actors_runtime::EAM_ACTOR_ID;
-use fvm_shared::address::{Address, Payload};
+use fil_actors_runtime::{actor_error, runtime::EMPTY_ARR_CID, AsActorError, EAM_ACTOR_ID};
+use fvm_ipld_blockstore::Block;
+use fvm_ipld_encoding::{CborStore, RawBytes};
+use fvm_shared::{
+    address::{Address, Payload},
+    econ::TokenAmount,
+    error::ExitCode,
+    MethodNum, IPLD_RAW,
+};
+use multihash::Code;
 
-use super::address::EthAddress;
+use crate::state::State;
+
+use super::{address::EthAddress, Bytecode};
 
 use {
     crate::interpreter::{StatusCode, U256},
@@ -27,26 +37,161 @@ pub enum StorageStatus {
     Deleted,
 }
 
+struct SystemState {}
+
 /// Platform Abstraction Layer
 /// that bridges the FVM world to EVM world
 pub struct System<'r, BS: Blockstore, RT: Runtime<BS>> {
     pub rt: &'r mut RT,
-    state: &'r mut Hamt<BS, U256, U256>,
+
+    bytecode: Option<Cid>,
+    slots: Hamt<BS, U256, U256>,
+    nonce: u64,
+    saved_state_root: Option<Cid>,
 }
 
 impl<'r, BS: Blockstore, RT: Runtime<BS>> System<'r, BS, RT> {
-    pub fn new(rt: &'r mut RT, state: &'r mut Hamt<BS, U256, U256>) -> anyhow::Result<Self> {
-        Ok(Self { rt, state })
+    /// Create the actor.
+    pub fn create(rt: &'r mut RT) -> Result<Self, ActorError>
+    where
+        BS: Clone,
+    {
+        let state_root = rt.get_state_root()?;
+        if state_root != EMPTY_ARR_CID {
+            return Err(actor_error!(illegal_state, "can't create over an existing actor"));
+        }
+        let store = rt.store().clone();
+        Ok(Self {
+            rt,
+            slots: Hamt::<_, U256, U256>::new(store),
+            nonce: 1,
+            saved_state_root: None,
+            bytecode: None,
+        })
     }
 
-    /// Reborrow the system with a shorter lifetime.
-    #[allow(clippy::needless_lifetimes)]
-    pub fn reborrow<'a>(&'a mut self) -> System<'a, BS, RT> {
-        System { rt: &mut *self.rt, state: &mut *self.state }
+    /// Load the actor from state.
+    pub fn load(rt: &'r mut RT) -> Result<Self, ActorError>
+    where
+        BS: Clone,
+    {
+        let store = rt.store().clone();
+        let state_root = rt.get_state_root()?;
+        let state: State = store
+            .get_cbor(&state_root)
+            .context_code(ExitCode::USR_SERIALIZATION, "failed to decode state")?
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "state not in blockstore")?;
+
+        Ok(Self {
+            rt,
+            slots: Hamt::<_, U256, U256>::load(&state.contract_state, store)
+                .context_code(ExitCode::USR_ILLEGAL_STATE, "state not in blockstore")?,
+            nonce: state.nonce,
+            saved_state_root: Some(state_root),
+            bytecode: Some(state.bytecode),
+        })
     }
 
-    pub fn flush_state(&mut self) -> Result<Cid, ActorError> {
-        self.state.flush().map_err(|e| ActorError::illegal_state(e.to_string()))
+    pub fn send(
+        &mut self,
+        to: &Address,
+        method: MethodNum,
+        params: RawBytes,
+        value: TokenAmount,
+    ) -> Result<RawBytes, ActorError> {
+        self.flush()?;
+        let result = self.rt.send(to, method, params, value)?;
+        self.reload()?;
+        Ok(result)
+    }
+
+    /// Flush the actor state (bytecode, nonce, and slots).
+    pub fn flush(&mut self) -> Result<(), ActorError> {
+        if self.saved_state_root.is_some() {
+            return Ok(());
+        }
+        let bytecode_cid = match self.bytecode {
+            Some(cid) => cid,
+            None => self.set_bytecode(&[])?,
+        };
+        let new_root = self
+            .rt
+            .store()
+            .put_cbor(
+                &State {
+                    bytecode: bytecode_cid,
+                    contract_state: self.slots.flush().context_code(
+                        ExitCode::USR_ILLEGAL_STATE,
+                        "failed to flush contract state",
+                    )?,
+                    nonce: self.nonce,
+                },
+                Code::Blake2b256,
+            )
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to write contract state")?;
+
+        self.rt.set_state_root(&new_root)?;
+        self.saved_state_root = Some(new_root);
+        Ok(())
+    }
+
+    /// Reload the actor state if changed.
+    pub fn reload(&mut self) -> Result<(), ActorError> {
+        let root = self.rt.get_state_root()?;
+        if self.saved_state_root == Some(root) {
+            return Ok(());
+        }
+        let state: State = self
+            .rt
+            .store()
+            .get_cbor(&root)
+            .context_code(ExitCode::USR_SERIALIZATION, "failed to decode state")?
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "state not in blockstore")?;
+
+        self.slots
+            .set_root(&state.contract_state)
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "state not in blockstore")?;
+        self.nonce = state.nonce;
+        self.saved_state_root = Some(root);
+        self.bytecode = Some(state.bytecode);
+        Ok(())
+    }
+
+    /// Load the bytecode.
+    pub fn load_bytecode(&self) -> Result<Option<Bytecode>, ActorError> {
+        match &self.bytecode {
+            Some(cid) => {
+                let bytecode = self
+                    .rt
+                    .store()
+                    .get(cid)
+                    .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to read state")?
+                    .expect("bytecode not in state tree");
+                if bytecode.is_empty() {
+                    return Ok(None);
+                }
+                Ok(Some(Bytecode::new(bytecode)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Set the bytecode.
+    pub fn set_bytecode(&mut self, bytecode: &[u8]) -> Result<Cid, ActorError> {
+        self.saved_state_root = None;
+        // Reject code starting with 0xEF, EIP-3541
+        if bytecode.first() == Some(&0xEF) {
+            return Err(ActorError::illegal_argument(
+                "EIP-3541: Contract code starting with the 0xEF byte is disallowed.".into(),
+            ));
+        }
+        let k = self
+            .rt
+            .store()
+            .put(Code::Blake2b256, &Block::new(IPLD_RAW, bytecode))
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to write bytecode")?;
+        self.bytecode = Some(k);
+        Ok(k)
     }
 
     /// Get value of a storage key.
@@ -54,7 +199,7 @@ impl<'r, BS: Blockstore, RT: Runtime<BS>> System<'r, BS, RT> {
         let mut key_bytes = [0u8; 32];
         key.to_big_endian(&mut key_bytes);
 
-        Ok(self.state.get(&key).map_err(|e| StatusCode::InternalError(e.to_string()))?.cloned())
+        Ok(self.slots.get(&key).map_err(|e| StatusCode::InternalError(e.to_string()))?.cloned())
     }
 
     /// Set value of a storage key.
@@ -63,20 +208,22 @@ impl<'r, BS: Blockstore, RT: Runtime<BS>> System<'r, BS, RT> {
         key: U256,
         value: Option<U256>,
     ) -> Result<StorageStatus, StatusCode> {
+        self.saved_state_root = None; // dirty.
+
         let mut key_bytes = [0u8; 32];
         key.to_big_endian(&mut key_bytes);
 
         let prev_value =
-            self.state.get(&key).map_err(|e| StatusCode::InternalError(e.to_string()))?.cloned();
+            self.slots.get(&key).map_err(|e| StatusCode::InternalError(e.to_string()))?.cloned();
 
         let mut storage_status =
             if prev_value == value { StorageStatus::Unchanged } else { StorageStatus::Modified };
 
         if value.is_none() {
-            self.state.delete(&key).map_err(|e| StatusCode::InternalError(e.to_string()))?;
+            self.slots.delete(&key).map_err(|e| StatusCode::InternalError(e.to_string()))?;
             storage_status = StorageStatus::Deleted;
         } else {
-            self.state
+            self.slots
                 .set(key, value.unwrap())
                 .map_err(|e| StatusCode::InternalError(e.to_string()))?;
         }

--- a/actors/evm/src/state.rs
+++ b/actors/evm/src/state.rs
@@ -1,14 +1,9 @@
 use {
     cid::Cid,
-    fvm_ipld_blockstore::Block,
-    fvm_ipld_blockstore::Blockstore,
     fvm_ipld_encoding::tuple::*,
-    fvm_ipld_encoding::{Cbor, RawBytes},
-    multihash::Code,
+    fvm_ipld_encoding::Cbor,
     serde_tuple::{Deserialize_tuple, Serialize_tuple},
 };
-
-pub const RAW: u64 = 0x55;
 
 /// Data stored by an EVM contract.
 /// This runs on the fvm-evm-runtime actor code cid.
@@ -29,14 +24,3 @@ pub struct State {
 }
 
 impl Cbor for State {}
-
-impl State {
-    pub fn new<BS: Blockstore>(
-        store: &BS,
-        bytecode: RawBytes,
-        contract_state: Cid,
-    ) -> anyhow::Result<Self> {
-        let bytecode_cid = store.put(Code::Blake2b256, &Block::new(RAW, bytecode.to_vec()))?;
-        Ok(Self { bytecode: bytecode_cid, contract_state, nonce: 0 })
-    }
-}

--- a/actors/evm/tests/create.rs
+++ b/actors/evm/tests/create.rs
@@ -81,7 +81,7 @@ fn test_create() {
 
     let mut create_params = CreateParams {
         code: hex_literal::hex!("666F6F206261722062617A20626F7879").to_vec(),
-        nonce: 0,
+        nonce: 1,
     };
 
     // byte 3 is method num

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -39,7 +39,7 @@ use rand::prelude::*;
 use crate::runtime::builtins::Type;
 use crate::runtime::{
     ActorCode, DomainSeparationTag, MessageInfo, Policy, Primitives, Runtime, RuntimePolicy,
-    Verifier,
+    Verifier, EMPTY_ARR_CID,
 };
 use crate::{actor_error, ActorError};
 use libsecp256k1::{recover, Message, RecoveryId, Signature as EcsdaSignature};
@@ -1008,6 +1008,15 @@ impl<BS: Blockstore> Runtime<Rc<BS>> for MockRuntime<BS> {
 
     fn state<C: Cbor>(&self) -> Result<C, ActorError> {
         Ok(self.store_get(self.state.as_ref().unwrap()))
+    }
+
+    fn get_state_root(&self) -> Result<Cid, ActorError> {
+        Ok(self.state.unwrap_or(EMPTY_ARR_CID))
+    }
+
+    fn set_state_root(&mut self, root: &Cid) -> Result<(), ActorError> {
+        self.state = Some(*root);
+        Ok(())
     }
 
     fn transaction<C, RT, F>(&mut self, f: F) -> Result<RT, ActorError>


### PR DESCRIPTION
This also refactors the "system" object to manage state. We should probably rename/move it.

We could also consider not _storing_ the runtime inside this object and instead passing it in when we need to?

It also fixes the lifetime issues we were having before without having to reborrow. Apparently, it was just an issue with some of the opcode definitions.

fixes https://github.com/filecoin-project/ref-fvm/issues/960
fixes https://github.com/filecoin-project/ref-fvm/issues/961