### PR TITLE
fix: truncate addresses in instructions

### DIFF
--- a/actors/evm/src/interpreter/address.rs
+++ b/actors/evm/src/interpreter/address.rs
@@ -11,19 +11,14 @@ use fvm_shared::ActorID;
 #[derive(serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Copy)]
 pub struct EthAddress(#[serde(with = "strict_bytes")] pub [u8; 20]);
 
-impl TryFrom<U256> for EthAddress {
-    type Error = StatusCode;
-
-    fn try_from(v: U256) -> Result<Self, Self::Error> {
-        // top 12 bytes must be 0s;
-        // enforce that constraint so that we validate that the word is a valid address
+/// Converts a U256 to an EthAddress by taking the lower 20 bytes.
+///
+/// Per the EVM spec, this simply discards the high bytes.
+impl From<U256> for EthAddress {
+    fn from(v: U256) -> Self {
         let mut bytes = [0u8; 32];
         v.to_big_endian(&mut bytes);
-        if !bytes[..12].iter().all(|&byte| byte == 0) {
-            Err(StatusCode::BadAddress(format!("invalid address: {}", hex::encode(bytes))))
-        } else {
-            Ok(Self(bytes[12..].try_into().unwrap()))
-        }
+        Self(bytes[12..].try_into().unwrap())
     }
 }
 

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -157,13 +157,14 @@ pub fn call<BS: Blockstore, RT: Runtime<BS>>(
         };
 
         if precompiles::Precompiles::<BS, RT>::is_precompile(&dst) {
+            // TODO: DO NOT FAIL!!!
             precompiles::Precompiles::call_precompile(system.rt, dst, input_data)
                 .map_err(|_| StatusCode::PrecompileFailure)?
         } else {
             let call_result = match kind {
                 CallKind::Call | CallKind::StaticCall => {
-                    let dst_addr: EthAddress = dst.try_into()?;
-                    let dst_addr: Address = dst_addr.try_into()?;
+                    let dst_addr: EthAddress = dst.into();
+                    let dst_addr: Address = dst_addr.try_into().expect("address is a precompile");
 
                     // Special casing for account/embryo/non-existent actors: we just do a SEND (method 0)
                     // which allows us to transfer funds (and create embryos)
@@ -294,7 +295,8 @@ pub fn callactor<BS: Blockstore, RT: Runtime<BS>>(
         .map_err(|_| StatusCode::InvalidMemoryAccess)?;
 
     let result = {
-        let dst_addr: EthAddress = dst.try_into()?;
+        // TODO: this is wrong https://github.com/filecoin-project/ref-fvm/issues/1018
+        let dst_addr: EthAddress = dst.into();
         let dst_addr: Address = dst_addr.try_into()?;
 
         if method.bits() > 64 {

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -61,7 +61,7 @@ pub fn get_evm_bytecode_cid<BS: Blockstore, RT: Runtime<BS>>(
     rt: &RT,
     addr: U256,
 ) -> Result<Cid, StatusCode> {
-    let addr: EthAddress = addr.try_into()?;
+    let addr: EthAddress = addr.into();
     let addr: Address = addr.try_into()?;
     // TODO: just return none in most of these cases?
     let actor_id = rt.resolve_address(&addr).ok_or_else(|| {

--- a/actors/evm/src/interpreter/instructions/lifecycle.rs
+++ b/actors/evm/src/interpreter/instructions/lifecycle.rs
@@ -156,9 +156,8 @@ pub fn selfdestruct<BS: Blockstore, RT: Runtime<BS>>(
     if system.readonly {
         return Err(StatusCode::StaticModeViolation);
     }
-    let beneficiary_addr = state.stack.pop();
+    let beneficiary_addr: EthAddress = state.stack.pop().into();
     // TODO: how do we handle errors here? Just ignore them?
-    state.selfdestroyed =
-        beneficiary_addr.try_into().and_then(|addr: EthAddress| addr.try_into()).ok();
+    state.selfdestroyed = beneficiary_addr.try_into().ok();
     Ok(())
 }

--- a/actors/evm/src/interpreter/instructions/state.rs
+++ b/actors/evm/src/interpreter/instructions/state.rs
@@ -13,11 +13,10 @@ pub fn balance<'r, BS: Blockstore, RT: Runtime<BS>>(
     state: &mut ExecutionState,
     system: &'r System<'r, BS, RT>,
 ) -> Result<(), StatusCode> {
-    let actor = state.stack.pop();
+    let actor: EthAddress = state.stack.pop().into();
 
     let balance = actor
         .try_into()
-        .and_then(|addr: EthAddress| addr.try_into())
         .ok()
         .and_then(|addr: Address| system.rt.resolve_address(&addr))
         .and_then(|id| system.rt.actor_balance(id).as_ref().map(U256::from))


### PR DESCRIPTION
This is what the EVM does. They're defined to take the low 20 bytes.