### PR TITLE
EVM: perf experiments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ fvm_actor_utils = { git = "https://github.com/filecoin-project/filecoin-actor-ut
 inherits = "release"
 # This needs to be unwind, not abort, so that we can handle panics within our panic hook.
 panic = "unwind"
-overflow-checks = true
+overflow-checks = false
 lto = "thin"
 opt-level = "z"
 strip = true

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -65,14 +65,16 @@ impl Stack {
 
     #[inline]
     pub unsafe fn push(&mut self, v: U256) {
-        *self.sk.get_unchecked_mut(self.d) = v;
+        //*self.sk.get_unchecked_mut(self.d) = v;
+        self.sk[self.d] = v;
         self.d += 1;
     }
 
     #[inline]
     pub unsafe fn pop(&mut self) -> U256 {
         self.d -= 1;
-        *self.sk.get_unchecked(self.d)
+        //*self.sk.get_unchecked(self.d)
+        self.sk[self.d]
     }
 
     #[inline]


### PR DESCRIPTION
A couple of experiments trying to understand the safety/performance tradeoff.

Summary from running SimpleCoin:
- next prior to the grand refactoring: Gas Used: 2290168
- next after the grand refactoring: Gas Used: 2252508
- next with unsafe stack and overflow checks off: Gas Used: 2189956
- next with ovreflow checks and safe push/pop: Gas Used: 2235824

***NOTE***: Your gas numbers may vary depending on what version of ref-fvm you have sitting in your tree; be warned. My ref-fvm for the numbers above is at 32f4897368aaf411195d4073ea99c639fa2a165d from Friday Nov 18.