### PR TITLE
fix: correctly encode revert data

### DIFF
--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -125,7 +125,7 @@ impl EvmContractActor {
             Outcome::Revert => Err(ActorError::unchecked_with_data(
                 EVM_CONTRACT_REVERTED,
                 "constructor reverted".to_string(),
-                RawBytes::from(output.return_data.to_vec()),
+                RawBytes::serialize(BytesSer(&output.return_data)).unwrap(),
             )),
             Outcome::Delete => Ok(()),
         }
@@ -183,7 +183,7 @@ impl EvmContractActor {
             Outcome::Revert => Err(ActorError::unchecked_with_data(
                 EVM_CONTRACT_REVERTED,
                 "contract reverted".to_string(),
-                RawBytes::from(output.return_data.to_vec()),
+                RawBytes::serialize(BytesSer(&output.return_data)).unwrap(),
             )),
             Outcome::Delete => Ok(Vec::new()),
         }

--- a/actors/evm/tests/revert.rs
+++ b/actors/evm/tests/revert.rs
@@ -30,5 +30,5 @@ revert
     assert!(result.is_err());
     let e = result.unwrap_err();
     assert_eq!(e.exit_code(), evm::EVM_CONTRACT_REVERTED);
-    assert_eq!(e.data(), RawBytes::from(vec![0xde, 0xad, 0xbe, 0xef]));
+    assert_eq!(e.data(), RawBytes::serialize(BytesSer(&[0xde, 0xad, 0xbe, 0xef])).unwrap());
 }


### PR DESCRIPTION
This will be _properly_ fixed in https://github.com/filecoin-project/ref-fvm/issues/987, but we need to return proper CBOR till then.