### PR TITLE
Drop CALLER_TYPES_SIGNABLE and signable caller validation

### DIFF
--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -32,9 +32,8 @@ use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Policy, Runtime};
 use fil_actors_runtime::{
     actor_error, cbor, restrict_internal_api, ActorContext, ActorDowncast, ActorError,
-    AsActorError, BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE, CRON_ACTOR_ADDR,
-    DATACAP_TOKEN_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
-    VERIFIED_REGISTRY_ACTOR_ADDR,
+    AsActorError, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR, DATACAP_TOKEN_ACTOR_ADDR,
+    REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 
 use crate::ext::verifreg::{AllocationID, AllocationRequest};
@@ -114,8 +113,7 @@ impl Actor {
             ));
         }
 
-        // only signing parties can add balance for client AND provider.
-        rt.validate_immediate_caller_type(CALLER_TYPES_SIGNABLE.iter())?;
+        rt.validate_immediate_caller_accept_any()?;
 
         let (nominal, _, _) = escrow_address(rt, &provider_or_client)?;
 
@@ -228,9 +226,7 @@ impl Actor {
         rt: &mut impl Runtime,
         params: PublishStorageDealsParams,
     ) -> Result<PublishStorageDealsReturn, ActorError> {
-        // Deal message must have a From field identical to the provider of all the deals.
-        // This allows us to retain and verify only the client's signature in each deal proposal itself.
-        rt.validate_immediate_caller_type(CALLER_TYPES_SIGNABLE.iter())?;
+        rt.validate_immediate_caller_accept_any()?;
         if params.deals.is_empty() {
             return Err(actor_error!(illegal_argument, "Empty deals parameter"));
         }

--- a/actors/market/tests/cron_tick_timedout_deals.rs
+++ b/actors/market/tests/cron_tick_timedout_deals.rs
@@ -6,7 +6,7 @@ use fil_actor_market::{
 };
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::test_utils::*;
-use fil_actors_runtime::{BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE};
+use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::Signature;
@@ -84,7 +84,7 @@ fn publishing_timed_out_deal_again_should_work_after_cron_tick_as_it_should_no_l
     let client_deal_proposal =
         ClientDealProposal { proposal: deal_proposal2.clone(), client_signature: sig };
     let params = PublishStorageDealsParams { deals: vec![client_deal_proposal] };
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
     expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
     expect_query_network_info(&mut rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -27,8 +27,8 @@ use fil_actors_runtime::{
     network::EPOCHS_IN_DAY,
     runtime::{builtins::Type, Policy, Runtime},
     test_utils::*,
-    ActorError, BatchReturn, SetMultimap, BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE,
-    CRON_ACTOR_ADDR, DATACAP_TOKEN_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
+    ActorError, BatchReturn, SetMultimap, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR,
+    DATACAP_TOKEN_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
     STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_ipld_encoding::{to_vec, RawBytes};
@@ -167,7 +167,7 @@ pub fn add_provider_funds(rt: &mut MockRuntime, amount: TokenAmount, addrs: &Min
     rt.set_value(amount.clone());
     rt.set_address_actor_type(addrs.provider, *MINER_ACTOR_CODE_ID);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addrs.owner);
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
 
     expect_provider_control_address(rt, addrs.provider, addrs.owner, addrs.worker);
 
@@ -188,8 +188,7 @@ pub fn add_participant_funds(rt: &mut MockRuntime, addr: Address, amount: TokenA
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addr);
 
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
-
+    rt.expect_validate_caller_any();
     assert!(rt
         .call::<MarketActor>(Method::AddBalance as u64, &RawBytes::serialize(addr).unwrap())
         .is_ok());
@@ -440,8 +439,7 @@ pub fn publish_deals(
     publish_deals: &[DealProposal],
     next_allocation_id: AllocationID,
 ) -> Vec<DealID> {
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
-
+    rt.expect_validate_caller_any();
     let return_value = GetControlAddressesReturnParams {
         owner: addrs.owner,
         worker: addrs.worker,
@@ -564,7 +562,7 @@ pub fn publish_deals_expect_abort(
     proposal: DealProposal,
     expected_exit_code: ExitCode,
 ) {
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
     expect_provider_control_address(
         rt,
         miner_addresses.provider,
@@ -747,7 +745,7 @@ where
     rt.set_epoch(current_epoch);
     post_setup(&mut rt, &mut deal_proposal);
 
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
     expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
     expect_query_network_info(&mut rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);

--- a/actors/market/tests/publish_storage_deals_failures.rs
+++ b/actors/market/tests/publish_storage_deals_failures.rs
@@ -9,7 +9,6 @@ use fil_actor_market::{
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::test_utils::*;
-use fil_actors_runtime::CALLER_TYPES_SIGNABLE;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
@@ -255,7 +254,7 @@ fn fail_when_provider_has_some_funds_but_not_enough_for_a_deal() {
         deals: vec![ClientDealProposal { proposal: deal1.clone(), client_signature: sig }],
     };
 
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
     expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
     expect_query_network_info(&mut rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
@@ -315,7 +314,7 @@ fn fail_when_deals_have_different_providers() {
         ],
     };
 
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
     expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
     expect_query_network_info(&mut rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
@@ -364,35 +363,11 @@ fn fail_when_deals_have_different_providers() {
 }
 
 #[test]
-fn fail_when_caller_is_not_of_signable_type() {
-    let start_epoch = 10;
-    let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
-
-    let mut rt = setup();
-    let deal = generate_deal_proposal(CLIENT_ADDR, PROVIDER_ADDR, start_epoch, end_epoch);
-    let sig = Signature::new_bls("does not matter".as_bytes().to_vec());
-    let params = PublishStorageDealsParams {
-        deals: vec![ClientDealProposal { proposal: deal, client_signature: sig }],
-    };
-    let w = Address::new_id(1000);
-    rt.set_caller(*MINER_ACTOR_CODE_ID, w);
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
-    expect_abort(
-        ExitCode::USR_FORBIDDEN,
-        rt.call::<MarketActor>(
-            Method::PublishStorageDeals as u64,
-            &RawBytes::serialize(params).unwrap(),
-        ),
-    );
-    check_state(&rt);
-}
-
-#[test]
 fn fail_when_no_deals_in_params() {
     let mut rt = setup();
     let params = PublishStorageDealsParams { deals: vec![] };
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         rt.call::<MarketActor>(
@@ -417,7 +392,7 @@ fn fail_to_resolve_provider_address() {
         deals: vec![ClientDealProposal { proposal: deal, client_signature: sig }],
     };
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
     expect_abort(
         ExitCode::USR_NOT_FOUND,
         rt.call::<MarketActor>(
@@ -440,7 +415,7 @@ fn caller_is_not_the_same_as_the_worker_address_for_miner() {
         deals: vec![ClientDealProposal { proposal: deal, client_signature: sig }],
     };
 
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
     expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(999));
     expect_abort(
@@ -469,7 +444,7 @@ fn fails_if_provider_is_not_a_storage_miner_actor() {
         deals: vec![ClientDealProposal { proposal: deal, client_signature: sig }],
     };
 
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -22,7 +22,7 @@ use fvm_shared::randomness::*;
 use fvm_shared::reward::ThisEpochRewardReturn;
 use fvm_shared::sector::*;
 use fvm_shared::smooth::FilterEstimate;
-use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND};
+use fvm_shared::{ActorID, MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND};
 use itertools::Itertools;
 use log::{error, info, warn};
 use multihash::Code::Blake2b256;
@@ -42,8 +42,8 @@ use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, DomainSeparationTag, Policy, Runtime};
 use fil_actors_runtime::{
     actor_error, cbor, restrict_internal_api, ActorContext, ActorDowncast, ActorError,
-    BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR,
-    STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+    BURNT_FUNDS_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
+    STORAGE_POWER_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 pub use monies::*;
 pub use partition_state::*;
@@ -151,12 +151,19 @@ impl Actor {
         check_peer_info(rt.policy(), &params.peer_id, &params.multi_addresses)?;
         check_valid_post_proof_type(rt.policy(), params.window_post_proof_type)?;
 
-        let owner = resolve_control_address(rt, params.owner)?;
+        let owner = rt.resolve_address(&params.owner).ok_or_else(|| {
+            actor_error!(illegal_argument, "unable to resolve owner address: {}", params.owner)
+        })?;
+
         let worker = resolve_worker_address(rt, params.worker)?;
         let control_addresses: Vec<_> = params
             .control_addresses
             .into_iter()
-            .map(|address| resolve_control_address(rt, address))
+            .map(|address| {
+                rt.resolve_address(&address).ok_or_else(|| {
+                    actor_error!(illegal_argument, "unable to resolve control address: {}", address)
+                })
+            })
             .collect::<Result<_, _>>()?;
 
         let policy = rt.policy();
@@ -297,11 +304,16 @@ impl Actor {
     ) -> Result<(), ActorError> {
         check_control_addresses(rt.policy(), &params.new_control_addresses)?;
 
-        let new_worker = resolve_worker_address(rt, params.new_worker)?;
+        let new_worker = Address::new_id(resolve_worker_address(rt, params.new_worker)?);
         let control_addresses: Vec<Address> = params
             .new_control_addresses
             .into_iter()
-            .map(|address| resolve_control_address(rt, address))
+            .map(|address| {
+                rt.resolve_address(&address).ok_or_else(|| {
+                    actor_error!(illegal_argument, "unable to resolve control address: {}", address)
+                })
+            })
+            .map(|id_result| id_result.map(Address::new_id))
             .collect::<Result<_, _>>()?;
 
         rt.transaction(|state: &mut State, rt| {
@@ -1419,7 +1431,7 @@ impl Actor {
         rt: &mut impl Runtime,
         params: DisputeWindowedPoStParams,
     ) -> Result<(), ActorError> {
-        rt.validate_immediate_caller_type(CALLER_TYPES_SIGNABLE.iter())?;
+        rt.validate_immediate_caller_accept_any()?;
         let reporter = rt.message().caller();
 
         {
@@ -3057,7 +3069,7 @@ impl Actor {
         // Note: only the first report of any fault is processed because it sets the
         // ConsensusFaultElapsed state variable to an epoch after the fault, and reports prior to
         // that epoch are no longer valid
-        rt.validate_immediate_caller_type(CALLER_TYPES_SIGNABLE.iter())?;
+        rt.validate_immediate_caller_accept_any()?;
         let reporter = rt.message().caller();
 
         let fault = rt
@@ -4319,36 +4331,9 @@ fn request_current_total_power(
     Ok(power)
 }
 
-/// Resolves an address to an ID address and verifies that it is address of an account or multisig actor.
-fn resolve_control_address(rt: &impl Runtime, raw: Address) -> Result<Address, ActorError> {
-    let resolved = rt
-        .resolve_address(&raw)
-        .ok_or_else(|| actor_error!(illegal_argument, "unable to resolve address: {}", raw))?;
-
-    let owner_code = rt
-        .get_actor_code_cid(&resolved)
-        .ok_or_else(|| actor_error!(illegal_argument, "no code for address: {}", resolved))?;
-
-    let is_principal = rt
-        .resolve_builtin_actor_type(&owner_code)
-        .as_ref()
-        .map(|t| CALLER_TYPES_SIGNABLE.contains(t))
-        .unwrap_or(false);
-
-    if !is_principal {
-        return Err(actor_error!(
-            illegal_argument,
-            "owner actor type must be a principal, was {}",
-            owner_code
-        ));
-    }
-
-    Ok(Address::new_id(resolved))
-}
-
 /// Resolves an address to an ID address and verifies that it is address of an account actor with an associated BLS key.
 /// The worker must be BLS since the worker key will be used alongside a BLS-VRF.
-fn resolve_worker_address(rt: &mut impl Runtime, raw: Address) -> Result<Address, ActorError> {
+fn resolve_worker_address(rt: &mut impl Runtime, raw: Address) -> Result<ActorID, ActorError> {
     let resolved = rt
         .resolve_address(&raw)
         .ok_or_else(|| actor_error!(illegal_argument, "unable to resolve address: {}", raw))?;
@@ -4381,7 +4366,7 @@ fn resolve_worker_address(rt: &mut impl Runtime, raw: Address) -> Result<Address
             ));
         }
     }
-    Ok(Address::new_id(resolved))
+    Ok(resolved)
 }
 
 fn burn_funds(rt: &mut impl Runtime, amount: TokenAmount) -> Result<(), ActorError> {

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -24,7 +24,8 @@ use fvm_shared::clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, SectorSize, MAX_SECTOR_NUMBER};
-use fvm_shared::HAMT_BIT_WIDTH;
+use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
+use itertools::Itertools;
 use num_traits::Zero;
 
 use super::beneficiary::*;
@@ -1266,9 +1267,9 @@ pub struct MinerInfo {
 
 impl MinerInfo {
     pub fn new(
-        owner: Address,
-        worker: Address,
-        control_addresses: Vec<Address>,
+        owner: ActorID,
+        worker: ActorID,
+        control_addresses: Vec<ActorID>,
         peer_id: Vec<u8>,
         multi_address: Vec<BytesDe>,
         window_post_proof_type: RegisteredPoStProof,
@@ -1282,11 +1283,12 @@ impl MinerInfo {
             .map_err(|e| actor_error!(illegal_argument, "invalid partition sectors: {}", e))?;
 
         Ok(Self {
-            owner,
-            worker,
-            control_addresses,
+            owner: Address::new_id(owner),
+            worker: Address::new_id(worker),
+            control_addresses: control_addresses.into_iter().map(Address::new_id).collect_vec(),
+
             pending_worker_key: None,
-            beneficiary: owner,
+            beneficiary: Address::new_id(owner),
             beneficiary_term: BeneficiaryTerm::default(),
             pending_beneficiary_term: None,
             peer_id,

--- a/actors/miner/tests/miner_actor_test_construction.rs
+++ b/actors/miner/tests/miner_actor_test_construction.rs
@@ -169,34 +169,6 @@ fn control_addresses_are_resolved_during_construction() {
 }
 
 #[test]
-fn fails_if_control_address_is_not_an_account_actor() {
-    let mut env = prepare_env();
-
-    let control1 = Address::new_id(501);
-    env.control_addrs = vec![control1];
-    env.rt.actor_code_cids.insert(control1, *PAYCH_ACTOR_CODE_ID);
-
-    let params = constructor_params(&env);
-    env.rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
-    env.rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
-    env.rt.expect_send(
-        env.worker,
-        AccountMethod::PubkeyAddress as u64,
-        RawBytes::default(),
-        TokenAmount::zero(),
-        RawBytes::serialize(env.worker_key).unwrap(),
-        ExitCode::OK,
-    );
-
-    let result = env
-        .rt
-        .call::<Actor>(Method::Constructor as u64, &RawBytes::serialize(params).unwrap())
-        .unwrap_err();
-    assert_eq!(result.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
-    env.rt.verify();
-}
-
-#[test]
 fn test_construct_with_invalid_peer_id() {
     let mut env = prepare_env();
     env.peer_id = vec![0; env.rt.policy.max_peer_id_length + 1];

--- a/actors/miner/tests/miner_actor_test_wpost.rs
+++ b/actors/miner/tests/miner_actor_test_wpost.rs
@@ -4,7 +4,6 @@ use fil_actor_miner as miner;
 use fil_actor_miner::PowerPair;
 use fil_actors_runtime::runtime::DomainSeparationTag;
 use fil_actors_runtime::test_utils::*;
-use fil_actors_runtime::CALLER_TYPES_SIGNABLE;
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::clock::ChainEpoch;
@@ -1031,7 +1030,7 @@ fn cannot_dispute_posts_when_the_challenge_window_is_open() {
     let params = miner::DisputeWindowedPoStParams { deadline: dlinfo.index, post_index: 0 };
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
     h.expect_query_network_info(&mut rt);
 
     let result = rt.call::<miner::Actor>(
@@ -1092,8 +1091,7 @@ fn can_dispute_up_till_window_end_but_not_after() {
     // Now try to dispute.
     let params = miner::DisputeWindowedPoStParams { deadline: dlidx, post_index: 0 };
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
-
+    rt.expect_validate_caller_any();
     h.expect_query_network_info(&mut rt);
 
     let result = rt.call::<miner::Actor>(
@@ -1125,7 +1123,7 @@ fn cant_dispute_up_with_an_invalid_deadline() {
     let params = miner::DisputeWindowedPoStParams { deadline: 50, post_index: 0 };
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
 
     let result = rt.call::<miner::Actor>(
         miner::Method::DisputeWindowedPoSt as u64,

--- a/actors/miner/tests/state_harness.rs
+++ b/actors/miner/tests/state_harness.rs
@@ -10,7 +10,6 @@ use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::BytesDe;
 use fvm_ipld_encoding::CborStore;
 use fvm_ipld_hamt::Error as HamtError;
-use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::{SectorNumber, SectorSize};
 use fvm_shared::{clock::ChainEpoch, clock::QuantSpec, sector::RegisteredPoStProof};
@@ -34,8 +33,8 @@ impl StateHarness {
         // store init
         let store = MemoryBlockstore::default();
         // state field init
-        let owner = Address::new_id(1);
-        let worker = Address::new_id(2);
+        let owner = 1;
+        let worker = 2;
 
         let test_window_post_proof_type = RegisteredPoStProof::StackedDRGWindow2KiBV1;
 

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -45,8 +45,8 @@ use fil_actors_runtime::runtime::{DomainSeparationTag, Policy, Runtime, RuntimeP
 use fil_actors_runtime::{test_utils::*, BatchReturn, BatchReturnGen};
 use fil_actors_runtime::{
     ActorDowncast, ActorError, Array, DealWeight, MessageAccumulator, BURNT_FUNDS_ACTOR_ADDR,
-    CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
-    STORAGE_POWER_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+    INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_ipld_amt::Amt;
 use fvm_shared::bigint::Zero;
@@ -1435,7 +1435,7 @@ impl ActorHarness {
         expect_success: Option<PoStDisputeResult>,
     ) {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
-        rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+        rt.expect_validate_caller_any();
 
         self.expect_query_network_info(rt);
 
@@ -1875,7 +1875,7 @@ impl ActorHarness {
         from: Address,
         fault: Option<ConsensusFault>,
     ) -> Result<(), ActorError> {
-        rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+        rt.expect_validate_caller_any();
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, from);
         let params =
             ReportConsensusFaultParams { header1: vec![], header2: vec![], header_extra: vec![] };

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -13,7 +13,7 @@ use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Zero};
 
 use fil_actors_runtime::cbor::serialize_vec;
-use fil_actors_runtime::runtime::{builtins::Type, ActorCode, Primitives, Runtime};
+use fil_actors_runtime::runtime::{ActorCode, Primitives, Runtime};
 use fil_actors_runtime::{
     actor_error, cbor, make_empty_map, make_map_with_root, resolve_to_actor_id,
     restrict_internal_api, ActorContext, ActorError, AsActorError, Map, INIT_ACTOR_ADDR,
@@ -132,7 +132,7 @@ impl Actor {
         rt: &mut impl Runtime,
         params: ProposeParams,
     ) -> Result<ProposeReturn, ActorError> {
-        rt.validate_immediate_caller_type(&[Type::Account, Type::Multisig])?;
+        rt.validate_immediate_caller_accept_any()?;
         let proposer: Address = rt.message().caller();
 
         if params.value.is_negative() {
@@ -185,7 +185,7 @@ impl Actor {
         rt: &mut impl Runtime,
         params: TxnIDParams,
     ) -> Result<ApproveReturn, ActorError> {
-        rt.validate_immediate_caller_type(&[Type::Account, Type::Multisig])?;
+        rt.validate_immediate_caller_accept_any()?;
         let approver: Address = rt.message().caller();
 
         let id = params.id;
@@ -217,7 +217,7 @@ impl Actor {
 
     /// Multisig actor cancel function
     pub fn cancel(rt: &mut impl Runtime, params: TxnIDParams) -> Result<(), ActorError> {
-        rt.validate_immediate_caller_type(&[Type::Account, Type::Multisig])?;
+        rt.validate_immediate_caller_accept_any()?;
         let caller_addr: Address = rt.message().caller();
 
         rt.transaction(|st: &mut State, rt| {

--- a/actors/multisig/tests/util.rs
+++ b/actors/multisig/tests/util.rs
@@ -5,8 +5,8 @@ use fil_actor_multisig::{
 };
 use fil_actor_multisig::{ChangeNumApprovalsThresholdParams, LockBalanceParams};
 use fil_actors_runtime::test_utils::*;
+use fil_actors_runtime::INIT_ACTOR_ADDR;
 use fil_actors_runtime::{make_map_with_root, ActorError};
-use fil_actors_runtime::{CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR};
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
@@ -125,7 +125,7 @@ impl ActorHarness {
         method: MethodNum,
         params: RawBytes,
     ) -> Result<RawBytes, ActorError> {
-        rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+        rt.expect_validate_caller_any();
         let propose_params = ProposeParams { to, value, method, params };
         let ret =
             rt.call::<Actor>(Method::Propose as u64, &RawBytes::serialize(propose_params).unwrap());
@@ -139,7 +139,7 @@ impl ActorHarness {
         txn_id: TxnID,
         proposal_hash: [u8; 32],
     ) -> Result<RawBytes, ActorError> {
-        rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+        rt.expect_validate_caller_any();
         let approve_params =
             TxnIDParams { id: txn_id, proposal_hash: Vec::<u8>::from(proposal_hash) };
         let ret =
@@ -154,7 +154,7 @@ impl ActorHarness {
         txn_id: TxnID,
         proposal_hash: [u8; 32],
     ) -> Result<RawBytes, ActorError> {
-        rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+        rt.expect_validate_caller_any();
         let cancel_params =
             TxnIDParams { id: txn_id, proposal_hash: Vec::<u8>::from(proposal_hash) };
         let ret =

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -87,7 +87,7 @@ impl Actor {
         rt: &mut impl Runtime,
         params: CreateMinerParams,
     ) -> Result<CreateMinerReturn, ActorError> {
-        rt.validate_immediate_caller_type(&[Type::Account, Type::Multisig])?;
+        rt.validate_immediate_caller_accept_any()?;
         let value = rt.message().value_received();
 
         let constructor_params = RawBytes::serialize(ext::miner::MinerConstructorParams {

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -13,7 +13,6 @@ use fil_actor_power::CRON_QUEUE_HAMT_BITWIDTH;
 use fil_actors_runtime::runtime::RuntimePolicy;
 use fil_actors_runtime::test_utils::CRON_ACTOR_CODE_ID;
 use fil_actors_runtime::Multimap;
-use fil_actors_runtime::CALLER_TYPES_SIGNABLE;
 use fil_actors_runtime::CRON_ACTOR_ADDR;
 use fil_actors_runtime::REWARD_ACTOR_ADDR;
 use fvm_ipld_blockstore::Blockstore;
@@ -142,7 +141,7 @@ impl Harness {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *owner);
         rt.set_value(value.clone());
         rt.set_balance(value.clone());
-        rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+        rt.expect_validate_caller_any();
 
         let miner_ctor_params = MinerConstructorParams {
             owner: *owner,

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -5,7 +5,7 @@ use fil_actors_runtime::test_utils::{
     expect_abort, expect_abort_contains_message, make_identity_cid, ACCOUNT_ACTOR_CODE_ID,
     MINER_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID,
 };
-use fil_actors_runtime::{runtime::Policy, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR};
+use fil_actors_runtime::{runtime::Policy, INIT_ACTOR_ADDR};
 use fvm_ipld_encoding::{BytesDe, RawBytes};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser::BigIntSer;
@@ -78,34 +78,6 @@ fn create_miner() {
 }
 
 #[test]
-fn create_miner_given_caller_is_not_of_signable_type_should_fail() {
-    let (h, mut rt) = setup();
-
-    let peer = "miner".as_bytes().to_vec();
-    let multiaddrs = vec![BytesDe("multiaddr".as_bytes().to_vec())];
-
-    let create_miner_params = CreateMinerParams {
-        owner: *OWNER,
-        worker: *OWNER,
-        window_post_proof_type: RegisteredPoStProof::StackedDRGWindow32GiBV1,
-        peer,
-        multiaddrs,
-    };
-
-    rt.set_caller(*MINER_ACTOR_CODE_ID, *OWNER);
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
-    expect_abort(
-        ExitCode::USR_FORBIDDEN,
-        rt.call::<PowerActor>(
-            Method::CreateMiner as u64,
-            &RawBytes::serialize(&create_miner_params).unwrap(),
-        ),
-    );
-    rt.verify();
-    h.check_state(&rt);
-}
-
-#[test]
 fn create_miner_given_send_to_init_actor_fails_should_fail() {
     let (h, mut rt) = setup();
 
@@ -124,7 +96,7 @@ fn create_miner_given_send_to_init_actor_fails_should_fail() {
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *OWNER);
     rt.value_received = TokenAmount::from_atto(10);
     rt.set_balance(TokenAmount::from_atto(10));
-    rt.expect_validate_caller_type((*CALLER_TYPES_SIGNABLE).to_vec());
+    rt.expect_validate_caller_any();
 
     let message_params = ExecParams {
         code_cid: *MINER_ACTOR_CODE_ID,

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -6,15 +6,9 @@ use fvm_shared::address::Address;
 use fvm_shared::METHOD_SEND;
 use fvm_shared::{ActorID, MethodNum};
 
-use crate::runtime::builtins::Type;
 use crate::runtime::Runtime;
 
 pub const HAMT_BIT_WIDTH: u32 = 5;
-
-/// Types of built-in actors that can be treated as principals.
-/// This distinction is legacy and should be removed prior to FVM support for
-/// user-programmable actors.
-pub const CALLER_TYPES_SIGNABLE: &[Type] = &[Type::Account, Type::Multisig];
 
 /// ResolveToActorID resolves the given address to it's actor ID.
 /// If an actor ID for the given address dosen't exist yet, it tries to create one by sending


### PR DESCRIPTION
#806 

This PR changes all methods that validated callers were either Account / Multisigs to accepting any callers. This will allow for user-defined actors (eg. other multisigs) to call these methods.

Note that a lot of these methods are not yet exported, but likely will eventually be.

As part of this change, this PR rewires some of the miner actor/state's internal methods to use ActorIDs when referring to owner/worker/control address. This is in line with the enforced requirement today that all such addresses must be resolveable, though it does lead to some excessive type-converting when receiving input params and reading to / writing from state.