### PR TITLE
Paych actor: Drop account req, use AuthenticateMessage to verify sigs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "cid",
  "derive_builder",
  "fil_actors_runtime",
+ "frc42_dispatch",
  "fvm_ipld_amt",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
+frc42_dispatch = "1.0.0"
 fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/paych/src/ext.rs
+++ b/actors/paych/src/ext.rs
@@ -1,0 +1,16 @@
+use fvm_ipld_encoding::serde_bytes;
+use fvm_ipld_encoding::tuple::*;
+
+pub mod account {
+    use super::*;
+
+    pub const AUTHENTICATE_MESSAGE_METHOD: u64 = 3;
+
+    #[derive(Serialize_tuple, Deserialize_tuple)]
+    pub struct AuthenticateMessageParams {
+        #[serde(with = "serde_bytes")]
+        pub signature: Vec<u8>,
+        #[serde(with = "serde_bytes")]
+        pub message: Vec<u8>,
+    }
+}

--- a/actors/paych/src/ext.rs
+++ b/actors/paych/src/ext.rs
@@ -4,7 +4,8 @@ use fvm_ipld_encoding::tuple::*;
 pub mod account {
     use super::*;
 
-    pub const AUTHENTICATE_MESSAGE_METHOD: u64 = 3;
+    pub const AUTHENTICATE_MESSAGE_METHOD: u64 =
+        frc42_dispatch::method_hash!("AuthenticateMessage");
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct AuthenticateMessageParams {

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -4,11 +4,12 @@
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, cbor, restrict_internal_api, ActorDowncast, ActorError, Array, AsActorError,
+    actor_error, cbor, resolve_to_actor_id, restrict_internal_api, ActorDowncast, ActorError,
+    Array, AsActorError,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::address::{Address, Protocol};
+use fvm_shared::address::Address;
 
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -52,12 +53,12 @@ impl Actor {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Init))?;
 
         // Resolve both parties, confirming they exist in the state tree.
-        let to = Self::resolve_address(rt, params.to)
+        let to = Self::resolve_address(rt, &params.to)
             .with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
                 format!("to address not found {}", params.to)
             })?;
 
-        let from = Self::resolve_address(rt, params.from)
+        let from = Self::resolve_address(rt, &params.from)
             .with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
                 format!("to address not found {}", params.to)
             })?;
@@ -74,27 +75,13 @@ impl Actor {
     }
 
     /// Resolves an address to a canonical ID address and confirms it exists in the state tree.
