### PR TITLE
feat: avoid exposing the gas limit in the runtime

### DIFF
--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -94,10 +94,6 @@ impl MessageInfo for FvmMessage {
         fvm::message::value_received()
     }
 
-    fn gas_limit(&self) -> u64 {
-        fvm::message::gas_limit()
-    }
-
     fn gas_premium(&self) -> TokenAmount {
         fvm::message::gas_premium()
     }

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -265,9 +265,6 @@ pub trait MessageInfo {
     /// added to current_balance() before method invocation.
     fn value_received(&self) -> TokenAmount;
 
-    /// The message gas limit
-    fn gas_limit(&self) -> u64;
-
     /// The message gas premium
     fn gas_premium(&self) -> TokenAmount;
 }

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -821,9 +821,6 @@ impl<BS> MessageInfo for MockRuntime<BS> {
     fn value_received(&self) -> TokenAmount {
         self.value_received.clone()
     }
-    fn gas_limit(&self) -> u64 {
-        self.gas_limit
-    }
     fn gas_premium(&self) -> TokenAmount {
         self.gas_premium.clone()
     }

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -573,9 +573,6 @@ impl MessageInfo for InvocationCtx<'_, '_> {
     fn value_received(&self) -> TokenAmount {
         self.msg.value.clone()
     }
-    fn gas_limit(&self) -> u64 {
-        u32::MAX.into()
-    }
     fn gas_premium(&self) -> TokenAmount {
         TokenAmount::zero()
     }


### PR DESCRIPTION
We exposed this for the GASLIMIT opcode, but didn't actually need it. I'm removing it here to reduce the diff and API surface area.

See https://github.com/filecoin-project/ref-fvm/issues/1168 for context.