### PR TITLE
fix: encode/decode EVM parameters as CBOR

### DIFF
--- a/actors/evm/tests/basic.rs
+++ b/actors/evm/tests/basic.rs
@@ -31,9 +31,7 @@ fn basic_contract_construction_and_invocation() {
     let mut arg0 = vec![0u8; 32];
     solidity_params.append(&mut arg0);
 
-    let input_data = RawBytes::from(solidity_params);
-
-    let result = util::invoke_contract(&mut rt, input_data);
+    let result = util::invoke_contract(&mut rt, &solidity_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(0));
 
     // invoke contract -- getBalance
@@ -46,9 +44,7 @@ fn basic_contract_construction_and_invocation() {
     arg0[31] = 100; // the owner address
     solidity_params.append(&mut arg0);
 
-    let input_data = RawBytes::from(solidity_params);
-
-    let result = util::invoke_contract(&mut rt, input_data);
+    let result = util::invoke_contract(&mut rt, &solidity_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(10000));
 }
 

--- a/actors/evm/tests/calc.rs
+++ b/actors/evm/tests/calc.rs
@@ -2,7 +2,6 @@ mod asm;
 
 use evm::interpreter::U256;
 use fil_actor_evm as evm;
-use fvm_ipld_encoding::RawBytes;
 
 mod util;
 
@@ -75,26 +74,23 @@ fn test_magic_calc() {
 
     // invoke contract -- get_magic
     let contract_params = vec![0u8; 32];
-    let input_data = RawBytes::from(contract_params);
 
-    let result = util::invoke_contract(&mut rt, input_data);
+    let result = util::invoke_contract(&mut rt, &contract_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(0x42));
 
     // invoke contract -- add_magic
     let mut contract_params = vec![0u8; 36];
     contract_params[3] = 0x01;
     contract_params[35] = 0x01;
-    let input_data = RawBytes::from(contract_params);
 
-    let result = util::invoke_contract(&mut rt, input_data);
+    let result = util::invoke_contract(&mut rt, &contract_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(0x43));
 
     // invoke contract -- mul_magic
     let mut contract_params = vec![0u8; 36];
     contract_params[3] = 0x02;
     contract_params[35] = 0x02;
-    let input_data = RawBytes::from(contract_params);
 
-    let result = util::invoke_contract(&mut rt, input_data);
+    let result = util::invoke_contract(&mut rt, &contract_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(0x84));
 }

--- a/actors/evm/tests/create.rs
+++ b/actors/evm/tests/create.rs
@@ -100,7 +100,7 @@ fn test_create() {
             ExitCode::OK,
         );
 
-        let result = util::invoke_contract(&mut rt, RawBytes::from(contract_params.to_vec()));
+        let result = util::invoke_contract(&mut rt, &contract_params);
         let result: [u8; 20] = result[12..].try_into().unwrap();
         let result = EthAddress(result);
         // make sure we arent doing weird things to EAM's return value
@@ -122,7 +122,7 @@ fn test_create() {
             ExitCode::OK,
         );
 
-        let result = util::invoke_contract(&mut rt, RawBytes::from(contract_params.to_vec()));
+        let result = util::invoke_contract(&mut rt, &contract_params);
         let result: [u8; 20] = result[12..].try_into().unwrap();
         let result = EthAddress(result);
         // make sure we arent doing weird things to EAM's return value
@@ -144,7 +144,7 @@ fn test_create() {
             ExitCode::OK,
         );
 
-        let result = util::invoke_contract(&mut rt, RawBytes::from(contract_params.to_vec()));
+        let result = util::invoke_contract(&mut rt, &contract_params);
         let result: [u8; 20] = result[12..].try_into().unwrap();
         let result = EthAddress(result);
         // make sure we arent doing weird things to EAM's return value
@@ -162,7 +162,7 @@ fn test_create() {
             ExitCode::OK,
         );
 
-        let result = util::invoke_contract(&mut rt, RawBytes::from(contract_params.to_vec()));
+        let result = util::invoke_contract(&mut rt, &contract_params);
         assert_eq!(&result[..], &[0; 32]);
     }
 
@@ -181,7 +181,7 @@ fn test_create() {
             ExitCode::OK,
         );
 
-        let result = util::invoke_contract(&mut rt, RawBytes::from(contract_params.to_vec()));
+        let result = util::invoke_contract(&mut rt, &contract_params);
         assert_eq!(&result[..], &[0; 32]);
     }
 }

--- a/actors/evm/tests/ext_opcodes.rs
+++ b/actors/evm/tests/ext_opcodes.rs
@@ -53,7 +53,7 @@ fn test_extcodesize() {
         ExitCode::OK,
     );
 
-    let result = util::invoke_contract(&mut rt, RawBytes::default());
+    let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(0x04));
 }
 
@@ -96,7 +96,7 @@ fn test_extcodehash() {
         ExitCode::OK,
     );
 
-    let result = util::invoke_contract(&mut rt, RawBytes::default());
+    let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(&bytecode_cid.hash().digest()[..32]));
 }
 
@@ -139,6 +139,6 @@ fn test_extcodecopy() {
         ExitCode::OK,
     );
 
