### PR TITLE
Account actor: Deprecate AuthenticateMessage

### DIFF
--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -32,7 +32,8 @@ fil_actors_runtime::wasm_trampoline!(Actor);
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
     PubkeyAddress = 2,
-    AuthenticateMessage = 3,
+    // Deprecated in v10
+    // AuthenticateMessage = 3,
     AuthenticateMessageExported = frc42_dispatch::method_hash!("AuthenticateMessage"),
     UniversalReceiverHook = frc42_dispatch::method_hash!("Receive"),
 }
@@ -121,7 +122,7 @@ impl ActorCode for Actor {
                 let addr = Self::pubkey_address(rt)?;
                 Ok(RawBytes::serialize(addr)?)
             }
-            Some(Method::AuthenticateMessage) | Some(Method::AuthenticateMessageExported) => {
+            Some(Method::AuthenticateMessageExported) => {
                 Self::authenticate_message(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }

--- a/actors/account/tests/account_actor_test.rs
+++ b/actors/account/tests/account_actor_test.rs
@@ -122,14 +122,6 @@ fn authenticate_message() {
     );
     rt.verify();
 
-    // Invalid caller of internal method number
-    rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1000));
-    expect_abort_contains_message(
-        ExitCode::USR_FORBIDDEN,
-        "must be built-in",
-        rt.call::<AccountActor>(Method::AuthenticateMessage as MethodNum, &params),
-    );
-
     // Ok to call exported method number
     rt.expect_validate_caller_any();
     rt.expect_verify_signature(ExpectedVerifySig {


### PR DESCRIPTION
Only builtin actors call this method in v9 actors, and in v10 all uses have been updated to call the exported method. We can sunset this method.