### PR TITLE
v8: generate bundles for the Wallaby testnet.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       CACHE_SKIP_SAVE: ${{ matrix.push == '' || matrix.push == 'false' }}
     strategy:
       matrix:
-        network: [ 'mainnet', 'caterpillarnet', 'butterflynet', 'calibrationnet', 'devnet', 'testing', 'testing-fake-proofs' ]
+        network: [ 'mainnet', 'caterpillarnet', 'butterflynet', 'wallaby', 'calibrationnet', 'devnet', 'testing', 'testing-fake-proofs' ]
     steps:
     - name: Checking out
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       CACHE_SKIP_SAVE: ${{ matrix.push == '' || matrix.push == 'false' }}
     strategy:
       matrix:
-        network: [ 'mainnet', 'caterpillarnet', 'butterflynet', 'calibrationnet', 'devnet', 'testing', 'testing-fake-proofs' ]
+        network: [ 'mainnet', 'caterpillarnet', 'butterflynet', 'wallaby', 'calibrationnet', 'devnet', 'testing', 'testing-fake-proofs' ]
     steps:
     - name: Checking out
       uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ default = [] ## translates to mainnet
 mainnet = []
 caterpillarnet = []
 butterflynet = []
+wallaby = []
 calibrationnet = []
 devnet = []
 testing = []

--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,16 @@ bundle: deps-build
 	cargo run -- -o output/builtin-actors.car
 
 # Create all canonical network bundles
-all-bundles: bundle-mainnet bundle-caterpillarnet bundle-butterflynet bundle-calibrationnet bundle-devnet bundle-testing bundle-testing
+all-bundles: bundle-mainnet bundle-caterpillarnet bundle-butterflynet bundle-wallaby bundle-calibrationnet bundle-devnet bundle-testing bundle-testing
 
 bundle-mainnet: deps-build
 	BUILD_FIL_NETWORK=mainnet cargo run -- -o output/builtin-actors-mainnet.car
 
 bundle-caterpillarnet: deps-build
 	BUILD_FIL_NETWORK=caterpillarnet cargo run -- -o output/builtin-actors-caterpillarnet.car
+
+bundle-wallaby: deps-build
+	BUILD_FIL_NETWORK=wallaby cargo run -- -o output/builtin-actors-wallaby.car
 
 bundle-butterflynet: deps-build
 	BUILD_FIL_NETWORK=butterflynet cargo run -- -o output/builtin-actors-butterflynet.car

--- a/build.rs
+++ b/build.rs
@@ -39,6 +39,8 @@ fn network_name() -> String {
         Some("caterpillarnet")
     } else if cfg!(feature = "butterflynet") {
         Some("butterflynet")
+    } else if cfg!(feature = "wallaby") {
+        Some("wallaby")
     } else if cfg!(feature = "calibrationnet") {
         Some("calibrationnet")
     } else if cfg!(feature = "devnet") {

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -12,6 +12,7 @@ static NETWORKS: &[(&str, &[&str])] = &[
         ],
     ),
     ("butterflynet", &["sector-512m", "sector-32g", "sector-64g", "min-power-2g"]),
+    ("wallaby", &["sector-512m", "sector-32g", "sector-64g", "min-power-16g", "short-precommit"]),
     ("calibrationnet", &["sector-32g", "sector-64g", "min-power-32g"]),
     ("devnet", &["sector-2k", "sector-8m", "small-deals", "short-precommit", "min-power-2k"]),
     (


### PR DESCRIPTION
This testnet was created after the last and only release of v8 bundles (v8.0.0), but there's no reason it shouldn't be able to run v8 actors.