-    let result = util::invoke_contract(&mut rt, RawBytes::default());
-    assert_eq!(other_bytecode.as_slice(), result.bytes());
+    let result = util::invoke_contract(&mut rt, &[]);
+    assert_eq!(other_bytecode.as_slice(), result);
 }

--- a/actors/evm/tests/misc.rs
+++ b/actors/evm/tests/misc.rs
@@ -4,7 +4,6 @@ mod util;
 use cid::Cid;
 use evm::interpreter::U256;
 use fil_actor_evm as evm;
-use fvm_ipld_encoding::RawBytes;
 use fvm_shared::econ::TokenAmount;
 
 #[test]
@@ -25,7 +24,7 @@ return
 
     let mut rt = util::construct_and_verify(contract);
     rt.tipset_timestamp = 123;
-    let result = util::invoke_contract(&mut rt, RawBytes::default());
+    let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(123));
 }
 
@@ -51,7 +50,7 @@ return
     let test_cid =
         Cid::try_from("bafy2bzacecu7n7wbtogznrtuuvf73dsz7wasgyneqasksdblxupnyovmtwxxu").unwrap();
     rt.tipset_cids = vec![test_cid];
-    let result = util::invoke_contract(&mut rt, RawBytes::default());
+    let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(result.to_vec(), test_cid.hash().digest());
 }
 
@@ -72,7 +71,7 @@ return
     .unwrap();
 
     let mut rt = util::construct_and_verify(contract);
-    let result = util::invoke_contract(&mut rt, RawBytes::default());
+    let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(31415926));
 }
 
@@ -93,7 +92,7 @@ return
     .unwrap();
 
     let mut rt = util::construct_and_verify(contract);
-    let result = util::invoke_contract(&mut rt, RawBytes::default());
+    let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(10_000_000_000u64));
 }
 
@@ -116,7 +115,7 @@ return
     let mut rt = util::construct_and_verify(contract);
     rt.base_fee = TokenAmount::from_atto(123);
     rt.gas_premium = TokenAmount::from_atto(345);
-    let result = util::invoke_contract(&mut rt, RawBytes::default());
+    let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(123 + 345));
 }
 
@@ -147,7 +146,7 @@ return
     let mut input_data = vec![0u8; 32];
     input_data[12] = 0xff;
     input_data[31] = 0x64;
-    let result = util::invoke_contract(&mut rt, RawBytes::from(input_data));
+    let result = util::invoke_contract(&mut rt, &input_data);
     assert_eq!(U256::from_big_endian(&result), U256::from(123));
 }
 
@@ -176,7 +175,7 @@ return
     let mut rt = util::construct_and_verify(contract);
     let mut input_data = vec![0u8; 32];
     input_data[31] = 123;
-    let result = util::invoke_contract(&mut rt, RawBytes::from(input_data));
+    let result = util::invoke_contract(&mut rt, &input_data);
     assert_eq!(U256::from_big_endian(&result), U256::from(0));
 }
 
@@ -198,7 +197,7 @@ return
     .unwrap();
 
     let mut rt = util::construct_and_verify(contract);
-    let result = util::invoke_contract(&mut rt, RawBytes::default());
+    let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(0));
 }
 
@@ -220,6 +219,6 @@ return
 
     let mut rt = util::construct_and_verify(contract);
     rt.expect_gas_available(123);
-    let result = util::invoke_contract(&mut rt, RawBytes::default());
+    let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(123));
 }

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -2,7 +2,6 @@ mod asm;
 
 use evm::interpreter::U256;
 use fil_actor_evm as evm;
-use fvm_ipld_encoding::RawBytes;
 
 mod util;
 
@@ -44,9 +43,8 @@ fn test_precompile_hash() {
 
     // invoke contract
     let contract_params = vec![0u8; 32];
-    let input_data = RawBytes::from(contract_params);
 
-    let result = util::invoke_contract(&mut rt, input_data);
+    let result = util::invoke_contract(&mut rt, &contract_params);
     let expected =
         hex_literal::hex!("ace8597929092c14bd028ede7b07727875788c7e130278b5afed41940d965aba");
     assert_eq!(

--- a/actors/evm/tests/selfdestruct.rs
+++ b/actors/evm/tests/selfdestruct.rs
@@ -1,5 +1,4 @@
 use fil_actors_runtime::test_utils::*;
-use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 
 mod util;
@@ -17,11 +16,9 @@ fn test_selfdestruct() {
     });
 
     let solidity_params = hex::decode("35f46994").unwrap();
-    let input_data = RawBytes::from(solidity_params);
     rt.expect_validate_caller_any();
     rt.expect_delete_actor(beneficiary);
 
-    let result = util::invoke_contract(&mut rt, input_data);
-    expect_empty(result);
+    assert!(util::invoke_contract(&mut rt, &solidity_params).is_empty());
     rt.verify();
 }


### PR DESCRIPTION
The previous code was passing parameters as raw bytes, but telling the system that these bytes were valid CBOR. Unfortunately:

- This is incorrect and will break once we actually start enforcing this.
- This makes it _very_ difficult to test the EVM because we have quite a bit of testing code that assumes CBOR.

The long-term solution is to correctly handle IPLD (see https://github.com/filecoin-project/builtin-actors/issues/758). But the short-term solution is to just encode/decode parameters as CBOR.

part of https://github.com/filecoin-project/ref-fvm/issues/884