### PR TITLE
Transfer value in embryonic actor calls

### DIFF
--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -139,6 +139,11 @@ pub fn call<BS: Blockstore, RT: Runtime<BS>>(
         ),
     };
 
+    if system.readonly && value > U256::zero() {
+        // non-zero sends are side-effects and hence a static mode violation
+        return Err(StatusCode::StaticModeViolation);
+    }
+
     let input_region = get_memory_region(memory, input_offset, input_size)
         .map_err(|_| StatusCode::InvalidMemoryAccess)?;
 

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -166,13 +166,15 @@ pub fn call<BS: Blockstore, RT: Runtime<BS>>(
 
             // Special casing for embryo/non-existent actors: we just do a SEND (method 0)
             // which allows us to transfer funds (and create embryos)
-            let is_embryonic = if let Some(actor_id) = system.rt.resolve_address(&dst_addr) {
+            let is_embryonic = if dst_addr.protocol() == AddressProtocol::ID {
+                // sanity check: this shouldn't be an ID address, as you can't predict
+                // what actor is gonna sit there.
+                false
+            } else if let Some(actor_id) = system.rt.resolve_address(&dst_addr) {
                 if let Some(cid) = system.rt.get_actor_code_cid(&actor_id) {
                     system.rt.resolve_builtin_actor_type(&cid) == Some(Type::Embryo)
                 } else {
-                    // sanity check: this shouldn't be an ID address, as you can't predict
-                    // what actor is gonna sit there.
-                    dst_addr.protocol() != AddressProtocol::ID
+                    true
                 }
             } else {
                 true

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -914,7 +914,10 @@ impl<BS: Blockstore> Runtime<Rc<BS>> for MockRuntime<BS> {
             return Some(id);
         }
         if Protocol::Delegated == address.protocol() {
-            return self.delegated_addresses_source.get(address).and_then(|a| self.resolve_address(a));
+            return self
+                .delegated_addresses_source
+                .get(address)
+                .and_then(|a| self.resolve_address(a));
         }
 
         match self.get_id_address(address) {


### PR DESCRIPTION
Currently we have no way to transfer value to embryos (or actors that don't exist yet).
This adds an embryonic state check and turns the call into a send if that's the case.
Also adds a check that we don't transfer value in staticcall context, as this would be a violation of readonly semantics.

Fixes https://github.com/filecoin-project/ref-fvm/issues/1004.