### PR TITLE
fix: return data from callactor on revert as well

### DIFF
--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -301,7 +301,7 @@ pub fn call_generic<RT: Runtime>(
                         (1, result)
                     }
                 }
-                Err(ae) => (0, ae.data().to_vec()),
+                Err(mut ae) => (0, ae.take_data().into()),
             }
         }
     };

--- a/actors/evm/src/interpreter/precompiles.rs
+++ b/actors/evm/src/interpreter/precompiles.rs
@@ -497,14 +497,14 @@ pub fn call_actor<RT: Runtime>(
         // positive values are user/actor errors
         // success is 0
         let (exit_code, data) = match result {
-            Err(ae) => {
+            Err(mut ae) => {
                 // TODO handle revert
                 // TODO https://github.com/filecoin-project/ref-fvm/issues/1020
                 // put error number from call into revert
                 let exit_code = U256::from(ae.exit_code().value());
 
                 // no return only exit code
-                (exit_code, RawBytes::default())
+                (exit_code, ae.take_data())
             }
             Ok(ret) => (U256::zero(), ret),
         };
@@ -525,7 +525,7 @@ pub fn call_actor<RT: Runtime>(
         // NOTE:
         // we dont pad out to 32 bytes here, the idea being that users will already be in the "everythig is bytes" mode
         // and will want re-pack align and whatever else by themselves
-        output.extend_from_slice(&data);
+        output.extend_from_slice(data.bytes());
         output
     };
 

--- a/actors/evm/tests/revert.rs
+++ b/actors/evm/tests/revert.rs
@@ -30,5 +30,5 @@ revert
     assert!(result.is_err());
     let e = result.unwrap_err();
     assert_eq!(e.exit_code(), evm::EVM_CONTRACT_REVERTED);
-    assert_eq!(e.data(), RawBytes::serialize(BytesSer(&[0xde, 0xad, 0xbe, 0xef])).unwrap());
+    assert_eq!(e.data(), RawBytes::serialize(BytesSer(&[0xde, 0xad, 0xbe, 0xef])).unwrap().bytes());
 }

--- a/runtime/src/actor_error.rs
+++ b/runtime/src/actor_error.rs
@@ -67,8 +67,13 @@ impl ActorError {
     }
 
     /// Returns the optional data that might be associated with the error
-    pub fn data(&self) -> RawBytes {
-        self.data.clone()
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Extracts the optional associated data without copying.
+    pub fn take_data(&mut self) -> RawBytes {
+        std::mem::take(&mut self.data)
     }
 
     /// Prefix error message with a string message.

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -684,8 +684,9 @@ pub fn trampoline<C: ActorCode>(params: u32) -> u32 {
     // Construct a new runtime.
     let mut rt = FvmRuntime::default();
     // Invoke the method, aborting if the actor returns an errored exit code.
-    let ret = C::invoke_method(&mut rt, method, &params)
-        .unwrap_or_else(|err| fvm::vm::exit(err.exit_code().value(), err.data(), Some(err.msg())));
+    let ret = C::invoke_method(&mut rt, method, &params).unwrap_or_else(|mut err| {
+        fvm::vm::exit(err.exit_code().value(), err.take_data(), Some(err.msg()))
+    });
 
     // Abort with "assertion failed" if the actor failed to validate the caller somewhere.
     // We do this after handling the error, because the actor may have encountered an error before

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -597,7 +597,11 @@ impl<BS: Blockstore> MockRuntime<BS> {
 
         match expected_msg.exit_code {
             ExitCode::OK => Ok(expected_msg.send_return),
-            x => Err(ActorError::unchecked(x, "Expected message Fail".to_string())),
+            x => Err(ActorError::unchecked_with_data(
+                x,
+                "Expected message Fail".to_string(),
+                expected_msg.send_return,
+            )),
         }
     }
 

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -465,12 +465,12 @@ impl<'bs> VM<'bs> {
             invocs
         });
         match res {
-            Err(ae) => {
+            Err(mut ae) => {
                 self.rollback(prior_root);
                 Ok(MessageResult {
                     code: ae.exit_code(),
                     message: ae.msg().to_string(),
-                    ret: ae.data(),
+                    ret: ae.take_data(),
                 })
             }
             Ok(ret) => {


### PR DESCRIPTION
Also, avoid cloning unnecessarily.