### PR TITLE
Exported API for market deal activation state

### DIFF
--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -1156,14 +1156,15 @@ impl Actor {
     /// Fetches activation state for a deal.
     /// This will be available from when the proposal is published until an undefined period after
     /// the deal finishes (either normally or by termination).
-    /// Outside that period, returns USR_NOT_FOUND.
+    /// Returns USR_NOT_FOUND if the deal doesn't exist (yet), or EX_DEAL_EXPIRED if the deal
+    /// has been removed from state.
     fn get_deal_activation(
         rt: &mut impl Runtime,
         params: GetDealActivationParams,
     ) -> Result<GetDealActivationReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let st = rt.state::<State>()?;
-        let found = st.find_state(rt.store(), params.id)?;
+        let found = st.find_deal_state(rt.store(), params.id)?;
         match found {
             Some(state) => Ok(GetDealActivationReturn {
                 // If we have state, the deal has been activated.

--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -139,7 +139,7 @@ impl State {
         Ok(maybe.cloned())
     }
 
-    pub fn find_state<BS: Blockstore>(
+    pub fn find_deal_state<BS: Blockstore>(
         &self,
         store: &BS,
         id: DealID,

--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -131,6 +131,19 @@ impl State {
         Ok(found.clone())
     }
 
+    pub fn get_state<BS: Blockstore>(
+        &self,
+        store: &BS,
+        id: DealID,
+    ) -> Result<Option<DealState>, ActorError> {
+        let states = DealMetaArray::load(&self.states, store)
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load deal states")?;
+        let found = states.get(id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+            format!("failed to load deal state {}", id)
+        })?;
+        Ok(found.cloned())
+    }
+
     pub(super) fn mutator<'bs, BS: Blockstore>(
         &mut self,
         store: &'bs BS,

--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -120,18 +120,26 @@ impl State {
         store: &BS,
         id: DealID,
     ) -> Result<DealProposal, ActorError> {
-        let proposals = DealArray::load(&self.proposals, store)
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load deal proposals")?;
-        let found = proposals
-            .get(id)
-            .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
-                format!("failed to load deal proposal {}", id)
-            })?
+        let found = self
+            .find_proposal(store, id)?
             .with_context_code(ExitCode::USR_NOT_FOUND, || format!("no such deal {}", id))?;
-        Ok(found.clone())
+        Ok(found)
     }
 
-    pub fn get_state<BS: Blockstore>(
+    pub fn find_proposal<BS: Blockstore>(
+        &self,
+        store: &BS,
+        id: DealID,
+    ) -> Result<Option<DealProposal>, ActorError> {
+        let proposals = DealArray::load(&self.proposals, store)
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load deal proposals")?;
+        let maybe = proposals.get(id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+            format!("failed to load deal proposal {}", id)
+        })?;
+        Ok(maybe.cloned())
+    }
+
+    pub fn find_state<BS: Blockstore>(
         &self,
         store: &BS,
         id: DealID,

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -206,3 +206,13 @@ pub type GetDealVerifiedParams = DealQueryParams;
 pub struct GetDealVerifiedReturn {
     pub verified: bool,
 }
+
+pub type GetDealActivationParams = DealQueryParams;
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+pub struct GetDealActivationReturn {
+    /// Epoch at which the deal was activated, or -1.
+    /// This may be before the proposed start epoch.
+    pub activated: ChainEpoch,
+    /// Epoch at which the deal was terminated abnormally, or -1.
+    pub terminated: ChainEpoch,
+}

--- a/runtime/src/actor_error.rs
+++ b/runtime/src/actor_error.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 #[error("ActorError(exit_code: {exit_code:?}, msg: {msg})")]
 pub struct ActorError {
     /// The exit code for this invocation.
-    /// Codes less than `FIRST_ACTOR_EXIT_CODE` are prohibited and will be overwritten by the VM.
+    /// Codes less than `FIRST_USER_EXIT_CODE` are prohibited and will be overwritten by the VM.
     exit_code: ExitCode,
     /// Message for debugging purposes,
     msg: String,


### PR DESCRIPTION
A basic API for deal state. This is far from an ideal state API, but works with what the market actor actually knows. There's no information preserved after a deal is cleaned up.

- [x] Remove duplication from #818 before merging