### PR TITLE
fix: Add runtime caller validation for change_beneficiary

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3297,6 +3297,7 @@ impl Actor {
         BS: Blockstore,
         RT: Runtime<BS>,
     {
+        rt.validate_immediate_caller_accept_any()?;
         let caller = rt.message().caller();
         let new_beneficiary =
             Address::new_id(rt.resolve_address(&params.new_beneficiary).ok_or_else(|| {

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2266,10 +2266,12 @@ impl ActorHarness {
             new_expiration: beneficiary_term.expiration,
         };
         let raw_bytes = &RawBytes::serialize(param).unwrap();
+        rt.expect_validate_caller_any();
         rt.call::<Actor>(Method::ChangeBeneficiary as u64, raw_bytes)?;
         rt.verify();
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, beneficiary_id_addr);
+        rt.expect_validate_caller_any();
         rt.call::<Actor>(Method::ChangeBeneficiary as u64, raw_bytes)?;
         rt.verify();
 
@@ -2284,6 +2286,7 @@ impl ActorHarness {
         beneficiary_change: &BeneficiaryChange,
         expect_beneficiary_addr: Option<Address>,
     ) -> Result<RawBytes, ActorError> {
+        rt.expect_validate_caller_any();
         rt.set_address_actor_type(
             beneficiary_change.beneficiary_addr.clone(),
             *ACCOUNT_ACTOR_CODE_ID,

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -14,6 +14,7 @@ use fil_actor_power::{Actor as PowerActor, Method as MethodPower, State as Power
 use fil_actor_reward::{Actor as RewardActor, State as RewardState};
 use fil_actor_system::{Actor as SystemActor, State as SystemState};
 use fil_actor_verifreg::{Actor as VerifregActor, State as VerifRegState};
+use fil_actors_runtime::actor_error;
 use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{
@@ -688,10 +689,7 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
             Type::DataCap => DataCapActor::invoke_method(self, self.msg.method, &params),
         };
         if res.is_ok() && !self.caller_validated {
-            res = Err(ActorError::unchecked(
-                ExitCode::SYS_ASSERTION_FAILED,
-                format!("caller wasn't validated!"),
-            ));
+            res = Err(actor_error!(assertion_failed, "failed to validate caller"));
         }
         if res.is_err() {
             self.v.rollback(prior_root)


### PR DESCRIPTION
Acceptable callers for `change_beneficiary` are `owner` `beneficiary` or `pending_term.new_beneficiary`. We could unwrap all the miner info and check if the caller is one of these three addresses, but caller validation is already handled in the logic of this function, so I opted for using `rt.validate_immediate_caller_accept_any()?;`.

Closes https://github.com/filecoin-project/builtin-actors/issues/760