### PR TITLE
Backport #909: Datacap actor: Modify exported methods 

### DIFF
--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -51,27 +51,29 @@ lazy_static! {
 #[repr(u64)]
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
-    // Non-standard.
-    Mint = 2,
-    Destroy = 3,
-    // Static method numbers for token standard methods, for private use.
-    Name = 10,
-    Symbol = 11,
-    TotalSupply = 12,
-    BalanceOf = 13,
-    Transfer = 14,
-    TransferFrom = 15,
-    IncreaseAllowance = 16,
-    DecreaseAllowance = 17,
-    RevokeAllowance = 18,
-    Burn = 19,
-    BurnFrom = 20,
-    Allowance = 21,
+    // Deprecated in v10
+    // Mint = 2,
+    // Destroy = 3,
+    // Name = 10,
+    // Symbol = 11,
+    // TotalSupply = 12,
+    // BalanceOf = 13,
+    // Transfer = 14,
+    // TransferFrom = 15,
+    // IncreaseAllowance = 16,
+    // DecreaseAllowance = 17,
+    // RevokeAllowance = 18,
+    // Burn = 19,
+    // BurnFrom = 20,
+    // Allowance = 21,
     // Method numbers derived from FRC-0042 standards
+    MintExported = frc42_dispatch::method_hash!("Mint"),
+    DestroyExported = frc42_dispatch::method_hash!("Destroy"),
     NameExported = frc42_dispatch::method_hash!("Name"),
     SymbolExported = frc42_dispatch::method_hash!("Symbol"),
+    GranularityExported = frc42_dispatch::method_hash!("GranularityExported"),
     TotalSupplyExported = frc42_dispatch::method_hash!("TotalSupply"),
-    BalanceOfExported = frc42_dispatch::method_hash!("BalanceOf"),
+    BalanceExported = frc42_dispatch::method_hash!("Balance"),
     TransferExported = frc42_dispatch::method_hash!("Transfer"),
     TransferFromExported = frc42_dispatch::method_hash!("TransferFrom"),
     IncreaseAllowanceExported = frc42_dispatch::method_hash!("IncreaseAllowance"),
@@ -108,6 +110,11 @@ impl Actor {
         Ok("DCAP".to_string())
     }
 
+    pub fn granularity(rt: &mut impl Runtime) -> Result<GranularityReturn, ActorError> {
+        rt.validate_immediate_caller_accept_any()?;
+        Ok(GranularityReturn { granularity: DATACAP_GRANULARITY })
+    }
+
     pub fn total_supply(rt: &mut impl Runtime, _: ()) -> Result<TokenAmount, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let mut st: State = rt.state()?;
@@ -116,7 +123,7 @@ impl Actor {
         Ok(token.total_supply())
     }
 
-    pub fn balance_of(rt: &mut impl Runtime, address: Address) -> Result<TokenAmount, ActorError> {
+    pub fn balance(rt: &mut impl Runtime, address: Address) -> Result<TokenAmount, ActorError> {
         // NOTE: mutability and method caller here are awkward for a read-only call
         rt.validate_immediate_caller_accept_any()?;
         let mut st: State = rt.state()?;
@@ -477,59 +484,63 @@ impl ActorCode for Actor {
                 Self::constructor(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            Some(Method::Mint) => {
+            Some(Method::MintExported) => {
                 let ret = Self::mint(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "mint result")
             }
-            Some(Method::Destroy) => {
+            Some(Method::DestroyExported) => {
                 let ret = Self::destroy(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "destroy result")
             }
-            Some(Method::Name) | Some(Method::NameExported) => {
+            Some(Method::NameExported) => {
                 let ret = Self::name(rt)?;
                 serialize(&ret, "name result")
             }
-            Some(Method::Symbol) | Some(Method::SymbolExported) => {
+            Some(Method::SymbolExported) => {
                 let ret = Self::symbol(rt)?;
                 serialize(&ret, "symbol result")
             }
-            Some(Method::TotalSupply) | Some(Method::TotalSupplyExported) => {
+            Some(Method::GranularityExported) => {
+                let ret = Self::granularity(rt)?;
+                serialize(&ret, "granularity result")
+            }
+            Some(Method::TotalSupplyExported) => {
                 let ret = Self::total_supply(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "total_supply result")
             }
-            Some(Method::BalanceOf) | Some(Method::BalanceOfExported) => {
-                let ret = Self::balance_of(rt, cbor::deserialize_params(params)?)?;
+            Some(Method::BalanceExported) => {
+                let ret = Self::balance(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "balance_of result")
             }
-            Some(Method::Transfer) | Some(Method::TransferExported) => {
+            Some(Method::TransferExported) => {
                 let ret = Self::transfer(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "transfer result")
             }
-            Some(Method::TransferFrom) | Some(Method::TransferFromExported) => {
+            Some(Method::TransferFromExported) => {
                 let ret = Self::transfer_from(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "transfer_from result")
             }
-            Some(Method::IncreaseAllowance) | Some(Method::IncreaseAllowanceExported) => {
+            Some(Method::IncreaseAllowanceExported) => {
                 let ret = Self::increase_allowance(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "increase_allowance result")
             }
-            Some(Method::DecreaseAllowance) | Some(Method::DecreaseAllowanceExported) => {
+            Some(Method::DecreaseAllowanceExported) => {
                 let ret = Self::decrease_allowance(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "decrease_allowance result")
             }
-            Some(Method::RevokeAllowance) | Some(Method::RevokeAllowanceExported) => {
+            Some(Method::RevokeAllowanceExported) => {
                 Self::revoke_allowance(rt, cbor::deserialize_params(params)?)?;
                 Ok(RawBytes::default())
             }
-            Some(Method::Burn) | Some(Method::BurnExported) => {
+            Some(Method::BurnExported) => {
                 let ret = Self::burn(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "burn result")
             }
-            Some(Method::BurnFrom) | Some(Method::BurnFromExported) => {
+            Some(Method::BurnFromExported) => {
                 let ret = Self::burn_from(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "burn_from result")
             }
-            Some(Method::Allowance) | Some(Method::AllowanceExported) => {
+            Some(Method::AllowanceExported) => {
                 let ret = Self::allowance(rt, cbor::deserialize_params(params)?)?;
                 serialize(&ret, "allowance result")
             }

--- a/actors/datacap/src/types.rs
+++ b/actors/datacap/src/types.rs
@@ -22,3 +22,9 @@ pub struct DestroyParams {
 }
 
 impl Cbor for DestroyParams {}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
+pub struct GranularityReturn {
+    pub granularity: u64,
+}

--- a/actors/datacap/tests/harness/mod.rs
+++ b/actors/datacap/tests/harness/mod.rs
@@ -93,8 +93,10 @@ impl Harness {
 
         let params = MintParams { to: *to, amount: amount.clone(), operators };
         rt.set_caller(*VERIFREG_ACTOR_CODE_ID, VERIFIED_REGISTRY_ACTOR_ADDR);
-        let ret =
-            rt.call::<DataCapActor>(Method::Mint as MethodNum, &serialize(&params, "params")?)?;
+        let ret = rt.call::<DataCapActor>(
+            Method::MintExported as MethodNum,
+            &serialize(&params, "params")?,
+        )?;
 
         rt.verify();
         Ok(ret.deserialize().unwrap())
@@ -111,8 +113,10 @@ impl Harness {
         let params = DestroyParams { owner: *owner, amount: amount.clone() };
 
         rt.set_caller(*VERIFREG_ACTOR_CODE_ID, VERIFIED_REGISTRY_ACTOR_ADDR);
-        let ret =
-            rt.call::<DataCapActor>(Method::Destroy as MethodNum, &serialize(&params, "params")?)?;
+        let ret = rt.call::<DataCapActor>(
+            Method::DestroyExported as MethodNum,
+            &serialize(&params, "params")?,
+        )?;
 
         rt.verify();
         Ok(ret.deserialize().unwrap())
@@ -155,8 +159,10 @@ impl Harness {
         );
 
         let params = TransferParams { to: *to, amount: amount.clone(), operator_data };
-        let ret =
-            rt.call::<DataCapActor>(Method::Transfer as MethodNum, &serialize(&params, "params")?)?;
+        let ret = rt.call::<DataCapActor>(
+            Method::TransferExported as MethodNum,
+            &serialize(&params, "params")?,
+        )?;
 
         rt.verify();
         Ok(ret.deserialize().unwrap())
@@ -202,7 +208,7 @@ impl Harness {
         let params =
             TransferFromParams { to: *to, from: *from, amount: amount.clone(), operator_data };
         let ret = rt.call::<DataCapActor>(
-            Method::TransferFrom as MethodNum,
+            Method::TransferFromExported as MethodNum,
             &serialize(&params, "params")?,
         )?;
 
@@ -216,8 +222,18 @@ impl Harness {
     }
 
     // Reads a balance from state directly.
-    pub fn get_balance(&self, rt: &MockRuntime, address: &Address) -> TokenAmount {
-        rt.get_state::<State>().token.get_balance(rt.store(), address.id().unwrap()).unwrap()
+    pub fn get_balance(&self, rt: &mut MockRuntime, address: &Address) -> TokenAmount {
+        rt.expect_validate_caller_any();
+        let ret = rt
+            .call::<DataCapActor>(
+                Method::BalanceExported as MethodNum,
+                &serialize(&address, "params").unwrap(),
+            )
+            .unwrap()
+            .deserialize()
+            .unwrap();
+        rt.verify();
+        ret
     }
 
     // Reads allowance from state directly

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -36,10 +36,12 @@ pub enum Method {
     InstallCode = 4,
     // Method numbers derived from FRC-0042 standards
     ExecExported = frc42_dispatch::method_hash!("Exec"),
+    // TODO: Export Exec4
 }
 
 /// Init actor
 pub struct Actor;
+
 impl Actor {
     /// Init actor constructor
     pub fn constructor(rt: &mut impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {

--- a/actors/market/src/ext.rs
+++ b/actors/market/src/ext.rs
@@ -80,7 +80,7 @@ pub mod verifreg {
 }
 
 pub mod datacap {
-    pub const TRANSFER_FROM_METHOD: u64 = 15;
+    pub const TRANSFER_FROM_METHOD: u64 = frc42_dispatch::method_hash!("TransferFrom");
 }
 
 pub mod reward {

--- a/actors/verifreg/src/ext.rs
+++ b/actors/verifreg/src/ext.rs
@@ -8,21 +8,11 @@ pub mod datacap {
 
     #[repr(u64)]
     pub enum Method {
-        // Non-standard.
-        Mint = 2,
-        Destroy = 3,
-        // Static method numbers for token standard methods, for private use.
-        // Name = 10,
-        // Symbol = 11,
-        // TotalSupply = 12,
-        BalanceOf = 13,
-        Transfer = 14,
-        // TransferFrom = 15,
-        // IncreaseAllowance = 16,
-        // DecreaseAllowance = 17,
-        // RevokeAllowance = 18,
-        Burn = 19,
-        // BurnFrom = 20,
+        Mint = frc42_dispatch::method_hash!("Mint"),
+        Destroy = frc42_dispatch::method_hash!("Destroy"),
+        Balance = frc42_dispatch::method_hash!("Balance"),
+        Transfer = frc42_dispatch::method_hash!("Transfer"),
+        Burn = frc42_dispatch::method_hash!("Burn"),
     }
 
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -114,7 +114,7 @@ impl Actor {
         }
 
         // Disallow existing clients as verifiers.
-        let token_balance = balance_of(rt, &verifier)?;
+        let token_balance = balance(rt, &verifier)?;
         if token_balance.is_positive() {
             return Err(actor_error!(
                 illegal_argument,
@@ -288,7 +288,7 @@ impl Actor {
         })?;
 
         // Burn the client's data cap tokens.
-        let balance = balance_of(rt, &client).context("failed to fetch balance")?;
+        let balance = balance(rt, &client).context("failed to fetch balance")?;
         let burnt = std::cmp::min(balance, params.data_cap_amount_to_remove);
         destroy(rt, &client, &burnt)
             .context(format!("failed to destroy {} from allowance for {}", &burnt, &client))?;
@@ -719,13 +719,13 @@ fn is_verifier(rt: &impl Runtime, st: &State, address: Address) -> Result<bool, 
     Ok(found)
 }
 
-// Invokes BalanceOf on the data cap token actor, and converts the result to whole units of data cap.
-fn balance_of(rt: &mut impl Runtime, owner: &Address) -> Result<DataCap, ActorError> {
+// Invokes Balance on the data cap token actor, and converts the result to whole units of data cap.
+fn balance(rt: &mut impl Runtime, owner: &Address) -> Result<DataCap, ActorError> {
     let params = serialize(owner, "owner address")?;
     let ret = rt
         .send(
             &DATACAP_TOKEN_ACTOR_ADDR,
-            ext::datacap::Method::BalanceOf as u64,
+            ext::datacap::Method::Balance as u64,
             params,
             TokenAmount::zero(),
         )

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -102,7 +102,7 @@ impl Harness {
         // Expect checking the verifier's token balance.
         rt.expect_send(
             DATACAP_TOKEN_ACTOR_ADDR,
-            ext::datacap::Method::BalanceOf as MethodNum,
+            ext::datacap::Method::Balance as MethodNum,
             RawBytes::serialize(&verifier_resolved).unwrap(),
             TokenAmount::zero(),
             serialize(&BigIntSer(&(cap * TOKEN_PRECISION)), "").unwrap(),

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -854,7 +854,7 @@ pub fn verifreg_add_verifier(v: &VM, verifier: Address, data_cap: StoragePower) 
             params: Some(serialize(&add_verifier_params, "verifreg add verifier params").unwrap()),
             subinvocs: Some(vec![ExpectInvocation {
                 to: DATACAP_TOKEN_ACTOR_ADDR,
-                method: DataCapMethod::BalanceOf as u64,
+                method: DataCapMethod::BalanceExported as u64,
                 params: Some(serialize(&verifier, "balance of params").unwrap()),
                 code: Some(ExitCode::OK),
                 ..Default::default()
@@ -882,7 +882,7 @@ pub fn verifreg_add_client(v: &VM, verifier: Address, client: Address, allowance
         method: VerifregMethod::AddVerifiedClient as u64,
         subinvocs: Some(vec![ExpectInvocation {
             to: DATACAP_TOKEN_ACTOR_ADDR,
-            method: DataCapMethod::Mint as u64,
+            method: DataCapMethod::MintExported as u64,
             params: Some(
                 serialize(
                     &MintParams {
@@ -949,7 +949,7 @@ pub fn verifreg_remove_expired_allocations(
         method: VerifregMethod::RemoveExpiredAllocations as u64,
         subinvocs: Some(vec![ExpectInvocation {
             to: DATACAP_TOKEN_ACTOR_ADDR,
-            method: DataCapMethod::Transfer as u64,
+            method: DataCapMethod::TransferExported as u64,
             code: Some(ExitCode::OK),
             params: Some(
                 serialize(
@@ -975,7 +975,7 @@ pub fn datacap_get_balance(v: &VM, address: Address) -> TokenAmount {
         address,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::BalanceOf as u64,
+        DataCapMethod::BalanceExported as u64,
         address,
     );
     deserialize(&ret, "balance of return value").unwrap()
@@ -1006,13 +1006,13 @@ pub fn datacap_extend_claim(
         client,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::Transfer as u64,
+        DataCapMethod::TransferExported as u64,
         transfer_params,
     );
 
     ExpectInvocation {
         to: DATACAP_TOKEN_ACTOR_ADDR,
-        method: DataCapMethod::Transfer as u64,
+        method: DataCapMethod::TransferExported as u64,
         subinvocs: Some(vec![ExpectInvocation {
             to: VERIFIED_REGISTRY_ACTOR_ADDR,
             method: VerifregMethod::UniversalReceiverHook as u64,
@@ -1040,7 +1040,7 @@ pub fn datacap_extend_claim(
             ),
             subinvocs: Some(vec![ExpectInvocation {
                 to: DATACAP_TOKEN_ACTOR_ADDR,
-                method: DataCapMethod::Burn as u64,
+                method: DataCapMethod::BurnExported as u64,
                 code: Some(ExitCode::OK),
                 params: Some(
                     serialize(&BurnParams { amount: token_amount }, "burn params").unwrap(),
@@ -1153,7 +1153,7 @@ pub fn market_publish_deal(
         };
         expect_publish_invocs.push(ExpectInvocation {
             to: DATACAP_TOKEN_ACTOR_ADDR,
-            method: DataCapMethod::TransferFrom as u64,
+            method: DataCapMethod::TransferFromExported as u64,
             params: Some(
                 RawBytes::serialize(&TransferFromParams {
                     from: deal_client,

--- a/test_vm/tests/datacap_tests.rs
+++ b/test_vm/tests/datacap_tests.rs
@@ -48,7 +48,7 @@ fn datacap_transfer_scenario() {
         operator,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::Mint as u64,
+        DataCapMethod::MintExported as u64,
         mint_params.clone(),
         ExitCode::USR_FORBIDDEN,
     );
@@ -59,7 +59,7 @@ fn datacap_transfer_scenario() {
         VERIFIED_REGISTRY_ACTOR_ADDR,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::Mint as u64,
+        DataCapMethod::MintExported as u64,
         mint_params,
     );
 
@@ -70,7 +70,7 @@ fn datacap_transfer_scenario() {
         owner,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::Allowance as u64,
+        DataCapMethod::AllowanceExported as u64,
         GetAllowanceParams { owner: client, operator },
     );
 
@@ -116,7 +116,7 @@ fn datacap_transfer_scenario() {
         operator,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         params_piece_too_small,
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
@@ -130,7 +130,7 @@ fn datacap_transfer_scenario() {
         operator,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         params_mismatched_datacap,
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
@@ -149,7 +149,7 @@ fn datacap_transfer_scenario() {
         operator,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         params_bad_term,
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
@@ -162,7 +162,7 @@ fn datacap_transfer_scenario() {
         owner,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         clone_params(&params_bad_receiver),
         ExitCode::USR_FORBIDDEN, // ExitCode(19) because non-operator has insufficient allowance
     );
@@ -173,7 +173,7 @@ fn datacap_transfer_scenario() {
         owner,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         clone_params(&transfer_from_params),
         ExitCode::USR_INSUFFICIENT_FUNDS, // ExitCode(19) because non-operator has insufficient allowance
     );
@@ -183,7 +183,7 @@ fn datacap_transfer_scenario() {
         operator,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         clone_params(&transfer_from_params),
     );
 
@@ -193,7 +193,7 @@ fn datacap_transfer_scenario() {
         operator,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::TransferFrom as u64,
+        DataCapMethod::TransferFromExported as u64,
         transfer_from_params,
         ExitCode::USR_INSUFFICIENT_FUNDS,
     );
@@ -212,7 +212,7 @@ fn call_name_symbol() {
         sender,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::Name as u64,
+        DataCapMethod::NameExported as u64,
         RawBytes::default(),
     )
     .deserialize()
@@ -224,7 +224,7 @@ fn call_name_symbol() {
         sender,
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
-        DataCapMethod::Symbol as u64,
+        DataCapMethod::SymbolExported as u64,
         RawBytes::default(),
     )
     .deserialize()

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -68,7 +68,7 @@ fn remove_datacap_simple_successful_path() {
         params: Some(serialize(&add_verified_client_params, "add verifier params").unwrap()),
         subinvocs: Some(vec![ExpectInvocation {
             to: DATACAP_TOKEN_ACTOR_ADDR,
-            method: DataCapMethod::Mint as u64,
+            method: DataCapMethod::MintExported as u64,
             params: Some(serialize(&mint_params, "mint params").unwrap()),
             subinvocs: None,
             ..Default::default()
@@ -334,7 +334,7 @@ fn expect_remove_datacap(params: &RemoveDataCapParams) -> ExpectInvocation {
         subinvocs: Some(vec![
             ExpectInvocation {
                 to: DATACAP_TOKEN_ACTOR_ADDR,
-                method: DataCapMethod::BalanceOf as u64,
+                method: DataCapMethod::BalanceExported as u64,
                 params: Some(
                     serialize(&params.verified_client_to_remove, "balance_of params").unwrap(),
                 ),
@@ -344,7 +344,7 @@ fn expect_remove_datacap(params: &RemoveDataCapParams) -> ExpectInvocation {
             },
             ExpectInvocation {
                 to: DATACAP_TOKEN_ACTOR_ADDR,
-                method: DataCapMethod::Destroy as u64,
+                method: DataCapMethod::DestroyExported as u64,
                 params: Some(
                     serialize(
                         &DestroyParams {


### PR DESCRIPTION
* Datacap: Export Mint and Destroy

* Datacap actor: Deprecate all internal methods

* Datacap actor: Rename BalanceOf to Balance

* Datacap actor: Add Granularity method