### PR TITLE
EVM: simplify and fix evm storage

### DIFF
--- a/actors/evm/src/interpreter/instructions/storage.rs
+++ b/actors/evm/src/interpreter/instructions/storage.rs
@@ -1,5 +1,5 @@
 use {
-    crate::interpreter::{ExecutionState, StatusCode, System, U256},
+    crate::interpreter::{ExecutionState, StatusCode, System},
     fil_actors_runtime::runtime::Runtime,
 };
 
@@ -12,11 +12,7 @@ pub fn sload(
     let location = state.stack.pop();
 
     // get from storage and place on stack
-    let value = match system.get_storage(location)? {
-        Some(val) => val,
-        None => U256::zero(),
-    };
-    state.stack.push(value);
+    state.stack.push(system.get_storage(location)?);
     Ok(())
 }
 
@@ -29,10 +25,6 @@ pub fn sstore(
         return Err(StatusCode::StaticModeViolation);
     }
 
-    let location = state.stack.pop();
-    let value = state.stack.pop();
-    let opt_value = if value == U256::zero() { None } else { Some(value) };
-
-    system.set_storage(location, opt_value)?;
+    system.set_storage(state.stack.pop(), state.stack.pop())?;
     Ok(())
 }

--- a/actors/evm/src/interpreter/instructions/storage.rs
+++ b/actors/evm/src/interpreter/instructions/storage.rs
@@ -25,6 +25,9 @@ pub fn sstore(
         return Err(StatusCode::StaticModeViolation);
     }
 
-    system.set_storage(state.stack.pop(), state.stack.pop())?;
+    let key = state.stack.pop();
+    let value = state.stack.pop();
+
+    system.set_storage(key, value)?;
     Ok(())
 }

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use fil_actors_runtime::{runtime::builtins::Type, EAM_ACTOR_ID};
+use fil_actors_runtime::{runtime::builtins::Type, AsActorError, EAM_ACTOR_ID};
 use fvm_ipld_encoding::{strict_bytes, BytesDe, BytesSer};
 use fvm_shared::address::{Address, Payload};
 use interpreter::{address::EthAddress, system::load_bytecode};
@@ -233,8 +233,7 @@ impl EvmContractActor {
 
         System::load(rt, true)?
             .get_storage(params.storage_key)
-            .map_err(|st| ActorError::unspecified(format!("failed to get storage key: {}", &st)))?
-            .ok_or_else(|| ActorError::not_found(String::from("storage key not found")))
+            .context_code(ExitCode::USR_ASSERTION_FAILED, "failed to get storage key")
     }
 }
 

--- a/actors/evm/tests/basic.rs
+++ b/actors/evm/tests/basic.rs
@@ -4,7 +4,6 @@ use cid::Cid;
 use evm::interpreter::U256;
 use fil_actor_evm as evm;
 use fil_actors_runtime::test_utils::*;
-use fil_actors_runtime::ActorError;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
@@ -129,16 +128,20 @@ sstore";
     assert_eq!(U256::from(0xfffa), value);
 
     //
-    // Get a storage key that doesn't exist.
+    // Get a storage key that doesn't exist, should default to zero.
     //
     let params = evm::GetStorageAtParams { storage_key: 0xaaaa.into() };
 
     rt.expect_validate_caller_addr(vec![sender]);
-    let ret = rt.call::<evm::EvmContractActor>(
-        evm::Method::GetStorageAt as u64,
-        &RawBytes::serialize(params).unwrap(),
-    );
-    rt.verify();
+    let value: U256 = rt
+        .call::<evm::EvmContractActor>(
+            evm::Method::GetStorageAt as u64,
+            &RawBytes::serialize(params).unwrap(),
+        )
+        .unwrap()
+        .deserialize()
+        .unwrap();
 
-    assert_eq!(ActorError::not_found("storage key not found".to_string()), ret.err().unwrap());
+    assert_eq!(U256::from(0), value);
+    rt.verify();
 }


### PR DESCRIPTION
1. The EVM doesn't distinguish between "exists" and "doesn't exist".
2. There was some interesting dead code.
3. Only mark the state-tree dirty if something has changed.

fixes the second half of https://github.com/filecoin-project/ref-fvm/issues/912