### PR TITLE
Built-in market API for deal proposal metadata

### DIFF
--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -115,6 +115,22 @@ impl State {
             + &self.total_client_storage_fee
     }
 
+    pub fn get_proposal<BS: Blockstore>(
+        &self,
+        store: &BS,
+        id: DealID,
+    ) -> Result<DealProposal, ActorError> {
+        let proposals = DealArray::load(&self.proposals, store)
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load deal proposals")?;
+        let found = proposals
+            .get(id)
+            .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+                format!("failed to load deal proposal {}", id)
+            })?
+            .with_context_code(ExitCode::USR_NOT_FOUND, || format!("no such deal {}", id))?;
+        Ok(found.clone())
+    }
+
     pub(super) fn mutator<'bs, BS: Blockstore>(
         &mut self,
         store: &'bs BS,

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -15,6 +15,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::ActorID;
 
+use crate::Label;
 use fvm_shared::sector::RegisteredSealProof;
 
 use super::deal::{ClientDealProposal, DealProposal, DealState};
@@ -135,4 +136,72 @@ pub type DealMetaArray<'bs, BS> = Array<'bs, DealState, BS>;
 pub struct SectorDataSpec {
     pub deal_ids: Vec<DealID>,
     pub sector_type: RegisteredSealProof,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct DealQueryParams {
+    pub id: DealID,
+}
+
+pub type GetDealDataCommitmentParams = DealQueryParams;
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+pub struct GetDealDataCommitmentReturn {
+    pub data: Cid,
+    pub size: PaddedPieceSize,
+}
+
+pub type GetDealClientParams = DealQueryParams;
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct GetDealClientReturn {
+    pub client: ActorID,
+}
+
+pub type GetDealProviderParams = DealQueryParams;
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct GetDealProviderReturn {
+    pub provider: ActorID,
+}
+
+pub type GetDealLabelParams = DealQueryParams;
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct GetDealLabelReturn {
+    pub label: Label,
+}
+
+pub type GetDealTermParams = DealQueryParams;
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+pub struct GetDealTermReturn {
+    pub start: ChainEpoch, // First epoch for the deal (inclusive)
+    pub end: ChainEpoch,   // Epoch at which the deal expires (i.e. exclusive).
+}
+
+pub type GetDealEpochPriceParams = DealQueryParams;
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+pub struct GetDealEpochPriceReturn {
+    pub price_per_epoch: TokenAmount,
+}
+
+pub type GetDealClientCollateralParams = DealQueryParams;
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct GetDealClientCollateralReturn {
+    pub collateral: TokenAmount,
+}
+
+pub type GetDealProviderCollateralParams = DealQueryParams;
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct GetDealProviderCollateralReturn {
+    pub collateral: TokenAmount,
+}
+
+pub type GetDealVerifiedParams = DealQueryParams;
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct GetDealVerifiedReturn {
+    pub verified: bool,
 }

--- a/actors/market/tests/deal_api_test.rs
+++ b/actors/market/tests/deal_api_test.rs
@@ -1,0 +1,81 @@
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::clock::ChainEpoch;
+use serde::de::DeserializeOwned;
+
+use fil_actor_market::{
+    Actor as MarketActor, DealQueryParams, GetDealClientCollateralReturn, GetDealClientReturn,
+    GetDealDataCommitmentReturn, GetDealEpochPriceReturn, GetDealLabelReturn,
+    GetDealProviderCollateralReturn, GetDealProviderReturn, GetDealTermReturn,
+    GetDealVerifiedReturn, Method,
+};
+use fil_actors_runtime::network::EPOCHS_IN_DAY;
+use fil_actors_runtime::test_utils::{MockRuntime, ACCOUNT_ACTOR_CODE_ID};
+use harness::*;
+
+mod harness;
+
+#[test]
+fn proposal_data() {
+    let start_epoch = 1000;
+    let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+    let publish_epoch = ChainEpoch::from(1);
+
+    let mut rt = setup();
+    rt.set_epoch(publish_epoch);
+    let next_allocation_id = 1;
+
+    let proposal = generate_deal_and_add_funds(
+        &mut rt,
+        CLIENT_ADDR,
+        &MinerAddresses::default(),
+        start_epoch,
+        end_epoch,
+    );
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let id =
+        publish_deals(&mut rt, &MinerAddresses::default(), &[proposal.clone()], next_allocation_id)
+            [0];
+
+    let data: GetDealDataCommitmentReturn =
+        query_deal(&mut rt, Method::GetDealDataCommitmentExported, id);
+    assert_eq!(proposal.piece_cid, data.data);
+    assert_eq!(proposal.piece_size, data.size);
+
+    let client: GetDealClientReturn = query_deal(&mut rt, Method::GetDealClientExported, id);
+    assert_eq!(proposal.client.id().unwrap(), client.client);
+
+    let provider: GetDealProviderReturn = query_deal(&mut rt, Method::GetDealProviderExported, id);
+    assert_eq!(proposal.provider.id().unwrap(), provider.provider);
+
+    let label: GetDealLabelReturn = query_deal(&mut rt, Method::GetDealLabelExported, id);
+    assert_eq!(proposal.label, label.label);
+
+    let term: GetDealTermReturn = query_deal(&mut rt, Method::GetDealTermExported, id);
+    assert_eq!(proposal.start_epoch, term.start);
+    assert_eq!(proposal.end_epoch, term.end);
+
+    let price: GetDealEpochPriceReturn = query_deal(&mut rt, Method::GetDealEpochPriceExported, id);
+    assert_eq!(proposal.storage_price_per_epoch, price.price_per_epoch);
+
+    let client_collateral: GetDealClientCollateralReturn =
+        query_deal(&mut rt, Method::GetDealClientCollateralExported, id);
+    assert_eq!(proposal.client_collateral, client_collateral.collateral);
+
+    let provider_collateral: GetDealProviderCollateralReturn =
+        query_deal(&mut rt, Method::GetDealProviderCollateralExported, id);
+    assert_eq!(proposal.provider_collateral, provider_collateral.collateral);
+
+    let verified: GetDealVerifiedReturn = query_deal(&mut rt, Method::GetDealVerifiedExported, id);
+    assert_eq!(proposal.verified_deal, verified.verified);
+
+    check_state(&rt);
+}
+
+fn query_deal<T: DeserializeOwned>(rt: &mut MockRuntime, method: Method, id: u64) -> T {
+    let params = DealQueryParams { id };
+    rt.expect_validate_caller_any();
+    rt.call::<MarketActor>(method as u64, &RawBytes::serialize(params).unwrap())
+        .unwrap()
+        .deserialize()
+        .unwrap()
+}


### PR DESCRIPTION
This API is given as a bunch of smaller methods to:
- hide the DealProposal type, so it can change
- increase chance that some parts of this API can be matched by other markets

I haven't thought too deeply about standard deal APIs here, just exposing what we have. We can come and add new methods here to support some better standard in the future.