### PR TITLE
Miner: Export several more methods

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -130,6 +130,7 @@ pub enum Method {
     WithdrawBalanceExported = frc42_dispatch::method_hash!("WithdrawBalance"),
     ChangeMultiaddrsExported = frc42_dispatch::method_hash!("ChangeMultiaddrs"),
     ConfirmUpdateWorkerKeyExported = frc42_dispatch::method_hash!("ConfirmUpdateWorkerKey"),
+    RepayDebtExported = frc42_dispatch::method_hash!("RepayDebt"),
     ChangeBenificiaryExported = frc42_dispatch::method_hash!("ChangeBeneficiary"),
     GetBeneficiaryExported = frc42_dispatch::method_hash!("GetBeneficiary"),
     GetOwnerExported = frc42_dispatch::method_hash!("GetOwner"),
@@ -5018,7 +5019,7 @@ impl ActorCode for Actor {
                 Self::confirm_update_worker_key(rt)?;
                 Ok(RawBytes::default())
             }
-            Some(Method::RepayDebt) => {
+            Some(Method::RepayDebt) | Some(Method::RepayDebtExported) => {
                 Self::repay_debt(rt)?;
                 Ok(RawBytes::default())
             }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -131,6 +131,7 @@ pub enum Method {
     ChangeMultiaddrsExported = frc42_dispatch::method_hash!("ChangeMultiaddrs"),
     ConfirmUpdateWorkerKeyExported = frc42_dispatch::method_hash!("ConfirmUpdateWorkerKey"),
     RepayDebtExported = frc42_dispatch::method_hash!("RepayDebt"),
+    ChangeOwnerAddressExported = frc42_dispatch::method_hash!("ChangeOwnerAddress"),
     ChangeBenificiaryExported = frc42_dispatch::method_hash!("ChangeBeneficiary"),
     GetBeneficiaryExported = frc42_dispatch::method_hash!("GetBeneficiary"),
     GetOwnerExported = frc42_dispatch::method_hash!("GetOwner"),
@@ -5023,7 +5024,7 @@ impl ActorCode for Actor {
                 Self::repay_debt(rt)?;
                 Ok(RawBytes::default())
             }
-            Some(Method::ChangeOwnerAddress) => {
+            Some(Method::ChangeOwnerAddress) | Some(Method::ChangeOwnerAddressExported) => {
                 Self::change_owner_address(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -128,6 +128,7 @@ pub enum Method {
     ChangeWorkerAddressExported = frc42_dispatch::method_hash!("ChangeWorkerAddress"),
     ChangePeerIDExported = frc42_dispatch::method_hash!("ChangePeerID"),
     WithdrawBalanceExported = frc42_dispatch::method_hash!("WithdrawBalance"),
+    ChangeMultiaddrsExported = frc42_dispatch::method_hash!("ChangeMultiaddrs"),
     ChangeBenificiaryExported = frc42_dispatch::method_hash!("ChangeBeneficiary"),
     GetBeneficiaryExported = frc42_dispatch::method_hash!("GetBeneficiary"),
     GetOwnerExported = frc42_dispatch::method_hash!("GetOwner"),
@@ -5000,7 +5001,7 @@ impl ActorCode for Actor {
                 Self::confirm_sector_proofs_valid(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            Some(Method::ChangeMultiaddrs) => {
+            Some(Method::ChangeMultiaddrs) | Some(Method::ChangeMultiaddrsExported) => {
                 Self::change_multiaddresses(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -129,6 +129,7 @@ pub enum Method {
     ChangePeerIDExported = frc42_dispatch::method_hash!("ChangePeerID"),
     WithdrawBalanceExported = frc42_dispatch::method_hash!("WithdrawBalance"),
     ChangeMultiaddrsExported = frc42_dispatch::method_hash!("ChangeMultiaddrs"),
+    ConfirmUpdateWorkerKeyExported = frc42_dispatch::method_hash!("ConfirmUpdateWorkerKey"),
     ChangeBenificiaryExported = frc42_dispatch::method_hash!("ChangeBeneficiary"),
     GetBeneficiaryExported = frc42_dispatch::method_hash!("GetBeneficiary"),
     GetOwnerExported = frc42_dispatch::method_hash!("GetOwner"),
@@ -5013,7 +5014,7 @@ impl ActorCode for Actor {
                 Self::compact_sector_numbers(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            Some(Method::ConfirmUpdateWorkerKey) => {
+            Some(Method::ConfirmUpdateWorkerKey) | Some(Method::ConfirmUpdateWorkerKeyExported) => {
                 Self::confirm_update_worker_key(rt)?;
                 Ok(RawBytes::default())
             }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -127,6 +127,7 @@ pub enum Method {
     // Method numbers derived from FRC-0042 standards
     ChangeWorkerAddressExported = frc42_dispatch::method_hash!("ChangeWorkerAddress"),
     ChangePeerIDExported = frc42_dispatch::method_hash!("ChangePeerID"),
+    WithdrawBalanceExported = frc42_dispatch::method_hash!("WithdrawBalance"),
     ChangeBenificiaryExported = frc42_dispatch::method_hash!("ChangeBeneficiary"),
     GetBeneficiaryExported = frc42_dispatch::method_hash!("GetBeneficiary"),
     GetOwnerExported = frc42_dispatch::method_hash!("GetOwner"),
@@ -4991,7 +4992,7 @@ impl ActorCode for Actor {
                 Self::report_consensus_fault(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            Some(Method::WithdrawBalance) => {
+            Some(Method::WithdrawBalance) | Some(Method::WithdrawBalanceExported) => {
                 let res = Self::withdraw_balance(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::serialize(&res)?)
             }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -126,6 +126,7 @@ pub enum Method {
     ExtendSectorExpiration2 = 32,
     // Method numbers derived from FRC-0042 standards
     ChangeWorkerAddressExported = frc42_dispatch::method_hash!("ChangeWorkerAddress"),
+    ChangePeerIDExported = frc42_dispatch::method_hash!("ChangePeerID"),
     ChangeBenificiaryExported = frc42_dispatch::method_hash!("ChangeBeneficiary"),
     GetBeneficiaryExported = frc42_dispatch::method_hash!("GetBeneficiary"),
     GetOwnerExported = frc42_dispatch::method_hash!("GetOwner"),
@@ -4942,7 +4943,7 @@ impl ActorCode for Actor {
                 Self::change_worker_address(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            Some(Method::ChangePeerID) => {
+            Some(Method::ChangePeerID) | Some(Method::ChangePeerIDExported) => {
                 Self::change_peer_id(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -125,6 +125,7 @@ pub enum Method {
     GetBeneficiary = 31,
     ExtendSectorExpiration2 = 32,
     // Method numbers derived from FRC-0042 standards
+    ChangeWorkerAddressExported = frc42_dispatch::method_hash!("ChangeWorkerAddress"),
     ChangeBenificiaryExported = frc42_dispatch::method_hash!("ChangeBeneficiary"),
     GetBeneficiaryExported = frc42_dispatch::method_hash!("GetBeneficiary"),
     GetOwnerExported = frc42_dispatch::method_hash!("GetOwner"),
@@ -4937,7 +4938,7 @@ impl ActorCode for Actor {
                 let res = Self::control_addresses(rt)?;
                 Ok(RawBytes::serialize(&res)?)
             }
-            Some(Method::ChangeWorkerAddress) => {
+            Some(Method::ChangeWorkerAddress) | Some(Method::ChangeWorkerAddressExported) => {
                 Self::change_worker_address(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -112,7 +112,7 @@ pub enum Method {
     ChangeMultiaddrs = 18,
     CompactPartitions = 19,
     CompactSectorNumbers = 20,
-    ConfirmUpdateWorkerKey = 21,
+    ConfirmChangeWorkerAddress = 21,
     RepayDebt = 22,
     ChangeOwnerAddress = 23,
     DisputeWindowedPoSt = 24,
@@ -129,7 +129,7 @@ pub enum Method {
     ChangePeerIDExported = frc42_dispatch::method_hash!("ChangePeerID"),
     WithdrawBalanceExported = frc42_dispatch::method_hash!("WithdrawBalance"),
     ChangeMultiaddrsExported = frc42_dispatch::method_hash!("ChangeMultiaddrs"),
-    ConfirmUpdateWorkerKeyExported = frc42_dispatch::method_hash!("ConfirmUpdateWorkerKey"),
+    ConfirmChangeWorkerAddressExported = frc42_dispatch::method_hash!("ConfirmChangeWorkerAddress"),
     RepayDebtExported = frc42_dispatch::method_hash!("RepayDebt"),
     ChangeOwnerAddressExported = frc42_dispatch::method_hash!("ChangeOwnerAddress"),
     ChangeBenificiaryExported = frc42_dispatch::method_hash!("ChangeBeneficiary"),
@@ -353,7 +353,7 @@ impl Actor {
     }
 
     /// Triggers a worker address change if a change has been requested and its effective epoch has arrived.
-    fn confirm_update_worker_key(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    fn confirm_change_worker_address(rt: &mut impl Runtime) -> Result<(), ActorError> {
         rt.transaction(|state: &mut State, rt| {
             let mut info = get_miner_info(rt.store(), state)?;
 
@@ -5032,8 +5032,9 @@ impl ActorCode for Actor {
                 Self::compact_sector_numbers(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            Some(Method::ConfirmUpdateWorkerKey) | Some(Method::ConfirmUpdateWorkerKeyExported) => {
-                Self::confirm_update_worker_key(rt)?;
+            Some(Method::ConfirmChangeWorkerAddress)
+            | Some(Method::ConfirmChangeWorkerAddressExported) => {
+                Self::confirm_change_worker_address(rt)?;
                 Ok(RawBytes::default())
             }
             Some(Method::RepayDebt) | Some(Method::RepayDebtExported) => {

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -529,3 +529,14 @@ pub struct GetVestingFundsReturn {
 }
 
 impl Cbor for GetVestingFundsReturn {}
+
+#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize_tuple, Deserialize_tuple)]
+pub struct GetPeerIDReturn {
+    #[serde(with = "serde_bytes")]
+    pub peer_id: Vec<u8>,
+}
+
+#[derive(Debug, Default, PartialEq, Clone, Serialize_tuple, Deserialize_tuple)]
+pub struct GetMultiaddrsReturn {
+    pub multi_addrs: Vec<BytesDe>,
+}

--- a/actors/miner/tests/change_owner_address_test.rs
+++ b/actors/miner/tests/change_owner_address_test.rs
@@ -67,7 +67,7 @@ fn change_owner_address_restricted_correctly() {
     expect_abort_contains_message(
         ExitCode::USR_FORBIDDEN,
         "must be built-in",
-        rt.call::<Actor>(Method::ChangeOwnerAddress as u64, &params),
+        rt.call::<Actor>(Method::ChangeOwnerAddress as u64, params),
     );
 
     // can call the exported method

--- a/actors/miner/tests/change_peer_id_test.rs
+++ b/actors/miner/tests/change_peer_id_test.rs
@@ -1,4 +1,10 @@
-use fil_actors_runtime::test_utils::MockRuntime;
+use fil_actor_miner::{Actor, ChangePeerIDParams, Method, State};
+use fil_actors_runtime::runtime::Runtime;
+use fil_actors_runtime::test_utils::{
+    expect_abort_contains_message, make_identity_cid, MockRuntime,
+};
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::error::ExitCode;
 
 mod util;
 use util::*;
@@ -21,6 +27,40 @@ fn successfully_change_peer_id() {
     let (h, mut rt) = setup();
     let new_pid = b"cthulhu".to_vec();
     h.change_peer_id(&mut rt, new_pid);
+
+    h.check_state(&rt);
+}
+
+#[test]
+fn change_peer_id_restricted_correctly() {
+    let (h, mut rt) = setup();
+
+    let new_id = b"cthulhu".to_vec();
+
+    let params = RawBytes::serialize(ChangePeerIDParams { new_id: new_id.clone() }).unwrap();
+
+    rt.set_caller(make_identity_cid(b"1234"), h.worker);
+
+    // fail to call the unexported method
+
+    expect_abort_contains_message(
+        ExitCode::USR_FORBIDDEN,
+        "must be built-in",
+        rt.call::<Actor>(Method::ChangePeerID as u64, &params),
+    );
+
+    // call the exported method
+
+    rt.expect_validate_caller_addr(h.caller_addrs());
+
+    rt.call::<Actor>(Method::ChangePeerIDExported as u64, &params).unwrap();
+
+    let state: State = rt.get_state();
+    let info = state.get_info(rt.store()).unwrap();
+
+    assert_eq!(new_id, info.peer_id);
+
+    rt.verify();
 
     h.check_state(&rt);
 }

--- a/actors/miner/tests/change_worker_address_test.rs
+++ b/actors/miner/tests/change_worker_address_test.rs
@@ -51,7 +51,7 @@ fn successfully_change_only_the_worker_address() {
     rt.set_epoch(deadline.period_end());
     assert!(deadline.period_end() < effective_epoch);
 
-    h.confirm_update_worker_key(&mut rt).unwrap();
+    h.confirm_change_worker_address(&mut rt).unwrap();
 
     let info = h.get_info(&rt);
     assert_eq!(info.pending_worker_key.unwrap().new_worker, new_worker);
@@ -61,7 +61,7 @@ fn successfully_change_only_the_worker_address() {
     rt.set_epoch(effective_epoch);
 
     // enact worker change
-    h.confirm_update_worker_key(&mut rt).unwrap();
+    h.confirm_change_worker_address(&mut rt).unwrap();
 
     // assert address has changed
     let info = h.get_info(&rt);
@@ -129,12 +129,13 @@ fn change_and_confirm_worker_address_restricted_correctly() {
     expect_abort_contains_message(
         ExitCode::USR_FORBIDDEN,
         "must be built-in",
-        rt.call::<Actor>(Method::ConfirmUpdateWorkerKey as u64, &RawBytes::default()),
+        rt.call::<Actor>(Method::ConfirmChangeWorkerAddress as u64, &RawBytes::default()),
     );
 
     // call the exported method
     rt.expect_validate_caller_addr(vec![h.owner]);
-    rt.call::<Actor>(Method::ConfirmUpdateWorkerKeyExported as u64, &RawBytes::default()).unwrap();
+    rt.call::<Actor>(Method::ConfirmChangeWorkerAddressExported as u64, &RawBytes::default())
+        .unwrap();
     rt.verify();
 
     // assert address has changed
@@ -171,7 +172,7 @@ fn change_cannot_be_overridden() {
     assert_eq!(pending_worker_key.effective_at, effective_epoch);
 
     rt.set_epoch(effective_epoch);
-    h.confirm_update_worker_key(&mut rt).unwrap();
+    h.confirm_change_worker_address(&mut rt).unwrap();
 
     // assert original change is effected
     assert_eq!(new_worker_1, h.get_info(&rt).worker);
@@ -217,7 +218,7 @@ fn successfully_change_both_worker_and_control_addresses() {
 
     // set current epoch and update worker key
     rt.set_epoch(effective_epoch);
-    h.confirm_update_worker_key(&mut rt).unwrap();
+    h.confirm_change_worker_address(&mut rt).unwrap();
 
     // assert both worker and control addresses have changed
     let info = h.get_info(&rt);

--- a/actors/miner/tests/confirm_update_worker_key_test.rs
+++ b/actors/miner/tests/confirm_update_worker_key_test.rs
@@ -32,7 +32,7 @@ fn successfully_changes_the_worker_address() {
 
     // confirm at effective epoch
     rt.set_epoch(effective_epoch);
-    h.confirm_update_worker_key(&mut rt).unwrap();
+    h.confirm_change_worker_address(&mut rt).unwrap();
 
     let state: State = rt.get_state();
     let info = state.get_info(rt.store()).unwrap();
@@ -52,7 +52,7 @@ fn does_nothing_before_the_effective_date() {
 
     // confirm right before the effective epoch
     rt.set_epoch(effective_epoch - 1);
-    h.confirm_update_worker_key(&mut rt).unwrap();
+    h.confirm_change_worker_address(&mut rt).unwrap();
 
     let state: State = rt.get_state();
     let info = state.get_info(rt.store()).unwrap();
@@ -70,7 +70,7 @@ fn does_nothing_before_the_effective_date() {
 fn does_nothing_when_no_update_is_set() {
     let (h, mut rt) = setup();
 
-    h.confirm_update_worker_key(&mut rt).unwrap();
+    h.confirm_change_worker_address(&mut rt).unwrap();
 
     let state: State = rt.get_state();
     let info = state.get_info(rt.store()).unwrap();

--- a/actors/miner/tests/repay_debts.rs
+++ b/actors/miner/tests/repay_debts.rs
@@ -1,7 +1,12 @@
-use fil_actor_miner::locked_reward_from_reward;
+use fil_actor_miner::{locked_reward_from_reward, Actor, Method};
+use fil_actors_runtime::test_utils::{expect_abort_contains_message, make_identity_cid};
+use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
+use fvm_ipld_encoding::RawBytes;
 use fvm_shared::bigint::Zero;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
+use fvm_shared::METHOD_SEND;
 
 mod util;
 use util::*;
@@ -42,6 +47,52 @@ fn pay_debt_entirely_from_balance() {
 
     let debt_to_repay = 2 * &fee_debt;
     h.repay_debts(&mut rt, &debt_to_repay, &TokenAmount::zero(), &fee_debt).unwrap();
+
+    let st = h.get_state(&rt);
+    assert!(st.fee_debt.is_zero());
+    h.check_state(&rt);
+}
+
+#[test]
+fn repay_debt_restricted_correctly() {
+    let h = ActorHarness::new(PERIOD_OFFSET);
+    let mut rt = h.new_runtime();
+    h.construct_and_verify(&mut rt);
+
+    // introduce fee debt
+    let mut st = h.get_state(&rt);
+    let fee_debt: TokenAmount = 4 * &*BIG_BALANCE;
+    st.fee_debt = fee_debt.clone();
+    rt.replace_state(&st);
+
+    rt.set_caller(make_identity_cid(b"1234"), h.owner);
+
+    // fail to call the unexported method
+    expect_abort_contains_message(
+        ExitCode::USR_FORBIDDEN,
+        "must be built-in",
+        rt.call::<Actor>(Method::RepayDebt as u64, &RawBytes::default()),
+    );
+
+    // can call the exported method
+
+    rt.expect_validate_caller_addr(h.caller_addrs());
+
+    rt.add_balance(fee_debt.clone());
+    rt.set_received(fee_debt.clone());
+
+    rt.expect_send(
+        BURNT_FUNDS_ACTOR_ADDR,
+        METHOD_SEND,
+        RawBytes::default(),
+        fee_debt.clone(),
+        RawBytes::default(),
+        ExitCode::OK,
+    );
+
+    rt.call::<Actor>(Method::RepayDebtExported as u64, &RawBytes::default()).unwrap();
+
+    rt.verify();
 
     let st = h.get_state(&rt);
     assert!(st.fee_debt.is_zero());

--- a/actors/miner/tests/repay_debts.rs
+++ b/actors/miner/tests/repay_debts.rs
@@ -85,7 +85,7 @@ fn repay_debt_restricted_correctly() {
         BURNT_FUNDS_ACTOR_ADDR,
         METHOD_SEND,
         RawBytes::default(),
-        fee_debt.clone(),
+        fee_debt,
         RawBytes::default(),
         ExitCode::OK,
     );

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2260,10 +2260,10 @@ impl ActorHarness {
         ret
     }
 
-    pub fn confirm_update_worker_key(&self, rt: &mut MockRuntime) -> Result<(), ActorError> {
+    pub fn confirm_change_worker_address(&self, rt: &mut MockRuntime) -> Result<(), ActorError> {
         rt.expect_validate_caller_addr(vec![self.owner]);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.owner);
-        rt.call::<Actor>(Method::ConfirmUpdateWorkerKey as u64, &RawBytes::default())?;
+        rt.call::<Actor>(Method::ConfirmChangeWorkerAddress as u64, &RawBytes::default())?;
         rt.verify();
 
         Ok(())

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -23,13 +23,14 @@ use fil_actor_miner::{
     DeclareFaultsRecoveredParams, DeferredCronEventParams, DisputeWindowedPoStParams,
     ExpirationQueue, ExpirationSet, ExtendSectorExpiration2Params, ExtendSectorExpirationParams,
     FaultDeclaration, GetAvailableBalanceReturn, GetBeneficiaryReturn, GetControlAddressesReturn,
-    Method, MinerConstructorParams as ConstructorParams, MinerInfo, Partition,
-    PendingBeneficiaryChange, PoStPartition, PowerPair, PreCommitSectorBatchParams,
-    PreCommitSectorBatchParams2, PreCommitSectorParams, ProveCommitSectorParams,
-    RecoveryDeclaration, ReportConsensusFaultParams, SectorOnChainInfo, SectorPreCommitInfo,
-    SectorPreCommitOnChainInfo, Sectors, State, SubmitWindowedPoStParams, TerminateSectorsParams,
-    TerminationDeclaration, VestingFunds, WindowedPoSt, WithdrawBalanceParams,
-    WithdrawBalanceReturn, CRON_EVENT_PROVING_DEADLINE, SECTORS_AMT_BITWIDTH,
+    GetMultiaddrsReturn, GetPeerIDReturn, Method, MinerConstructorParams as ConstructorParams,
+    MinerInfo, Partition, PendingBeneficiaryChange, PoStPartition, PowerPair,
+    PreCommitSectorBatchParams, PreCommitSectorBatchParams2, PreCommitSectorParams,
+    ProveCommitSectorParams, RecoveryDeclaration, ReportConsensusFaultParams, SectorOnChainInfo,
+    SectorPreCommitInfo, SectorPreCommitOnChainInfo, Sectors, State, SubmitWindowedPoStParams,
+    TerminateSectorsParams, TerminationDeclaration, VestingFunds, WindowedPoSt,
+    WithdrawBalanceParams, WithdrawBalanceReturn, CRON_EVENT_PROVING_DEADLINE,
+    SECTORS_AMT_BITWIDTH,
 };
 use fil_actor_miner::{Method as MinerMethod, ProveCommitAggregateParams};
 use fil_actor_power::{
@@ -288,10 +289,15 @@ impl ActorHarness {
         expect_empty(result);
         rt.verify();
 
-        let state = self.get_state(rt);
-        let info = state.get_info(&rt.store).unwrap();
+        rt.expect_validate_caller_any();
+        let ret: GetPeerIDReturn = rt
+            .call::<Actor>(Method::GetPeerIDExported as u64, &RawBytes::default())
+            .unwrap()
+            .deserialize()
+            .unwrap();
+        rt.verify();
 
-        assert_eq!(new_id, info.peer_id);
+        assert_eq!(new_id, ret.peer_id);
     }
 
     pub fn set_peer_id_fail(&self, rt: &mut MockRuntime, new_id: Vec<u8>) {
@@ -318,10 +324,15 @@ impl ActorHarness {
         expect_empty(result);
         rt.verify();
 
-        let state = self.get_state(rt);
-        let info = state.get_info(&rt.store).unwrap();
+        rt.expect_validate_caller_any();
+        let ret: GetMultiaddrsReturn = rt
+            .call::<Actor>(Method::GetMultiaddrsExported as u64, &RawBytes::default())
+            .unwrap()
+            .deserialize()
+            .unwrap();
+        rt.verify();
 
-        assert_eq!(new_multiaddrs, info.multi_address);
+        assert_eq!(new_multiaddrs, ret.multi_addrs);
     }
 
     pub fn set_multiaddr_fail(&self, rt: &mut MockRuntime, new_multiaddrs: Vec<BytesDe>) {
@@ -2084,10 +2095,15 @@ impl ActorHarness {
             .unwrap();
         rt.verify();
 
-        let state: State = rt.get_state();
-        let info = state.get_info(rt.store()).unwrap();
+        rt.expect_validate_caller_any();
+        let ret: GetPeerIDReturn = rt
+            .call::<Actor>(Method::GetPeerIDExported as u64, &RawBytes::default())
+            .unwrap()
+            .deserialize()
+            .unwrap();
+        rt.verify();
 
-        assert_eq!(new_id, info.peer_id);
+        assert_eq!(new_id, ret.peer_id);
     }
 
     pub fn repay_debts(


### PR DESCRIPTION
As in the commits:

[Miner: Export ChangeWorkerAddress](https://github.com/filecoin-project/builtin-actors/commit/b945adda81a22aeb56ef8bb2fcafda1e1aa801b3)

[Miner: Export ChangePeerID](https://github.com/filecoin-project/builtin-actors/commit/935c69f4076475cc8b12f2b901e1831c2734ed6e)


 
[Miner: Export WithdrawBalance](https://github.com/filecoin-project/builtin-actors/commit/4812c4c04dc4af91fcbc87ccf281ebe852eb1afb)


 
[Miner: Export ChangeMultiaddrs](https://github.com/filecoin-project/builtin-actors/commit/26dd56193d28b06bdfa3b2fd9fca312526d8d38c)


 
[Miner: Export ConfirmUpdateWorkerKey](https://github.com/filecoin-project/builtin-actors/commit/1d54c88c45a95f7b07b43b91d511c887f71c85f7)

 
[Miner: Export RepayDebt](https://github.com/filecoin-project/builtin-actors/commit/573f45dcbb92e38942215137dbdb415a23241f4b)

 
[Miner: Export ChangeOwnerAddress](https://github.com/filecoin-project/builtin-actors/commit/34a9e8c827a3dda1f796816ce00cd80442a671ed)

[Miner: Add exported getters for PeerID & multiaddrs](https://github.com/filecoin-project/builtin-actors/commit/0084e8173209826e8972873c37b879a44a29e73c)