-    fn resolve_address(rt: &mut impl Runtime, raw: Address) -> Result<Address, ActorError> {
-        match raw.protocol() {
-            // if raw was an ID address, we need to confirm that it actually exists in the state tree
-            Protocol::ID => {
-                let resolved = raw.id().map_err(|_| {
-                    actor_error!(illegal_state, "failed to convert ID address to ID")
-                })?;
-                rt.get_actor_code_cid(&resolved)
-                    .map(|_| raw)
-                    .with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
-                        format!("no code for address {}", raw)
-                    })
-            }
-            // just resolve all other cases, will fail if not in state tree
-            _ => rt
-                .resolve_address(&raw)
-                .with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
-                    format!("failed to resolve address {}", raw)
-                })
-                .map(Address::new_id),
-        }
+    fn resolve_address(rt: &mut impl Runtime, raw: &Address) -> Result<Address, ActorError> {
+        let resolved = resolve_to_actor_id(rt, raw)?;
+
+        // so long as we can find code for this, return `resolved`
+        rt.get_actor_code_cid(&resolved)
+            .map(|_| Address::new_id(resolved))
+            .ok_or_else(|| actor_error!(illegal_argument, "no code for address {}", resolved))
     }
 
     pub fn update_channel_state(

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -4,7 +4,7 @@
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_error, cbor, resolve_to_actor_id, restrict_internal_api, ActorDowncast, ActorError, Array,
+    actor_error, cbor, restrict_internal_api, ActorDowncast, ActorError, Array, AsActorError,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
@@ -22,6 +22,7 @@ pub use self::types::*;
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
 
+pub mod ext;
 mod state;
 pub mod testing;
 mod types;
@@ -42,6 +43,7 @@ pub const ERR_CHANNEL_STATE_UPDATE_AFTER_SETTLED: ExitCode = ExitCode::new(32);
 
 /// Payment Channel actor
 pub struct Actor;
+
 impl Actor {
     /// Constructor for Payment channel actor
     pub fn constructor(rt: &mut impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
@@ -49,10 +51,17 @@ impl Actor {
         // behalf of the payer/payee.
         rt.validate_immediate_caller_type(std::iter::once(&Type::Init))?;
 
-        // Check both parties are capable of signing vouchers
-        let to = Self::resolve_account(rt, &params.to)?;
+        // Resolve both parties if necessary.
+        // Note that this does NOT guarantee that the parties exist in state yet.
+        let to =
+            rt.resolve_address(&params.to).with_context_code(ExitCode::USR_NOT_FOUND, || {
+                format!("to address not found {}", params.to)
+            })?;
 
-        let from = Self::resolve_account(rt, &params.from)?;
+        let from =
+            rt.resolve_address(&params.from).with_context_code(ExitCode::USR_NOT_FOUND, || {
+                format!("to address not found {}", params.to)
+            })?;
 
         let empty_arr_cid =
             Array::<(), _>::new_with_bit_width(rt.store(), LANE_STATES_AMT_BITWIDTH)
@@ -63,28 +72,6 @@ impl Actor {
 
         rt.create(&State::new(from, to, empty_arr_cid))?;
         Ok(())
-    }
-
-    /// Resolves an address to a canonical ID address and requires it to address an account actor.
-    fn resolve_account(rt: &mut impl Runtime, raw: &Address) -> Result<Address, ActorError> {
-        let resolved = resolve_to_actor_id(rt, raw)?;
-
-        let code_cid = rt
-            .get_actor_code_cid(&resolved)
-            .ok_or_else(|| actor_error!(illegal_argument, "no code for address {}", resolved))?;
-
-        let typ = rt.resolve_builtin_actor_type(&code_cid);
-        if typ != Some(Type::Account) {
-            Err(actor_error!(
-                forbidden,
-                "actor {} must be an account, was {} ({:?})",
-                raw,
-                code_cid,
-                typ
-            ))
-        } else {
-            Ok(Address::new_id(resolved))
-        }
     }
 
     pub fn update_channel_state(
@@ -98,10 +85,11 @@ impl Actor {
         let sv = params.sv;
 
         // Pull signature from signed voucher
-        let sig = sv
+        let sig = &sv
             .signature
             .as_ref()
-            .ok_or_else(|| actor_error!(illegal_argument, "voucher has no signature"))?;
+            .ok_or_else(|| actor_error!(illegal_argument, "voucher has no signature"))?
+            .bytes;
 
         if st.settling_at != 0 && rt.curr_epoch() >= st.settling_at {
             return Err(ActorError::unchecked(
@@ -120,9 +108,17 @@ impl Actor {
         })?;
 
         // Validate signature
-        rt.verify_signature(sig, &signer, &sv_bz).map_err(|e| {
-            e.downcast_default(ExitCode::USR_ILLEGAL_ARGUMENT, "voucher signature invalid")
-        })?;
+
+        rt.send(
+            &signer,
+            ext::account::AUTHENTICATE_MESSAGE_METHOD,
+            RawBytes::serialize(ext::account::AuthenticateMessageParams {
+                signature: sig.to_vec(),
+                message: sv_bz,
+            })?,
+            TokenAmount::zero(),
+        )
+        .map_err(|e| e.wrap("voucher sig authentication failed"))?;
 
         let pch_addr = rt.message().receiver();
         let svpch_id = rt.resolve_address(&sv.channel_addr).ok_or_else(|| {

--- a/actors/paych/src/state.rs
+++ b/actors/paych/src/state.rs
@@ -5,6 +5,7 @@ use cid::Cid;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
+use fvm_shared::ActorID;
 
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
@@ -29,10 +30,10 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(from: Address, to: Address, empty_arr_cid: Cid) -> Self {
+    pub fn new(from: ActorID, to: ActorID, empty_arr_cid: Cid) -> Self {
         Self {
-            from,
-            to,
+            from: Address::new_id(from),
+            to: Address::new_id(to),
             to_send: Default::default(),
             settling_at: 0,
             min_settle_height: 0,

--- a/actors/paych/src/state.rs
+++ b/actors/paych/src/state.rs
@@ -5,7 +5,6 @@ use cid::Cid;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
-use fvm_shared::ActorID;
 
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
@@ -30,10 +29,10 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(from: ActorID, to: ActorID, empty_arr_cid: Cid) -> Self {
+    pub fn new(from: Address, to: Address, empty_arr_cid: Cid) -> Self {
         Self {
-            from: Address::new_id(from),
-            to: Address::new_id(to),
+            from,
+            to,
             to_send: Default::default(),
             settling_at: 0,
             min_settle_height: 0,
@@ -58,5 +57,7 @@ pub struct Merge {
 }
 
 impl Cbor for State {}
+
 impl Cbor for LaneState {}
+
 impl Cbor for Merge {}

--- a/actors/paych/tests/paych_actor_test.rs
+++ b/actors/paych/tests/paych_actor_test.rs
@@ -4,14 +4,15 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use anyhow::anyhow;
 use cid::Cid;
 use derive_builder::Builder;
+use fil_actor_paych::ext::account::{AuthenticateMessageParams, AUTHENTICATE_MESSAGE_METHOD};
 use fil_actor_paych::testing::check_state_invariants;
 use fil_actor_paych::{
     Actor as PaychActor, ConstructorParams, LaneState, Merge, Method, ModVerifyParams,
     SignedVoucher, State as PState, UpdateChannelStateParams, MAX_LANE, SETTLE_DELAY,
 };
+
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::test_utils::*;
@@ -23,7 +24,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::METHOD_CONSTRUCTOR;
+use fvm_shared::{ActorID, METHOD_CONSTRUCTOR};
 use num_traits::Zero;
 
 const PAYCH_ID: u64 = 100;
@@ -70,14 +71,11 @@ fn check_state(rt: &MockRuntime) {
 mod paych_constructor {
     use fil_actors_runtime::runtime::builtins::Type;
     use fvm_shared::METHOD_CONSTRUCTOR;
-    use fvm_shared::METHOD_SEND;
-    use num_traits::Zero;
 
     use super::*;
 
     const TEST_PAYCH_ADDR: u64 = 100;
     const TEST_PAYER_ADDR: u64 = 101;
-    const TEST_PAYEE_ADDR: u64 = 102;
     const TEST_CALLER_ADDR: u64 = 102;
 
     fn construct_runtime() -> MockRuntime {
@@ -112,13 +110,13 @@ mod paych_constructor {
         rt.expect_validate_caller_type(vec![Type::Init]);
         let params = ConstructorParams {
             to: Address::new_id(TEST_PAYCH_ADDR),
-            from: Address::new_id(TEST_PAYER_ADDR),
+            from: Address::new_secp256k1(&[2; fvm_shared::address::SECP_PUB_LEN]).unwrap(),
         };
         expect_abort(
             &mut rt,
             METHOD_CONSTRUCTOR,
             &RawBytes::serialize(params).unwrap(),
-            ExitCode::USR_ILLEGAL_ARGUMENT,
+            ExitCode::USR_NOT_FOUND,
         );
     }
 
@@ -138,142 +136,6 @@ mod paych_constructor {
 
         construct_and_verify(&mut rt, payer_non_id, payee_non_id);
         check_state(&rt);
-    }
-
-    #[test]
-    fn actor_constructor_fails() {
-        let paych_addr = Address::new_id(TEST_PAYCH_ADDR);
-        let payer_addr = Address::new_id(TEST_PAYER_ADDR);
-        let payee_addr = Address::new_id(TEST_PAYEE_ADDR);
-        let caller_addr = Address::new_id(TEST_CALLER_ADDR);
-
-        struct TestCase {
-            from_code: Cid,
-            from_addr: Address,
-            to_code: Cid,
-            to_addr: Address,
-            expected_exit_code: ExitCode,
-        }
-
-        let test_cases: Vec<TestCase> = vec![
-            // fails if target (to) is not account actor
-            TestCase {
-                from_code: *ACCOUNT_ACTOR_CODE_ID,
-                from_addr: payer_addr,
-                to_code: *MULTISIG_ACTOR_CODE_ID,
-                to_addr: payee_addr,
-                expected_exit_code: ExitCode::USR_FORBIDDEN,
-            },
-            // fails if sender (from) is not account actor
-            TestCase {
-                from_code: *MULTISIG_ACTOR_CODE_ID,
-                from_addr: payer_addr,
-                to_code: *ACCOUNT_ACTOR_CODE_ID,
-                to_addr: payee_addr,
-                expected_exit_code: ExitCode::USR_FORBIDDEN,
-            },
-        ];
-
-        for test_case in test_cases {
-            let mut actor_code_cids = HashMap::default();
-            actor_code_cids.insert(paych_addr, *PAYCH_ACTOR_CODE_ID);
-            actor_code_cids.insert(test_case.to_addr, test_case.to_code);
-            actor_code_cids.insert(test_case.from_addr, test_case.from_code);
-
-            let mut rt = MockRuntime {
-                receiver: paych_addr,
-                caller: caller_addr,
-                caller_type: *INIT_ACTOR_CODE_ID,
-                actor_code_cids,
-                ..Default::default()
-            };
-
-            rt.expect_validate_caller_type(vec![Type::Init]);
-            let params = ConstructorParams { to: test_case.to_addr, from: test_case.from_addr };
-            expect_abort(
-                &mut rt,
-                METHOD_CONSTRUCTOR,
-                &RawBytes::serialize(params).unwrap(),
-                test_case.expected_exit_code,
-            );
-        }
-    }
-
-    #[test]
-    fn sendr_addr_not_resolvable_to_id_addr() {
-        const TO_ADDR: u64 = 101;
-        let to_addr = Address::new_id(TO_ADDR);
-        let paych_addr = Address::new_id(TEST_PAYCH_ADDR);
-        let caller_addr = Address::new_id(TEST_CALLER_ADDR);
-        let non_id_addr = Address::new_bls(&[111; fvm_shared::address::BLS_PUB_LEN]).unwrap();
-
-        let mut actor_code_cids = HashMap::default();
-        actor_code_cids.insert(to_addr, *ACCOUNT_ACTOR_CODE_ID);
-
-        let mut rt = MockRuntime {
-            receiver: paych_addr,
-            caller: caller_addr,
-            caller_type: *INIT_ACTOR_CODE_ID,
-            actor_code_cids,
-            ..Default::default()
-        };
-
-        rt.expect_send(
-            non_id_addr,
-            METHOD_SEND,
-            Default::default(),
-            TokenAmount::zero(),
-            Default::default(),
-            ExitCode::OK,
-        );
-
-        rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
-        rt.expect_validate_caller_type(vec![Type::Init]);
-        let params = ConstructorParams { from: non_id_addr, to: to_addr };
-        expect_abort(
-            &mut rt,
-            METHOD_CONSTRUCTOR,
-            &RawBytes::serialize(&params).unwrap(),
-            ExitCode::USR_ILLEGAL_ARGUMENT,
-        );
-    }
-
-    #[test]
-    fn target_addr_not_resolvable_to_id_addr() {
-        let from_addr = Address::new_id(5555_u64);
-        let paych_addr = Address::new_id(TEST_PAYCH_ADDR);
-        let caller_addr = Address::new_id(TEST_CALLER_ADDR);
-        let non_id_addr = Address::new_bls(&[111; fvm_shared::address::BLS_PUB_LEN]).unwrap();
-
-        let mut actor_code_cids = HashMap::default();
-        actor_code_cids.insert(from_addr, *ACCOUNT_ACTOR_CODE_ID);
-
-        let mut rt = MockRuntime {
-            receiver: paych_addr,
-            caller: caller_addr,
-            caller_type: *INIT_ACTOR_CODE_ID,
-            actor_code_cids,
-            ..Default::default()
-        };
-
-        rt.expect_send(
-            non_id_addr,
-            METHOD_SEND,
-            Default::default(),
-            TokenAmount::zero(),
-            Default::default(),
-            ExitCode::OK,
-        );
-
-        rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
-        rt.expect_validate_caller_type(vec![Type::Init]);
-        let params = ConstructorParams { from: from_addr, to: non_id_addr };
-        expect_abort(
-            &mut rt,
-            METHOD_CONSTRUCTOR,
-            &RawBytes::serialize(&params).unwrap(),
-            ExitCode::USR_ILLEGAL_ARGUMENT,
-        );
     }
 }
 
@@ -447,17 +309,26 @@ mod create_lane_tests {
             rt.expect_validate_caller_addr(vec![payer_addr, payee_addr]);
 
             if test_case.sig.is_some() && test_case.secret_preimage.is_empty() {
-                let exp_exit_code =
-                    if !test_case.verify_sig { Err(anyhow!("bad signature")) } else { Ok(()) };
-                rt.expect_verify_signature(ExpectedVerifySig {
-                    sig: sv.clone().signature.unwrap(),
-                    signer: payer_addr,
-                    plaintext: sv.signing_bytes().unwrap(),
-                    result: exp_exit_code,
-                });
+                let exp_exit_code = if !test_case.verify_sig {
+                    ExitCode::USR_ILLEGAL_ARGUMENT
+                } else {
+                    ExitCode::OK
+                };
+                rt.expect_send(
+                    payer_addr,
+                    AUTHENTICATE_MESSAGE_METHOD,
+                    RawBytes::serialize(AuthenticateMessageParams {
+                        signature: sv.clone().signature.unwrap().bytes,
+                        message: sv.signing_bytes().unwrap(),
+                    })
+                    .unwrap(),
+                    TokenAmount::zero(),
+                    RawBytes::default(),
+                    exp_exit_code,
+                );
             }
 
-            if test_case.exp_exit_code == ExitCode::OK {
+            if test_case.exp_exit_code.is_success() {
                 call(
                     &mut rt,
                     Method::UpdateChannelState as u64,
@@ -479,7 +350,7 @@ mod create_lane_tests {
                     &RawBytes::serialize(ucp).unwrap(),
                     test_case.exp_exit_code,
                 );
-                verify_initial_state(&rt, payer_addr, payee_addr);
+                verify_initial_state(&rt, PAYER_ADDR, PAYEE_ADDR);
             }
             rt.verify();
         }
@@ -502,12 +373,18 @@ mod update_channel_state_redeem {
 
         let payer_addr = Address::new_id(PAYER_ID);
 
-        rt.expect_verify_signature(ExpectedVerifySig {
-            sig: sv.clone().signature.unwrap(),
-            signer: payer_addr,
-            plaintext: sv.signing_bytes().unwrap(),
-            result: Ok(()),
-        });
+        rt.expect_send(
+            payer_addr,
+            AUTHENTICATE_MESSAGE_METHOD,
+            RawBytes::serialize(AuthenticateMessageParams {
+                signature: sv.clone().signature.unwrap().bytes,
+                message: sv.signing_bytes().unwrap(),
+            })
+            .unwrap(),
+            TokenAmount::zero(),
+            RawBytes::default(),
+            ExitCode::OK,
+        );
 
         call(
             &mut rt,
@@ -545,12 +422,18 @@ mod update_channel_state_redeem {
         sv.nonce = ls_to_update.nonce + 1;
         let payer_addr = Address::new_id(PAYER_ID);
 
-        rt.expect_verify_signature(ExpectedVerifySig {
-            sig: sv.clone().signature.unwrap(),
-            signer: payer_addr,
-            plaintext: sv.signing_bytes().unwrap(),
-            result: Ok(()),
-        });
+        rt.expect_send(
+            payer_addr,
+            AUTHENTICATE_MESSAGE_METHOD,
+            RawBytes::serialize(AuthenticateMessageParams {
+                signature: sv.clone().signature.unwrap().bytes,
+                message: sv.signing_bytes().unwrap(),
+            })
+            .unwrap(),
+            TokenAmount::zero(),
+            RawBytes::default(),
+            ExitCode::OK,
+        );
 
         call(
             &mut rt,
@@ -585,12 +468,18 @@ mod update_channel_state_redeem {
 
         let payer_addr = Address::new_id(PAYER_ID);
 
-        rt.expect_verify_signature(ExpectedVerifySig {
-            sig: sv.clone().signature.unwrap(),
-            signer: payer_addr,
-            plaintext: sv.signing_bytes().unwrap(),
-            result: Ok(()),
-        });
+        rt.expect_send(
+            payer_addr,
+            AUTHENTICATE_MESSAGE_METHOD,
+            RawBytes::serialize(AuthenticateMessageParams {
+                signature: sv.clone().signature.unwrap().bytes,
+                message: sv.signing_bytes().unwrap(),
+            })
+            .unwrap(),
+            TokenAmount::zero(),
+            RawBytes::default(),
+            ExitCode::OK,
+        );
 
         expect_abort(
             &mut rt,
@@ -617,12 +506,18 @@ mod merge_tests {
 
     fn failure_end(rt: &mut MockRuntime, sv: SignedVoucher, exp_exit_code: ExitCode) {
         let payee_addr = Address::new_id(PAYEE_ID);
-        rt.expect_verify_signature(ExpectedVerifySig {
-            sig: sv.clone().signature.unwrap(),
-            signer: payee_addr,
-            plaintext: sv.signing_bytes().unwrap(),
-            result: Ok(()),
-        });
+        rt.expect_send(
+            payee_addr,
+            AUTHENTICATE_MESSAGE_METHOD,
+            RawBytes::serialize(AuthenticateMessageParams {
+                signature: sv.clone().signature.unwrap().bytes,
+                message: sv.signing_bytes().unwrap(),
+            })
+            .unwrap(),
+            TokenAmount::zero(),
+            RawBytes::default(),
+            ExitCode::OK,
+        );
         expect_abort(
             rt,
             Method::UpdateChannelState as u64,
@@ -645,12 +540,18 @@ mod merge_tests {
 
         sv.merges = vec![Merge { lane: 1, nonce: merge_nonce }];
         let payee_addr = Address::new_id(PAYEE_ID);
-        rt.expect_verify_signature(ExpectedVerifySig {
-            sig: sv.clone().signature.unwrap(),
-            signer: payee_addr,
-            plaintext: sv.signing_bytes().unwrap(),
-            result: Ok(()),
-        });
+        rt.expect_send(
+            payee_addr,
+            AUTHENTICATE_MESSAGE_METHOD,
+            RawBytes::serialize(AuthenticateMessageParams {
+                signature: sv.clone().signature.unwrap().bytes,
+                message: sv.signing_bytes().unwrap(),
+            })
+            .unwrap(),
+            TokenAmount::zero(),
+            RawBytes::default(),
+            ExitCode::OK,
+        );
 
         call(
             &mut rt,
@@ -770,12 +671,18 @@ mod update_channel_state_extra {
             method: Method::UpdateChannelState as u64,
             data: fake_params.clone(),
         });
-        rt.expect_verify_signature(ExpectedVerifySig {
-            sig: sv.clone().signature.unwrap(),
-            signer: state.to,
-            plaintext: sv.signing_bytes().unwrap(),
-            result: Ok(()),
-        });
+        rt.expect_send(
+            state.to,
+            AUTHENTICATE_MESSAGE_METHOD,
+            RawBytes::serialize(AuthenticateMessageParams {
+                signature: sv.clone().signature.unwrap().bytes,
+                message: sv.signing_bytes().unwrap(),
+            })
+            .unwrap(),
+            TokenAmount::zero(),
+            RawBytes::default(),
+            ExitCode::OK,
+        );
 
         rt.expect_send(
             other_addr,
@@ -852,12 +759,20 @@ fn update_channel_settling() {
     for tc in test_cases {
         ucp.sv.min_settle_height = tc.min_settle;
         rt.expect_validate_caller_addr(vec![state.from, state.to]);
-        rt.expect_verify_signature(ExpectedVerifySig {
-            sig: sv.clone().signature.unwrap(),
-            signer: state.to,
-            plaintext: ucp.sv.signing_bytes().unwrap(),
-            result: Ok(()),
-        });
+
+        rt.expect_send(
+            state.to,
+            AUTHENTICATE_MESSAGE_METHOD,
+            RawBytes::serialize(AuthenticateMessageParams {
+                signature: sv.clone().signature.unwrap().bytes,
+                message: ucp.sv.signing_bytes().unwrap(),
+            })
+            .unwrap(),
+            TokenAmount::zero(),
+            RawBytes::default(),
+            ExitCode::OK,
+        );
+
         call(&mut rt, Method::UpdateChannelState as u64, &RawBytes::serialize(&ucp).unwrap());
         let new_state: PState = rt.get_state();
         assert_eq!(tc.exp_settling_at, new_state.settling_at);
@@ -878,12 +793,18 @@ mod secret_preimage {
 
         let ucp = UpdateChannelStateParams::from(sv.clone());
 
-        rt.expect_verify_signature(ExpectedVerifySig {
-            sig: sv.clone().signature.unwrap(),
-            signer: state.to,
-            plaintext: sv.signing_bytes().unwrap(),
-            result: Ok(()),
-        });
+        rt.expect_send(
+            state.to,
+            AUTHENTICATE_MESSAGE_METHOD,
+            RawBytes::serialize(AuthenticateMessageParams {
+                signature: sv.clone().signature.unwrap().bytes,
+                message: sv.signing_bytes().unwrap(),
+            })
+            .unwrap(),
+            TokenAmount::zero(),
+            RawBytes::default(),
+            ExitCode::OK,
+        );
 
         call(&mut rt, Method::UpdateChannelState as u64, &RawBytes::serialize(ucp).unwrap());
 
@@ -903,12 +824,20 @@ mod secret_preimage {
         ucp.sv.secret_pre_image = mag;
 
         rt.expect_validate_caller_addr(vec![state.from, state.to]);
-        rt.expect_verify_signature(ExpectedVerifySig {
-            sig: sv.signature.unwrap(),
-            signer: state.to,
-            plaintext: ucp.sv.signing_bytes().unwrap(),
-            result: Ok(()),
-        });
+
+        rt.expect_send(
+            state.to,
+            AUTHENTICATE_MESSAGE_METHOD,
+            RawBytes::serialize(AuthenticateMessageParams {
+                signature: sv.signature.unwrap().bytes,
+                message: ucp.sv.signing_bytes().unwrap(),
+            })
+            .unwrap(),
+            TokenAmount::zero(),
+            RawBytes::default(),
+            ExitCode::OK,
+        );
+
         expect_abort(
             &mut rt,
             Method::UpdateChannelState as u64,
@@ -971,12 +900,19 @@ mod actor_settle {
         let ucp = UpdateChannelStateParams::from(sv.clone());
 
         rt.expect_validate_caller_addr(vec![state.from, state.to]);
-        rt.expect_verify_signature(ExpectedVerifySig {
-            sig: ucp.sv.signature.clone().unwrap(),
-            signer: state.to,
-            plaintext: sv.signing_bytes().unwrap(),
-            result: Ok(()),
-        });
+        rt.expect_send(
+            state.to,
+            AUTHENTICATE_MESSAGE_METHOD,
+            RawBytes::serialize(AuthenticateMessageParams {
+                signature: sv.clone().signature.unwrap().bytes,
+                message: sv.signing_bytes().unwrap(),
+            })
+            .unwrap(),
+            TokenAmount::zero(),
+            RawBytes::default(),
+            ExitCode::OK,
+        );
+
         call(&mut rt, Method::UpdateChannelState as u64, &RawBytes::serialize(&ucp).unwrap());
 
         state = rt.get_state();
@@ -1186,12 +1122,20 @@ fn require_add_new_lane(rt: &mut MockRuntime, param: LaneParams) -> SignedVouche
     };
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, param.from);
     rt.expect_validate_caller_addr(vec![param.from, param.to]);
-    rt.expect_verify_signature(ExpectedVerifySig {
-        sig,
-        signer: payee_addr,
-        plaintext: sv.signing_bytes().unwrap(),
-        result: Ok(()),
-    });
+
+    rt.expect_send(
+        payee_addr,
+        AUTHENTICATE_MESSAGE_METHOD,
+        RawBytes::serialize(AuthenticateMessageParams {
+            signature: sig.bytes,
+            message: sv.signing_bytes().unwrap(),
+        })
+        .unwrap(),
+        TokenAmount::zero(),
+        RawBytes::default(),
+        ExitCode::OK,
+    );
+
     call(
         rt,
         Method::UpdateChannelState as u64,
@@ -1208,12 +1152,12 @@ fn construct_and_verify(rt: &mut MockRuntime, sender: Address, receiver: Address
     rt.expect_validate_caller_type(vec![Type::Init]);
     call(rt, METHOD_CONSTRUCTOR, &RawBytes::serialize(&params).unwrap());
     rt.verify();
-    let sender_id = rt.id_addresses.get(&sender).unwrap_or(&sender);
-    let receiver_id = rt.id_addresses.get(&receiver).unwrap_or(&receiver);
-    verify_initial_state(rt, *sender_id, *receiver_id);
+    let sender_id = rt.id_addresses.get(&sender).unwrap_or(&sender).id().unwrap();
+    let receiver_id = rt.id_addresses.get(&receiver).unwrap_or(&receiver).id().unwrap();
+    verify_initial_state(rt, sender_id, receiver_id);
 }
 
-fn verify_initial_state(rt: &MockRuntime, sender: Address, receiver: Address) {
+fn verify_initial_state(rt: &MockRuntime, sender: ActorID, receiver: ActorID) {
     let _state: PState = rt.get_state();
     let empt_arr_cid = Amt::<(), _>::new(&rt.store).flush().unwrap();
     let expected_state = PState::new(sender, receiver, empt_arr_cid);

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -10,8 +10,8 @@ use crate::runtime::Runtime;
 
 pub const HAMT_BIT_WIDTH: u32 = 5;
 
-/// ResolveToActorID resolves the given address to it's actor ID.
-/// If an actor ID for the given address dosen't exist yet, it tries to create one by sending
+/// ResolveToActorID resolves the given address to its actor ID.
+/// If an actor ID for the given address doesn't exist yet, it tries to create one by sending
 /// a zero balance to the given address.
 pub fn resolve_to_actor_id(
     rt: &mut impl Runtime,


### PR DESCRIPTION
Part of #424.

In addition to obviating the need for Paych to/from addresses to be accounts, this also removes the need for them to exist in state at the time of creation -- this PR makes it possible to supply to/from ID addresses that don't actually exist in state at the time of paych creation.

 We need to decide if this is something we want, or is undesirable. If the latter, we probably want a new syscall to check for ID addrs existing in state (we could achieve this by misusing existing syscalls, but I would prefer not to).