### PR TITLE
Add market notify deal

### DIFF
--- a/actors/market/src/ext.rs
+++ b/actors/market/src/ext.rs
@@ -20,6 +20,15 @@ pub mod account {
         #[serde(with = "serde_bytes")]
         pub message: Vec<u8>,
     }
+
+    pub const MARKET_NOTIFY_DEAL: u64 =
+        frc42_dispatch::method_hash!("MarketNotifyDeal");
+
+    pub struct MarketNotifyDealParams {
+        #[serde(with = "serde_bytes")]
+        pub proposal: Vec<u8>,
+        pub deal_id: u64,
+    }
 }
 
 pub mod miner {

--- a/actors/market/src/ext.rs
+++ b/actors/market/src/ext.rs
@@ -21,9 +21,9 @@ pub mod account {
         pub message: Vec<u8>,
     }
 
-    pub const MARKET_NOTIFY_DEAL: u64 =
-        frc42_dispatch::method_hash!("MarketNotifyDeal");
+    pub const MARKET_NOTIFY_DEAL: u64 = frc42_dispatch::method_hash!("MarketNotifyDeal");
 
+    #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct MarketNotifyDealParams {
         #[serde(with = "serde_bytes")]
         pub proposal: Vec<u8>,

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -249,15 +249,15 @@ impl Actor {
         let state: State = rt.state()?;
 
         for (di, mut deal) in params.deals.into_iter().enumerate() {
-
-            let serialized_proposal = match validate_deal(rt, &deal, &network_raw_power, &baseline_power) {
-                // drop malformed deals
-                Err(e) => {
-                    info!("invalid deal {}: {}", di, e);
-                    continue;
-                }
-                Ok(b) => b,
-            };
+            let serialized_proposal =
+                match validate_deal(rt, &deal, &network_raw_power, &baseline_power) {
+                    // drop malformed deals
+                    Err(e) => {
+                        info!("invalid deal {}: {}", di, e);
+                        continue;
+                    }
+                    Ok(b) => b,
+                };
 
             if deal.proposal.provider != Address::new_id(provider_id)
                 && deal.proposal.provider != provider_raw

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -435,6 +435,12 @@ impl Actor {
             Ok(())
         })?;
 
+        // notify clients ignoring any errors
+        for (i, valid_deal) in valid_deals.iter().enumerate() {
+            let raw_proposal = serialize_vec(&valid_deal.proposal, "deal proposal")?;
+            rt.send(&valid_deal.proposal.client, ext::account::MARKET_NOTIFY_DEAL, RawBytes::Serialize(ext::account::MarketNotifyDealParams{proposal: raw_proposal, deal_id: new_deal_ids[i]}), TokenAmount::zero());
+        }
+
         Ok(PublishStorageDealsReturn { ids: new_deal_ids, valid_deals: valid_input_bf })
     }
 

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -27,7 +27,7 @@ use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Zero};
 
 use crate::balance_table::BalanceTable;
