### PR TITLE
test: make the mock runtime generic over the blockstore

### DIFF
--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use anyhow::anyhow;
 use cid::multihash::{Code, Multihash as OtherMultihash};
 use cid::Cid;
-use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::de::DeserializeOwned;
 use fvm_ipld_encoding::{Cbor, CborStore, RawBytes};
 use fvm_shared::address::Payload;
@@ -103,7 +103,7 @@ pub fn make_builtin(bz: &[u8]) -> Cid {
     Cid::new_v1(IPLD_RAW, OtherMultihash::wrap(0, bz).expect("name too long"))
 }
 
-pub struct MockRuntime {
+pub struct MockRuntime<BS = MemoryBlockstore> {
     pub epoch: ChainEpoch,
     pub miner: Address,
     pub base_fee: TokenAmount,
@@ -124,7 +124,7 @@ pub struct MockRuntime {
 
     // VM Impl
     pub in_call: bool,
-    pub store: Rc<MemoryBlockstore>,
+    pub store: Rc<BS>,
     pub in_transaction: bool,
 
     // Expectations
@@ -249,6 +249,12 @@ impl Expectations {
 
 impl Default for MockRuntime {
     fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+impl<BS> MockRuntime<BS> {
+    pub fn new(store: BS) -> Self {
         Self {
             epoch: Default::default(),
             miner: Address::new_id(0),
@@ -265,7 +271,7 @@ impl Default for MockRuntime {
             state: Default::default(),
             balance: Default::default(),
             in_call: Default::default(),
-            store: Default::default(),
+            store: Rc::new(store),
             in_transaction: Default::default(),
             expectations: Default::default(),
             policy: Default::default(),
@@ -391,7 +397,7 @@ pub fn expect_abort<T: fmt::Debug>(exit_code: ExitCode, res: Result<T, ActorErro
     expect_abort_contains_message(exit_code, "", res);
 }
 
-impl MockRuntime {
+impl<BS: Blockstore> MockRuntime<BS> {
     ///// Runtime access for tests /////
 
     pub fn get_state<T: Cbor>(&self) -> T {
@@ -655,7 +661,7 @@ impl MockRuntime {
     }
 }
 
-impl MessageInfo for MockRuntime {
+impl<BS> MessageInfo for MockRuntime<BS> {
     fn caller(&self) -> Address {
         self.caller
     }
@@ -667,7 +673,7 @@ impl MessageInfo for MockRuntime {
     }
 }
 
-impl Runtime<Rc<MemoryBlockstore>> for MockRuntime {
+impl<BS: Blockstore> Runtime<Rc<BS>> for MockRuntime<BS> {
     fn network_version(&self) -> NetworkVersion {
         self.network_version
     }
@@ -880,7 +886,7 @@ impl Runtime<Rc<MemoryBlockstore>> for MockRuntime {
         ret
     }
 
-    fn store(&self) -> &Rc<MemoryBlockstore> {
+    fn store(&self) -> &Rc<BS> {
         &self.store
     }
 
@@ -1010,7 +1016,7 @@ impl Runtime<Rc<MemoryBlockstore>> for MockRuntime {
     }
 }
 
-impl Primitives for MockRuntime {
+impl<BS> Primitives for MockRuntime<BS> {
     fn verify_signature(
         &self,
         signature: &Signature,
@@ -1085,7 +1091,7 @@ impl Primitives for MockRuntime {
     }
 }
 
-impl Verifier for MockRuntime {
+impl<BS> Verifier for MockRuntime<BS> {
     fn verify_seal(&self, seal: &SealVerifyInfo) -> anyhow::Result<()> {
         let exp = self
             .expectations
@@ -1213,7 +1219,7 @@ impl Verifier for MockRuntime {
     }
 }
 
-impl RuntimePolicy for MockRuntime {
+impl<BS> RuntimePolicy for MockRuntime<BS> {
     fn policy(&self) -> &Policy {
         &self.policy
     }


### PR DESCRIPTION
This can be useful for tests that need to track read/write stats.
Specifically, we use this in the EVM tests.

(ported from next, originally by @aakoshh)