### PR TITLE
EVM runtime: implement LOG{0..4} opcodes by emitting actor events (FIP-0049)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ version = "10.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "fil_actors_runtime",
- "frc42_dispatch 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
+ "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared",
@@ -1382,9 +1382,9 @@ version = "10.0.0-alpha.1"
 dependencies = [
  "cid",
  "fil_actors_runtime",
- "frc42_dispatch 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
+ "frc42_dispatch",
  "frc46_token",
- "fvm_actor_utils 0.1.0",
+ "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
@@ -1542,7 +1542,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
- "frc42_dispatch 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
+ "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
@@ -1631,7 +1631,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
- "frc42_dispatch 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
+ "frc42_dispatch",
  "frc46_token",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
@@ -1771,21 +1771,8 @@ dependencies = [
 name = "frc42_dispatch"
 version = "1.0.0"
 dependencies = [
- "frc42_hasher 1.0.0",
- "frc42_macros 1.0.0",
- "fvm_ipld_encoding",
- "fvm_sdk",
- "fvm_shared",
- "thiserror",
-]
-
-[[package]]
-name = "frc42_dispatch"
-version = "1.0.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#93f90c3cd340a2396ee2e0344fe09bb476362a92"
-dependencies = [
- "frc42_hasher 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
- "frc42_macros 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
+ "frc42_hasher",
+ "frc42_macros",
  "fvm_ipld_encoding",
  "fvm_sdk",
  "fvm_shared",
@@ -1802,33 +1789,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "frc42_hasher"
-version = "1.0.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#93f90c3cd340a2396ee2e0344fe09bb476362a92"
-dependencies = [
- "fvm_sdk",
- "fvm_shared",
- "thiserror",
-]
-
-[[package]]
 name = "frc42_macros"
 version = "1.0.0"
 dependencies = [
  "blake2b_simd",
- "frc42_hasher 1.0.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "frc42_macros"
-version = "1.0.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#93f90c3cd340a2396ee2e0344fe09bb476362a92"
-dependencies = [
- "blake2b_simd",
- "frc42_hasher 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
+ "frc42_hasher",
  "proc-macro2",
  "quote",
  "syn",
@@ -1837,12 +1802,11 @@ dependencies = [
 [[package]]
 name = "frc46_token"
 version = "1.1.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#93f90c3cd340a2396ee2e0344fe09bb476362a92"
 dependencies = [
  "anyhow",
  "cid",
- "frc42_dispatch 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
- "fvm_actor_utils 0.1.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
+ "frc42_dispatch",
+ "fvm_actor_utils",
  "fvm_ipld_amt",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
@@ -1989,23 +1953,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cid",
- "frc42_dispatch 1.0.0",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
- "fvm_sdk",
- "fvm_shared",
- "num-traits",
- "thiserror",
-]
-
-[[package]]
-name = "fvm_actor_utils"
-version = "0.1.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#93f90c3cd340a2396ee2e0344fe09bb476362a92"
-dependencies = [
- "anyhow",
- "cid",
- "frc42_dispatch 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
+ "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.5.0"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
 dependencies = [
  "anyhow",
  "cid",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
 dependencies = [
  "fvm_ipld_encoding",
  "serde",
@@ -1996,7 +1996,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
 dependencies = [
  "anyhow",
  "cid",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.3.0"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
 dependencies = [
  "anyhow",
  "cid",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.6.1"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2056,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.0.0-alpha.10"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -2070,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.0.0-alpha.10"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "frc42_dispatch"
 version = "1.0.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=raulk/events#7783857bbb1f67036128387e3d60fbc2523e3486"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#aa39d65847a57cea2fcf04bab464bac75cf99b97"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "frc42_hasher"
 version = "1.0.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=raulk/events#7783857bbb1f67036128387e3d60fbc2523e3486"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#aa39d65847a57cea2fcf04bab464bac75cf99b97"
 dependencies = [
  "fvm_sdk",
  "fvm_shared",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "frc42_macros"
 version = "1.0.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=raulk/events#7783857bbb1f67036128387e3d60fbc2523e3486"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#aa39d65847a57cea2fcf04bab464bac75cf99b97"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
@@ -1805,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "frc46_token"
 version = "1.1.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=raulk/events#7783857bbb1f67036128387e3d60fbc2523e3486"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#aa39d65847a57cea2fcf04bab464bac75cf99b97"
 dependencies = [
  "anyhow",
  "cid",
@@ -1954,7 +1954,7 @@ dependencies = [
 [[package]]
 name = "fvm_actor_utils"
 version = "0.1.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=raulk/events#7783857bbb1f67036128387e3d60fbc2523e3486"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#aa39d65847a57cea2fcf04bab464bac75cf99b97"
 dependencies = [
  "anyhow",
  "cid",
@@ -1970,7 +1970,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.5.0"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21efabb8ae696f1cfd90b176a3600176010bd6ad3fb9919b16a24b43ba866b3d"
 dependencies = [
  "anyhow",
  "cid",
@@ -1985,7 +1986,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
 dependencies = [
  "fvm_ipld_encoding",
  "serde",
@@ -1996,7 +1998,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688239a96199577f6705a3f9689abfd795f867f91f5847bc7e236017cc672df7"
 dependencies = [
  "anyhow",
  "cid",
@@ -2021,7 +2024,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.3.0"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf531c59e7c9a4c9044a34d1b44c9d544fab1eb0ba50aaa18121fe698d4fec35"
 dependencies = [
  "anyhow",
  "cid",
@@ -2037,7 +2041,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.6.1"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c942494dde990aeac314311bde34c787be99cab7d0836397a75556cbaa2c3e7"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2055,8 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.10"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
+version = "3.0.0-alpha.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee761116262c35151071675ec3345d821b0b90143616dec348c74e46116e150"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -2069,8 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0-alpha.10"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#10e4f51bebdc65ce1fdfb12527b92c4d688cbdcb"
+version = "3.0.0-alpha.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66b85f8971273def3bb366008319f8dc855be3172210c3b83b7b20353709b29"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2289,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
 dependencies = [
  "http",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.5.0"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
 dependencies = [
  "anyhow",
  "cid",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
 dependencies = [
  "fvm_ipld_encoding",
  "serde",
@@ -1996,7 +1996,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
 dependencies = [
  "anyhow",
  "cid",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.3.0"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
 dependencies = [
  "anyhow",
  "cid",
@@ -2036,8 +2036,8 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_hamt"
-version = "0.6.0"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
+version = "0.6.1"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2055,8 +2055,8 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.9"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
+version = "3.0.0-alpha.10"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -2069,8 +2069,8 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0-alpha.9"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
+version = "3.0.0-alpha.10"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,6 +1770,7 @@ dependencies = [
 [[package]]
 name = "frc42_dispatch"
 version = "1.0.0"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=raulk/events#7783857bbb1f67036128387e3d60fbc2523e3486"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
@@ -1782,6 +1783,7 @@ dependencies = [
 [[package]]
 name = "frc42_hasher"
 version = "1.0.0"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=raulk/events#7783857bbb1f67036128387e3d60fbc2523e3486"
 dependencies = [
  "fvm_sdk",
  "fvm_shared",
@@ -1791,6 +1793,7 @@ dependencies = [
 [[package]]
 name = "frc42_macros"
 version = "1.0.0"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=raulk/events#7783857bbb1f67036128387e3d60fbc2523e3486"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
@@ -1802,6 +1805,7 @@ dependencies = [
 [[package]]
 name = "frc46_token"
 version = "1.1.0"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=raulk/events#7783857bbb1f67036128387e3d60fbc2523e3486"
 dependencies = [
  "anyhow",
  "cid",
@@ -1950,6 +1954,7 @@ dependencies = [
 [[package]]
 name = "fvm_actor_utils"
 version = "0.1.0"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=raulk/events#7783857bbb1f67036128387e3d60fbc2523e3486"
 dependencies = [
  "anyhow",
  "cid",
@@ -1965,6 +1970,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.5.0"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
 dependencies = [
  "anyhow",
  "cid",
@@ -1979,6 +1985,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
 dependencies = [
  "fvm_ipld_encoding",
  "serde",
@@ -1989,6 +1996,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
 dependencies = [
  "anyhow",
  "cid",
@@ -2013,6 +2021,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.3.0"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
 dependencies = [
  "anyhow",
  "cid",
@@ -2028,6 +2037,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.6.0"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2046,6 +2056,7 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.0.0-alpha.9"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -2059,6 +2070,7 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.0.0-alpha.9"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#fa75d193b8c7f6f5b5d3580aeaba8c238d358ad5"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.5.0"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
 dependencies = [
  "anyhow",
  "cid",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
 dependencies = [
  "fvm_ipld_encoding",
  "serde",
@@ -1996,7 +1996,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
 dependencies = [
  "anyhow",
  "cid",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.3.0"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
 dependencies = [
  "anyhow",
  "cid",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.6.1"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2056,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.0.0-alpha.10"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -2070,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.0.0-alpha.10"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#3d2b971c40cc81fde4598afab6aac06770f5a9ba"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2438,9 +2438,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "kv-log-macro"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ version = "10.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "fil_actors_runtime",
- "frc42_dispatch",
+ "frc42_dispatch 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared",
@@ -1382,9 +1382,9 @@ version = "10.0.0-alpha.1"
 dependencies = [
  "cid",
  "fil_actors_runtime",
- "frc42_dispatch",
+ "frc42_dispatch 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
  "frc46_token",
- "fvm_actor_utils",
+ "fvm_actor_utils 0.1.0",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
@@ -1542,7 +1542,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
- "frc42_dispatch",
+ "frc42_dispatch 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
@@ -1631,7 +1631,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
- "frc42_dispatch",
+ "frc42_dispatch 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
  "frc46_token",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
@@ -1770,11 +1770,32 @@ dependencies = [
 [[package]]
 name = "frc42_dispatch"
 version = "1.0.0"
+dependencies = [
+ "frc42_hasher 1.0.0",
+ "frc42_macros 1.0.0",
+ "fvm_ipld_encoding",
+ "fvm_sdk",
+ "fvm_shared",
+ "thiserror",
+]
+
+[[package]]
+name = "frc42_dispatch"
+version = "1.0.0"
 source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#93f90c3cd340a2396ee2e0344fe09bb476362a92"
 dependencies = [
- "frc42_hasher",
- "frc42_macros",
+ "frc42_hasher 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
+ "frc42_macros 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
  "fvm_ipld_encoding",
+ "fvm_sdk",
+ "fvm_shared",
+ "thiserror",
+]
+
+[[package]]
+name = "frc42_hasher"
+version = "1.0.0"
+dependencies = [
  "fvm_sdk",
  "fvm_shared",
  "thiserror",
@@ -1793,10 +1814,21 @@ dependencies = [
 [[package]]
 name = "frc42_macros"
 version = "1.0.0"
+dependencies = [
+ "blake2b_simd",
+ "frc42_hasher 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "frc42_macros"
+version = "1.0.0"
 source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#93f90c3cd340a2396ee2e0344fe09bb476362a92"
 dependencies = [
  "blake2b_simd",
- "frc42_hasher",
+ "frc42_hasher 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
  "proc-macro2",
  "quote",
  "syn",
@@ -1809,8 +1841,8 @@ source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=fe
 dependencies = [
  "anyhow",
  "cid",
- "frc42_dispatch",
- "fvm_actor_utils",
+ "frc42_dispatch 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
+ "fvm_actor_utils 0.1.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
  "fvm_ipld_amt",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
@@ -1954,11 +1986,26 @@ dependencies = [
 [[package]]
 name = "fvm_actor_utils"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cid",
+ "frc42_dispatch 1.0.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_sdk",
+ "fvm_shared",
+ "num-traits",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_actor_utils"
+version = "0.1.0"
 source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#93f90c3cd340a2396ee2e0344fe09bb476362a92"
 dependencies = [
  "anyhow",
  "cid",
- "frc42_dispatch",
+ "frc42_dispatch 1.0.0 (git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2)",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_sdk",
@@ -1970,8 +2017,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21efabb8ae696f1cfd90b176a3600176010bd6ad3fb9919b16a24b43ba866b3d"
 dependencies = [
  "anyhow",
  "cid",
@@ -1986,8 +2031,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
 dependencies = [
  "fvm_ipld_encoding",
  "serde",
@@ -1998,8 +2041,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688239a96199577f6705a3f9689abfd795f867f91f5847bc7e236017cc672df7"
 dependencies = [
  "anyhow",
  "cid",
@@ -2024,8 +2065,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf531c59e7c9a4c9044a34d1b44c9d544fab1eb0ba50aaa18121fe698d4fec35"
 dependencies = [
  "anyhow",
  "cid",
@@ -2041,8 +2080,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48ac0db0c676fe9663f34782d448320b0c71d5e0afb7df38914983ae4d46faa"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2061,8 +2098,6 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.0.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c35ecb57fe0544b997b4378b93b53e8896f4aee50544b3b4e4a17f0ffbdca2"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -2076,10 +2111,9 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.0.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d8c7088aaf2f51e4373bb708b97d0fd013807e565c68e5642e206744954df6"
 dependencies = [
  "anyhow",
+ "bitflags",
  "blake2b_simd",
  "byteorder",
  "cid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.5.0"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
 dependencies = [
  "anyhow",
  "cid",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
 dependencies = [
  "fvm_ipld_encoding",
  "serde",
@@ -1996,7 +1996,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
 dependencies = [
  "anyhow",
  "cid",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.3.0"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
 dependencies = [
  "anyhow",
  "cid",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.6.1"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2056,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.0.0-alpha.10"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -2070,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.0.0-alpha.10"
-source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#f1ac14b5e22a12fc2bacdde3cebb10a8cca7cf06"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=raulk/events#44cfc4055f8b9f2acceb06707424e8a0eb9587f4"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ members = [
 ]
 
 [patch.crates-io]
-frc42_dispatch = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "feat/fvm-m2" }
-frc46_token = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "feat/fvm-m2" }
+#frc42_dispatch = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "feat/fvm-m2" }
+#frc46_token = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "feat/fvm-m2" }
 
 #fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
 #fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
@@ -92,6 +92,9 @@ fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
 fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
 fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
 fvm_actor_utils = { path = "../filecoin-actor-utils/fvm_actor_utils" }
+frc42_dispatch = { path = "../filecoin-actor-utils/frc42_dispatch" }
+frc46_token = { path = "../filecoin-actor-utils/frc46_token" }
+
 
 [profile.wasm]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,16 +57,17 @@ members = [
 ]
 
 [patch.crates-io]
-#frc42_dispatch = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "feat/fvm-m2" }
-#frc46_token = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "feat/fvm-m2" }
+frc42_dispatch = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "raulk/events" }
+frc46_token = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "raulk/events" }
+fvm_actor_utils = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "raulk/events" }
 
-#fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
-#fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
-#fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
-#fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
-#fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
-#fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
-#fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
 
 ## Uncomment when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
@@ -84,17 +85,13 @@ members = [
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
 ## (Valid once FVM modules are published to crates.io)
 # [patch.crates-io]
-fvm_shared = { path = "../ref-fvm/shared" }
-fvm_sdk = { path = "../ref-fvm/sdk" }
-fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
-fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
-fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
-fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
-fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
-fvm_actor_utils = { path = "../filecoin-actor-utils/fvm_actor_utils" }
-frc42_dispatch = { path = "../filecoin-actor-utils/frc42_dispatch" }
-frc46_token = { path = "../filecoin-actor-utils/frc46_token" }
-
+# fvm_shared = { path = "../ref-fvm/shared" }
+# fvm_sdk = { path = "../ref-fvm/sdk" }
+# fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
+# fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
+# fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
+# fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
+# fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
 
 [profile.wasm]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,15 +59,14 @@ members = [
 [patch.crates-io]
 frc42_dispatch = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "feat/fvm-m2" }
 frc46_token = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "feat/fvm-m2" }
-fvm_actor_utils = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "feat/fvm-m2" }
 
-#fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+#fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+#fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+#fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+#fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+#fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+#fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
 
 ## Uncomment when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
@@ -85,13 +84,14 @@ fvm_actor_utils = { git = "https://github.com/filecoin-project/filecoin-actor-ut
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
 ## (Valid once FVM modules are published to crates.io)
 # [patch.crates-io]
-# fvm_shared = { path = "../ref-fvm/shared" }
-# fvm_sdk = { path = "../ref-fvm/sdk" }
-# fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
-# fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
-# fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
-# fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
-# fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
+fvm_shared = { path = "../ref-fvm/shared" }
+fvm_sdk = { path = "../ref-fvm/sdk" }
+fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
+fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
+fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
+fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
+fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
+fvm_actor_utils = { path = "../filecoin-actor-utils/fvm_actor_utils" }
 
 [profile.wasm]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,17 +57,17 @@ members = [
 ]
 
 [patch.crates-io]
-frc42_dispatch = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "raulk/events" }
-frc46_token = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "raulk/events" }
-fvm_actor_utils = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "raulk/events" }
+frc42_dispatch = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "feat/fvm-m2" }
+frc46_token = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "feat/fvm-m2" }
+fvm_actor_utils = { git = "https://github.com/filecoin-project/filecoin-actor-utils", branch = "feat/fvm-m2" }
 
-fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
-fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
-fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
-fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
-fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
-fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
-fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm", branch = "raulk/events" }
+#fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm" }
+#fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm" }
 
 ## Uncomment when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "1.0.0"
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -23,7 +23,7 @@ fvm_actor_utils = "0.1.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.0"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 lazy_static = "1.4.0"
 num-derive = "0.3.3"
 num-traits = "0.2.14"

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -390,15 +390,19 @@ where
         let res = self.rt.send(to, method, params.clone(), value.clone());
 
         let rec = match res {
-            Ok(bytes) => {
-                Receipt { exit_code: ExitCode::OK, return_data: bytes, gas_used: fake_gas_used }
-            }
+            Ok(bytes) => Receipt {
+                exit_code: ExitCode::OK,
+                return_data: bytes,
+                gas_used: fake_gas_used,
+                events_root: None,
+            },
             Err(ae) => {
                 info!("datacap messenger failed: {}", ae.msg());
                 Receipt {
                     exit_code: ae.exit_code(),
                     return_data: RawBytes::default(),
                     gas_used: fake_gas_used,
+                    events_root: None,
                 }
             }
         };

--- a/actors/eam/Cargo.toml
+++ b/actors/eam/Cargo.toml
@@ -24,7 +24,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.0"
 multihash = { version = "0.16.1", default-features = false }
 cid = "0.8.6"
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 hex-literal = "0.3.4"

--- a/actors/embryo/Cargo.toml
+++ b/actors/embryo/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fvm_sdk = { version = "3.0.0-alpha.10", optional = true }
-fvm_shared = { version = "3.0.0-alpha.10", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.11", optional = true }
+fvm_shared = { version = "3.0.0-alpha.11", optional = true }
 
 [features]
 fil-actor = ["fvm_sdk", "fvm_shared"]

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5"

--- a/actors/evm/src/interpreter/instructions/log.rs
+++ b/actors/evm/src/interpreter/instructions/log.rs
@@ -35,7 +35,7 @@ pub fn log(
         let entry = Entry {
             flags: Flags::FLAG_INDEXED_VALUE,
             key: (*key).to_owned(),
-            value: to_vec(&topic)?, // U256 serializes as a byte string.
+            value: to_vec(&topic)?.into(), // U256 serializes as a byte string.
         };
         entries.push(entry);
     }
@@ -46,7 +46,7 @@ pub fn log(
         let entry = Entry {
             flags: Flags::FLAG_INDEXED_VALUE,
             key: EVENT_DATA_KEY.to_owned(),
-            value: to_vec(&RawBytes::new(data))?,
+            value: to_vec(&RawBytes::new(data))?.into(),
         };
         entries.push(entry);
     }

--- a/actors/evm/src/interpreter/instructions/log.rs
+++ b/actors/evm/src/interpreter/instructions/log.rs
@@ -1,26 +1,57 @@
 use crate::interpreter::instructions::memory::get_memory_region;
+use fvm_ipld_encoding::to_vec;
+use fvm_shared::event::{Entry, Flags};
 use {
     crate::interpreter::{ExecutionState, StatusCode, System},
     fil_actors_runtime::runtime::Runtime,
 };
 
+/// The event key for the Ethereum log data.
+const EVENT_DATA_KEY: &str = "data";
+
+/// The event keys for the Ethereum log topics.
+const EVENT_TOPIC_KEYS: &[&str] = &["topic1", "topic2", "topic3", "topic4"];
+
 #[inline]
 pub fn log(
     state: &mut ExecutionState,
-    _system: &System<impl Runtime>,
+    system: &System<impl Runtime>,
     num_topics: usize,
 ) -> Result<(), StatusCode> {
-    // Handle the payload.
+    // Handle the data.
+    // Passing in a zero-sized memory region omits the data key entirely.
+    // LOG0 + a zero-sized memory region emits an event with no entries whatsoever. In this case,
+    // the FVM will record a hollow event carrying only the emitter actor ID.
     let mem_index = state.stack.pop();
     let size = state.stack.pop();
-    let payload = get_memory_region(&mut state.memory, mem_index, size)
+    let region = get_memory_region(&mut state.memory, mem_index, size)
         .map_err(|_| StatusCode::InvalidMemoryAccess)?;
 
-    // Extract the topics.
-    let topics: Vec<_> = (0..num_topics).map(|_| state.stack.pop()).collect();
-    for _ in 0..num_topics {
-        state.stack.pop();
+    // Extract the topics. Prefer to allocate an extra item than to incur in the cost of a
+    // decision based on the size of the data.
+    let mut entries: Vec<Entry> = Vec::with_capacity(num_topics + 1);
+    for key in EVENT_TOPIC_KEYS.iter().take(num_topics) {
+        let topic = state.stack.pop();
+        let entry = Entry {
+            flags: Flags::FLAG_INDEXED_VALUE,
+            key: (*key).to_owned(),
+            value: to_vec(&topic)?,
+        };
+        entries.push(entry);
     }
+
+    // Skip adding the data if it's zero-sized.
+    if let Some(r) = region {
+        let data = state.memory[r.offset..r.offset + r.size.get()].to_vec();
+        let entry = Entry {
+            flags: Flags::FLAG_INDEXED_VALUE,
+            key: EVENT_DATA_KEY.to_owned(),
+            value: to_vec(&data)?,
+        };
+        entries.push(entry);
+    }
+
+    system.rt.emit_event(&entries.into())?;
 
     Ok(())
 }

--- a/actors/evm/src/interpreter/instructions/log.rs
+++ b/actors/evm/src/interpreter/instructions/log.rs
@@ -1,5 +1,5 @@
 use crate::interpreter::instructions::memory::get_memory_region;
-use fvm_ipld_encoding::{to_vec, RawBytes};
+use fvm_ipld_encoding::{to_vec, BytesSer, RawBytes};
 use fvm_shared::event::{Entry, Flags};
 use {
     crate::interpreter::{ExecutionState, StatusCode, System},
@@ -46,7 +46,7 @@ pub fn log(
         let entry = Entry {
             flags: Flags::FLAG_INDEXED_VALUE,
             key: EVENT_DATA_KEY.to_owned(),
-            value: to_vec(&RawBytes::new(data))?.into(),
+            value: RawBytes::serialize(BytesSer(&data))?,
         };
         entries.push(entry);
     }

--- a/actors/evm/src/interpreter/instructions/log.rs
+++ b/actors/evm/src/interpreter/instructions/log.rs
@@ -1,5 +1,5 @@
 use crate::interpreter::instructions::memory::get_memory_region;
-use fvm_ipld_encoding::to_vec;
+use fvm_ipld_encoding::{to_vec, RawBytes};
 use fvm_shared::event::{Entry, Flags};
 use {
     crate::interpreter::{ExecutionState, StatusCode, System},
@@ -35,7 +35,7 @@ pub fn log(
         let entry = Entry {
             flags: Flags::FLAG_INDEXED_VALUE,
             key: (*key).to_owned(),
-            value: to_vec(&topic)?,
+            value: to_vec(&topic)?, // U256 serializes as a byte string.
         };
         entries.push(entry);
     }
@@ -46,7 +46,7 @@ pub fn log(
         let entry = Entry {
             flags: Flags::FLAG_INDEXED_VALUE,
             key: EVENT_DATA_KEY.to_owned(),
-            value: to_vec(&data)?,
+            value: to_vec(&RawBytes::new(data))?,
         };
         entries.push(entry);
     }

--- a/actors/evm/src/interpreter/instructions/log.rs
+++ b/actors/evm/src/interpreter/instructions/log.rs
@@ -1,28 +1,26 @@
+use crate::interpreter::instructions::memory::get_memory_region;
 use {
     crate::interpreter::{ExecutionState, StatusCode, System},
     fil_actors_runtime::runtime::Runtime,
 };
 
-#[cfg(debug_assertions)]
-pub fn log(
-    _state: &mut ExecutionState,
-    _system: &System<impl Runtime>,
-    _num_topics: usize,
-) -> Result<(), StatusCode> {
-    todo!("unimplemented");
-}
-
-#[cfg(not(debug_assertions))]
 #[inline]
 pub fn log(
     state: &mut ExecutionState,
     _system: &System<impl Runtime>,
     num_topics: usize,
 ) -> Result<(), StatusCode> {
-    // TODO: Right now, we just drop everything. But we implement this in production anyways so
-    // things work.
+    // Handle the payload.
+    let mem_index = state.stack.pop();
+    let size = state.stack.pop();
+    let payload = get_memory_region(&mut state.memory, mem_index, size)
+        .map_err(|_| StatusCode::InvalidMemoryAccess)?;
+
+    // Extract the topics.
+    let topics: Vec<_> = (0..num_topics).map(|_| state.stack.pop()).collect();
     for _ in 0..num_topics {
         state.stack.pop();
     }
+
     Ok(())
 }

--- a/actors/evm/tests/events.rs
+++ b/actors/evm/tests/events.rs
@@ -1,0 +1,132 @@
+mod asm;
+
+use fil_actor_evm as evm;
+use fvm_ipld_encoding::{to_vec, RawBytes};
+use fvm_shared::event::{ActorEvent, Entry, Flags};
+
+mod util;
+
+#[allow(dead_code)]
+pub fn events_contract() -> Vec<u8> {
+    let init = r#"
+"#;
+    let body = r#"
+# method dispatch:
+# - 0x00000000 -> log_zero_data
+# - 0x00000001 -> log_zero_nodata
+# - 0x00000002 -> log_four_data
+
+%dispatch_begin()
+%dispatch(0x00, log_zero_data)
+%dispatch(0x01, log_zero_nodata)
+%dispatch(0x02, log_four_data)
+%dispatch_end()
+
+#### log a zero topic event with data
+log_zero_data:
+jumpdest
+push8 0x1122334455667788
+push1 0x00
+mstore
+push1 0x08
+push1 0x18 ## index 24 into memory as mstore writes a full word
+log0
+push1 0x00
+push1 0x00
+return
+
+#### log a zero topic event with no data
+log_zero_nodata:
+jumpdest
+push1 0x00
+push1 0x00
+log0
+push1 0x00
+push1 0x00
+return
+
+#### log a four topic event with data
+log_four_data:
+jumpdest
+push8 0x1122334455667788
+push1 0x00
+mstore
+push4 0x4444
+push3 0x3333
+push2 0x2222
+push2 0x1111
+push1 0x08
+push1 0x18 ## index 24 into memory as mstore writes a full word
+log4
+push1 0x00
+push1 0x00
+return
+
+"#;
+
+    asm::new_contract("events", init, body).unwrap()
+}
+
+#[test]
+fn test_events() {
+    let contract = events_contract();
+
+    let mut rt = util::construct_and_verify(contract);
+
+    // log zero with data
+    let mut contract_params = vec![0u8; 32];
+    rt.expect_emitted_event(ActorEvent {
+        entries: vec![Entry {
+            flags: Flags::FLAG_INDEXED_VALUE,
+            key: "data".to_string(),
+            value: to_vec(&RawBytes::from(
+                [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88].to_vec(),
+            ))
+            .unwrap(),
+        }],
+    });
+    util::invoke_contract(&mut rt, &contract_params);
+
+    // log zero without data
+    contract_params[3] = 0x01;
+    rt.expect_emitted_event(ActorEvent { entries: vec![] });
+    util::invoke_contract(&mut rt, &contract_params);
+
+    // log four with data
+    contract_params[3] = 0x02;
+    rt.expect_emitted_event(ActorEvent {
+        entries: vec![
+            Entry {
+                flags: Flags::FLAG_INDEXED_VALUE,
+                key: "topic1".to_string(),
+                value: to_vec(&RawBytes::from([0x11, 0x11].to_vec())).unwrap(),
+            },
+            Entry {
+                flags: Flags::FLAG_INDEXED_VALUE,
+                key: "topic2".to_string(),
+                value: to_vec(&RawBytes::from([0x22, 0x22].to_vec())).unwrap(),
+            },
+            Entry {
+                flags: Flags::FLAG_INDEXED_VALUE,
+                key: "topic3".to_string(),
+                value: to_vec(&RawBytes::from([0x33, 0x33].to_vec())).unwrap(),
+            },
+            Entry {
+                flags: Flags::FLAG_INDEXED_VALUE,
+                key: "topic4".to_string(),
+                value: to_vec(&RawBytes::from([0x44, 0x44].to_vec())).unwrap(),
+            },
+            Entry {
+                flags: Flags::FLAG_INDEXED_VALUE,
+                key: "data".to_string(),
+                value: to_vec(&RawBytes::from(
+                    [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88].to_vec(),
+                ))
+                .unwrap(),
+            },
+        ],
+    });
+    util::invoke_contract(&mut rt, &contract_params);
+
+    rt.verify();
+}

--- a/actors/evm/tests/events.rs
+++ b/actors/evm/tests/events.rs
@@ -81,7 +81,8 @@ fn test_events() {
             value: to_vec(&RawBytes::from(
                 [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88].to_vec(),
             ))
-            .unwrap(),
+            .unwrap()
+            .into(),
         }],
     });
     util::invoke_contract(&mut rt, &contract_params);
@@ -98,22 +99,22 @@ fn test_events() {
             Entry {
                 flags: Flags::FLAG_INDEXED_VALUE,
                 key: "topic1".to_string(),
-                value: to_vec(&RawBytes::from([0x11, 0x11].to_vec())).unwrap(),
+                value: to_vec(&RawBytes::from([0x11, 0x11].to_vec())).unwrap().into(),
             },
             Entry {
                 flags: Flags::FLAG_INDEXED_VALUE,
                 key: "topic2".to_string(),
-                value: to_vec(&RawBytes::from([0x22, 0x22].to_vec())).unwrap(),
+                value: to_vec(&RawBytes::from([0x22, 0x22].to_vec())).unwrap().into(),
             },
             Entry {
                 flags: Flags::FLAG_INDEXED_VALUE,
                 key: "topic3".to_string(),
-                value: to_vec(&RawBytes::from([0x33, 0x33].to_vec())).unwrap(),
+                value: to_vec(&RawBytes::from([0x33, 0x33].to_vec())).unwrap().into(),
             },
             Entry {
                 flags: Flags::FLAG_INDEXED_VALUE,
                 key: "topic4".to_string(),
-                value: to_vec(&RawBytes::from([0x44, 0x44].to_vec())).unwrap(),
+                value: to_vec(&RawBytes::from([0x44, 0x44].to_vec())).unwrap().into(),
             },
             Entry {
                 flags: Flags::FLAG_INDEXED_VALUE,
@@ -121,7 +122,8 @@ fn test_events() {
                 value: to_vec(&RawBytes::from(
                     [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88].to_vec(),
                 ))
-                .unwrap(),
+                .unwrap()
+                .into(),
             },
         ],
     });

--- a/actors/evm/tests/events.rs
+++ b/actors/evm/tests/events.rs
@@ -1,6 +1,5 @@
 mod asm;
 
-use fil_actor_evm as evm;
 use fvm_ipld_encoding::{to_vec, RawBytes};
 use fvm_shared::event::{ActorEvent, Entry, Flags};
 

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -23,7 +23,7 @@ fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.0"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 integer-encoding = { version = "3.0.3", default-features = false }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 log = "0.4.14"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_amt = { version = "0.5.0", features = ["go-interop"] }
 fvm_ipld_hamt = "0.6.1"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -22,7 +22,7 @@ frc42_dispatch = "1.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.0"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 num-derive = "0.3.3"

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 fvm_ipld_encoding = "0.3.0"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -23,7 +23,7 @@ frc46_token = "1.1.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.0"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 lazy_static = "1.4.0"
 log = "0.4.14"
 num-derive = "0.3.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 [dependencies]
 fvm_ipld_hamt = "0.6.1"
 fvm_ipld_amt = { version = "0.5.0", features = ["go-interop"] }
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -34,7 +34,7 @@ paste = "1.0.9"
 sha2 = "0.10"
 
 # fil-actor
-fvm_sdk = { version = "3.0.0-alpha.10", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.11", optional = true }
 
 # test_util
 rand = { version = "0.8.5", default-features = false, optional = true }

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -13,6 +13,7 @@ use fvm_shared::crypto::signature::{
 };
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
+use fvm_shared::event::ActorEvent;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
 use fvm_shared::sector::{
@@ -419,6 +420,11 @@ where
 
     fn tipset_cid(&self, epoch: i64) -> Option<Cid> {
         fvm::network::tipset_cid(epoch).ok()
+    }
+
+    fn emit_event(&self, event: &ActorEvent) -> Result<(), ActorError> {
+        fvm::event::emit_event(event)
+            .map_err(|e| actor_error!(assertion_failed; "failed to emit event: {}", e))
     }
 }
 

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -32,7 +32,7 @@ use crate::runtime::{
     ActorCode, ConsensusFault, DomainSeparationTag, MessageInfo, Policy, Primitives, RuntimePolicy,
     Verifier,
 };
-use crate::{actor_error, ActorError, Runtime};
+use crate::{actor_error, ActorError, AsActorError, Runtime};
 
 /// A runtime that bridges to the FVM environment through the FVM SDK.
 pub struct FvmRuntime<B = ActorBlockstore> {
@@ -424,7 +424,7 @@ where
 
     fn emit_event(&self, event: &ActorEvent) -> Result<(), ActorError> {
         fvm::event::emit_event(event)
-            .map_err(|e| actor_error!(assertion_failed; "failed to emit event: {}", e))
+            .context_code(ExitCode::USR_ASSERTION_FAILED, "failed to emit event")
     }
 }
 

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -12,6 +12,7 @@ use fvm_shared::crypto::signature::{
     Signature, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
 };
 use fvm_shared::econ::TokenAmount;
+use fvm_shared::event::ActorEvent;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
 use fvm_shared::sector::{
@@ -240,6 +241,8 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
 
     /// The hash of on of the last 256 blocks
     fn tipset_cid(&self, epoch: i64) -> Option<Cid>;
+
+    fn emit_event(&self, event: &ActorEvent) -> Result<(), ActorError>;
 }
 
 /// Message information available to the actor about executing message.

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -242,6 +242,7 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// The hash of on of the last 256 blocks
     fn tipset_cid(&self, epoch: i64) -> Option<Cid>;
 
+    /// Emits an event denoting that something externally noteworthy has ocurred.
     fn emit_event(&self, event: &ActorEvent) -> Result<(), ActorError>;
 }
 

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -42,6 +42,7 @@ use crate::runtime::{
     Verifier, EMPTY_ARR_CID,
 };
 use crate::{actor_error, ActorError};
+use fvm_shared::event::ActorEvent;
 use libsecp256k1::{recover, Message, RecoveryId, Signature as EcsdaSignature};
 
 lazy_static::lazy_static! {
@@ -188,6 +189,7 @@ pub struct Expectations {
     pub expect_replica_verify: Option<ExpectReplicaVerify>,
     pub expect_gas_charge: VecDeque<i64>,
     pub expect_gas_available: VecDeque<u64>,
+    pub expect_emitted_events: VecDeque<ActorEvent>,
 }
 
 impl Expectations {
@@ -750,6 +752,11 @@ impl<BS: Blockstore> MockRuntime<BS> {
         self.expectations.borrow_mut().expect_gas_available.push_back(value);
     }
 
+    #[allow(dead_code)]
+    pub fn expect_emitted_event(&mut self, event: ActorEvent) {
+        self.expectations.borrow_mut().expect_emitted_events.push_back(event)
+    }
+
     ///// Private helpers /////
 
     fn require_in_call(&self) {
@@ -1242,6 +1249,19 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         );
 
         Ok(expected.out)
+    }
+
+    fn emit_event(&self, event: &ActorEvent) -> Result<(), ActorError> {
+        let expected = self
+            .expectations
+            .borrow_mut()
+            .expect_emitted_events
+            .pop_front()
+            .expect("unexpected call to emit_evit");
+
+        assert_eq!(*event, expected);
+
+        Ok(())
     }
 }
 

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -289,6 +289,11 @@ impl Expectations {
             "expect_gas_charge {:?}, not received",
             self.expect_gas_available
         );
+        assert!(
+            self.expect_emitted_events.is_empty(),
+            "expect_emitted_events {:?}, not received",
+            self.expect_emitted_events
+        );
     }
 }
 

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -27,7 +27,7 @@ fil_actor_reward = { version = "10.0.0-alpha.1", path = "../actors/reward"}
 fil_actor_system = { version = "10.0.0-alpha.1", path = "../actors/system"}
 fil_actor_init = { version = "10.0.0-alpha.1", path = "../actors/init"}
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../runtime"}
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 fvm_ipld_encoding = "0.3.0"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -37,7 +37,7 @@ fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_blockstore = { version = "0.1.1", default-features = false }
 fvm_ipld_encoding = { version = "0.3.0", default-features = false }
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.10", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.11", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 lazy_static = "1.4.0"

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -47,6 +47,7 @@ use fvm_shared::crypto::signature::{
 };
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
+use fvm_shared::event::ActorEvent;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::Randomness;
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
@@ -1062,6 +1063,11 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
 
     fn tipset_cid(&self, _epoch: i64) -> Option<Cid> {
         Some(Cid::new_v1(IPLD_RAW, Multihash::wrap(0, b"faketipset").unwrap()))
+    }
+
+    // TODO No support for events yet.
+    fn emit_event(&self, _event: &ActorEvent) -> Result<(), ActorError> {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/filecoin-project/ref-fvm/issues/1048.

---

* Adds support for `LOG{0..4}` EVM opcodes by emitting actor events.
* Adds a unit test for the above.

## TODO

Prior to merging:

- [x] Remove ref-fvm patches once https://github.com/filecoin-project/ref-fvm/pull/1049 is merged and released.