### PR TITLE
fix: handle errors and non-existent addresses in selfdestruct

### DIFF
--- a/actors/evm/tests/selfdestruct.rs
+++ b/actors/evm/tests/selfdestruct.rs
@@ -1,5 +1,6 @@
-use fil_actors_runtime::test_utils::*;
-use fvm_shared::address::Address;
+use fil_actors_runtime::{test_utils::*, BURNT_FUNDS_ACTOR_ADDR};
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::{address::Address, error::ExitCode, METHOD_SEND};
 
 mod util;
 
@@ -17,7 +18,43 @@ fn test_selfdestruct() {
 
     let solidity_params = hex::decode("35f46994").unwrap();
     rt.expect_validate_caller_any();
-    rt.expect_delete_actor(beneficiary);
+    rt.expect_send(
+        beneficiary,
+        METHOD_SEND,
+        RawBytes::default(),
+        rt.get_balance(),
+        RawBytes::default(),
+        ExitCode::OK,
+    );
+    rt.expect_delete_actor(BURNT_FUNDS_ACTOR_ADDR);
+
+    assert!(util::invoke_contract(&mut rt, &solidity_params).is_empty());
+    rt.verify();
+}
+
+#[test]
+fn test_selfdestruct_missing() {
+    let bytecode = hex::decode(include_str!("contracts/selfdestruct.hex")).unwrap();
+
+    let contract = Address::new_id(100);
+    let beneficiary = Address::new_id(1001);
+
+    let mut rt = util::init_construct_and_verify(bytecode, |rt| {
+        rt.actor_code_cids.insert(contract, *EVM_ACTOR_CODE_ID);
+        rt.set_origin(contract);
+    });
+
+    let solidity_params = hex::decode("35f46994").unwrap();
+    rt.expect_validate_caller_any();
+    rt.expect_send(
+        beneficiary,
+        METHOD_SEND,
+        RawBytes::default(),
+        rt.get_balance(),
+        RawBytes::default(),
+        ExitCode::SYS_INVALID_RECEIVER,
+    );
+    rt.expect_delete_actor(BURNT_FUNDS_ACTOR_ADDR);
 
     assert!(util::invoke_contract(&mut rt, &solidity_params).is_empty());
     rt.verify();


### PR DESCRIPTION
In the EVM:

1. Self destruct continues even if it sends funds into oblivion.
2. Self destruct will auto-create a beneficiary.

This lets us punt https://github.com/filecoin-project/ref-fvm/issues/736 to M2.2.