### PR TITLE
EVM: rework jump instructions

### DIFF
--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -333,23 +333,14 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
         }}
 
         JUMP: {(m) => {
-            try_ins! { JUMP(m) => (res) {
-                if let Some(dest) = res {
-                    m.pc = dest;
-                } else {
-                    // cant happen, unless it's a cosmic ray
-                    m.exit = Some(StatusCode::Failure);
-                }
+            try_ins! { JUMP(m) => (dest) {
+                m.pc = dest;
             }}
         }}
 
         JUMPI: {(m) => {
-            try_ins! { JUMPI(m) => (res) {
-                if let Some(dest) = res {
-                    m.pc = dest;
-                } else {
-                    m.pc += 1;
-                }
+            try_ins! { JUMPI(m) => (dest) {
+                m.pc = dest;
             }}
         }}
 

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -65,7 +65,8 @@ pub fn jump(bytecode: &Bytecode, _pc: usize, dest: U256) -> Result<usize, Status
     if !bytecode.valid_jump_destination(dst) {
         return Err(StatusCode::BadJumpDestination);
     }
-    Ok(dst)
+    // skip the JMPDEST noop sled
+    Ok(dst + 1)
 }
 
 #[inline]
@@ -75,7 +76,8 @@ pub fn jumpi(bytecode: &Bytecode, pc: usize, dest: U256, test: U256) -> Result<u
         if !bytecode.valid_jump_destination(dst) {
             return Err(StatusCode::BadJumpDestination);
         }
-        Ok(dst)
+        // skip the JMPDEST noop sled
+        Ok(dst + 1)
     } else {
         Ok(pc + 1)
     }

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -60,23 +60,23 @@ pub fn returndatacopy(
 }
 
 #[inline]
-pub fn jump(bytecode: &Bytecode, dest: U256) -> Result<Option<usize>, StatusCode> {
+pub fn jump(bytecode: &Bytecode, _pc: usize, dest: U256) -> Result<usize, StatusCode> {
     let dst = dest.try_into().map_err(|_| StatusCode::BadJumpDestination)?;
     if !bytecode.valid_jump_destination(dst) {
         return Err(StatusCode::BadJumpDestination);
     }
-    Ok(Some(dst))
+    Ok(dst)
 }
 
 #[inline]
-pub fn jumpi(bytecode: &Bytecode, dest: U256, test: U256) -> Result<Option<usize>, StatusCode> {
+pub fn jumpi(bytecode: &Bytecode, pc: usize, dest: U256, test: U256) -> Result<usize, StatusCode> {
     if !test.is_zero() {
         let dst = dest.try_into().map_err(|_| StatusCode::BadJumpDestination)?;
         if !bytecode.valid_jump_destination(dst) {
             return Err(StatusCode::BadJumpDestination);
         }
-        Ok(Some(dst))
+        Ok(dst)
     } else {
-        Ok(None)
+        Ok(pc + 1)
     }
 }

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -146,11 +146,11 @@ macro_rules! def_stdlog {
 macro_rules! def_jmp {
     ($op:ident ($($arg:ident),*) => $impl:path) => {
         #[allow(non_snake_case)]
-        pub fn $op<'r, 'a, RT: Runtime + 'a>(m: &mut Machine<'r, 'a, RT> ) -> Result<Option<usize>, StatusCode> {
+        pub fn $op<'r, 'a, RT: Runtime + 'a>(m: &mut Machine<'r, 'a, RT> ) -> Result<usize, StatusCode> {
             check_arity!($op, ($($arg),*));
             check_stack!($op, m.state.stack);
             $(let $arg = unsafe {m.state.stack.pop()};)*
-            $impl(m.bytecode, $($arg),*)
+            $impl(m.bytecode, m.pc, $($arg),*)
         }
     }
 


### PR DESCRIPTION
- avoid the Option and the resulting branches
- skip the noop seld to save a cycle

Results:
- base (68a2b1b4): 2212852
- drop option: 2211804
- skip sled: 2206548

Overall a nice little improvement in our trivial benchmark.