### PR TITLE
EVM: optimize push ins for u64 sizes

### DIFF
--- a/actors/evm/src/interpreter/instructions/stack.rs
+++ b/actors/evm/src/interpreter/instructions/stack.rs
@@ -3,17 +3,40 @@
 use crate::interpreter::StatusCode;
 use {crate::interpreter::stack::Stack, crate::interpreter::U256};
 
+macro_rules! be_u64 {
+    ($byte:expr) => {$byte as u64};
+    ($byte1:expr, $byte2:expr $(,$rest:expr)*) => {
+        be_u64!{((($byte1 as u64) << 8) | ($byte2 as u64)) $(,$rest)*}
+    };
+}
+
 #[inline]
 pub(crate) fn push<const LEN: usize>(stack: &mut Stack, code: &[u8]) -> Result<usize, StatusCode> {
-    stack
-        .push(if code.len() < LEN {
-            let mut padded = [0; LEN];
-            padded[..code.len()].copy_from_slice(code);
-            U256::from_big_endian(&padded)
-        } else {
-            U256::from_big_endian(&code[..LEN])
-        })
-        .map(|_| LEN)
+    if code.len() < LEN {
+        // this is a pathological edge case, as the contract will immediately stop execution.
+        // we still handle it for correctness sake (and obviously avoid crashing out of bounds)
+        let mut padded = [0; LEN];
+        padded[..code.len()].copy_from_slice(code);
+        stack.push(U256::from_big_endian(&padded))?;
+    } else {
+        stack.push(match LEN {
+            // explicitly unroll up to u64 (single limb) pushes
+            1 => U256::from_u64(be_u64! {code[0]}),
+            2 => U256::from_u64(be_u64! {code[0], code[1]}),
+            3 => U256::from_u64(be_u64! {code[0], code[1], code[2]}),
+            4 => U256::from_u64(be_u64! {code[0], code[1], code[2], code[3]}),
+            5 => U256::from_u64(be_u64! {code[0], code[1], code[2], code[3], code[4]}),
+            6 => U256::from_u64(be_u64! {code[0], code[1], code[2], code[3], code[4], code[5]}),
+            7 => U256::from_u64(
+                be_u64! {code[0], code[1], code[2], code[3], code[4], code[5], code[6]},
+            ),
+            8 => U256::from_u64(
+                be_u64! {code[0], code[1], code[2], code[3], code[4], code[5], code[6], code[7]},
+            ),
+            _ => U256::from_big_endian(&code[..LEN]),
+        })?;
+    }
+    Ok(LEN)
 }
 
 #[inline]

--- a/actors/evm/src/interpreter/instructions/stack.rs
+++ b/actors/evm/src/interpreter/instructions/stack.rs
@@ -5,9 +5,14 @@ use {crate::interpreter::stack::Stack, crate::interpreter::U256};
 
 macro_rules! be_u64 {
     ($byte:expr) => {$byte as u64};
-    ($byte1:expr, $byte2:expr $(,$rest:expr)*) => {
-        be_u64!{((($byte1 as u64) << 8) | ($byte2 as u64)) $(,$rest)*}
+    ($byte1:expr $(,$rest:expr)*) => {
+        (($byte1 as u64) << (be_shift!{$($rest),*})) + be_u64!{$($rest),*}
     };
+}
+
+macro_rules! be_shift {
+    ($byte:expr) => {8};
+    ($byte:expr $(,$rest:expr)*) => {8 + be_shift!{$($rest),*}};
 }
 
 #[inline]


### PR DESCRIPTION
A tiny bit faster in simplecoin, but that doesn't push all that much. I am pretty sure we could demonstrate more significant gains in a push-heavy benchmark.

Closes https://github.com/filecoin-project/ref-fvm/issues/1193