### PR TITLE
EVM: further dispatch tweaks

### DIFF
--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -170,7 +170,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
     }
 
     unsafe fn step(&mut self) {
-        // Note: safe because we check ounds in execute (only caller)
+        // Note: safe because we check bounds in execute (only caller)
         let op = OpCode::try_from(*self.bytecode.get_unchecked(self.pc));
         match op {
             // Note: safe because u8 index

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -154,8 +154,10 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
     }
 
     pub fn execute(&mut self) -> Result<(), StatusCode> {
-        while self.pc <  self.bytecode.len() {
-            unsafe { self.step(); }
+        while self.pc < self.bytecode.len() {
+            unsafe {
+                self.step();
+            }
 
             if self.exit.is_some() {
                 break;

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -154,11 +154,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
     }
 
     pub fn execute(&mut self) -> Result<(), StatusCode> {
-        loop {
-            if self.pc >= self.bytecode.len() {
-                break;
-            }
-
+        while self.pc <  self.bytecode.len() {
             self.step();
 
             if self.exit.is_some() {


### PR DESCRIPTION
This concludes the war on bounds checking:
```
vyzo@carbon6 fvm-bench $ ./target/debug/fvm-bench -b bundles/builtin-actors-next-dd76d3ea.car ../builtin-actors/actors/evm/tests/contracts/SimpleCoin.bin f8b2cb4f 000000000000000000000000ff00000000000000000000000000000000000064
Result: 0000000000000000000000000000000000000000000000000000000000002710
Gas Used: 2233792
vyzo@carbon6 fvm-bench $ cp /home/vyzo/src/fvm/builtin-actors/output/builtin-actors.car bundles/builtin-actors-next-dispatch-tweaks.car
vyzo@carbon6 fvm-bench $ ./target/debug/fvm-bench -b bundles/builtin-actors-next-dispatch-tweaks.car ../builtin-actors/actors/evm/tests/contracts/SimpleCoin.bin f8b2cb4f 000000000000000000000000ff00000000000000000000000000000000000064
Result: 0000000000000000000000000000000000000000000000000000000000002710
Gas Used: 2227772
```