### PR TITLE
EVM: reserve methods < 1024 for EVM internals

### DIFF
--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -189,6 +189,20 @@ return
 }
 
 #[test]
+fn test_reserved_method() {
+    let contract = methodnum_contract();
+
+    let mut rt = util::construct_and_verify(contract);
+
+    // invoke the contract
+    rt.expect_validate_caller_any();
+
+    let code =
+        rt.call::<evm::EvmContractActor>(0x42, &RawBytes::default()).unwrap_err().exit_code();
+    assert_eq!(ExitCode::USR_UNHANDLED_MESSAGE, code);
+}
+
+#[test]
 fn test_methodnum() {
     let contract = methodnum_contract();
 
@@ -197,8 +211,8 @@ fn test_methodnum() {
     // invoke the contract
     rt.expect_validate_caller_any();
 
-    let result = rt.call::<evm::EvmContractActor>(0x42, &RawBytes::default()).unwrap();
-    assert_eq!(U256::from_big_endian(&result), U256::from(0x42));
+    let result = rt.call::<evm::EvmContractActor>(1024, &RawBytes::default()).unwrap();
+    assert_eq!(U256::from_big_endian(&result), U256::from(1024));
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
We only delegate methods >= 1024 to the contract. This is more than sufficient to cover any methods exported by [FRC0042](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0042.md).

part of https://github.com/filecoin-project/ref-fvm/issues/1056

I still haven't restricted _calling_ methods <= 1024, but we can handle that in a followup PR (if we still want to).