### PR TITLE
feat: improve a few more math ops

### DIFF
--- a/actors/evm/src/interpreter/instructions/bitwise.rs
+++ b/actors/evm/src/interpreter/instructions/bitwise.rs
@@ -5,21 +5,11 @@ pub fn byte(stack: &mut Stack) {
     let i = stack.pop();
     let x = stack.get_mut(0);
 
-    if i >= U256::from_u64(32) {
+    if i >= 32 {
         *x = U256::ZERO;
-        return;
-    }
-
-    let mut i = i.low_u128();
-
-    let x_word = if i >= 16 {
-        i -= 16;
-        x.low_u128()
     } else {
-        x.high_u128()
-    };
-
-    *x = U256::from((x_word >> (120 - i * 8)) & 0xFF);
+        *x = U256::from_u64(x.byte(31 - i.low_u64() as usize) as u64);
+    }
 }
 
 #[inline]
@@ -58,14 +48,14 @@ pub fn sar(stack: &mut Stack) {
 
     stack.push(if value.is_zero() || shift >= 256 {
         if negative {
-            // value is <0, pushing -1
-            U256::ONE.i256_neg()
+            // value is < 0, pushing U256::MAX (== -1)
+            U256::MAX
         } else {
-            // value is 0 or >=1, pushing 0
+            // value is >= 0, pushing 0
             U256::ONE
         }
     } else {
-        let shift = shift.as_u128();
+        let shift = shift.low_u32();
 
         if negative {
             let shifted =

--- a/actors/evm/src/interpreter/uints.rs
+++ b/actors/evm/src/interpreter/uints.rs
@@ -47,11 +47,6 @@ impl U256 {
     }
 
     #[inline(always)]
-    pub const fn high_u128(&self) -> u128 {
-        ((self.0[3] as u128) << u64::BITS) | (self.0[2] as u128)
-    }
-
-    #[inline(always)]
     pub const fn i256_is_negative(&self) -> bool {
         (self.0[3] as i64) < 0
     }
@@ -145,25 +140,6 @@ impl_hamt_hash!(U512);
 // RLP Support
 impl_rlp_codec_uint!(U256, 32);
 impl_rlp_codec_uint!(U512, 64);
-
-#[inline]
-pub fn log2floor(value: U256) -> u64 {
-    debug_assert!(value != U256::zero());
-    let mut l: u64 = 256;
-    for v in [value.high_u128(), value.low_u128()] {
-        if v == 0 {
-            l -= 128;
-        } else {
-            l -= v.leading_zeros() as u64;
-            if l == 0 {
-                return l;
-            } else {
-                return l - 1;
-            }
-        }
-    }
-    l
-}
 
 #[inline(always)]
 pub fn i256_div(mut first: U256, mut second: U256) -> U256 {


### PR DESCRIPTION
- byte: use the built-in byte and don't touch u128s.
- sar: simplify a bit
- remove dead code