### PR TITLE
feat: refactor blockstore into associated type

### DIFF
--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::{Address, Protocol};
 use fvm_shared::crypto::signature::SignatureType::{Secp256k1, BLS};
@@ -42,11 +41,7 @@ pub struct Actor;
 
 impl Actor {
     /// Constructor for Account actor
-    pub fn constructor<BS, RT>(rt: &mut RT, address: Address) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn constructor(rt: &mut impl Runtime, address: Address) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
         match address.protocol() {
             Protocol::Secp256k1 | Protocol::BLS => {}
@@ -60,11 +55,7 @@ impl Actor {
     }
 
     /// Fetches the pubkey-type address from this actor.
-    pub fn pubkey_address<BS, RT>(rt: &mut RT) -> Result<Address, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn pubkey_address(rt: &mut impl Runtime) -> Result<Address, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let st: State = rt.state()?;
         Ok(st.address)
@@ -73,14 +64,10 @@ impl Actor {
     /// Authenticates whether the provided signature is valid for the provided message.
     /// Should be called with the raw bytes of a signature, NOT a serialized Signature object that includes a SignatureType.
     /// Errors with USR_ILLEGAL_ARGUMENT if the authentication is invalid.
-    pub fn authenticate_message<BS, RT>(
-        rt: &mut RT,
+    pub fn authenticate_message(
+        rt: &mut impl Runtime,
         params: AuthenticateMessageParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let st: State = rt.state()?;
         let address = st.address;
@@ -104,28 +91,23 @@ impl Actor {
     }
 
     // Always succeeds, accepting any transfers.
-    pub fn universal_receiver_hook<BS, RT>(
-        rt: &mut RT,
+    pub fn universal_receiver_hook(
+        rt: &mut impl Runtime,
         _params: &RawBytes,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         Ok(())
     }
 }
 
 impl ActorCode for Actor {
-    fn invoke_method<BS, RT>(
+    fn invoke_method<RT>(
         rt: &mut RT,
         method: MethodNum,
         params: &RawBytes,
     ) -> Result<RawBytes, ActorError>
     where
-        BS: Blockstore,
-        RT: Runtime<BS>,
+        RT: Runtime,
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use frc46_token::token::types::{
     BurnFromParams, BurnFromReturn, BurnParams, BurnReturn, DecreaseAllowanceParams,
     GetAllowanceParams, IncreaseAllowanceParams, MintReturn, RevokeAllowanceParams,
@@ -7,7 +5,6 @@ use frc46_token::token::types::{
 };
 use frc46_token::token::{Token, TokenError, TOKEN_PRECISION};
 use fvm_actor_utils::messaging::{Messaging, MessagingError};
-use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
@@ -74,11 +71,7 @@ pub struct Actor;
 
 impl Actor {
     /// Constructor for DataCap Actor
-    pub fn constructor<BS, RT>(rt: &mut RT, governor: Address) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn constructor(rt: &mut impl Runtime, governor: Address) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
         // Confirm the governor address is an ID.
@@ -90,60 +83,40 @@ impl Actor {
         Ok(())
     }
 
-    pub fn name<BS, RT>(rt: &mut RT) -> Result<String, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn name(rt: &mut impl Runtime) -> Result<String, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         Ok("DataCap".to_string())
     }
 
-    pub fn symbol<BS, RT>(rt: &mut RT) -> Result<String, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn symbol(rt: &mut impl Runtime) -> Result<String, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         Ok("DCAP".to_string())
     }
 
-    pub fn total_supply<BS, RT>(rt: &mut RT, _: ()) -> Result<TokenAmount, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn total_supply(rt: &mut impl Runtime, _: ()) -> Result<TokenAmount, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let mut st: State = rt.state()?;
-        let msg = Messenger { rt, dummy: Default::default() };
+        let msg = Messenger { rt };
         let token = as_token(&mut st, &msg);
         Ok(token.total_supply())
     }
 
-    pub fn balance_of<BS, RT>(rt: &mut RT, address: Address) -> Result<TokenAmount, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn balance_of(rt: &mut impl Runtime, address: Address) -> Result<TokenAmount, ActorError> {
         // NOTE: mutability and method caller here are awkward for a read-only call
         rt.validate_immediate_caller_accept_any()?;
         let mut st: State = rt.state()?;
-        let msg = Messenger { rt, dummy: Default::default() };
+        let msg = Messenger { rt };
         let token = as_token(&mut st, &msg);
         token.balance_of(&address).actor_result()
     }
 
-    pub fn allowance<BS, RT>(
-        rt: &mut RT,
+    pub fn allowance(
+        rt: &mut impl Runtime,
         params: GetAllowanceParams,
-    ) -> Result<TokenAmount, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<TokenAmount, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let mut st: State = rt.state()?;
-        let msg = Messenger { rt, dummy: Default::default() };
+        let msg = Messenger { rt };
         let token = as_token(&mut st, &msg);
         token.allowance(&params.owner, &params.operator).actor_result()
     }
@@ -152,18 +125,14 @@ impl Actor {
     /// Simultaneously sets the allowance for any specified operators to effectively infinite.
     /// Only the governor can call this method.
     /// This method is not part of the fungible token standard.
-    pub fn mint<BS, RT>(rt: &mut RT, params: MintParams) -> Result<MintReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn mint(rt: &mut impl Runtime, params: MintParams) -> Result<MintReturn, ActorError> {
         let mut hook = rt
             .transaction(|st: &mut State, rt| {
                 // Only the governor can mint datacap tokens.
                 rt.validate_immediate_caller_is(std::iter::once(&st.governor))?;
                 let operator = st.governor;
 
-                let msg = Messenger { rt, dummy: Default::default() };
+                let msg = Messenger { rt };
                 let mut token = as_token(st, &msg);
                 // Mint tokens "from" the operator to the beneficiary.
                 let ret = token
@@ -188,7 +157,7 @@ impl Actor {
             .context("state transaction failed")?;
 
         let mut st: State = rt.state()?;
-        let msg = Messenger { rt, dummy: Default::default() };
+        let msg = Messenger { rt };
         let intermediate = hook.call(&&msg).actor_result()?;
         as_token(&mut st, &msg).mint_return(intermediate).actor_result()
     }
@@ -197,16 +166,12 @@ impl Actor {
     /// Only the governor can call this method.
     /// This method is not part of the fungible token standard, and is named distinctly from
     /// "burn" to reflect that distinction.
-    pub fn destroy<BS, RT>(rt: &mut RT, params: DestroyParams) -> Result<BurnReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn destroy(rt: &mut impl Runtime, params: DestroyParams) -> Result<BurnReturn, ActorError> {
         rt.transaction(|st: &mut State, rt| {
             // Only the governor can destroy datacap tokens on behalf of a holder.
             rt.validate_immediate_caller_is(std::iter::once(&st.governor))?;
 
-            let msg = Messenger { rt, dummy: Default::default() };
+            let msg = Messenger { rt };
             let mut token = as_token(st, &msg);
             // Burn tokens as if the holder had invoked burn() themselves.
             // The governor doesn't need an allowance.
@@ -218,14 +183,10 @@ impl Actor {
     /// Transfers data cap tokens to an address.
     /// Data cap tokens are not generally transferable.
     /// Succeeds if the to or from address is the governor, otherwise always fails.
-    pub fn transfer<BS, RT>(
-        rt: &mut RT,
+    pub fn transfer(
+        rt: &mut impl Runtime,
         params: TransferParams,
-    ) -> Result<TransferReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<TransferReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let operator = &rt.message().caller();
         let from = operator;
@@ -248,7 +209,7 @@ impl Actor {
                     ));
                 }
 
-                let msg = Messenger { rt, dummy: Default::default() };
+                let msg = Messenger { rt };
                 let mut token = as_token(st, &msg);
                 token
                     .transfer(
@@ -263,7 +224,7 @@ impl Actor {
             .context("state transaction failed")?;
 
         let mut st: State = rt.state()?;
-        let msg = Messenger { rt, dummy: Default::default() };
+        let msg = Messenger { rt };
         let intermediate = hook.call(&&msg).actor_result()?;
         as_token(&mut st, &msg).transfer_return(intermediate).actor_result()
     }
@@ -271,14 +232,10 @@ impl Actor {
     /// Transfers data cap tokens between addresses.
     /// Data cap tokens are not generally transferable between addresses.
     /// Succeeds if the to address is the governor, otherwise always fails.
-    pub fn transfer_from<BS, RT>(
-        rt: &mut RT,
+    pub fn transfer_from(
+        rt: &mut impl Runtime,
         params: TransferFromParams,
-    ) -> Result<TransferFromReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<TransferFromReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let operator = rt.message().caller();
         let from = params.from;
@@ -301,7 +258,7 @@ impl Actor {
                     ));
                 }
 
-                let msg = Messenger { rt, dummy: Default::default() };
+                let msg = Messenger { rt };
                 let mut token = as_token(st, &msg);
                 token
                     .transfer_from(
@@ -317,101 +274,81 @@ impl Actor {
             .context("state transaction failed")?;
 
         let mut st: State = rt.state()?;
-        let msg = Messenger { rt, dummy: Default::default() };
+        let msg = Messenger { rt };
         let intermediate = hook.call(&&msg).actor_result()?;
         as_token(&mut st, &msg).transfer_from_return(intermediate).actor_result()
     }
 
-    pub fn increase_allowance<BS, RT>(
-        rt: &mut RT,
+    pub fn increase_allowance(
+        rt: &mut impl Runtime,
         params: IncreaseAllowanceParams,
-    ) -> Result<TokenAmount, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<TokenAmount, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let owner = rt.message().caller();
         let operator = params.operator;
 
         rt.transaction(|st: &mut State, rt| {
-            let msg = Messenger { rt, dummy: Default::default() };
+            let msg = Messenger { rt };
             let mut token = as_token(st, &msg);
             token.increase_allowance(&owner, &operator, &params.increase).actor_result()
         })
         .context("state transaction failed")
     }
 
-    pub fn decrease_allowance<BS, RT>(
-        rt: &mut RT,
+    pub fn decrease_allowance(
+        rt: &mut impl Runtime,
         params: DecreaseAllowanceParams,
-    ) -> Result<TokenAmount, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<TokenAmount, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let owner = &rt.message().caller();
         let operator = &params.operator;
 
         rt.transaction(|st: &mut State, rt| {
-            let msg = Messenger { rt, dummy: Default::default() };
+            let msg = Messenger { rt };
             let mut token = as_token(st, &msg);
             token.decrease_allowance(owner, operator, &params.decrease).actor_result()
         })
         .context("state transaction failed")
     }
 
-    pub fn revoke_allowance<BS, RT>(
-        rt: &mut RT,
+    pub fn revoke_allowance(
+        rt: &mut impl Runtime,
         params: RevokeAllowanceParams,
-    ) -> Result<TokenAmount, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<TokenAmount, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let owner = &rt.message().caller();
         let operator = &params.operator;
 
         rt.transaction(|st: &mut State, rt| {
-            let msg = Messenger { rt, dummy: Default::default() };
+            let msg = Messenger { rt };
             let mut token = as_token(st, &msg);
             token.revoke_allowance(owner, operator).actor_result()
         })
         .context("state transaction failed")
     }
 
-    pub fn burn<BS, RT>(rt: &mut RT, params: BurnParams) -> Result<BurnReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn burn(rt: &mut impl Runtime, params: BurnParams) -> Result<BurnReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let owner = &rt.message().caller();
 
         rt.transaction(|st: &mut State, rt| {
-            let msg = Messenger { rt, dummy: Default::default() };
+            let msg = Messenger { rt };
             let mut token = as_token(st, &msg);
             token.burn(owner, &params.amount).actor_result()
         })
         .context("state transaction failed")
     }
 
-    pub fn burn_from<BS, RT>(
-        rt: &mut RT,
+    pub fn burn_from(
+        rt: &mut impl Runtime,
         params: BurnFromParams,
-    ) -> Result<BurnFromReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<BurnFromReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let operator = &rt.message().caller();
         let owner = &params.owner;
 
         rt.transaction(|st: &mut State, rt| {
-            let msg = Messenger { rt, dummy: Default::default() };
+            let msg = Messenger { rt };
             let mut token = as_token(st, &msg);
             token.burn_from(operator, owner, &params.amount).actor_result()
         })
@@ -421,24 +358,16 @@ impl Actor {
 
 /// Implementation of the token library's messenger trait in terms of the built-in actors'
 /// runtime library.
-struct Messenger<'a, BS, RT>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+struct Messenger<'a, RT> {
     rt: &'a mut RT,
-    // Without this, Rust complains the BS parameter is unused.
-    // This might be solved better by having BS as an associated type of the Runtime trait.
-    dummy: PhantomData<BS>,
 }
 
 // The trait is implemented for Messenger _reference_ since the mutable ref to rt has been
 // moved into it and we can't move the messenger instance since callers need to get at the
 // rt that's now in there.
-impl<'a, BS, RT> Messaging for &Messenger<'a, BS, RT>
+impl<'a, RT> Messaging for &Messenger<'a, RT>
 where
-    BS: Blockstore,
-    RT: Runtime<BS>,
+    RT: Runtime,
 {
     fn actor_id(&self) -> ActorID {
         // The Runtime unhelpfully wraps receiver in an address, while the Messaging trait
@@ -490,13 +419,12 @@ where
 }
 
 // Returns a token instance wrapping the token state.
-fn as_token<'st, BS, RT>(
+fn as_token<'st, RT>(
     st: &'st mut State,
-    msg: &'st Messenger<'st, BS, RT>,
-) -> Token<'st, &'st BS, &'st Messenger<'st, BS, RT>>
+    msg: &'st Messenger<'st, RT>,
+) -> Token<'st, &'st RT::Blockstore, &'st Messenger<'st, RT>>
 where
-    BS: Blockstore,
-    RT: Runtime<BS>,
+    RT: Runtime,
 {
     Token::wrap(msg.rt.store(), msg, DATACAP_GRANULARITY, &mut st.token)
 }
@@ -512,14 +440,13 @@ impl<T> AsActorResult<T> for Result<T, TokenError> {
 }
 
 impl ActorCode for Actor {
-    fn invoke_method<BS, RT>(
+    fn invoke_method<RT>(
         rt: &mut RT,
         method: MethodNum,
         params: &RawBytes,
     ) -> Result<RawBytes, ActorError>
     where
-        BS: Blockstore,
-        RT: Runtime<BS>,
+        RT: Runtime,
     {
         // I'm trying to find a fixed template for these blocks so we can macro it.
         // Current blockers:

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -77,11 +77,7 @@ pub enum Method {
 pub struct Actor;
 
 impl Actor {
-    pub fn constructor<BS, RT>(rt: &mut RT) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn constructor(rt: &mut impl Runtime) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
         let st = State::new(rt.store()).map_err(|e| {
@@ -92,11 +88,7 @@ impl Actor {
     }
 
     /// Deposits the received value into the balance held in escrow.
-    fn add_balance<BS, RT>(rt: &mut RT, provider_or_client: Address) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    fn add_balance(rt: &mut impl Runtime, provider_or_client: Address) -> Result<(), ActorError> {
         let msg_value = rt.message().value_received();
 
         if msg_value <= TokenAmount::zero() {
@@ -138,14 +130,10 @@ impl Actor {
 
     /// Attempt to withdraw the specified amount from the balance held in escrow.
     /// If less than the specified amount is available, yields the entire available balance.
-    fn withdraw_balance<BS, RT>(
-        rt: &mut RT,
+    fn withdraw_balance(
+        rt: &mut impl Runtime,
         params: WithdrawBalanceParams,
-    ) -> Result<WithdrawBalanceReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<WithdrawBalanceReturn, ActorError> {
         if params.amount < TokenAmount::zero() {
             return Err(actor_error!(illegal_argument, "negative amount: {}", params.amount));
         }
@@ -194,14 +182,10 @@ impl Actor {
     }
 
     /// Publish a new set of storage deals (not yet included in a sector).
-    fn publish_storage_deals<BS, RT>(
-        rt: &mut RT,
+    fn publish_storage_deals(
+        rt: &mut impl Runtime,
         params: PublishStorageDealsParams,
-    ) -> Result<PublishStorageDealsReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<PublishStorageDealsReturn, ActorError> {
         // Deal message must have a From field identical to the provider of all the deals.
         // This allows us to retain and verify only the client's signature in each deal proposal itself.
         rt.validate_immediate_caller_type(CALLER_TYPES_SIGNABLE.iter())?;
@@ -494,14 +478,10 @@ impl Actor {
 
     /// Verify that a given set of storage deals is valid for a sector currently being PreCommitted
     /// and return UnsealedCID for the set of deals.
-    fn verify_deals_for_activation<BS, RT>(
-        rt: &mut RT,
+    fn verify_deals_for_activation(
+        rt: &mut impl Runtime,
         params: VerifyDealsForActivationParams,
-    ) -> Result<VerifyDealsForActivationReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<VerifyDealsForActivationReturn, ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
         let miner_addr = rt.message().caller();
         let curr_epoch = rt.curr_epoch();
@@ -539,14 +519,10 @@ impl Actor {
         Ok(VerifyDealsForActivationReturn { sectors: sectors_data })
     }
     /// Activate a set of deals, returning the combined deal space and extra info for verified deals.
-    fn activate_deals<BS, RT>(
-        rt: &mut RT,
+    fn activate_deals(
+        rt: &mut impl Runtime,
         params: ActivateDealsParams,
-    ) -> Result<ActivateDealsResult, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<ActivateDealsResult, ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
         let miner_addr = rt.message().caller();
         let curr_epoch = rt.curr_epoch();
@@ -676,14 +652,10 @@ impl Actor {
     /// Terminate a set of deals in response to their containing sector being terminated.
     /// Slash provider collateral, refund client collateral, and refund partial unpaid escrow
     /// amount to client.
-    fn on_miner_sectors_terminate<BS, RT>(
-        rt: &mut RT,
+    fn on_miner_sectors_terminate(
+        rt: &mut impl Runtime,
         params: OnMinerSectorsTerminateParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
         let miner_addr = rt.message().caller();
 
@@ -760,14 +732,10 @@ impl Actor {
         Ok(())
     }
 
-    fn compute_data_commitment<BS, RT>(
-        rt: &mut RT,
+    fn compute_data_commitment(
+        rt: &mut impl Runtime,
         params: ComputeDataCommitmentParams,
-    ) -> Result<ComputeDataCommitmentReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<ComputeDataCommitmentReturn, ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
 
         let st: State = rt.state()?;
@@ -788,11 +756,7 @@ impl Actor {
         Ok(ComputeDataCommitmentReturn { commds })
     }
 
-    fn cron_tick<BS, RT>(rt: &mut RT) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    fn cron_tick(rt: &mut impl Runtime) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&CRON_ACTOR_ADDR))?;
 
         let mut amount_slashed = TokenAmount::zero();
@@ -1054,16 +1018,12 @@ impl Actor {
     }
 }
 
-fn compute_data_commitment<BS, RT>(
-    rt: &RT,
+fn compute_data_commitment<BS: Blockstore>(
+    rt: &impl Runtime,
     proposals: &DealArray<BS>,
     sector_type: RegisteredSealProof,
     deal_ids: &[DealID],
-) -> Result<Cid, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<Cid, ActorError> {
     let mut pieces = Vec::with_capacity(deal_ids.len());
     for deal_id in deal_ids {
         let deal = proposals
@@ -1082,17 +1042,14 @@ where
     })
 }
 
-pub fn validate_and_return_deal_space<BS>(
+pub fn validate_and_return_deal_space<BS: Blockstore>(
     proposals: &DealArray<BS>,
     deal_ids: &[DealID],
     miner_addr: &Address,
     sector_expiry: ChainEpoch,
     sector_activation: ChainEpoch,
     sector_size: Option<SectorSize>,
-) -> Result<DealSpaces, ActorError>
-where
-    BS: Blockstore,
-{
+) -> Result<DealSpaces, ActorError> {
     let mut seen_deal_ids = BTreeSet::new();
     let mut deal_space = BigInt::zero();
     let mut verified_deal_space = BigInt::zero();
@@ -1234,16 +1191,12 @@ fn validate_deal_can_activate(
     Ok(())
 }
 
-fn validate_deal<BS, RT>(
-    rt: &RT,
+fn validate_deal(
+    rt: &impl Runtime,
     deal: &ClientDealProposal,
     network_raw_power: &StoragePower,
     baseline_power: &StoragePower,
-) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<(), ActorError> {
     deal_proposal_is_internally_valid(rt, deal)?;
 
     let proposal = &deal.proposal;
@@ -1312,14 +1265,10 @@ where
     Ok(())
 }
 
-fn deal_proposal_is_internally_valid<BS, RT>(
-    rt: &RT,
+fn deal_proposal_is_internally_valid(
+    rt: &impl Runtime,
     proposal: &ClientDealProposal,
-) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<(), ActorError> {
     let signature_bytes = proposal.client_signature.bytes.clone();
     // Generate unsigned bytes
     let proposal_bytes = serialize_vec(&proposal.proposal, "deal proposal")?;
@@ -1340,11 +1289,7 @@ where
 pub const DAG_CBOR: u64 = 0x71; // TODO is there a better place to get this?
 
 /// Compute a deal CID using the runtime.
-pub(crate) fn rt_deal_cid<BS, RT>(rt: &RT, proposal: &DealProposal) -> Result<Cid, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+pub(crate) fn rt_deal_cid(rt: &impl Runtime, proposal: &DealProposal) -> Result<Cid, ActorError> {
     const DIGEST_SIZE: u32 = 32;
     let data = &proposal.marshal_cbor()?;
     let hash = MultihashGeneric::wrap(Code::Blake2b256.into(), &rt.hash_blake2b(data))
@@ -1362,14 +1307,10 @@ pub(crate) fn deal_cid(proposal: &DealProposal) -> Result<Cid, ActorError> {
     Ok(Cid::new_v1(DAG_CBOR, hash))
 }
 
-fn request_miner_control_addrs<BS, RT>(
-    rt: &mut RT,
+fn request_miner_control_addrs(
+    rt: &mut impl Runtime,
     miner_id: ActorID,
-) -> Result<(Address, Address, Vec<Address>), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<(Address, Address, Vec<Address>), ActorError> {
     let ret = rt.send(
         &Address::new_id(miner_id),
         ext::miner::CONTROL_ADDRESSES_METHOD,
@@ -1383,14 +1324,10 @@ where
 
 /// Resolves a provider or client address to the canonical form against which a balance should be held, and
 /// the designated recipient address of withdrawals (which is the same, for simple account parties).
-fn escrow_address<BS, RT>(
-    rt: &mut RT,
+fn escrow_address(
+    rt: &mut impl Runtime,
     addr: &Address,
-) -> Result<(Address, Address, Vec<Address>), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<(Address, Address, Vec<Address>), ActorError> {
     // Resolve the provided address to the canonical form against which the balance is held.
     let nominal = rt
         .resolve_address(addr)
@@ -1412,11 +1349,7 @@ where
 }
 
 /// Requests the current epoch target block reward from the reward actor.
-fn request_current_baseline_power<BS, RT>(rt: &mut RT) -> Result<StoragePower, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn request_current_baseline_power(rt: &mut impl Runtime) -> Result<StoragePower, ActorError> {
     let rwret = rt.send(
         &REWARD_ACTOR_ADDR,
         ext::reward::THIS_EPOCH_REWARD_METHOD,
@@ -1429,13 +1362,9 @@ where
 
 /// Requests the current network total power and pledge from the power actor.
 /// Returns a tuple of (raw_power, qa_power).
-fn request_current_network_power<BS, RT>(
-    rt: &mut RT,
-) -> Result<(StoragePower, StoragePower), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn request_current_network_power(
+    rt: &mut impl Runtime,
+) -> Result<(StoragePower, StoragePower), ActorError> {
     let rwret = rt.send(
         &STORAGE_POWER_ACTOR_ADDR,
         ext::power::CURRENT_TOTAL_POWER_METHOD,
@@ -1452,14 +1381,13 @@ pub fn deal_id_key(k: DealID) -> BytesKey {
 }
 
 impl ActorCode for Actor {
-    fn invoke_method<BS, RT>(
+    fn invoke_method<RT>(
         rt: &mut RT,
         method: MethodNum,
         params: &RawBytes,
     ) -> Result<RawBytes, ActorError>
     where
-        BS: Blockstore,
-        RT: Runtime<BS>,
+        RT: Runtime,
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {

--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -516,10 +516,7 @@ where
         &mut self,
         deal: &DealProposal,
         state: &DealState,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-    {
+    ) -> Result<(), ActorError> {
         if state.sector_start_epoch == EPOCH_UNDEFINED {
             return Err(actor_error!(illegal_state, "start sector epoch undefined"));
         }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -132,14 +132,10 @@ pub const ERR_BALANCE_INVARIANTS_BROKEN: ExitCode = ExitCode::new(1000);
 pub struct Actor;
 
 impl Actor {
-    pub fn constructor<BS, RT>(
-        rt: &mut RT,
+    pub fn constructor(
+        rt: &mut impl Runtime,
         params: MinerConstructorParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&INIT_ACTOR_ADDR))?;
 
         check_control_addresses(rt.policy(), &params.control_addresses)?;
@@ -206,11 +202,7 @@ impl Actor {
         Ok(())
     }
 
-    fn control_addresses<BS, RT>(rt: &mut RT) -> Result<GetControlAddressesReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    fn control_addresses(rt: &mut impl Runtime) -> Result<GetControlAddressesReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let state: State = rt.state()?;
         let info = get_miner_info(rt.store(), &state)?;
@@ -224,14 +216,10 @@ impl Actor {
     /// Will ALWAYS overwrite the existing control addresses with the control addresses passed in the params.
     /// If an empty addresses vector is passed, the control addresses will be cleared.
     /// A worker change will be scheduled if the worker passed in the params is different from the existing worker.
-    fn change_worker_address<BS, RT>(
-        rt: &mut RT,
+    fn change_worker_address(
+        rt: &mut impl Runtime,
         params: ChangeWorkerAddressParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         check_control_addresses(rt.policy(), &params.new_control_addresses)?;
 
         let new_worker = resolve_worker_address(rt, params.new_worker)?;
@@ -269,11 +257,7 @@ impl Actor {
     }
 
     /// Triggers a worker address change if a change has been requested and its effective epoch has arrived.
-    fn confirm_update_worker_key<BS, RT>(rt: &mut RT) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    fn confirm_update_worker_key(rt: &mut impl Runtime) -> Result<(), ActorError> {
         rt.transaction(|state: &mut State, rt| {
             let mut info = get_miner_info(rt.store(), state)?;
 
@@ -290,11 +274,7 @@ impl Actor {
     /// current owner address, revokes any existing proposal.
     /// If invoked by the previously proposed address, with the same proposal, changes the current owner address to be
     /// that proposed address.
-    fn change_owner_address<BS, RT>(rt: &mut RT, new_address: Address) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    fn change_owner_address(rt: &mut impl Runtime, new_address: Address) -> Result<(), ActorError> {
         // * Cannot match go checking for undef address, does go impl allow this to be
         // * deserialized over the wire? If so, a workaround will be needed
 
@@ -346,11 +326,7 @@ impl Actor {
         })
     }
 
-    fn change_peer_id<BS, RT>(rt: &mut RT, params: ChangePeerIDParams) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    fn change_peer_id(rt: &mut impl Runtime, params: ChangePeerIDParams) -> Result<(), ActorError> {
         let policy = rt.policy();
         check_peer_info(policy, &params.new_id, &[])?;
 
@@ -371,14 +347,10 @@ impl Actor {
         Ok(())
     }
 
-    fn change_multiaddresses<BS, RT>(
-        rt: &mut RT,
+    fn change_multiaddresses(
+        rt: &mut impl Runtime,
         params: ChangeMultiaddrsParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         let policy = rt.policy();
         check_peer_info(policy, &[], &params.new_multi_addrs)?;
 
@@ -400,14 +372,10 @@ impl Actor {
     }
 
     /// Invoked by miner's worker address to submit their fallback post
-    fn submit_windowed_post<BS, RT>(
-        rt: &mut RT,
+    fn submit_windowed_post(
+        rt: &mut impl Runtime,
         mut params: SubmitWindowedPoStParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         let current_epoch = rt.curr_epoch();
 
         {
@@ -676,14 +644,10 @@ impl Actor {
     /// Checks state of the corresponding sector pre-commitments and verifies aggregate proof of replication
     /// of these sectors. If valid, the sectors' deals are activated, sectors are assigned a deadline and charged pledge
     /// and precommit state is removed.
-    fn prove_commit_aggregate<BS, RT>(
-        rt: &mut RT,
+    fn prove_commit_aggregate(
+        rt: &mut impl Runtime,
         params: ProveCommitAggregateParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         let sector_numbers = params.sector_numbers.validate().map_err(|e| {
             actor_error!(illegal_state, "Failed to validate bitfield for aggregated sectors: {}", e)
         })?;
@@ -857,15 +821,15 @@ impl Actor {
         Ok(())
     }
 
-    fn prove_replica_updates<BS, RT>(
+    fn prove_replica_updates<RT>(
         rt: &mut RT,
         params: ProveReplicaUpdatesParams,
     ) -> Result<BitField, ActorError>
     where
         // + Clone because we messed up and need to keep a copy around between transactions.
         // https://github.com/filecoin-project/builtin-actors/issues/133
-        BS: Blockstore + Clone,
-        RT: Runtime<BS>,
+        RT::Blockstore: Clone,
+        RT: Runtime,
     {
         // In this entry point, the unsealed CID is computed from deals via the market actor.
         // A future entry point will take the unsealed CID as parameter
@@ -886,15 +850,15 @@ impl Actor {
         Self::prove_replica_updates_inner(rt, updates)
     }
 
-    fn prove_replica_updates2<BS, RT>(
+    fn prove_replica_updates2<RT>(
         rt: &mut RT,
         params: ProveReplicaUpdatesParams2,
     ) -> Result<BitField, ActorError>
     where
         // + Clone because we messed up and need to keep a copy around between transactions.
         // https://github.com/filecoin-project/builtin-actors/issues/133
-        BS: Blockstore + Clone,
-        RT: Runtime<BS>,
+        RT::Blockstore: Blockstore + Clone,
+        RT: Runtime,
     {
         let updates = params
             .updates
@@ -912,15 +876,15 @@ impl Actor {
             .collect();
         Self::prove_replica_updates_inner(rt, updates)
     }
-    fn prove_replica_updates_inner<BS, RT>(
+    fn prove_replica_updates_inner<RT>(
         rt: &mut RT,
         updates: Vec<ReplicaUpdateInner>,
     ) -> Result<BitField, ActorError>
     where
         // + Clone because we messed up and need to keep a copy around between transactions.
         // https://github.com/filecoin-project/builtin-actors/issues/133
-        BS: Blockstore + Clone,
-        RT: Runtime<BS>,
+        RT::Blockstore: Blockstore + Clone,
+        RT: Runtime,
     {
         // Validate inputs
 
@@ -1376,14 +1340,10 @@ impl Actor {
         Ok(succeeded_sectors)
     }
 
-    fn dispute_windowed_post<BS, RT>(
-        rt: &mut RT,
+    fn dispute_windowed_post(
+        rt: &mut impl Runtime,
         params: DisputeWindowedPoStParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_type(CALLER_TYPES_SIGNABLE.iter())?;
         let reporter = rt.message().caller();
 
@@ -1592,14 +1552,10 @@ impl Actor {
 
     /// Pledges to seal and commit a single sector.
     /// See PreCommitSectorBatch for details.
-    fn pre_commit_sector<BS, RT>(
-        rt: &mut RT,
+    fn pre_commit_sector(
+        rt: &mut impl Runtime,
         params: PreCommitSectorParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         let batch_params = PreCommitSectorBatchParams { sectors: vec![params] };
         Self::pre_commit_sector_batch(rt, batch_params)
     }
@@ -1612,14 +1568,10 @@ impl Actor {
     /// when proven.
     /// This method calculates the sector's power, locks a pre-commit deposit for the sector, stores information about the
     /// sector in state and waits for it to be proven or expire.
-    fn pre_commit_sector_batch<BS, RT>(
-        rt: &mut RT,
+    fn pre_commit_sector_batch(
+        rt: &mut impl Runtime,
         params: PreCommitSectorBatchParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         let sectors = params
             .sectors
             .into_iter()
@@ -1653,14 +1605,10 @@ impl Actor {
     /// to the storage market actor.
     /// This method calculates the sector's power, locks a pre-commit deposit for the sector, stores information about the
     /// sector in state and waits for it to be proven or expire.
-    fn pre_commit_sector_batch2<BS, RT>(
-        rt: &mut RT,
+    fn pre_commit_sector_batch2(
+        rt: &mut impl Runtime,
         params: PreCommitSectorBatchParams2,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         Self::pre_commit_sector_batch_inner(
             rt,
             params
@@ -1682,14 +1630,10 @@ impl Actor {
 
     /// This function combines old and new flows for PreCommit with use Option<CommpactCommD>
     /// The old PreCommits will call this with None, new ones with Some(CompactCommD).
-    fn pre_commit_sector_batch_inner<BS, RT>(
-        rt: &mut RT,
+    fn pre_commit_sector_batch_inner(
+        rt: &mut impl Runtime,
         sectors: Vec<SectorPreCommitInfoInner>,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         let curr_epoch = rt.curr_epoch();
         {
             let policy = rt.policy();
@@ -1948,14 +1892,10 @@ impl Actor {
     /// Checks state of the corresponding sector pre-commitment, then schedules the proof to be verified in bulk
     /// by the power actor.
     /// If valid, the power actor will call ConfirmSectorProofsValid at the end of the same epoch as this message.
-    fn prove_commit_sector<BS, RT>(
-        rt: &mut RT,
+    fn prove_commit_sector(
+        rt: &mut impl Runtime,
         params: ProveCommitSectorParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
 
         if params.sector_number > MAX_SECTOR_NUMBER {
@@ -2036,14 +1976,10 @@ impl Actor {
         Ok(())
     }
 
-    fn confirm_sector_proofs_valid<BS, RT>(
-        rt: &mut RT,
+    fn confirm_sector_proofs_valid(
+        rt: &mut impl Runtime,
         params: ConfirmSectorProofsParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(iter::once(&STORAGE_POWER_ACTOR_ADDR))?;
 
         // This should be enforced by the power actor. We log here just in case
@@ -2074,14 +2010,10 @@ impl Actor {
         )
     }
 
-    fn check_sector_proven<BS, RT>(
-        rt: &mut RT,
+    fn check_sector_proven(
+        rt: &mut impl Runtime,
         params: CheckSectorProvenParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
 
         if params.sector_number > MAX_SECTOR_NUMBER {
@@ -2106,14 +2038,10 @@ impl Actor {
     /// The sector must not be terminated or faulty.
     /// The sector's power is recomputed for the new expiration.
     /// This method is legacy and should be replaced with calls to extend_sector_expiration2
-    fn extend_sector_expiration<BS, RT>(
-        rt: &mut RT,
+    fn extend_sector_expiration(
+        rt: &mut impl Runtime,
         params: ExtendSectorExpirationParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         let extend_expiration_inner =
             validate_legacy_extension_declarations(&params.extensions, rt.policy())?;
         Self::extend_sector_expiration_inner(
@@ -2126,14 +2054,10 @@ impl Actor {
     // Up to date version of extend_sector_expiration that correctly handles simple qap sectors
     // with FIL+ claims. Extension is only allowed if all claim max terms extend past new expiration
     // or claims are dropped.  Power only changes when claims are dropped.
-    fn extend_sector_expiration2<BS, RT>(
-        rt: &mut RT,
+    fn extend_sector_expiration2(
+        rt: &mut impl Runtime,
         params: ExtendSectorExpiration2Params,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         let extend_expiration_inner = validate_extension_declarations(rt, params.extensions)?;
         Self::extend_sector_expiration_inner(
             rt,
@@ -2142,15 +2066,11 @@ impl Actor {
         )
     }
 
-    fn extend_sector_expiration_inner<BS, RT>(
-        rt: &mut RT,
+    fn extend_sector_expiration_inner(
+        rt: &mut impl Runtime,
         inner: ExtendExpirationsInner,
         kind: ExtensionKind,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         let curr_epoch = rt.curr_epoch();
 
         /* Loop over sectors and do extension */
@@ -2368,14 +2288,10 @@ impl Actor {
     ///
     /// This function may be invoked with no new sectors to explicitly process the
     /// next batch of sectors.
-    fn terminate_sectors<BS, RT>(
-        rt: &mut RT,
+    fn terminate_sectors(
+        rt: &mut impl Runtime,
         params: TerminateSectorsParams,
-    ) -> Result<TerminateSectorsReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<TerminateSectorsReturn, ActorError> {
         // Note: this cannot terminate pre-committed but un-proven sectors.
         // They must be allowed to expire (and deposit burnt).
 
@@ -2525,11 +2441,10 @@ impl Actor {
         Ok(TerminateSectorsReturn { done: !more })
     }
 
-    fn declare_faults<BS, RT>(rt: &mut RT, params: DeclareFaultsParams) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    fn declare_faults(
+        rt: &mut impl Runtime,
+        params: DeclareFaultsParams,
+    ) -> Result<(), ActorError> {
         {
             let policy = rt.policy();
             if params.faults.len() as u64 > policy.declarations_max {
@@ -2665,14 +2580,10 @@ impl Actor {
         Ok(())
     }
 
-    fn declare_faults_recovered<BS, RT>(
-        rt: &mut RT,
+    fn declare_faults_recovered(
+        rt: &mut impl Runtime,
         params: DeclareFaultsRecoveredParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         {
             let policy = rt.policy();
             if params.recoveries.len() as u64 > policy.declarations_max {
@@ -2810,14 +2721,10 @@ impl Actor {
     /// The final partition in the deadline is always included in the compaction, whether or not explicitly requested.
     /// Removed sectors are removed from state entirely.
     /// May not be invoked if the deadline has any un-processed early terminations.
-    fn compact_partitions<BS, RT>(
-        rt: &mut RT,
+    fn compact_partitions(
+        rt: &mut impl Runtime,
         params: CompactPartitionsParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         {
             let policy = rt.policy();
             if params.deadline >= policy.wpost_period_deadlines {
@@ -2951,14 +2858,10 @@ impl Actor {
     /// can be called to mask out (throw away) entire ranges of unused sector IDs.
     /// For example, if sectors 1-99 and 101-200 have been allocated, sector number
     /// 99 can be masked out to collapse these two ranges into one.
-    fn compact_sector_numbers<BS, RT>(
-        rt: &mut RT,
+    fn compact_sector_numbers(
+        rt: &mut impl Runtime,
         params: CompactSectorNumbersParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         let mask_sector_numbers = params
             .mask_sector_numbers
             .validate()
@@ -2995,11 +2898,7 @@ impl Actor {
     }
 
     /// Locks up some amount of a the miner's unlocked balance (including funds received alongside the invoking message).
-    fn apply_rewards<BS, RT>(rt: &mut RT, params: ApplyRewardParams) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    fn apply_rewards(rt: &mut impl Runtime, params: ApplyRewardParams) -> Result<(), ActorError> {
         if params.reward.is_negative() {
             return Err(actor_error!(
                 illegal_argument,
@@ -3076,14 +2975,10 @@ impl Actor {
         Ok(())
     }
 
-    fn report_consensus_fault<BS, RT>(
-        rt: &mut RT,
+    fn report_consensus_fault(
+        rt: &mut impl Runtime,
         params: ReportConsensusFaultParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         // Note: only the first report of any fault is processed because it sets the
         // ConsensusFaultElapsed state variable to an epoch after the fault, and reports prior to
         // that epoch are no longer valid
@@ -3183,14 +3078,10 @@ impl Actor {
         Ok(())
     }
 
-    fn withdraw_balance<BS, RT>(
-        rt: &mut RT,
+    fn withdraw_balance(
+        rt: &mut impl Runtime,
         params: WithdrawBalanceParams,
-    ) -> Result<WithdrawBalanceReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<WithdrawBalanceReturn, ActorError> {
         if params.amount_requested.is_negative() {
             return Err(actor_error!(
                 illegal_argument,
@@ -3289,14 +3180,10 @@ impl Actor {
     /// A proposal must be submitted by the owner, and takes effect after approval of both the proposed beneficiary and current beneficiary,
     /// if applicable, any current beneficiary that has time and quota remaining.
     //// See FIP-0029, https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0029.md
-    fn change_beneficiary<BS, RT>(
-        rt: &mut RT,
+    fn change_beneficiary(
+        rt: &mut impl Runtime,
         params: ChangeBeneficiaryParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let caller = rt.message().caller();
         let new_beneficiary =
@@ -3423,11 +3310,7 @@ impl Actor {
     // GetBeneficiary retrieves the currently active and proposed beneficiary information.
     // This method is for use by other actors (such as those acting as beneficiaries),
     // and to abstract the state representation for clients.
-    fn get_beneficiary<BS, RT>(rt: &mut RT) -> Result<GetBeneficiaryReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    fn get_beneficiary(rt: &mut impl Runtime) -> Result<GetBeneficiaryReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let info = rt.transaction(|state: &mut State, rt| get_miner_info(rt.store(), state))?;
 
@@ -3440,11 +3323,7 @@ impl Actor {
         })
     }
 
-    fn repay_debt<BS, RT>(rt: &mut RT) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    fn repay_debt(rt: &mut impl Runtime) -> Result<(), ActorError> {
         let (from_vesting, from_balance, state) = rt.transaction(|state: &mut State, rt| {
             let info = get_miner_info(rt.store(), state)?;
             rt.validate_immediate_caller_is(
@@ -3473,14 +3352,10 @@ impl Actor {
         Ok(())
     }
 
-    fn on_deferred_cron_event<BS, RT>(
-        rt: &mut RT,
+    fn on_deferred_cron_event(
+        rt: &mut impl Runtime,
         params: DeferredCronEventParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&STORAGE_POWER_ACTOR_ADDR))?;
 
         let payload: CronEventPayload = from_slice(&params.event_payload).map_err(|e| {
@@ -3613,14 +3488,10 @@ fn validate_legacy_extension_declarations(
     Ok(ExtendExpirationsInner { extensions: vec_validated, claims: None })
 }
 
-fn validate_extension_declarations<BS, RT>(
-    rt: &mut RT,
+fn validate_extension_declarations(
+    rt: &mut impl Runtime,
     extensions: Vec<ExpirationExtension2>,
-) -> Result<ExtendExpirationsInner, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<ExtendExpirationsInner, ActorError> {
     let mut claim_space_by_sector = BTreeMap::<SectorNumber, (u64, u64)>::new();
 
     for decl in &extensions {
@@ -3829,15 +3700,11 @@ fn extend_non_simple_qap_sector(
 // TODO: We're using the current power+epoch reward. Technically, we
 // should use the power/reward at the time of termination.
 // https://github.com/filecoin-project/specs-actors/v6/pull/648
-fn process_early_terminations<BS, RT>(
-    rt: &mut RT,
+fn process_early_terminations(
+    rt: &mut impl Runtime,
     reward_smoothed: &FilterEstimate,
     quality_adj_power_smoothed: &FilterEstimate,
-) -> Result</* more */ bool, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result</* more */ bool, ActorError> {
     let (result, more, deals_to_terminate, penalty, pledge_delta) =
         rt.transaction(|state: &mut State, rt| {
             let store = rt.store();
@@ -3956,15 +3823,11 @@ where
 }
 
 /// Invoked at the end of the last epoch for each proving deadline.
-fn handle_proving_deadline<BS, RT>(
-    rt: &mut RT,
+fn handle_proving_deadline(
+    rt: &mut impl Runtime,
     reward_smoothed: &FilterEstimate,
     quality_adj_power_smoothed: &FilterEstimate,
-) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<(), ActorError> {
     let curr_epoch = rt.curr_epoch();
 
     let mut had_early_terminations = false;
@@ -4152,15 +4015,11 @@ fn validate_expiration(
     Ok(())
 }
 
-fn enroll_cron_event<BS, RT>(
-    rt: &mut RT,
+fn enroll_cron_event(
+    rt: &mut impl Runtime,
     event_epoch: ChainEpoch,
     cb: CronEventPayload,
-) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<(), ActorError> {
     let payload = serialize(&cb, "cron payload")?;
     let ser_params =
         serialize(&ext::power::EnrollCronEventParams { event_epoch, payload }, "cron params")?;
@@ -4174,11 +4033,7 @@ where
     Ok(())
 }
 
-fn request_update_power<BS, RT>(rt: &mut RT, delta: PowerPair) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn request_update_power(rt: &mut impl Runtime, delta: PowerPair) -> Result<(), ActorError> {
     if delta.is_zero() {
         return Ok(());
     }
@@ -4199,15 +4054,11 @@ where
     Ok(())
 }
 
-fn request_terminate_deals<BS, RT>(
-    rt: &mut RT,
+fn request_terminate_deals(
+    rt: &mut impl Runtime,
     epoch: ChainEpoch,
     deal_ids: Vec<DealID>,
-) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<(), ActorError> {
     const MAX_LENGTH: usize = 8192;
 
     for chunk in deal_ids.chunks(MAX_LENGTH) {
@@ -4225,11 +4076,7 @@ where
     Ok(())
 }
 
-fn schedule_early_termination_work<BS, RT>(rt: &mut RT) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn schedule_early_termination_work(rt: &mut impl Runtime) -> Result<(), ActorError> {
     info!("scheduling early terminations with cron...");
     enroll_cron_event(
         rt,
@@ -4244,16 +4091,12 @@ fn have_pending_early_terminations(state: &State) -> bool {
 }
 
 // returns true if valid, false if invalid, error if failed to validate either way!
-fn verify_windowed_post<BS, RT>(
-    rt: &RT,
+fn verify_windowed_post(
+    rt: &impl Runtime,
     challenge_epoch: ChainEpoch,
     sectors: &[SectorOnChainInfo],
     proofs: Vec<PoStProof>,
-) -> Result<bool, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<bool, ActorError> {
     let miner_actor_id: u64 = if let Payload::ID(i) = rt.message().receiver().payload() {
         *i
     } else {
@@ -4294,15 +4137,11 @@ where
     Ok(result.is_ok())
 }
 
-fn get_verify_info<BS, RT>(
-    rt: &mut RT,
+fn get_verify_info(
+    rt: &mut impl Runtime,
     params: SealVerifyParams,
     unsealed_cid: CompactCommD,
-) -> Result<SealVerifyInfo, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<SealVerifyInfo, ActorError> {
     if rt.curr_epoch() <= params.interactive_epoch {
         return Err(actor_error!(forbidden, "too early to prove sector"));
     }
@@ -4342,14 +4181,10 @@ where
     })
 }
 
-fn request_deal_data<BS, RT>(
-    rt: &mut RT,
+fn request_deal_data(
+    rt: &mut impl Runtime,
     sectors: &[ext::market::SectorDeals],
-) -> Result<ext::market::VerifyDealsForActivationReturn, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<ext::market::VerifyDealsForActivationReturn, ActorError> {
     // Short-circuit if there are no deals in any of the sectors.
     let mut deal_count = 0;
     for sector in sectors {
@@ -4373,13 +4208,9 @@ where
 
 /// Requests the current epoch target block reward from the reward actor.
 /// return value includes reward, smoothed estimate of reward, and baseline power
-fn request_current_epoch_block_reward<BS, RT>(
-    rt: &mut RT,
-) -> Result<ThisEpochRewardReturn, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn request_current_epoch_block_reward(
+    rt: &mut impl Runtime,
+) -> Result<ThisEpochRewardReturn, ActorError> {
     let ret = rt
         .send(
             &REWARD_ACTOR_ADDR,
@@ -4394,13 +4225,9 @@ where
 }
 
 /// Requests the current network total power and pledge from the power actor.
-fn request_current_total_power<BS, RT>(
-    rt: &mut RT,
-) -> Result<ext::power::CurrentTotalPowerReturn, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn request_current_total_power(
+    rt: &mut impl Runtime,
+) -> Result<ext::power::CurrentTotalPowerReturn, ActorError> {
     let ret = rt
         .send(
             &STORAGE_POWER_ACTOR_ADDR,
@@ -4415,11 +4242,7 @@ where
 }
 
 /// Resolves an address to an ID address and verifies that it is address of an account or multisig actor.
-fn resolve_control_address<BS, RT>(rt: &RT, raw: Address) -> Result<Address, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn resolve_control_address(rt: &impl Runtime, raw: Address) -> Result<Address, ActorError> {
     let resolved = rt
         .resolve_address(&raw)
         .ok_or_else(|| actor_error!(illegal_argument, "unable to resolve address: {}", raw))?;
@@ -4447,11 +4270,7 @@ where
 
 /// Resolves an address to an ID address and verifies that it is address of an account actor with an associated BLS key.
 /// The worker must be BLS since the worker key will be used alongside a BLS-VRF.
-fn resolve_worker_address<BS, RT>(rt: &mut RT, raw: Address) -> Result<Address, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn resolve_worker_address(rt: &mut impl Runtime, raw: Address) -> Result<Address, ActorError> {
     let resolved = rt
         .resolve_address(&raw)
         .ok_or_else(|| actor_error!(illegal_argument, "unable to resolve address: {}", raw))?;
@@ -4487,11 +4306,7 @@ where
     Ok(Address::new_id(resolved))
 }
 
-fn burn_funds<BS, RT>(rt: &mut RT, amount: TokenAmount) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn burn_funds(rt: &mut impl Runtime, amount: TokenAmount) -> Result<(), ActorError> {
     log::debug!("storage provder {} burning {}", rt.message().receiver(), amount);
     if amount.is_positive() {
         rt.send(&BURNT_FUNDS_ACTOR_ADDR, METHOD_SEND, RawBytes::default(), amount)?;
@@ -4499,11 +4314,10 @@ where
     Ok(())
 }
 
-fn notify_pledge_changed<BS, RT>(rt: &mut RT, pledge_delta: &TokenAmount) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn notify_pledge_changed(
+    rt: &mut impl Runtime,
+    pledge_delta: &TokenAmount,
+) -> Result<(), ActorError> {
     if !pledge_delta.is_zero() {
         rt.send(
             &STORAGE_POWER_ACTOR_ADDR,
@@ -4515,14 +4329,10 @@ where
     Ok(())
 }
 
-fn get_claims<BS, RT>(
-    rt: &mut RT,
+fn get_claims(
+    rt: &mut impl Runtime,
     ids: &Vec<ext::verifreg::ClaimID>,
-) -> Result<Vec<ext::verifreg::Claim>, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<Vec<ext::verifreg::Claim>, ActorError> {
     let params = ext::verifreg::GetClaimsParams {
         provider: rt.message().receiver().id().unwrap(),
         claim_ids: ids.clone(),
@@ -4687,15 +4497,11 @@ where
         .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "could not read miner info"))
 }
 
-fn process_pending_worker<BS, RT>(
+fn process_pending_worker(
     info: &mut MinerInfo,
-    rt: &RT,
+    rt: &impl Runtime,
     state: &mut State,
-) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<(), ActorError> {
     let pending_worker_key = if let Some(k) = &info.pending_worker_key {
         k
     } else {
@@ -4721,11 +4527,7 @@ where
 /// may be slightly lower than the true amount. Computing vesting here would be
 /// almost always redundant since vesting is quantized to ~daily units.  Vesting
 /// will be at most one proving period old if computed in the cron callback.
-fn repay_debts_or_abort<BS, RT>(rt: &RT, state: &mut State) -> Result<TokenAmount, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn repay_debts_or_abort(rt: &impl Runtime, state: &mut State) -> Result<TokenAmount, ActorError> {
     let res = state.repay_debts(&rt.current_balance()).map_err(|e| {
         e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "unlocked balance can not repay fee debt")
     })?;
@@ -4795,17 +4597,13 @@ fn check_peer_info(
     Ok(())
 }
 
-fn confirm_sector_proofs_valid_internal<BS, RT>(
-    rt: &mut RT,
+fn confirm_sector_proofs_valid_internal(
+    rt: &mut impl Runtime,
     pre_commits: Vec<SectorPreCommitOnChainInfo>,
     this_epoch_baseline_power: &BigInt,
     this_epoch_reward_smoothed: &FilterEstimate,
     quality_adj_power_smoothed: &FilterEstimate,
-) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<(), ActorError> {
     // get network stats from other actors
     let circulating_supply = rt.total_fil_circ_supply();
 
@@ -4982,16 +4780,12 @@ where
 // activate deals with builtin market and claim allocations with verified registry actor
 // returns an error in case of a fatal programmer error
 // returns Ok(None) in case deal activation or verified allocation claim fails
-fn activate_deals_and_claim_allocations<RT, BS>(
-    rt: &mut RT,
+fn activate_deals_and_claim_allocations(
+    rt: &mut impl Runtime,
     deal_ids: Vec<DealID>,
     sector_expiry: ChainEpoch,
     sector_number: SectorNumber,
-) -> Result<Option<crate::ext::market::DealSpaces>, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<Option<crate::ext::market::DealSpaces>, ActorError> {
     if deal_ids.is_empty() {
         return Ok(Some(ext::market::DealSpaces::default()));
     }
@@ -5061,14 +4855,14 @@ fn balance_invariants_broken(e: Error) -> ActorError {
 }
 
 impl ActorCode for Actor {
-    fn invoke_method<BS, RT>(
+    fn invoke_method<RT>(
         rt: &mut RT,
         method: MethodNum,
         params: &RawBytes,
     ) -> Result<RawBytes, ActorError>
     where
-        BS: Blockstore + Clone,
-        RT: Runtime<BS>,
+        RT: Runtime,
+        RT::Blockstore: Clone,
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -49,11 +49,7 @@ pub enum Method {
 pub struct Actor;
 impl Actor {
     /// Constructor for Multisig actor
-    pub fn constructor<BS, RT>(rt: &mut RT, params: ConstructorParams) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn constructor(rt: &mut impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&INIT_ACTOR_ADDR))?;
 
         if params.signers.is_empty() {
@@ -122,11 +118,10 @@ impl Actor {
     }
 
     /// Multisig actor propose function
-    pub fn propose<BS, RT>(rt: &mut RT, params: ProposeParams) -> Result<ProposeReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn propose(
+        rt: &mut impl Runtime,
+        params: ProposeParams,
+    ) -> Result<ProposeReturn, ActorError> {
         rt.validate_immediate_caller_type(&[Type::Account, Type::Multisig])?;
         let proposer: Address = rt.message().caller();
 
@@ -176,11 +171,10 @@ impl Actor {
     }
 
     /// Multisig actor approve function
-    pub fn approve<BS, RT>(rt: &mut RT, params: TxnIDParams) -> Result<ApproveReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn approve(
+        rt: &mut impl Runtime,
+        params: TxnIDParams,
+    ) -> Result<ApproveReturn, ActorError> {
         rt.validate_immediate_caller_type(&[Type::Account, Type::Multisig])?;
         let approver: Address = rt.message().caller();
 
@@ -212,11 +206,7 @@ impl Actor {
     }
 
     /// Multisig actor cancel function
-    pub fn cancel<BS, RT>(rt: &mut RT, params: TxnIDParams) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn cancel(rt: &mut impl Runtime, params: TxnIDParams) -> Result<(), ActorError> {
         rt.validate_immediate_caller_type(&[Type::Account, Type::Multisig])?;
         let caller_addr: Address = rt.message().caller();
 
@@ -261,11 +251,7 @@ impl Actor {
     }
 
     /// Multisig actor function to add signers to multisig
-    pub fn add_signer<BS, RT>(rt: &mut RT, params: AddSignerParams) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn add_signer(rt: &mut impl Runtime, params: AddSignerParams) -> Result<(), ActorError> {
         let receiver = rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let resolved_new_signer = resolve_to_actor_id(rt, &params.signer)?;
@@ -293,11 +279,10 @@ impl Actor {
     }
 
     /// Multisig actor function to remove signers to multisig
-    pub fn remove_signer<BS, RT>(rt: &mut RT, params: RemoveSignerParams) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn remove_signer(
+        rt: &mut impl Runtime,
+        params: RemoveSignerParams,
+    ) -> Result<(), ActorError> {
         let receiver = rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let resolved_old_signer = resolve_to_actor_id(rt, &params.signer)?;
@@ -344,11 +329,7 @@ impl Actor {
     }
 
     /// Multisig actor function to swap signers to multisig
-    pub fn swap_signer<BS, RT>(rt: &mut RT, params: SwapSignerParams) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn swap_signer(rt: &mut impl Runtime, params: SwapSignerParams) -> Result<(), ActorError> {
         let receiver = rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let from_resolved = resolve_to_actor_id(rt, &params.from)?;
@@ -377,14 +358,10 @@ impl Actor {
     }
 
     /// Multisig actor function to change number of approvals needed
-    pub fn change_num_approvals_threshold<BS, RT>(
-        rt: &mut RT,
+    pub fn change_num_approvals_threshold(
+        rt: &mut impl Runtime,
         params: ChangeNumApprovalsThresholdParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         let receiver = rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
 
@@ -403,11 +380,10 @@ impl Actor {
     }
 
     /// Multisig actor function to change number of approvals needed
-    pub fn lock_balance<BS, RT>(rt: &mut RT, params: LockBalanceParams) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn lock_balance(
+        rt: &mut impl Runtime,
+        params: LockBalanceParams,
+    ) -> Result<(), ActorError> {
         let receiver = rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
 
@@ -430,15 +406,11 @@ impl Actor {
         Ok(())
     }
 
-    fn approve_transaction<BS, RT>(
-        rt: &mut RT,
+    fn approve_transaction(
+        rt: &mut impl Runtime,
         tx_id: TxnID,
         mut txn: Transaction,
-    ) -> Result<(bool, RawBytes, ExitCode), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(bool, RawBytes, ExitCode), ActorError> {
         for previous_approver in &txn.approved {
             if *previous_approver == rt.message().caller() {
                 return Err(actor_error!(
@@ -475,29 +447,21 @@ impl Actor {
     }
 
     // Always succeeds, accepting any transfers.
-    pub fn universal_receiver_hook<BS, RT>(
-        rt: &mut RT,
+    pub fn universal_receiver_hook(
+        rt: &mut impl Runtime,
         _params: &RawBytes,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         Ok(())
     }
 }
 
-fn execute_transaction_if_approved<BS, RT>(
-    rt: &mut RT,
+fn execute_transaction_if_approved(
+    rt: &mut impl Runtime,
     st: &State,
     txn_id: TxnID,
     txn: &Transaction,
-) -> Result<(bool, RawBytes, ExitCode), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<(bool, RawBytes, ExitCode), ActorError> {
     let mut out = RawBytes::default();
     let mut code = ExitCode::OK;
     let mut applied = false;
@@ -543,7 +507,7 @@ fn get_transaction<'bs, 'm, BS, RT>(
 ) -> Result<&'m Transaction, ActorError>
 where
     BS: Blockstore,
-    RT: Runtime<BS>,
+    RT: Runtime,
 {
     let txn = ptx
         .get(&txn_id.key())
@@ -584,14 +548,13 @@ pub fn compute_proposal_hash(txn: &Transaction, sys: &dyn Primitives) -> anyhow:
 }
 
 impl ActorCode for Actor {
-    fn invoke_method<BS, RT>(
+    fn invoke_method<RT>(
         rt: &mut RT,
         method: MethodNum,
         params: &RawBytes,
     ) -> Result<RawBytes, ActorError>
     where
-        BS: Blockstore,
-        RT: Runtime<BS>,
+        RT: Runtime,
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -6,7 +6,7 @@ use fil_actors_runtime::{
     actor_error, cbor, ActorError, BURNT_FUNDS_ACTOR_ADDR, EXPECTED_LEADERS_PER_EPOCH,
     STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
-use fvm_ipld_blockstore::Blockstore;
+
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser::BigIntDe;
@@ -53,14 +53,10 @@ pub enum Method {
 pub struct Actor;
 impl Actor {
     /// Constructor for Reward actor
-    fn constructor<BS, RT>(
-        rt: &mut RT,
+    fn constructor(
+        rt: &mut impl Runtime,
         curr_realized_power: Option<StoragePower>,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
         if let Some(power) = curr_realized_power {
@@ -81,14 +77,10 @@ impl Actor {
     ///
     /// The reward is reduced before the residual is credited to the block producer, by:
     /// - a penalty amount, provided as a parameter, which is burnt,
-    fn award_block_reward<BS, RT>(
-        rt: &mut RT,
+    fn award_block_reward(
+        rt: &mut impl Runtime,
         params: AwardBlockRewardParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
         let prior_balance = rt.current_balance();
         if params.penalty.is_negative() {
@@ -185,11 +177,7 @@ impl Actor {
     /// The award value used for the current epoch, updated at the end of an epoch
     /// through cron tick.  In the case previous epochs were null blocks this
     /// is the reward value as calculated at the last non-null epoch.
-    fn this_epoch_reward<BS, RT>(rt: &mut RT) -> Result<ThisEpochRewardReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    fn this_epoch_reward(rt: &mut impl Runtime) -> Result<ThisEpochRewardReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let st: State = rt.state()?;
         Ok(ThisEpochRewardReturn {
@@ -201,14 +189,10 @@ impl Actor {
     /// Called at the end of each epoch by the power actor (in turn by its cron hook).
     /// This is only invoked for non-empty tipsets, but catches up any number of null
     /// epochs to compute the next epoch reward.
-    fn update_network_kpi<BS, RT>(
-        rt: &mut RT,
+    fn update_network_kpi(
+        rt: &mut impl Runtime,
         curr_realized_power: Option<StoragePower>,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&STORAGE_POWER_ACTOR_ADDR))?;
         let curr_realized_power = curr_realized_power
             .ok_or_else(|| actor_error!(illegal_argument, "argument cannot be None"))?;
@@ -231,14 +215,13 @@ impl Actor {
 }
 
 impl ActorCode for Actor {
-    fn invoke_method<BS, RT>(
+    fn invoke_method<RT>(
         rt: &mut RT,
         method: MethodNum,
         params: &RawBytes,
     ) -> Result<RawBytes, ActorError>
     where
-        BS: Blockstore,
-        RT: Runtime<BS>,
+        RT: Runtime,
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {

--- a/actors/system/src/lib.rs
+++ b/actors/system/src/lib.rs
@@ -55,11 +55,7 @@ impl State {
 pub struct Actor;
 impl Actor {
     /// System actor constructor.
-    pub fn constructor<BS, RT>(rt: &mut RT) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn constructor(rt: &mut impl Runtime) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
         let state = State::new(rt.store()).context("failed to construct state")?;
@@ -69,14 +65,13 @@ impl Actor {
 }
 
 impl ActorCode for Actor {
-    fn invoke_method<BS, RT>(
+    fn invoke_method<RT>(
         rt: &mut RT,
         method: MethodNum,
         _params: &RawBytes,
     ) -> Result<RawBytes, ActorError>
     where
-        BS: Blockstore,
-        RT: Runtime<BS>,
+        RT: Runtime,
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -67,11 +67,7 @@ pub struct Actor;
 
 impl Actor {
     /// Constructor for Registry Actor
-    pub fn constructor<BS, RT>(rt: &mut RT, root_key: Address) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn constructor(rt: &mut impl Runtime, root_key: Address) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
         // root should be an ID address
@@ -86,11 +82,10 @@ impl Actor {
         Ok(())
     }
 
-    pub fn add_verifier<BS, RT>(rt: &mut RT, params: AddVerifierParams) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn add_verifier(
+        rt: &mut impl Runtime,
+        params: AddVerifierParams,
+    ) -> Result<(), ActorError> {
         if params.allowance < rt.policy().minimum_verified_allocation_size {
             return Err(actor_error!(
                 illegal_argument,
@@ -129,11 +124,10 @@ impl Actor {
         })
     }
 
-    pub fn remove_verifier<BS, RT>(rt: &mut RT, verifier_addr: Address) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub fn remove_verifier(
+        rt: &mut impl Runtime,
+        verifier_addr: Address,
+    ) -> Result<(), ActorError> {
         let verifier = resolve_to_actor_id(rt, &verifier_addr)?;
         let verifier = Address::new_id(verifier);
 
@@ -145,14 +139,10 @@ impl Actor {
         })
     }
 
-    pub fn add_verified_client<BS, RT>(
-        rt: &mut RT,
+    pub fn add_verified_client(
+        rt: &mut impl Runtime,
         params: AddVerifierClientParams,
-    ) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<(), ActorError> {
         // The caller will be verified by checking table below
         rt.validate_immediate_caller_accept_any()?;
 
@@ -215,14 +205,10 @@ impl Actor {
     }
 
     /// Removes DataCap allocated to a verified client.
-    pub fn remove_verified_client_data_cap<BS, RT>(
-        rt: &mut RT,
+    pub fn remove_verified_client_data_cap(
+        rt: &mut impl Runtime,
         params: RemoveDataCapParams,
-    ) -> Result<RemoveDataCapReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<RemoveDataCapReturn, ActorError> {
         let client = resolve_to_actor_id(rt, &params.verified_client_to_remove)?;
         let client = Address::new_id(client);
 
@@ -310,14 +296,10 @@ impl Actor {
     // An allocation may be removed after its expiration epoch has passed (by anyone).
     // When removed, the DataCap tokens are transferred back to the client.
     // If no allocations are specified, all eligible allocations are removed.
-    pub fn remove_expired_allocations<BS, RT>(
-        rt: &mut RT,
+    pub fn remove_expired_allocations(
+        rt: &mut impl Runtime,
         params: RemoveExpiredAllocationsParams,
-    ) -> Result<RemoveExpiredAllocationsReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<RemoveExpiredAllocationsReturn, ActorError> {
         // Since the allocations are expired, this is safe to be called by anyone.
         rt.validate_immediate_caller_accept_any()?;
         let curr_epoch = rt.curr_epoch();
@@ -377,14 +359,10 @@ impl Actor {
     // Called by storage provider actor to claim allocations for data provably committed to storage.
     // For each allocation claim, the registry checks that the provided piece CID
     // and size match that of the allocation.
-    pub fn claim_allocations<BS, RT>(
-        rt: &mut RT,
+    pub fn claim_allocations(
+        rt: &mut impl Runtime,
         params: ClaimAllocationsParams,
-    ) -> Result<ClaimAllocationsReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<ClaimAllocationsReturn, ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
         let provider = rt.message().caller().id().unwrap();
         if params.sectors.is_empty() {
@@ -479,14 +457,10 @@ impl Actor {
     }
 
     // get claims for a provider
-    pub fn get_claims<BS, RT>(
-        rt: &mut RT,
+    pub fn get_claims(
+        rt: &mut impl Runtime,
         params: GetClaimsParams,
-    ) -> Result<GetClaimsReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<GetClaimsReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let mut batch_gen = BatchReturnGen::new(params.claim_ids.len());
         let claims = rt
@@ -519,14 +493,10 @@ impl Actor {
     /// Can extend the term even if the claim has already expired.
     /// Note that this method can't extend the term past the original limit,
     /// even if the term has previously been extended past that by spending new datacap.
-    pub fn extend_claim_terms<BS, RT>(
-        rt: &mut RT,
+    pub fn extend_claim_terms(
+        rt: &mut impl Runtime,
         params: ExtendClaimTermsParams,
-    ) -> Result<ExtendClaimTermsReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<ExtendClaimTermsReturn, ActorError> {
         // Permissions are checked per-claim.
         rt.validate_immediate_caller_accept_any()?;
         let caller_id = rt.message().caller().id().unwrap();
@@ -586,14 +556,10 @@ impl Actor {
 
     // A claim may be removed after its maximum term has elapsed (by anyone).
     // If no claims are specified, all eligible claims are removed.
-    pub fn remove_expired_claims<BS, RT>(
-        rt: &mut RT,
+    pub fn remove_expired_claims(
+        rt: &mut impl Runtime,
         params: RemoveExpiredClaimsParams,
-    ) -> Result<RemoveExpiredClaimsReturn, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<RemoveExpiredClaimsReturn, ActorError> {
         // Since the claims are expired, this is safe to be called by anyone.
         rt.validate_immediate_caller_accept_any()?;
         let curr_epoch = rt.curr_epoch();
@@ -639,14 +605,10 @@ impl Actor {
     // This method does not support partial success (yet): all allocations must succeed,
     // or the transfer will be rejected.
     // Returns the ids of the created allocations.
-    pub fn universal_receiver_hook<BS, RT>(
-        rt: &mut RT,
+    pub fn universal_receiver_hook(
+        rt: &mut impl Runtime,
         params: UniversalReceiverParams,
-    ) -> Result<AllocationsResponse, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> Result<AllocationsResponse, ActorError> {
         // Accept only the data cap token.
         rt.validate_immediate_caller_is(&[DATACAP_TOKEN_ACTOR_ADDR])?;
 
@@ -738,11 +700,7 @@ impl Actor {
 }
 
 // Checks whether an address has a verifier entry (which could be zero).
-fn is_verifier<BS, RT>(rt: &RT, st: &State, address: Address) -> Result<bool, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn is_verifier(rt: &impl Runtime, st: &State, address: Address) -> Result<bool, ActorError> {
     let verifiers =
         make_map_with_root_and_bitwidth::<_, BigIntDe>(&st.verifiers, rt.store(), HAMT_BIT_WIDTH)
             .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load verifiers")?;
@@ -756,11 +714,7 @@ where
 }
 
 // Invokes BalanceOf on the data cap token actor, and converts the result to whole units of data cap.
-fn balance_of<BS, RT>(rt: &mut RT, owner: &Address) -> Result<DataCap, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn balance_of(rt: &mut impl Runtime, owner: &Address) -> Result<DataCap, ActorError> {
     let params = serialize(owner, "owner address")?;
     let ret = rt
         .send(
@@ -775,16 +729,12 @@ where
 }
 
 // Invokes Mint on a data cap token actor for whole units of data cap.
-fn mint<BS, RT>(
-    rt: &mut RT,
+fn mint(
+    rt: &mut impl Runtime,
     to: &Address,
     amount: &DataCap,
     operators: Vec<Address>,
-) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<(), ActorError> {
     let token_amt = datacap_to_tokens(amount);
     let params = MintParams { to: *to, amount: token_amt, operators };
     rt.send(
@@ -798,11 +748,7 @@ where
 }
 
 // Invokes Burn on a data cap token actor for whole units of data cap.
-fn burn<BS, RT>(rt: &mut RT, amount: &DataCap) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn burn(rt: &mut impl Runtime, amount: &DataCap) -> Result<(), ActorError> {
     if amount.is_zero() {
         return Ok(());
     }
@@ -822,11 +768,7 @@ where
 }
 
 // Invokes Destroy on a data cap token actor for whole units of data cap.
-fn destroy<BS, RT>(rt: &mut RT, owner: &Address, amount: &DataCap) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn destroy(rt: &mut impl Runtime, owner: &Address, amount: &DataCap) -> Result<(), ActorError> {
     if amount.is_zero() {
         return Ok(());
     }
@@ -843,11 +785,7 @@ where
 }
 
 // Invokes transfer on a data cap token actor for whole units of data cap.
-fn transfer<BS, RT>(rt: &mut RT, to: ActorID, amount: &DataCap) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn transfer(rt: &mut impl Runtime, to: ActorID, amount: &DataCap) -> Result<(), ActorError> {
     let token_amt = datacap_to_tokens(amount);
     let params = TransferParams {
         to: Address::new_id(to),
@@ -912,17 +850,13 @@ where
     Ok(curr_id)
 }
 
-fn remove_data_cap_request_is_valid<BS, RT>(
-    rt: &RT,
+fn remove_data_cap_request_is_valid(
+    rt: &impl Runtime,
     request: &RemoveDataCapRequest,
     id: RemoveDataCapProposalID,
     to_remove: &DataCap,
     client: Address,
-) -> Result<(), ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+) -> Result<(), ActorError> {
     let proposal = RemoveDataCapProposal {
         removal_proposal_id: id,
         data_cap_amount: to_remove.clone(),
@@ -1083,11 +1017,7 @@ fn validate_claim_extension(
 }
 
 // Checks that an address corresponsds to a miner actor.
-fn resolve_miner_id<BS, RT>(rt: &mut RT, addr: &Address) -> Result<ActorID, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+fn resolve_miner_id(rt: &mut impl Runtime, addr: &Address) -> Result<ActorID, ActorError> {
     let id = rt.resolve_address(addr).with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
         format!("failed to resolve provider address {}", addr)
     })?;
@@ -1129,14 +1059,13 @@ fn can_claim_alloc(
 }
 
 impl ActorCode for Actor {
-    fn invoke_method<BS, RT>(
+    fn invoke_method<RT>(
         rt: &mut RT,
         method: MethodNum,
         params: &RawBytes,
     ) -> Result<RawBytes, ActorError>
     where
-        BS: Blockstore,
-        RT: Runtime<BS>,
+        RT: Runtime,
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{actor_error, ActorContext, ActorError};
-use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::address::Address;
 use fvm_shared::ActorID;
 use fvm_shared::METHOD_SEND;
@@ -20,11 +19,10 @@ pub const CALLER_TYPES_SIGNABLE: &[Type] = &[Type::Account, Type::Multisig];
 /// ResolveToActorID resolves the given address to it's actor ID.
 /// If an actor ID for the given address dosen't exist yet, it tries to create one by sending
 /// a zero balance to the given address.
-pub fn resolve_to_actor_id<BS, RT>(rt: &mut RT, address: &Address) -> Result<ActorID, ActorError>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+pub fn resolve_to_actor_id(
+    rt: &mut impl Runtime,
+    address: &Address,
+) -> Result<ActorID, ActorError> {
     // if we are able to resolve it to an ID address, return the resolved address
     if let Some(id) = rt.resolve_address(address) {
         return Ok(id);

--- a/runtime/src/runtime/actor_code.rs
+++ b/runtime/src/runtime/actor_code.rs
@@ -11,7 +11,7 @@ use crate::{ActorError, Runtime};
 pub trait ActorCode {
     /// Invokes method with runtime on the actor's code. Method number will match one
     /// defined by the Actor, and parameters will be serialized and used in execution
-    fn invoke_method<BS, RT>(
+    fn invoke_method<RT>(
         rt: &mut RT,
         method: MethodNum,
         params: &RawBytes,
@@ -20,6 +20,6 @@ pub trait ActorCode {
         // TODO: remove the clone requirement on the blockstore when we fix "replica update" to not
         // hold onto state between transactions.
         // https://github.com/filecoin-project/builtin-actors/issues/133
-        BS: Blockstore + Clone,
-        RT: Runtime<BS>;
+        RT: Runtime,
+        RT::Blockstore: Blockstore + Clone;
 }

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -89,10 +89,12 @@ impl MessageInfo for FvmMessage {
     }
 }
 
-impl<B> Runtime<B> for FvmRuntime<B>
+impl<B> Runtime for FvmRuntime<B>
 where
     B: Blockstore,
 {
+    type Blockstore = B;
+
     fn network_version(&self) -> NetworkVersion {
         fvm::network::version()
     }

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -41,7 +41,9 @@ pub use empty::EMPTY_ARR_CID;
 
 /// Runtime is the VM's internal runtime object.
 /// this is everything that is accessible to actors, beyond parameters.
-pub trait Runtime<BS: Blockstore>: Primitives + Verifier + RuntimePolicy {
+pub trait Runtime: Primitives + Verifier + RuntimePolicy {
+    type Blockstore: Blockstore;
+
     /// The network protocol version number at the current epoch.
     fn network_version(&self) -> NetworkVersion;
 
@@ -113,7 +115,7 @@ pub trait Runtime<BS: Blockstore>: Primitives + Verifier + RuntimePolicy {
         F: FnOnce(&mut C, &mut Self) -> Result<RT, ActorError>;
 
     /// Returns reference to blockstore
-    fn store(&self) -> &BS;
+    fn store(&self) -> &Self::Blockstore;
 
     /// Sends a message to another actor, returning the exit code and return value envelope.
     /// If the invoked method does not return successfully, its state changes

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -673,7 +673,9 @@ impl<BS> MessageInfo for MockRuntime<BS> {
     }
 }
 
-impl<BS: Blockstore> Runtime<Rc<BS>> for MockRuntime<BS> {
+impl<BS: Blockstore> Runtime for MockRuntime<BS> {
+    type Blockstore = Rc<BS>;
+
     fn network_version(&self) -> NetworkVersion {
         self.network_version
     }

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -699,7 +699,9 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
     }
 }
 
-impl<'invocation, 'bs> Runtime<&'bs MemoryBlockstore> for InvocationCtx<'invocation, 'bs> {
+impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
+    type Blockstore = &'bs MemoryBlockstore;
+
     fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {
         match NON_SINGLETON_CODES.get(&code_id) {
             Some(_) => (),


### PR DESCRIPTION
And use `impl Runtime` where possible. We don't use this in `invoke_method` so implementers can name the runtime if desired.