### PR TITLE
fix: make some EVM math a bit more robust

### DIFF
--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -42,10 +42,10 @@ pub fn returndatacopy(
     let region = get_memory_region(&mut state.memory, mem_index, size)
         .map_err(|_| StatusCode::InvalidMemoryAccess)?;
 
-    if input_index > U256::from(state.return_data.len()) {
+    let src = input_index.try_into().map_err(|_| StatusCode::InvalidMemoryAccess)?;
+    if src > state.return_data.len() {
         return Err(StatusCode::InvalidMemoryAccess);
     }
-    let src = input_index.as_usize();
 
     if src + region.as_ref().map(|r| r.size.get()).unwrap_or(0) > state.return_data.len() {
         return Err(StatusCode::InvalidMemoryAccess);
@@ -61,7 +61,7 @@ pub fn returndatacopy(
 
 #[inline]
 pub fn jump(bytecode: &Bytecode, dest: U256) -> Result<Option<usize>, StatusCode> {
-    let dst = dest.as_usize();
+    let dst = dest.try_into().map_err(|_| StatusCode::BadJumpDestination)?;
     if !bytecode.valid_jump_destination(dst) {
         return Err(StatusCode::BadJumpDestination);
     }
@@ -71,7 +71,7 @@ pub fn jump(bytecode: &Bytecode, dest: U256) -> Result<Option<usize>, StatusCode
 #[inline]
 pub fn jumpi(bytecode: &Bytecode, dest: U256, test: U256) -> Result<Option<usize>, StatusCode> {
     if !test.is_zero() {
-        let dst = dest.as_usize();
+        let dst = dest.try_into().map_err(|_| StatusCode::BadJumpDestination)?;
         if !bytecode.valid_jump_destination(dst) {
             return Err(StatusCode::BadJumpDestination);
         }


### PR DESCRIPTION
1. Avoid `as_usize` entirely.
2. Add some more explicit casts and overflow checking.

I still hate it, but I now hate it a bit less. I'd love to get rid of
the memory region abstraction, or replace it with something a little
less brittle.

fixes https://github.com/filecoin-project/ref-fvm/issues/1185

Gas benchmark is 0.11% slower, so I don't really care.