### PR TITLE
fix: correctly handle out-of-bounds cases when copying memory

### DIFF
--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -52,9 +52,7 @@ pub fn extcodecopy(
     let bytecode =
         get_evm_bytecode_cid(system.rt, addr).and_then(|cid| get_evm_bytecode(system.rt, &cid))?;
 
-    copy_to_memory(&mut state.memory, dest_offset, size, data_offset, bytecode.as_slice())?;
-
-    Ok(())
+    copy_to_memory(&mut state.memory, dest_offset, size, data_offset, bytecode.as_slice(), true)
 }
 
 pub fn get_evm_bytecode_cid(rt: &impl Runtime, addr: U256) -> Result<Cid, StatusCode> {


### PR DESCRIPTION
- CALL: truncates the return value, but doesn't zero fill.
- CALLDATA, EXTCODECOPY, CODECOPY: treat input as if it were followed by infinite zeros.
- RETURNDATACOPY: explicitly forbids out-of-bounds reads.

We might be able to change the behavior of EXTCODECOPY and CODECOPY to match RETURNDATACOPY, but we _can't_ change CALLDATA as solidity abuses this feature for zeroing memory. So we're just going to match what the EVM does because it's safer (and because we need to implement that behavior _anyways_ for CALLDATA).

fixes https://github.com/filecoin-project/ref-fvm/issues/1021
fixes https://github.com/filecoin-project/ref-fvm/issues/1024