### PR TITLE
datacap: add allowance to exported methods

### DIFF
--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -67,6 +67,7 @@ pub enum Method {
     RevokeAllowance = 18,
     Burn = 19,
     BurnFrom = 20,
+    Allowance = 21,
 }
 
 pub struct Actor;
@@ -578,6 +579,10 @@ impl ActorCode for Actor {
             Some(Method::BurnFrom) => {
                 let ret = Self::burn_from(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "burn_from result")
+            }
+            Some(Method::Allowance) => {
+                let ret = Self::allowance(rt, cbor::deserialize_params(params)?)?;
+                serialize(&ret, "allowance result")
             }
             None => Err(actor_error!(unhandled_message; "Invalid method")),
         }


### PR DESCRIPTION
I'm not sure whether this was intentionally excluded, feel free to close if I'm wrong.