### PR TITLE
Miner actor: Add exported getters for info and monies

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -131,10 +131,6 @@ pub enum Method {
     IsControllingAddressExported = frc42_dispatch::method_hash!("IsControllingAddress"),
     GetSectorSizeExported = frc42_dispatch::method_hash!("GetSectorSize"),
     GetAvailableBalanceExported = frc42_dispatch::method_hash!("GetAvailableBalance"),
-    GetPreCommitDepositExported = frc42_dispatch::method_hash!("GetPreCommitDeposit"),
-    GetInitialPledgeExported = frc42_dispatch::method_hash!("GetInitialPledge"),
-    GetFeeDebtExported = frc42_dispatch::method_hash!("GetFeeDebt"),
-    GetLockedFundsExported = frc42_dispatch::method_hash!("GetLockedFunds"),
     GetVestingFundsExported = frc42_dispatch::method_hash!("GetVestingFunds"),
 }
 
@@ -259,37 +255,6 @@ impl Actor {
         let state: State = rt.state()?;
         let sector_size = get_miner_info(rt.store(), &state)?.sector_size;
         Ok(GetSectorSizeReturn { sector_size })
-    }
-
-    /// Returns the miner's total funds locked as pre-commit deposits
-    fn get_pre_commit_deposit(
-        rt: &mut impl Runtime,
-    ) -> Result<GetPreCommitDepositReturn, ActorError> {
-        rt.validate_immediate_caller_accept_any()?;
-        let state: State = rt.state()?;
-        Ok(GetPreCommitDepositReturn { pre_commit_deposit: state.pre_commit_deposits })
-    }
-
-    /// Returns the sum of the initial pledge requirements of all active sectors of this miner.
-    fn get_initial_pledge(rt: &mut impl Runtime) -> Result<GetInitialPledgeReturn, ActorError> {
-        rt.validate_immediate_caller_accept_any()?;
-        let state: State = rt.state()?;
-        Ok(GetInitialPledgeReturn { initial_pledge: state.initial_pledge })
-    }
-
-    /// Returns the absolute value of debt this miner owes from unpaid fees.
-    fn get_fee_debt(rt: &mut impl Runtime) -> Result<GetFeeDebtReturn, ActorError> {
-        rt.validate_immediate_caller_accept_any()?;
-        let state: State = rt.state()?;
-        Ok(GetFeeDebtReturn { fee_debt: state.fee_debt })
-    }
-
-    /// Returns the absolute value of the locked funds in this miner's vesting table.
-    /// Note that this does NOT include other types of locked funds like precommit deposits.
-    fn get_locked_funds(rt: &mut impl Runtime) -> Result<GetLockedFundsReturn, ActorError> {
-        rt.validate_immediate_caller_accept_any()?;
-        let state: State = rt.state()?;
-        Ok(GetLockedFundsReturn { locked_funds: state.locked_funds })
     }
 
     /// Returns the available balance of this miner.
@@ -5115,24 +5080,8 @@ impl ActorCode for Actor {
                 let res = Self::get_sector_size(rt)?;
                 Ok(RawBytes::serialize(res)?)
             }
