### PR TITLE
datacap: fix Name and Symbol methods

### DIFF
--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -89,19 +89,21 @@ impl Actor {
         Ok(())
     }
 
-    pub fn name<BS, RT>(_: &RT, _: ()) -> Result<String, ActorError>
+    pub fn name<BS, RT>(rt: &mut RT) -> Result<String, ActorError>
     where
         BS: Blockstore,
         RT: Runtime<BS>,
     {
+        rt.validate_immediate_caller_accept_any()?;
         Ok("DataCap".to_string())
     }
 
-    pub fn symbol<BS, RT>(_: &RT, _: ()) -> Result<String, ActorError>
+    pub fn symbol<BS, RT>(rt: &mut RT) -> Result<String, ActorError>
     where
         BS: Blockstore,
         RT: Runtime<BS>,
     {
+        rt.validate_immediate_caller_accept_any()?;
         Ok("DCAP".to_string())
     }
 
@@ -536,11 +538,11 @@ impl ActorCode for Actor {
                 serialize(&ret, "destroy result")
             }
             Some(Method::Name) => {
-                let ret = Self::name(rt, cbor::deserialize_params(params)?)?;
+                let ret = Self::name(rt)?;
                 serialize(&ret, "name result")
             }
             Some(Method::Symbol) => {
-                let ret = Self::symbol(rt, cbor::deserialize_params(params)?)?;
+                let ret = Self::symbol(rt)?;
                 serialize(&ret, "symbol result")
             }
             Some(Method::TotalSupply) => {

--- a/test_vm/tests/datacap_tests.rs
+++ b/test_vm/tests/datacap_tests.rs
@@ -16,6 +16,7 @@ use test_vm::VM;
 
 use fil_actor_datacap::{Method as DataCapMethod, MintParams};
 use frc46_token::token::types::TransferFromParams;
+use fvm_ipld_encoding::RawBytes;
 
 /* Mint a token for client and transfer it to a receiver, exercising error cases */
 #[test]
@@ -185,4 +186,37 @@ fn datacap_transfer_scenario() {
         transfer_from_params,
         ExitCode::USR_INSUFFICIENT_FUNDS,
     );
+}
+
+/* Call name & symbol */
+#[test]
+fn call_name_symbol() {
+    let store = MemoryBlockstore::new();
+    let v = VM::new_with_singletons(&store);
+    let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
+    let sender = addrs[0];
+
+    let mut ret: String = apply_ok(
+        &v,
+        sender,
+        DATACAP_TOKEN_ACTOR_ADDR,
+        TokenAmount::zero(),
+        DataCapMethod::Name as u64,
+        RawBytes::default(),
+    )
+    .deserialize()
+    .unwrap();
+    assert_eq!("DataCap", ret, "expected name DataCap, got {}", ret);
+
+    ret = apply_ok(
+        &v,
+        sender,
+        DATACAP_TOKEN_ACTOR_ADDR,
+        TokenAmount::zero(),
+        DataCapMethod::Symbol as u64,
+        RawBytes::default(),
+    )
+    .deserialize()
+    .unwrap();
+    assert_eq!("DCAP", ret, "expected name DataCap, got {}", ret);
 }


### PR DESCRIPTION
I don't think calls to these methods will ever succeed right now.

2 changes:

- receive no params beside the runtime (cf. `Miner::control_addresses`)
- validate the caller (accept any), because all methods must do this.

And add a test.