### PR TITLE
Datacap actor: Modify exported methods

### DIFF
--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -71,6 +71,7 @@ pub enum Method {
     DestroyExported = frc42_dispatch::method_hash!("Destroy"),
     NameExported = frc42_dispatch::method_hash!("Name"),
     SymbolExported = frc42_dispatch::method_hash!("Symbol"),
+    GranularityExported = frc42_dispatch::method_hash!("GranularityExported"),
     TotalSupplyExported = frc42_dispatch::method_hash!("TotalSupply"),
     BalanceExported = frc42_dispatch::method_hash!("Balance"),
     TransferExported = frc42_dispatch::method_hash!("Transfer"),
@@ -107,6 +108,11 @@ impl Actor {
     pub fn symbol(rt: &mut impl Runtime) -> Result<String, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         Ok("DCAP".to_string())
+    }
+
+    pub fn granularity(rt: &mut impl Runtime) -> Result<GranularityReturn, ActorError> {
+        rt.validate_immediate_caller_accept_any()?;
+        Ok(GranularityReturn { granularity: DATACAP_GRANULARITY })
     }
 
     pub fn total_supply(rt: &mut impl Runtime, _: ()) -> Result<TokenAmount, ActorError> {
@@ -489,6 +495,10 @@ impl ActorCode for Actor {
             Some(Method::SymbolExported) => {
                 let ret = Self::symbol(rt)?;
                 serialize(&ret, "symbol result")
+            }
+            Some(Method::GranularityExported) => {
+                let ret = Self::granularity(rt)?;
+                serialize(&ret, "granularity result")
             }
             Some(Method::TotalSupplyExported) => {
                 let ret = Self::total_supply(rt, cbor::deserialize_params(params)?)?;

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -72,7 +72,7 @@ pub enum Method {
     NameExported = frc42_dispatch::method_hash!("Name"),
     SymbolExported = frc42_dispatch::method_hash!("Symbol"),
     TotalSupplyExported = frc42_dispatch::method_hash!("TotalSupply"),
-    BalanceOfExported = frc42_dispatch::method_hash!("BalanceOf"),
+    BalanceExported = frc42_dispatch::method_hash!("Balance"),
     TransferExported = frc42_dispatch::method_hash!("Transfer"),
     TransferFromExported = frc42_dispatch::method_hash!("TransferFrom"),
     IncreaseAllowanceExported = frc42_dispatch::method_hash!("IncreaseAllowance"),
@@ -117,7 +117,7 @@ impl Actor {
         Ok(token.total_supply())
     }
 
-    pub fn balance_of(rt: &mut impl Runtime, address: Address) -> Result<TokenAmount, ActorError> {
+    pub fn balance(rt: &mut impl Runtime, address: Address) -> Result<TokenAmount, ActorError> {
         // NOTE: mutability and method caller here are awkward for a read-only call
         rt.validate_immediate_caller_accept_any()?;
         let mut st: State = rt.state()?;
@@ -494,8 +494,8 @@ impl ActorCode for Actor {
                 let ret = Self::total_supply(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "total_supply result")
             }
-            Some(Method::BalanceOfExported) => {
-                let ret = Self::balance_of(rt, cbor::deserialize_params(params)?)?;
+            Some(Method::BalanceExported) => {
+                let ret = Self::balance(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "balance_of result")
             }
             Some(Method::TransferExported) => {

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -51,26 +51,25 @@ lazy_static! {
 #[repr(u64)]
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
-    // Non-standard.
-    Mint = 2,
-    Destroy = 3,
-    // Static method numbers for token standard methods, for private use.
-    Name = 10,
-    Symbol = 11,
-    TotalSupply = 12,
-    BalanceOf = 13,
-    Transfer = 14,
-    TransferFrom = 15,
-    IncreaseAllowance = 16,
-    DecreaseAllowance = 17,
-    RevokeAllowance = 18,
-    Burn = 19,
-    BurnFrom = 20,
-    Allowance = 21,
+    // Deprecated in v10
+    // Mint = 2,
+    // Destroy = 3,
+    // Name = 10,
+    // Symbol = 11,
+    // TotalSupply = 12,
+    // BalanceOf = 13,
+    // Transfer = 14,
+    // TransferFrom = 15,
+    // IncreaseAllowance = 16,
+    // DecreaseAllowance = 17,
+    // RevokeAllowance = 18,
+    // Burn = 19,
+    // BurnFrom = 20,
+    // Allowance = 21,
     // Method numbers derived from FRC-0042 standards
-    NameExported = frc42_dispatch::method_hash!("Name"),
     MintExported = frc42_dispatch::method_hash!("Mint"),
     DestroyExported = frc42_dispatch::method_hash!("Destroy"),
+    NameExported = frc42_dispatch::method_hash!("Name"),
     SymbolExported = frc42_dispatch::method_hash!("Symbol"),
     TotalSupplyExported = frc42_dispatch::method_hash!("TotalSupply"),
     BalanceOfExported = frc42_dispatch::method_hash!("BalanceOf"),
@@ -475,59 +474,59 @@ impl ActorCode for Actor {
                 Self::constructor(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            Some(Method::Mint) | Some(Method::MintExported) => {
+            Some(Method::MintExported) => {
                 let ret = Self::mint(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "mint result")
             }
-            Some(Method::Destroy) | Some(Method::DestroyExported) => {
+            Some(Method::DestroyExported) => {
                 let ret = Self::destroy(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "destroy result")
             }
-            Some(Method::Name) | Some(Method::NameExported) => {
+            Some(Method::NameExported) => {
                 let ret = Self::name(rt)?;
                 serialize(&ret, "name result")
             }
-            Some(Method::Symbol) | Some(Method::SymbolExported) => {
+            Some(Method::SymbolExported) => {
                 let ret = Self::symbol(rt)?;
                 serialize(&ret, "symbol result")
             }
-            Some(Method::TotalSupply) | Some(Method::TotalSupplyExported) => {
+            Some(Method::TotalSupplyExported) => {
                 let ret = Self::total_supply(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "total_supply result")
             }
-            Some(Method::BalanceOf) | Some(Method::BalanceOfExported) => {
+            Some(Method::BalanceOfExported) => {
                 let ret = Self::balance_of(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "balance_of result")
             }
-            Some(Method::Transfer) | Some(Method::TransferExported) => {
+            Some(Method::TransferExported) => {
                 let ret = Self::transfer(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "transfer result")
             }
-            Some(Method::TransferFrom) | Some(Method::TransferFromExported) => {
+            Some(Method::TransferFromExported) => {
                 let ret = Self::transfer_from(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "transfer_from result")
             }
-            Some(Method::IncreaseAllowance) | Some(Method::IncreaseAllowanceExported) => {
+            Some(Method::IncreaseAllowanceExported) => {
                 let ret = Self::increase_allowance(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "increase_allowance result")
             }
-            Some(Method::DecreaseAllowance) | Some(Method::DecreaseAllowanceExported) => {
+            Some(Method::DecreaseAllowanceExported) => {
                 let ret = Self::decrease_allowance(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "decrease_allowance result")
             }
-            Some(Method::RevokeAllowance) | Some(Method::RevokeAllowanceExported) => {
+            Some(Method::RevokeAllowanceExported) => {
                 Self::revoke_allowance(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            Some(Method::Burn) | Some(Method::BurnExported) => {
+            Some(Method::BurnExported) => {
                 let ret = Self::burn(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "burn result")
             }
-            Some(Method::BurnFrom) | Some(Method::BurnFromExported) => {
+            Some(Method::BurnFromExported) => {
                 let ret = Self::burn_from(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "burn_from result")
             }
-            Some(Method::Allowance) | Some(Method::AllowanceExported) => {
+            Some(Method::AllowanceExported) => {
                 let ret = Self::allowance(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "allowance result")
             }

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -69,6 +69,8 @@ pub enum Method {
     Allowance = 21,
     // Method numbers derived from FRC-0042 standards
     NameExported = frc42_dispatch::method_hash!("Name"),
+    MintExported = frc42_dispatch::method_hash!("Mint"),
+    DestroyExported = frc42_dispatch::method_hash!("Destroy"),
     SymbolExported = frc42_dispatch::method_hash!("Symbol"),
     TotalSupplyExported = frc42_dispatch::method_hash!("TotalSupply"),
     BalanceOfExported = frc42_dispatch::method_hash!("BalanceOf"),
@@ -473,11 +475,11 @@ impl ActorCode for Actor {
                 Self::constructor(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            Some(Method::Mint) => {
+            Some(Method::Mint) | Some(Method::MintExported) => {
                 let ret = Self::mint(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "mint result")
             }
-            Some(Method::Destroy) => {
+            Some(Method::Destroy) | Some(Method::DestroyExported) => {
                 let ret = Self::destroy(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "destroy result")
             }

--- a/actors/datacap/src/types.rs
+++ b/actors/datacap/src/types.rs
@@ -22,3 +22,9 @@ pub struct DestroyParams {
 }
 
 impl Cbor for DestroyParams {}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
+pub struct GranularityReturn {
+    pub granularity: u64,
+}

--- a/actors/datacap/tests/datacap_actor_test.rs
+++ b/actors/datacap/tests/datacap_actor_test.rs
@@ -16,7 +16,10 @@ lazy_static! {
 
 mod construction {
     use crate::*;
+    use fil_actor_datacap::{Actor, GranularityReturn, Method, DATACAP_GRANULARITY};
     use fil_actors_runtime::VERIFIED_REGISTRY_ACTOR_ADDR;
+    use fvm_ipld_encoding::RawBytes;
+    use fvm_shared::MethodNum;
 
     #[test]
     fn construct_with_verified() {
@@ -24,6 +27,15 @@ mod construction {
         let h = Harness { governor: VERIFIED_REGISTRY_ACTOR_ADDR };
         h.construct_and_verify(&mut rt, &h.governor);
         h.check_state(&rt);
+
+        rt.expect_validate_caller_any();
+        let ret: GranularityReturn = rt
+            .call::<Actor>(Method::GranularityExported as MethodNum, &RawBytes::default())
+            .unwrap()
+            .deserialize()
+            .unwrap();
+        rt.verify();
+        assert_eq!(ret.granularity, DATACAP_GRANULARITY)
     }
 }
 

--- a/actors/datacap/tests/datacap_actor_test.rs
+++ b/actors/datacap/tests/datacap_actor_test.rs
@@ -51,13 +51,13 @@ mod mint {
         assert_eq!(amt, ret.supply);
         assert_eq!(amt, ret.balance);
         assert_eq!(amt, h.get_supply(&rt));
-        assert_eq!(amt, h.get_balance(&rt, &*ALICE));
+        assert_eq!(amt, h.get_balance(&mut rt, &*ALICE));
 
         let ret = h.mint(&mut rt, &*BOB, &amt, vec![]).unwrap();
         assert_eq!(&amt * 2, ret.supply);
         assert_eq!(amt, ret.balance);
         assert_eq!(&amt * 2, h.get_supply(&rt));
-        assert_eq!(amt, h.get_balance(&rt, &*BOB));
+        assert_eq!(amt, h.get_balance(&mut rt, &*BOB));
 
         h.check_state(&rt);
     }

--- a/actors/datacap/tests/datacap_actor_test.rs
+++ b/actors/datacap/tests/datacap_actor_test.rs
@@ -34,9 +34,7 @@ mod mint {
 
     use fil_actor_datacap::{Actor, Method, MintParams, INFINITE_ALLOWANCE};
     use fil_actors_runtime::cbor::serialize;
-    use fil_actors_runtime::test_utils::{
-        expect_abort_contains_message, make_identity_cid, MARKET_ACTOR_CODE_ID,
-    };
+    use fil_actors_runtime::test_utils::{expect_abort_contains_message, MARKET_ACTOR_CODE_ID};
     use fil_actors_runtime::{STORAGE_MARKET_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR};
     use fvm_ipld_encoding::RawBytes;
     use std::ops::Sub;
@@ -65,21 +63,6 @@ mod mint {
     }
 
     #[test]
-    fn requires_builtin_caller() {
-        let (mut rt, h) = make_harness();
-        let amt = TokenAmount::from_whole(1);
-        let params = MintParams { to: *ALICE, amount: amt, operators: vec![] };
-
-        rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1000));
-        expect_abort_contains_message(
-            ExitCode::USR_FORBIDDEN,
-            "must be built-in",
-            rt.call::<Actor>(Method::Mint as MethodNum, &serialize(&params, "params").unwrap()),
-        );
-        h.check_state(&rt);
-    }
-
-    #[test]
     fn requires_verifreg_caller() {
         let (mut rt, h) = make_harness();
         let amt = TokenAmount::from_whole(1);
@@ -90,7 +73,10 @@ mod mint {
         expect_abort_contains_message(
             ExitCode::USR_FORBIDDEN,
             "caller address",
-            rt.call::<Actor>(Method::Mint as MethodNum, &serialize(&params, "params").unwrap()),
+            rt.call::<Actor>(
+                Method::MintExported as MethodNum,
+                &serialize(&params, "params").unwrap(),
+            ),
         );
         h.check_state(&rt);
     }
@@ -206,32 +192,14 @@ mod transfer {
 mod destroy {
     use crate::{make_harness, ALICE, BOB};
     use fil_actor_datacap::DestroyParams;
-    use fil_actors_runtime::test_utils::{
-        expect_abort_contains_message, make_identity_cid, ACCOUNT_ACTOR_CODE_ID,
-    };
+    use fil_actors_runtime::test_utils::{expect_abort_contains_message, ACCOUNT_ACTOR_CODE_ID};
     use fil_actors_runtime::VERIFIED_REGISTRY_ACTOR_ADDR;
-    use fvm_shared::address::Address;
     use fvm_shared::econ::TokenAmount;
     use fvm_shared::MethodNum;
 
     use fil_actor_datacap::{Actor, Method};
     use fil_actors_runtime::cbor::serialize;
     use fvm_shared::error::ExitCode;
-
-    #[test]
-    fn requires_builtin_caller() {
-        let (mut rt, h) = make_harness();
-        let amt = TokenAmount::from_whole(1);
-        let params = DestroyParams { owner: *ALICE, amount: amt };
-
-        rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1000));
-        expect_abort_contains_message(
-            ExitCode::USR_FORBIDDEN,
-            "must be built-in",
-            rt.call::<Actor>(Method::Destroy as MethodNum, &serialize(&params, "params").unwrap()),
-        );
-        h.check_state(&rt);
-    }
 
     #[test]
     fn only_governor_allowed() {
@@ -248,7 +216,10 @@ mod destroy {
         expect_abort_contains_message(
             ExitCode::USR_FORBIDDEN,
             "caller address",
-            rt.call::<Actor>(Method::Destroy as MethodNum, &serialize(&params, "params").unwrap()),
+            rt.call::<Actor>(
+                Method::DestroyExported as MethodNum,
+                &serialize(&params, "params").unwrap(),
+            ),
         );
 
         // Destroying from 0 allowance having governor works

--- a/actors/datacap/tests/harness/mod.rs
+++ b/actors/datacap/tests/harness/mod.rs
@@ -93,8 +93,10 @@ impl Harness {
 
         let params = MintParams { to: *to, amount: amount.clone(), operators };
         rt.set_caller(*VERIFREG_ACTOR_CODE_ID, VERIFIED_REGISTRY_ACTOR_ADDR);
-        let ret =
-            rt.call::<DataCapActor>(Method::Mint as MethodNum, &serialize(&params, "params")?)?;
+        let ret = rt.call::<DataCapActor>(
+            Method::MintExported as MethodNum,
+            &serialize(&params, "params")?,
+        )?;
 
         rt.verify();
         Ok(ret.deserialize().unwrap())
@@ -111,8 +113,10 @@ impl Harness {
         let params = DestroyParams { owner: *owner, amount: amount.clone() };
 
         rt.set_caller(*VERIFREG_ACTOR_CODE_ID, VERIFIED_REGISTRY_ACTOR_ADDR);
-        let ret =
-            rt.call::<DataCapActor>(Method::Destroy as MethodNum, &serialize(&params, "params")?)?;
+        let ret = rt.call::<DataCapActor>(
+            Method::DestroyExported as MethodNum,
+            &serialize(&params, "params")?,
+        )?;
 
         rt.verify();
         Ok(ret.deserialize().unwrap())
@@ -155,8 +159,10 @@ impl Harness {
         );
 
         let params = TransferParams { to: *to, amount: amount.clone(), operator_data };
-        let ret =
-            rt.call::<DataCapActor>(Method::Transfer as MethodNum, &serialize(&params, "params")?)?;
+        let ret = rt.call::<DataCapActor>(
+            Method::TransferExported as MethodNum,
+            &serialize(&params, "params")?,
+        )?;
 
         rt.verify();
         Ok(ret.deserialize().unwrap())
@@ -202,7 +208,7 @@ impl Harness {
         let params =
             TransferFromParams { to: *to, from: *from, amount: amount.clone(), operator_data };
         let ret = rt.call::<DataCapActor>(
-            Method::TransferFrom as MethodNum,
+            Method::TransferFromExported as MethodNum,
             &serialize(&params, "params")?,
         )?;
 

--- a/actors/datacap/tests/harness/mod.rs
+++ b/actors/datacap/tests/harness/mod.rs
@@ -222,8 +222,18 @@ impl Harness {
     }
 
     // Reads a balance from state directly.
-    pub fn get_balance(&self, rt: &MockRuntime, address: &Address) -> TokenAmount {
-        rt.get_state::<State>().token.get_balance(rt.store(), address.id().unwrap()).unwrap()
+    pub fn get_balance(&self, rt: &mut MockRuntime, address: &Address) -> TokenAmount {
+        rt.expect_validate_caller_any();
+        let ret = rt
+            .call::<DataCapActor>(
+                Method::BalanceExported as MethodNum,
+                &serialize(&address, "params").unwrap(),
+            )
+            .unwrap()
+            .deserialize()
+            .unwrap();
+        rt.verify();
+        ret
     }
 
     // Reads allowance from state directly

--- a/actors/market/src/ext.rs
+++ b/actors/market/src/ext.rs
@@ -80,7 +80,7 @@ pub mod verifreg {
 }
 
 pub mod datacap {
-    pub const TRANSFER_FROM_METHOD: u64 = 15;
+    pub const TRANSFER_FROM_METHOD: u64 = frc42_dispatch::method_hash!("TransferFrom");
 }
 
 pub mod reward {

--- a/actors/verifreg/src/ext.rs
+++ b/actors/verifreg/src/ext.rs
@@ -10,7 +10,7 @@ pub mod datacap {
     pub enum Method {
         Mint = frc42_dispatch::method_hash!("Mint"),
         Destroy = frc42_dispatch::method_hash!("Destroy"),
-        BalanceOf = frc42_dispatch::method_hash!("BalanceOf"),
+        Balance = frc42_dispatch::method_hash!("Balance"),
         Transfer = frc42_dispatch::method_hash!("Transfer"),
         Burn = frc42_dispatch::method_hash!("Burn"),
     }

--- a/actors/verifreg/src/ext.rs
+++ b/actors/verifreg/src/ext.rs
@@ -8,21 +8,11 @@ pub mod datacap {
 
     #[repr(u64)]
     pub enum Method {
-        // Non-standard.
-        Mint = 2,
-        Destroy = 3,
-        // Static method numbers for token standard methods, for private use.
-        // Name = 10,
-        // Symbol = 11,
-        // TotalSupply = 12,
-        BalanceOf = 13,
-        Transfer = 14,
-        // TransferFrom = 15,
-        // IncreaseAllowance = 16,
-        // DecreaseAllowance = 17,
-        // RevokeAllowance = 18,
-        Burn = 19,
-        // BurnFrom = 20,
+        Mint = frc42_dispatch::method_hash!("Mint"),
+        Destroy = frc42_dispatch::method_hash!("Destroy"),
+        BalanceOf = frc42_dispatch::method_hash!("BalanceOf"),
+        Transfer = frc42_dispatch::method_hash!("Transfer"),
+        Burn = frc42_dispatch::method_hash!("Burn"),
     }
 
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -114,7 +114,7 @@ impl Actor {
         }
 
         // Disallow existing clients as verifiers.
-        let token_balance = balance_of(rt, &verifier)?;
+        let token_balance = balance(rt, &verifier)?;
         if token_balance.is_positive() {
             return Err(actor_error!(
                 illegal_argument,
@@ -288,7 +288,7 @@ impl Actor {
         })?;
 
         // Burn the client's data cap tokens.
-        let balance = balance_of(rt, &client).context("failed to fetch balance")?;
+        let balance = balance(rt, &client).context("failed to fetch balance")?;
         let burnt = std::cmp::min(balance, params.data_cap_amount_to_remove);
         destroy(rt, &client, &burnt)
             .context(format!("failed to destroy {} from allowance for {}", &burnt, &client))?;
@@ -719,13 +719,13 @@ fn is_verifier(rt: &impl Runtime, st: &State, address: Address) -> Result<bool, 
     Ok(found)
 }
 
-// Invokes BalanceOf on the data cap token actor, and converts the result to whole units of data cap.
-fn balance_of(rt: &mut impl Runtime, owner: &Address) -> Result<DataCap, ActorError> {
+// Invokes Balance on the data cap token actor, and converts the result to whole units of data cap.
+fn balance(rt: &mut impl Runtime, owner: &Address) -> Result<DataCap, ActorError> {
     let params = serialize(owner, "owner address")?;
     let ret = rt
         .send(
             &DATACAP_TOKEN_ACTOR_ADDR,
-            ext::datacap::Method::BalanceOf as u64,
+            ext::datacap::Method::Balance as u64,
             params,
             TokenAmount::zero(),
         )

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -102,7 +102,7 @@ impl Harness {
         // Expect checking the verifier's token balance.
         rt.expect_send(
             DATACAP_TOKEN_ACTOR_ADDR,
-            ext::datacap::Method::BalanceOf as MethodNum,
+            ext::datacap::Method::Balance as MethodNum,
             RawBytes::serialize(&verifier_resolved).unwrap(),
             TokenAmount::zero(),
             serialize(&BigIntSer(&(cap * TOKEN_PRECISION)), "").unwrap(),

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -854,7 +854,7 @@ pub fn verifreg_add_verifier(v: &VM, verifier: Address, data_cap: StoragePower) 
             params: Some(serialize(&add_verifier_params, "verifreg add verifier params").unwrap()),
             subinvocs: Some(vec![ExpectInvocation {
                 to: DATACAP_TOKEN_ACTOR_ADDR,
-                method: DataCapMethod::BalanceOfExported as u64,
+                method: DataCapMethod::BalanceExported as u64,
                 params: Some(serialize(&verifier, "balance of params").unwrap()),
                 code: Some(ExitCode::OK),
                 ..Default::default()
@@ -975,7 +975,7 @@ pub fn datacap_get_balance(v: &VM, address: Address) -> TokenAmount {
         address,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::BalanceOfExported as u64,
+        DataCapMethod::BalanceExported as u64,
         address,
     );
     deserialize(&ret, "balance of return value").unwrap()

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -854,7 +854,7 @@ pub fn verifreg_add_verifier(v: &VM, verifier: Address, data_cap: StoragePower) 
             params: Some(serialize(&add_verifier_params, "verifreg add verifier params").unwrap()),
             subinvocs: Some(vec![ExpectInvocation {
                 to: DATACAP_TOKEN_ACTOR_ADDR,
-                method: DataCapMethod::BalanceOf as u64,
+                method: DataCapMethod::BalanceOfExported as u64,
                 params: Some(serialize(&verifier, "balance of params").unwrap()),
                 code: Some(ExitCode::OK),
                 ..Default::default()
@@ -882,7 +882,7 @@ pub fn verifreg_add_client(v: &VM, verifier: Address, client: Address, allowance
         method: VerifregMethod::AddVerifiedClient as u64,
         subinvocs: Some(vec![ExpectInvocation {
             to: DATACAP_TOKEN_ACTOR_ADDR,
-            method: DataCapMethod::Mint as u64,
+            method: DataCapMethod::MintExported as u64,
             params: Some(
                 serialize(
                     &MintParams {
@@ -949,7 +949,7 @@ pub fn verifreg_remove_expired_allocations(
         method: VerifregMethod::RemoveExpiredAllocations as u64,
         subinvocs: Some(vec![ExpectInvocation {
             to: DATACAP_TOKEN_ACTOR_ADDR,
-            method: DataCapMethod::Transfer as u64,
+            method: DataCapMethod::TransferExported as u64,
             code: Some(ExitCode::OK),
             params: Some(
                 serialize(
@@ -975,7 +975,7 @@ pub fn datacap_get_balance(v: &VM, address: Address) -> TokenAmount {
         address,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::BalanceOf as u64,
+        DataCapMethod::BalanceOfExported as u64,
         address,
     );
     deserialize(&ret, "balance of return value").unwrap()
@@ -1006,13 +1006,13 @@ pub fn datacap_extend_claim(
         client,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::Transfer as u64,
+        DataCapMethod::TransferExported as u64,
         transfer_params,
     );
 
     ExpectInvocation {
         to: DATACAP_TOKEN_ACTOR_ADDR,
-        method: DataCapMethod::Transfer as u64,
+        method: DataCapMethod::TransferExported as u64,
         subinvocs: Some(vec![ExpectInvocation {
             to: VERIFIED_REGISTRY_ACTOR_ADDR,
             method: VerifregMethod::UniversalReceiverHook as u64,
@@ -1040,7 +1040,7 @@ pub fn datacap_extend_claim(
             ),
             subinvocs: Some(vec![ExpectInvocation {
                 to: DATACAP_TOKEN_ACTOR_ADDR,
-                method: DataCapMethod::Burn as u64,
+                method: DataCapMethod::BurnExported as u64,
                 code: Some(ExitCode::OK),
                 params: Some(
                     serialize(&BurnParams { amount: token_amount }, "burn params").unwrap(),
@@ -1153,7 +1153,7 @@ pub fn market_publish_deal(
         };
         expect_publish_invocs.push(ExpectInvocation {
             to: DATACAP_TOKEN_ACTOR_ADDR,
-            method: DataCapMethod::TransferFrom as u64,
+            method: DataCapMethod::TransferFromExported as u64,
             params: Some(
                 RawBytes::serialize(&TransferFromParams {
                     from: deal_client,

--- a/test_vm/tests/datacap_tests.rs
+++ b/test_vm/tests/datacap_tests.rs
@@ -48,7 +48,7 @@ fn datacap_transfer_scenario() {
         operator,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::Mint as u64,
+        DataCapMethod::MintExported as u64,
         mint_params.clone(),
         ExitCode::USR_FORBIDDEN,
     );
@@ -59,7 +59,7 @@ fn datacap_transfer_scenario() {
         VERIFIED_REGISTRY_ACTOR_ADDR,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::Mint as u64,
+        DataCapMethod::MintExported as u64,
         mint_params,
     );
 
@@ -70,7 +70,7 @@ fn datacap_transfer_scenario() {
         owner,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::Allowance as u64,
+        DataCapMethod::AllowanceExported as u64,
         GetAllowanceParams { owner: client, operator },
     );
 
@@ -116,7 +116,7 @@ fn datacap_transfer_scenario() {
         operator,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         params_piece_too_small,
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
@@ -130,7 +130,7 @@ fn datacap_transfer_scenario() {
         operator,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         params_mismatched_datacap,
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
@@ -149,7 +149,7 @@ fn datacap_transfer_scenario() {
         operator,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         params_bad_term,
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
@@ -162,7 +162,7 @@ fn datacap_transfer_scenario() {
         owner,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         clone_params(&params_bad_receiver),
         ExitCode::USR_FORBIDDEN, // ExitCode(19) because non-operator has insufficient allowance
     );
@@ -173,7 +173,7 @@ fn datacap_transfer_scenario() {
         owner,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         clone_params(&transfer_from_params),
         ExitCode::USR_INSUFFICIENT_FUNDS, // ExitCode(19) because non-operator has insufficient allowance
     );
@@ -183,7 +183,7 @@ fn datacap_transfer_scenario() {
         operator,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         clone_params(&transfer_from_params),
     );
 
@@ -193,7 +193,7 @@ fn datacap_transfer_scenario() {
         operator,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         transfer_from_params,
         ExitCode::USR_INSUFFICIENT_FUNDS,
     );
@@ -212,7 +212,7 @@ fn call_name_symbol() {
         sender,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::Name as u64,
+        DataCapMethod::NameExported as u64,
         RawBytes::default(),
     )
     .deserialize()
@@ -224,7 +224,7 @@ fn call_name_symbol() {
         sender,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::Symbol as u64,
+        DataCapMethod::SymbolExported as u64,
         RawBytes::default(),
     )
     .deserialize()

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -334,7 +334,7 @@ fn expect_remove_datacap(params: &RemoveDataCapParams) -> ExpectInvocation {
         subinvocs: Some(vec![
             ExpectInvocation {
                 to: DATACAP_TOKEN_ACTOR_ADDR,
-                method: DataCapMethod::BalanceOfExported as u64,
+                method: DataCapMethod::BalanceExported as u64,
                 params: Some(
                     serialize(&params.verified_client_to_remove, "balance_of params").unwrap(),
                 ),

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -68,7 +68,7 @@ fn remove_datacap_simple_successful_path() {
         params: Some(serialize(&add_verified_client_params, "add verifier params").unwrap()),
         subinvocs: Some(vec![ExpectInvocation {
             to: DATACAP_TOKEN_ACTOR_ADDR,
-            method: DataCapMethod::Mint as u64,
+            method: DataCapMethod::MintExported as u64,
             params: Some(serialize(&mint_params, "mint params").unwrap()),
             subinvocs: None,
             ..Default::default()
@@ -334,7 +334,7 @@ fn expect_remove_datacap(params: &RemoveDataCapParams) -> ExpectInvocation {
         subinvocs: Some(vec![
             ExpectInvocation {
                 to: DATACAP_TOKEN_ACTOR_ADDR,
-                method: DataCapMethod::BalanceOf as u64,
+                method: DataCapMethod::BalanceOfExported as u64,
                 params: Some(
                     serialize(&params.verified_client_to_remove, "balance_of params").unwrap(),
                 ),
@@ -344,7 +344,7 @@ fn expect_remove_datacap(params: &RemoveDataCapParams) -> ExpectInvocation {
             },
             ExpectInvocation {
                 to: DATACAP_TOKEN_ACTOR_ADDR,
-                method: DataCapMethod::Destroy as u64,
+                method: DataCapMethod::DestroyExported as u64,
                 params: Some(
                     serialize(
                         &DestroyParams {


### PR DESCRIPTION
#808 

- Export the Mint & Destroy methods (restrictions on their caller addresses remain)
- Deprecate all internal methods:
  - Built-in actor callsites are updated to use the exported callers
  - There are no meaningful external callers of these methods today, so we deprecate them now
- Rename BalanceOf to Balance, to be in line with FRC-0046
- Add Granularity, to be in line with FRC-0046