-            Some(Method::GetPreCommitDepositExported) => {
-                let res = Self::get_pre_commit_deposit(rt)?;
-                Ok(RawBytes::serialize(res)?)
-            }
             Some(Method::GetAvailableBalanceExported) => {
                 let res = Self::get_available_balance(rt)?;
-                Ok(RawBytes::serialize(res)?)
-            }
-            Some(Method::GetInitialPledgeExported) => {
-                let res = Self::get_initial_pledge(rt)?;
-                Ok(RawBytes::serialize(res)?)
-            }
-            Some(Method::GetFeeDebtExported) => {
-                let res = Self::get_fee_debt(rt)?;
-                Ok(RawBytes::serialize(res)?)
-            }
-            Some(Method::GetLockedFundsExported) => {
-                let res = Self::get_locked_funds(rt)?;
                 Ok(RawBytes::serialize(res)?)
             }
             Some(Method::GetVestingFundsExported) => {

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -257,7 +257,7 @@ impl Actor {
         Ok(GetSectorSizeReturn { sector_size })
     }
 
-    /// Returns the miner's total funds locked as pre_commit_deposit
+    /// Returns the miner's total funds locked as pre-commit deposits
     fn get_pre_commit_deposit(
         rt: &mut impl Runtime,
     ) -> Result<GetPreCommitDepositReturn, ActorError> {

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -983,7 +983,7 @@ impl State {
         &self,
         actor_balance: &TokenAmount,
     ) -> anyhow::Result<TokenAmount> {
-        // (actor_balance - &self.locked_funds) - &self.pre_commit_deposit
+        // (actor_balance - &self.locked_funds) - &self.pre_commit_deposit - &self.initial_pledge
         Ok(self.get_unlocked_balance(actor_balance)? - &self.fee_debt)
     }
 

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -540,3 +540,11 @@ pub struct GetLockedFundsReturn {
 }
 
 impl Cbor for GetLockedFundsReturn {}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
+pub struct GetAvailableBalanceReturn {
+    pub available_balance: TokenAmount,
+}
+
+impl Cbor for GetAvailableBalanceReturn {}

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -491,18 +491,20 @@ pub struct GetOwnerReturn {
 impl Cbor for GetOwnerReturn {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct GetWorkerReturn {
-    pub worker: Address,
+#[serde(transparent)]
+pub struct IsControllingAddressParam {
+    pub address: Address,
 }
 
-impl Cbor for GetWorkerReturn {}
+impl Cbor for IsControllingAddressParam {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct GetControlsReturn {
-    pub controls: Vec<Address>,
+#[serde(transparent)]
+pub struct IsControllingAddressReturn {
+    pub is_controlling: bool,
 }
 
-impl Cbor for GetControlsReturn {}
+impl Cbor for IsControllingAddressReturn {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct GetSectorSizeReturn {

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -548,3 +548,10 @@ pub struct GetAvailableBalanceReturn {
 }
 
 impl Cbor for GetAvailableBalanceReturn {}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct GetVestingFundsReturn {
+    pub vesting_funds: Vec<(ChainEpoch, TokenAmount)>,
+}
+
+impl Cbor for GetVestingFundsReturn {}

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -514,34 +514,6 @@ pub struct GetSectorSizeReturn {
 impl Cbor for GetSectorSizeReturn {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct GetPreCommitDepositReturn {
-    pub pre_commit_deposit: TokenAmount,
-}
-
-impl Cbor for GetPreCommitDepositReturn {}
-
-#[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct GetInitialPledgeReturn {
-    pub initial_pledge: TokenAmount,
-}
-
-impl Cbor for GetInitialPledgeReturn {}
-
-#[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct GetFeeDebtReturn {
-    pub fee_debt: TokenAmount,
-}
-
-impl Cbor for GetFeeDebtReturn {}
-
-#[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct GetLockedFundsReturn {
-    pub locked_funds: TokenAmount,
-}
-
-impl Cbor for GetLockedFundsReturn {}
-
-#[derive(Serialize_tuple, Deserialize_tuple)]
 #[serde(transparent)]
 pub struct GetAvailableBalanceReturn {
     pub available_balance: TokenAmount,

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -484,6 +484,7 @@ pub struct GetBeneficiaryReturn {
 impl Cbor for GetBeneficiaryReturn {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
 pub struct GetOwnerReturn {
     pub owner: Address,
 }
@@ -507,6 +508,7 @@ pub struct IsControllingAddressReturn {
 impl Cbor for IsControllingAddressReturn {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
 pub struct GetSectorSizeReturn {
     pub sector_size: SectorSize,
 }

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -13,7 +13,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::randomness::Randomness;
 use fvm_shared::sector::{
     PoStProof, RegisteredPoStProof, RegisteredSealProof, RegisteredUpdateProof, SectorNumber,
-    StoragePower,
+    SectorSize, StoragePower,
 };
 use fvm_shared::smooth::FilterEstimate;
 
@@ -482,3 +482,59 @@ pub struct GetBeneficiaryReturn {
 }
 
 impl Cbor for GetBeneficiaryReturn {}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct GetOwnerReturn {
+    pub owner: Address,
+}
+
+impl Cbor for GetOwnerReturn {}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct GetWorkerReturn {
+    pub worker: Address,
+}
+
+impl Cbor for GetWorkerReturn {}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct GetControlsReturn {
+    pub controls: Vec<Address>,
+}
+
+impl Cbor for GetControlsReturn {}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct GetSectorSizeReturn {
+    pub sector_size: SectorSize,
+}
+
+impl Cbor for GetSectorSizeReturn {}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct GetPreCommitDepositReturn {
+    pub pre_commit_deposit: TokenAmount,
+}
+
+impl Cbor for GetPreCommitDepositReturn {}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct GetInitialPledgeReturn {
+    pub initial_pledge: TokenAmount,
+}
+
+impl Cbor for GetInitialPledgeReturn {}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct GetFeeDebtReturn {
+    pub fee_debt: TokenAmount,
+}
+
+impl Cbor for GetFeeDebtReturn {}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct GetLockedFundsReturn {
+    pub locked_funds: TokenAmount,
+}
+
+impl Cbor for GetLockedFundsReturn {}

--- a/actors/miner/tests/exported_getters.rs
+++ b/actors/miner/tests/exported_getters.rs
@@ -1,0 +1,222 @@
+use fil_actor_miner::{
+    locked_reward_from_reward, Actor, GetControlsReturn, GetFeeDebtReturn, GetInitialPledgeReturn,
+    GetLockedFundsReturn, GetOwnerReturn, GetPreCommitDepositReturn, GetSectorSizeReturn,
+    GetWorkerReturn, Method,
+};
+use fil_actors_runtime::test_utils::make_identity_cid;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::Address;
+use fvm_shared::{clock::ChainEpoch, econ::TokenAmount, sector::MAX_SECTOR_NUMBER};
+use num_traits::Zero;
+
+mod util;
+
+use util::*;
+
+const PERIOD_OFFSET: ChainEpoch = 100;
+
+// an expiration ~10 days greater than effective min expiration taking into account 30 days max
+// between pre and prove commit
+const DEFAULT_SECTOR_EXPIRATION: ChainEpoch = 220;
+
+#[test]
+fn info_getters() {
+    let h = ActorHarness::new(PERIOD_OFFSET);
+    let mut rt = h.new_runtime();
+    rt.set_balance(BIG_BALANCE.clone());
+    h.construct_and_verify(&mut rt);
+
+    // set caller to not-builtin
+    rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1234));
+
+    // owner is good
+    rt.expect_validate_caller_any();
+    let owner_ret: GetOwnerReturn = rt
+        .call::<Actor>(Method::GetOwnerExported as u64, &RawBytes::default())
+        .unwrap()
+        .deserialize()
+        .unwrap();
+
+    rt.verify();
+
+    assert_eq!(h.owner, owner_ret.owner);
+
+    // worker is good
+    rt.expect_validate_caller_any();
+    let worker_ret: GetWorkerReturn = rt
+        .call::<Actor>(Method::GetWorkerExported as u64, &RawBytes::default())
+        .unwrap()
+        .deserialize()
+        .unwrap();
+
+    rt.verify();
+
+    assert_eq!(h.worker, worker_ret.worker);
+
+    // controls are good
+    rt.expect_validate_caller_any();
+    let control_ret: GetControlsReturn = rt
+        .call::<Actor>(Method::GetControlsExported as u64, &RawBytes::default())
+        .unwrap()
+        .deserialize()
+        .unwrap();
+
+    rt.verify();
+
+    // let's be sure we're not vacuously testing this method
+    assert_ne!(0, h.control_addrs.len());
+    assert_eq!(h.control_addrs, control_ret.controls);
+
+    // sector size is good
+    rt.expect_validate_caller_any();
+    let sector_size_ret: GetSectorSizeReturn = rt
+        .call::<Actor>(Method::GetSectorSizeExported as u64, &RawBytes::default())
+        .unwrap()
+        .deserialize()
+        .unwrap();
+
+    rt.verify();
+
+    assert_eq!(h.sector_size, sector_size_ret.sector_size);
+
+    h.check_state(&rt);
+}
+
+#[test]
+fn collateral_getters() {
+    let h = ActorHarness::new(PERIOD_OFFSET);
+    let mut rt = h.new_runtime();
+    rt.balance.replace(BIG_BALANCE.clone());
+
+    let precommit_epoch = PERIOD_OFFSET + 1;
+    rt.set_epoch(precommit_epoch);
+
+    h.construct_and_verify(&mut rt);
+    let dl_info = h.deadline(&rt);
+
+    // Precommit a sector
+    // Use the max sector number to make sure everything works.
+    let sector_no = MAX_SECTOR_NUMBER;
+    let prove_commit_epoch = precommit_epoch + rt.policy.pre_commit_challenge_delay + 1;
+    let expiration =
+        dl_info.period_end() + DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period; // something on deadline boundary but > 180 days
+
+    let precommit_params =
+        h.make_pre_commit_params(sector_no, precommit_epoch - 1, expiration, vec![]);
+    let precommit =
+        h.pre_commit_sector_and_get(&mut rt, precommit_params, PreCommitConfig::empty(), true);
+
+    // Query the total precommit deposit from a non-builtin actor
+
+    // set caller to not-builtin
+    rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1234));
+
+    rt.expect_validate_caller_any();
+    let pre_commit_deposit_ret: GetPreCommitDepositReturn = rt
+        .call::<Actor>(Method::GetPreCommitDepositExported as u64, &RawBytes::default())
+        .unwrap()
+        .deserialize()
+        .unwrap();
+
+    rt.verify();
+
+    // let's be sure we're not vacuously testing this method
+    assert!(!precommit.pre_commit_deposit.is_zero());
+    assert_eq!(precommit.pre_commit_deposit, pre_commit_deposit_ret.pre_commit_deposit);
+
+    // run prove commit logic
+    rt.set_epoch(prove_commit_epoch);
+    rt.balance.replace(TokenAmount::from_whole(1000));
+    let pcc = ProveCommitConfig::empty();
+
+    let sector = h
+        .prove_commit_sector_and_confirm(
+            &mut rt,
+            &precommit,
+            h.make_prove_commit_params(sector_no),
+            pcc,
+        )
+        .unwrap();
+
+    // Query the total precommit deposits and initial pledge from a non-builtin actor
+
+    // set caller to not-builtin
+    rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1234));
+
+    // query PCD
+    rt.expect_validate_caller_any();
+    let pre_commit_deposit_ret: GetPreCommitDepositReturn = rt
+        .call::<Actor>(Method::GetPreCommitDepositExported as u64, &RawBytes::default())
+        .unwrap()
+        .deserialize()
+        .unwrap();
+
+    rt.verify();
+
+    assert!(pre_commit_deposit_ret.pre_commit_deposit.is_zero());
+
+    // query IP
+
+    rt.expect_validate_caller_any();
+    let initial_pledge_ret: GetInitialPledgeReturn = rt
+        .call::<Actor>(Method::GetInitialPledgeExported as u64, &RawBytes::default())
+        .unwrap()
+        .deserialize()
+        .unwrap();
+
+    rt.verify();
+
+    // let's be sure we're not vacuously testing this method
+    assert!(!sector.initial_pledge.is_zero());
+    assert_eq!(sector.initial_pledge, initial_pledge_ret.initial_pledge);
+
+    h.check_state(&rt);
+}
+
+#[test]
+fn debt_and_vesting_getters() {
+    let h = ActorHarness::new(PERIOD_OFFSET);
+    let mut rt = h.new_runtime();
+    h.construct_and_verify(&mut rt);
+
+    let reward_amount: TokenAmount = 4 * &*BIG_BALANCE;
+    let (amount_locked, _) = locked_reward_from_reward(reward_amount.clone());
+    rt.set_balance(amount_locked.clone());
+    h.apply_rewards(&mut rt, reward_amount, TokenAmount::zero());
+
+    // introduce fee debt
+    let mut st = h.get_state(&rt);
+    st.fee_debt = 4 * &*BIG_BALANCE;
+    rt.replace_state(&st);
+
+    // Query the total locked funds & debt from a non-builtin actor
+
+    // set caller to not-builtin
+    rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1234));
+
+    // locked funds
+    rt.expect_validate_caller_any();
+    let locked_funds_ret: GetLockedFundsReturn = rt
+        .call::<Actor>(Method::GetLockedFundsExported as u64, &RawBytes::default())
+        .unwrap()
+        .deserialize()
+        .unwrap();
+
+    rt.verify();
+
+    // let's be sure we're not vacuously testing this method
+    assert!(!amount_locked.is_zero());
+    assert_eq!(amount_locked, locked_funds_ret.locked_funds);
+
+    // debt
+    rt.expect_validate_caller_any();
+    let debt_ret: GetFeeDebtReturn = rt
+        .call::<Actor>(Method::GetFeeDebtExported as u64, &RawBytes::default())
+        .unwrap()
+        .deserialize()
+        .unwrap();
+
+    rt.verify();
+
+    assert_eq!(st.fee_debt, debt_ret.fee_debt);
+}

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -22,14 +22,14 @@ use fil_actor_miner::{
     CronEventPayload, Deadline, DeadlineInfo, Deadlines, DeclareFaultsParams,
     DeclareFaultsRecoveredParams, DeferredCronEventParams, DisputeWindowedPoStParams,
     ExpirationQueue, ExpirationSet, ExtendSectorExpiration2Params, ExtendSectorExpirationParams,
-    FaultDeclaration, GetBeneficiaryReturn, GetControlAddressesReturn, Method,
-    MinerConstructorParams as ConstructorParams, MinerInfo, Partition, PendingBeneficiaryChange,
-    PoStPartition, PowerPair, PreCommitSectorBatchParams, PreCommitSectorBatchParams2,
-    PreCommitSectorParams, ProveCommitSectorParams, RecoveryDeclaration,
-    ReportConsensusFaultParams, SectorOnChainInfo, SectorPreCommitInfo, SectorPreCommitOnChainInfo,
-    Sectors, State, SubmitWindowedPoStParams, TerminateSectorsParams, TerminationDeclaration,
-    VestingFunds, WindowedPoSt, WithdrawBalanceParams, WithdrawBalanceReturn,
-    CRON_EVENT_PROVING_DEADLINE, SECTORS_AMT_BITWIDTH,
+    FaultDeclaration, GetAvailableBalanceReturn, GetBeneficiaryReturn, GetControlAddressesReturn,
+    Method, MinerConstructorParams as ConstructorParams, MinerInfo, Partition,
+    PendingBeneficiaryChange, PoStPartition, PowerPair, PreCommitSectorBatchParams,
+    PreCommitSectorBatchParams2, PreCommitSectorParams, ProveCommitSectorParams,
+    RecoveryDeclaration, ReportConsensusFaultParams, SectorOnChainInfo, SectorPreCommitInfo,
+    SectorPreCommitOnChainInfo, Sectors, State, SubmitWindowedPoStParams, TerminateSectorsParams,
+    TerminationDeclaration, VestingFunds, WindowedPoSt, WithdrawBalanceParams,
+    WithdrawBalanceReturn, CRON_EVENT_PROVING_DEADLINE, SECTORS_AMT_BITWIDTH,
 };
 use fil_actor_miner::{Method as MinerMethod, ProveCommitAggregateParams};
 use fil_actor_power::{
@@ -2531,6 +2531,17 @@ impl ActorHarness {
             rt.reset();
         }
         ret
+    }
+
+    pub fn get_available_balance(&self, rt: &mut MockRuntime) -> Result<TokenAmount, ActorError> {
+        // set caller to non-builtin
+        rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1234));
+        rt.expect_validate_caller_any();
+        let available_balance_ret: GetAvailableBalanceReturn = rt
+            .call::<Actor>(Method::GetAvailableBalanceExported as u64, &RawBytes::default())?
+            .deserialize()?;
+        rt.verify();
+        Ok(available_balance_ret.available_balance)
     }
 }
 

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -860,6 +860,7 @@ impl ActorHarness {
         pc: &SectorPreCommitOnChainInfo,
         params: ProveCommitSectorParams,
     ) -> Result<(), ActorError> {
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
         let seal_rand = TEST_RANDOMNESS_ARRAY_FROM_ONE;
         let seal_int_rand = TEST_RANDOMNESS_ARRAY_FROM_TWO;
         let interactive_epoch = pc.pre_commit_epoch + rt.policy.pre_commit_challenge_delay;


### PR DESCRIPTION
Adds all-but-one of the new miner methods proposed [here](https://docs.google.com/spreadsheets/d/1McCcCDHLagBFd5miTcTDBPuTIzmY6uKTxX6SS-xsKVY/edit#gid=0).

The missing method is the vesting funds themselves. I'm not sure whether we wanna expose the `VestingFunds` structure, which is a list of `(epoch, amount)` tuples. This is _probably_ stable, but I would like a thumbsup before adding it.