-use fil_actors_runtime::cbor::{deserialize, serialize, serialize_vec};
+use fil_actors_runtime::cbor::{deserialize, serialize};
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Policy, Runtime};
 use fil_actors_runtime::{
@@ -231,6 +231,7 @@ impl Actor {
 
         struct ValidDeal {
             proposal: DealProposal,
+            serialized_proposal: RawBytes,
             cid: Cid,
             allocation: AllocationID,
         }
@@ -248,11 +249,15 @@ impl Actor {
         let state: State = rt.state()?;
 
         for (di, mut deal) in params.deals.into_iter().enumerate() {
-            // drop malformed deals
-            if let Err(e) = validate_deal(rt, &deal, &network_raw_power, &baseline_power) {
-                info!("invalid deal {}: {}", di, e);
-                continue;
-            }
+
+            let serialized_proposal = match validate_deal(rt, &deal, &network_raw_power, &baseline_power) {
+                // drop malformed deals
+                Err(e) => {
+                    info!("invalid deal {}: {}", di, e);
+                    continue;
+                }
+                Ok(b) => b,
+            };
 
             if deal.proposal.provider != Address::new_id(provider_id)
                 && deal.proposal.provider != provider_raw
@@ -370,6 +375,7 @@ impl Actor {
             proposal_cid_lookup.insert(pcid);
             valid_deals.push(ValidDeal {
                 proposal: deal.proposal,
+                serialized_proposal,
                 cid: pcid,
                 allocation: allocation_id,
             });
@@ -437,12 +443,11 @@ impl Actor {
 
         // notify clients ignoring any errors
         for (i, valid_deal) in valid_deals.iter().enumerate() {
-            let raw_proposal = serialize_vec(&valid_deal.proposal, "deal proposal")?;
             _ = rt.send(
                 &valid_deal.proposal.client,
                 ext::account::MARKET_NOTIFY_DEAL,
                 RawBytes::serialize(ext::account::MarketNotifyDealParams {
-                    proposal: raw_proposal,
+                    proposal: valid_deal.serialized_proposal.to_vec(),
                     deal_id: new_deal_ids[i],
                 })?,
                 TokenAmount::zero(),
@@ -1170,8 +1175,8 @@ fn validate_deal(
     deal: &ClientDealProposal,
     network_raw_power: &StoragePower,
     baseline_power: &StoragePower,
-) -> Result<(), ActorError> {
-    deal_proposal_is_internally_valid(rt, deal)?;
+) -> Result<RawBytes, ActorError> {
+    let proposal_bytes = deal_proposal_is_internally_valid(rt, deal)?;
 
     let proposal = &deal.proposal;
 
@@ -1236,28 +1241,28 @@ fn validate_deal(
         return Err(actor_error!(illegal_argument, "Client collateral out of bounds."));
     };
 
-    Ok(())
+    Ok(proposal_bytes)
 }
 
 fn deal_proposal_is_internally_valid(
     rt: &impl Runtime,
     proposal: &ClientDealProposal,
-) -> Result<(), ActorError> {
+) -> Result<RawBytes, ActorError> {
     let signature_bytes = proposal.client_signature.bytes.clone();
     // Generate unsigned bytes
-    let proposal_bytes = serialize_vec(&proposal.proposal, "deal proposal")?;
+    let proposal_bytes = serialize(&proposal.proposal, "deal proposal")?;
 
     rt.send(
         &proposal.proposal.client,
         ext::account::AUTHENTICATE_MESSAGE_METHOD,
         RawBytes::serialize(ext::account::AuthenticateMessageParams {
             signature: signature_bytes,
-            message: proposal_bytes,
+            message: proposal_bytes.to_vec(),
         })?,
         TokenAmount::zero(),
     )
     .map_err(|e| e.wrap("proposal authentication failed"))?;
-    Ok(())
+    Ok(proposal_bytes)
 }
 
 pub const DAG_CBOR: u64 = 0x71; // TODO is there a better place to get this?

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -438,7 +438,15 @@ impl Actor {
         // notify clients ignoring any errors
         for (i, valid_deal) in valid_deals.iter().enumerate() {
             let raw_proposal = serialize_vec(&valid_deal.proposal, "deal proposal")?;
-            rt.send(&valid_deal.proposal.client, ext::account::MARKET_NOTIFY_DEAL, RawBytes::Serialize(ext::account::MarketNotifyDealParams{proposal: raw_proposal, deal_id: new_deal_ids[i]}), TokenAmount::zero());
+            _ = rt.send(
+                &valid_deal.proposal.client,
+                ext::account::MARKET_NOTIFY_DEAL,
+                RawBytes::serialize(ext::account::MarketNotifyDealParams {
+                    proposal: raw_proposal,
+                    deal_id: new_deal_ids[i],
+                })?,
+                TokenAmount::zero(),
+            );
         }
 
         Ok(PublishStorageDealsReturn { ids: new_deal_ids, valid_deals: valid_input_bf })

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -439,6 +439,8 @@ pub fn publish_deals(
     publish_deals: &[DealProposal],
     next_allocation_id: AllocationID,
 ) -> Vec<DealID> {
+    let st: State = rt.get_state();
+    let next_deal_id = st.next_id;
     rt.expect_validate_caller_any();
     let return_value = GetControlAddressesReturnParams {
         owner: addrs.owner,
@@ -527,6 +529,25 @@ pub fn publish_deals(
             );
             alloc_id += 1
         }
+    }
+
+    let mut deal_id = next_deal_id;
+    for deal in publish_deals { 
+        let buf = RawBytes::serialize(deal.clone()).expect("failed to marshal deal proposal");
+        let params = RawBytes::serialize(ext::account::MarketNotifyDealParams {
+            proposal: buf.to_vec(),
+            deal_id,
+        })
+        .unwrap();
+        rt.expect_send(
+            deal.client,
+            ext::account::MARKET_NOTIFY_DEAL,
+            params,
+            TokenAmount::zero(),
+            RawBytes::default(),
+            ExitCode::USR_UNHANDLED_MESSAGE,
+        );
+        deal_id += 1;
     }
 
     let ret: PublishStorageDealsReturn = rt

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -532,7 +532,7 @@ pub fn publish_deals(
     }
 
     let mut deal_id = next_deal_id;
-    for deal in publish_deals { 
+    for deal in publish_deals {
         let buf = RawBytes::serialize(deal.clone()).expect("failed to marshal deal proposal");
         let params = RawBytes::serialize(ext::account::MarketNotifyDealParams {
             proposal: buf.to_vec(),

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -906,7 +906,7 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
         RawBytes::serialize(MarketNotifyDealParams { proposal: proposal_bytes.to_vec(), deal_id })
             .unwrap();
     rt.expect_send(
-        deal.client,
+        client_resolved,
         MARKET_NOTIFY_DEAL,
         notify_param,
         TokenAmount::zero(),

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -32,7 +32,7 @@ use fvm_shared::{MethodNum, HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR, METHOD_SEND};
 use regex::Regex;
 use std::ops::Add;
 
-use fil_actor_market::ext::account::{AuthenticateMessageParams, AUTHENTICATE_MESSAGE_METHOD};
+use fil_actor_market::ext::account::{AuthenticateMessageParams, AUTHENTICATE_MESSAGE_METHOD, MarketNotifyDealParams, MARKET_NOTIFY_DEAL};
 use fil_actor_market::ext::verifreg::{AllocationID, AllocationRequest, AllocationsResponse};
 use num_traits::{FromPrimitive, Zero};
 
@@ -832,6 +832,8 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
     expect_query_network_info(&mut rt);
 
     //  create a client proposal with a valid signature
+    let st: State = rt.get_state();
+    let deal_id = st.next_id;
     let mut params = PublishStorageDealsParams { deals: vec![] };
     let buf = RawBytes::serialize(&deal).expect("failed to marshal deal proposal");
     let sig = Signature::new_bls(buf.to_vec());
@@ -895,6 +897,20 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
         serialize(&transfer_return, "transfer from return").unwrap(),
         ExitCode::OK,
     );
+
+    let proposal_bytes = RawBytes::serialize(&deal).expect("failed to marshal deal proposal");
+    let notify_param = RawBytes::serialize(MarketNotifyDealParams{ 
+            proposal: proposal_bytes.to_vec(),
+            deal_id,
+        }).unwrap();
+    rt.expect_send(deal.client,
+        MARKET_NOTIFY_DEAL,
+        notify_param,
+        TokenAmount::zero(),
+        RawBytes::default(),
+        ExitCode::USR_UNHANDLED_MESSAGE,
+    );
+        
 
     let ret: PublishStorageDealsReturn = rt
         .call::<MarketActor>(
@@ -1722,7 +1738,10 @@ fn max_deal_label_size() {
 /// Tests that if 2 deals are published, and the client can't cover collateral for the first deal,
 /// but can cover the second, then the first deal fails, but the second passes
 fn insufficient_client_balance_in_a_batch() {
+
     let mut rt = setup();
+    let st: State = rt.get_state();
+    let next_deal_id = st.next_id;
 
     let mut deal1 = generate_deal_proposal(
         CLIENT_ADDR,
@@ -1810,6 +1829,29 @@ fn insufficient_client_balance_in_a_batch() {
         ExitCode::OK,
     );
 
+    let notify_param1 = RawBytes::serialize(MarketNotifyDealParams{ 
+        proposal: buf1.to_vec(),
+        deal_id: next_deal_id,
+    }).unwrap();
+    let notify_param2 = RawBytes::serialize(MarketNotifyDealParams{ 
+        proposal: buf2.to_vec(),
+        deal_id: next_deal_id + 1,
+    }).unwrap();
+    rt.expect_send(deal1.client,
+        MARKET_NOTIFY_DEAL,
+        notify_param1,
+        TokenAmount::zero(),
+        RawBytes::default(),
+        ExitCode::USR_UNHANDLED_MESSAGE,
+    );
+    rt.expect_send(deal2.client,
+        MARKET_NOTIFY_DEAL,
+        notify_param2,
+        TokenAmount::zero(),
+        RawBytes::default(),
+        ExitCode::USR_UNHANDLED_MESSAGE,
+    );
+
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
 
     let ret: PublishStorageDealsReturn = rt
@@ -1834,6 +1876,8 @@ fn insufficient_client_balance_in_a_batch() {
 /// but can cover the second, then the first deal fails, but the second passes
 fn insufficient_provider_balance_in_a_batch() {
     let mut rt = setup();
+    let st: State = rt.get_state();
+    let next_deal_id = st.next_id;
 
     let mut deal1 = generate_deal_proposal(
         CLIENT_ADDR,
@@ -1927,6 +1971,29 @@ fn insufficient_provider_balance_in_a_batch() {
         ExitCode::OK,
     );
 
+    let notify_param1 = RawBytes::serialize(MarketNotifyDealParams{ 
+        proposal: buf1.to_vec(),
+        deal_id: next_deal_id,
+    }).unwrap();
+    let notify_param2 = RawBytes::serialize(MarketNotifyDealParams{ 
+        proposal: buf2.to_vec(),
+        deal_id: next_deal_id + 1,
+    }).unwrap();
+    rt.expect_send(deal1.client,
+        MARKET_NOTIFY_DEAL,
+        notify_param1,
+        TokenAmount::zero(),
+        RawBytes::default(),
+        ExitCode::USR_UNHANDLED_MESSAGE,
+    );
+    rt.expect_send(deal2.client,
+        MARKET_NOTIFY_DEAL,
+        notify_param2,
+        TokenAmount::zero(),
+        RawBytes::default(),
+        ExitCode::USR_UNHANDLED_MESSAGE,
+    );
+
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
 
     let ret: PublishStorageDealsReturn = rt
@@ -1979,6 +2046,8 @@ fn add_balance_restricted_correctly() {
 #[test]
 fn psd_restricted_correctly() {
     let mut rt = setup();
+    let st: State = rt.get_state();
+    let deal_id = st.next_id;
 
     let deal = generate_deal_proposal(
         CLIENT_ADDR,
@@ -2049,6 +2118,18 @@ fn psd_restricted_correctly() {
         TokenAmount::zero(),
         RawBytes::default(),
         ExitCode::OK,
+    );
+
+    let notify_param = RawBytes::serialize(MarketNotifyDealParams{ 
+        proposal: buf.to_vec(),
+        deal_id,
+    }).unwrap();
+    rt.expect_send(deal.client,
+        MARKET_NOTIFY_DEAL,
+        notify_param,
+        TokenAmount::zero(),
+        RawBytes::default(),
+        ExitCode::USR_UNHANDLED_MESSAGE,
     );
 
     let ret: PublishStorageDealsReturn = rt

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -32,7 +32,10 @@ use fvm_shared::{MethodNum, HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR, METHOD_SEND};
 use regex::Regex;
 use std::ops::Add;
 
-use fil_actor_market::ext::account::{AuthenticateMessageParams, AUTHENTICATE_MESSAGE_METHOD, MarketNotifyDealParams, MARKET_NOTIFY_DEAL};
+use fil_actor_market::ext::account::{
+    AuthenticateMessageParams, MarketNotifyDealParams, AUTHENTICATE_MESSAGE_METHOD,
+    MARKET_NOTIFY_DEAL,
+};
 use fil_actor_market::ext::verifreg::{AllocationID, AllocationRequest, AllocationsResponse};
 use num_traits::{FromPrimitive, Zero};
 
@@ -899,18 +902,17 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
     );
 
     let proposal_bytes = RawBytes::serialize(&deal).expect("failed to marshal deal proposal");
-    let notify_param = RawBytes::serialize(MarketNotifyDealParams{ 
-            proposal: proposal_bytes.to_vec(),
-            deal_id,
-        }).unwrap();
-    rt.expect_send(deal.client,
+    let notify_param =
+        RawBytes::serialize(MarketNotifyDealParams { proposal: proposal_bytes.to_vec(), deal_id })
+            .unwrap();
+    rt.expect_send(
+        deal.client,
         MARKET_NOTIFY_DEAL,
         notify_param,
         TokenAmount::zero(),
         RawBytes::default(),
         ExitCode::USR_UNHANDLED_MESSAGE,
     );
-        
 
     let ret: PublishStorageDealsReturn = rt
         .call::<MarketActor>(
@@ -1738,7 +1740,6 @@ fn max_deal_label_size() {
 /// Tests that if 2 deals are published, and the client can't cover collateral for the first deal,
 /// but can cover the second, then the first deal fails, but the second passes
 fn insufficient_client_balance_in_a_batch() {
-
     let mut rt = setup();
     let st: State = rt.get_state();
     let next_deal_id = st.next_id;
@@ -1829,22 +1830,26 @@ fn insufficient_client_balance_in_a_batch() {
         ExitCode::OK,
     );
 
-    let notify_param1 = RawBytes::serialize(MarketNotifyDealParams{ 
+    let notify_param1 = RawBytes::serialize(MarketNotifyDealParams {
         proposal: buf1.to_vec(),
         deal_id: next_deal_id,
-    }).unwrap();
-    let notify_param2 = RawBytes::serialize(MarketNotifyDealParams{ 
+    })
+    .unwrap();
+    let notify_param2 = RawBytes::serialize(MarketNotifyDealParams {
         proposal: buf2.to_vec(),
         deal_id: next_deal_id + 1,
-    }).unwrap();
-    rt.expect_send(deal1.client,
+    })
+    .unwrap();
+    rt.expect_send(
+        deal1.client,
         MARKET_NOTIFY_DEAL,
         notify_param1,
         TokenAmount::zero(),
         RawBytes::default(),
         ExitCode::USR_UNHANDLED_MESSAGE,
     );
-    rt.expect_send(deal2.client,
+    rt.expect_send(
+        deal2.client,
         MARKET_NOTIFY_DEAL,
         notify_param2,
         TokenAmount::zero(),
@@ -1971,22 +1976,26 @@ fn insufficient_provider_balance_in_a_batch() {
         ExitCode::OK,
     );
 
-    let notify_param1 = RawBytes::serialize(MarketNotifyDealParams{ 
+    let notify_param1 = RawBytes::serialize(MarketNotifyDealParams {
         proposal: buf1.to_vec(),
         deal_id: next_deal_id,
-    }).unwrap();
-    let notify_param2 = RawBytes::serialize(MarketNotifyDealParams{ 
+    })
+    .unwrap();
+    let notify_param2 = RawBytes::serialize(MarketNotifyDealParams {
         proposal: buf2.to_vec(),
         deal_id: next_deal_id + 1,
-    }).unwrap();
-    rt.expect_send(deal1.client,
+    })
+    .unwrap();
+    rt.expect_send(
+        deal1.client,
         MARKET_NOTIFY_DEAL,
         notify_param1,
         TokenAmount::zero(),
         RawBytes::default(),
         ExitCode::USR_UNHANDLED_MESSAGE,
     );
-    rt.expect_send(deal2.client,
+    rt.expect_send(
+        deal2.client,
         MARKET_NOTIFY_DEAL,
         notify_param2,
         TokenAmount::zero(),
@@ -2120,11 +2129,10 @@ fn psd_restricted_correctly() {
         ExitCode::OK,
     );
 
-    let notify_param = RawBytes::serialize(MarketNotifyDealParams{ 
-        proposal: buf.to_vec(),
-        deal_id,
-    }).unwrap();
-    rt.expect_send(deal.client,
+    let notify_param =
+        RawBytes::serialize(MarketNotifyDealParams { proposal: buf.to_vec(), deal_id }).unwrap();
+    rt.expect_send(
+        deal.client,
         MARKET_NOTIFY_DEAL,
         notify_param,
         TokenAmount::zero(),

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -22,8 +22,8 @@ use fil_actor_market::ext::verifreg::{
     AllocationRequest, AllocationRequests, ClaimExtensionRequest,
 };
 use fil_actor_market::{
-    ClientDealProposal, DealProposal, Label, Method as MarketMethod, PublishStorageDealsParams,
-    PublishStorageDealsReturn,
+    ext::account::MARKET_NOTIFY_DEAL, ClientDealProposal, DealProposal, Label,
+    Method as MarketMethod, PublishStorageDealsParams, PublishStorageDealsReturn,
 };
 use fil_actor_miner::{
     aggregate_pre_commit_network_fee, max_prove_commit_duration,
@@ -1133,6 +1133,7 @@ pub fn market_publish_deal(
             method: AccountMethod::AuthenticateMessageExported as u64,
             ..Default::default()
         },
+        ExpectInvocation { to: deal_client, method: MARKET_NOTIFY_DEAL, ..Default::default() },
     ];
     if verified_deal {
         let deal_term = deal.end_epoch - deal.start_epoch;

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -1152,42 +1152,45 @@ pub fn market_publish_deal(
             }],
             extensions: vec![],
         };
-        expect_publish_invocs.push(ExpectInvocation {
-            to: DATACAP_TOKEN_ACTOR_ADDR,
-            method: DataCapMethod::TransferFromExported as u64,
-            params: Some(
-                RawBytes::serialize(&TransferFromParams {
-                    from: deal_client,
-                    to: VERIFIED_REGISTRY_ACTOR_ADDR,
-                    amount: token_amount.clone(),
-                    operator_data: RawBytes::serialize(&alloc_reqs).unwrap(),
-                })
-                .unwrap(),
-            ),
-            code: Some(ExitCode::OK),
-            subinvocs: Some(vec![ExpectInvocation {
-                to: VERIFIED_REGISTRY_ACTOR_ADDR,
-                method: VerifregMethod::UniversalReceiverHook as u64,
+        expect_publish_invocs.insert(
+            expect_publish_invocs.len() - 1,
+            ExpectInvocation {
+                to: DATACAP_TOKEN_ACTOR_ADDR,
+                method: DataCapMethod::TransferFromExported as u64,
                 params: Some(
-                    RawBytes::serialize(&UniversalReceiverParams {
-                        type_: FRC46_TOKEN_TYPE,
-                        payload: RawBytes::serialize(&FRC46TokenReceived {
-                            from: deal_client.id().unwrap(),
-                            to: VERIFIED_REGISTRY_ACTOR_ADDR.id().unwrap(),
-                            operator: STORAGE_MARKET_ACTOR_ADDR.id().unwrap(),
-                            amount: token_amount,
-                            operator_data: RawBytes::serialize(&alloc_reqs).unwrap(),
-                            token_data: Default::default(),
-                        })
-                        .unwrap(),
+                    RawBytes::serialize(&TransferFromParams {
+                        from: deal_client,
+                        to: VERIFIED_REGISTRY_ACTOR_ADDR,
+                        amount: token_amount.clone(),
+                        operator_data: RawBytes::serialize(&alloc_reqs).unwrap(),
                     })
                     .unwrap(),
                 ),
                 code: Some(ExitCode::OK),
+                subinvocs: Some(vec![ExpectInvocation {
+                    to: VERIFIED_REGISTRY_ACTOR_ADDR,
+                    method: VerifregMethod::UniversalReceiverHook as u64,
+                    params: Some(
+                        RawBytes::serialize(&UniversalReceiverParams {
+                            type_: FRC46_TOKEN_TYPE,
+                            payload: RawBytes::serialize(&FRC46TokenReceived {
+                                from: deal_client.id().unwrap(),
+                                to: VERIFIED_REGISTRY_ACTOR_ADDR.id().unwrap(),
+                                operator: STORAGE_MARKET_ACTOR_ADDR.id().unwrap(),
+                                amount: token_amount,
+                                operator_data: RawBytes::serialize(&alloc_reqs).unwrap(),
+                                token_data: Default::default(),
+                            })
+                            .unwrap(),
+                        })
+                        .unwrap(),
+                    ),
+                    code: Some(ExitCode::OK),
+                    ..Default::default()
+                }]),
                 ..Default::default()
-            }]),
-            ..Default::default()
-        })
+            },
+        )
     }
     ExpectInvocation {
         to: STORAGE_MARKET_ACTOR_ADDR,


### PR DESCRIPTION
Working off of the idea in [this fip discussion](https://github.com/filecoin-project/FIPs/discussions/549) the market actor now sends a notification to proposal client.  @anorth suggested the simplification of calling this method for all clients and ignoring failures which keeps this very simple.

Still WIP because it needs tests.  