### PR TITLE
feat: refactor sends to use the unified function

### DIFF
--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -265,9 +265,7 @@ pub fn call_generic<RT: Runtime>(
                         } else {
                             SendFlags::default()
                         };
-                        system.send_generalized(
-                            &dst_addr, method, params, value, gas_limit, send_flags,
-                        )
+                        system.send(&dst_addr, method, params, value, gas_limit, send_flags)
                     }
                 }
                 CallKind::DelegateCall => match get_cid_type(system.rt, dst) {
@@ -277,7 +275,7 @@ pub fn call_generic<RT: Runtime>(
 
                         // and then invoke self with delegate; readonly context is sticky
                         let params = DelegateCallParams { code, input: input_data.into() };
-                        system.send_generalized(
+                        system.send(
                             &system.rt.message().receiver(),
                             Method::InvokeContractDelegate as u64,
                             RawBytes::serialize(&params)?,

--- a/actors/evm/src/interpreter/instructions/lifecycle.rs
+++ b/actors/evm/src/interpreter/instructions/lifecycle.rs
@@ -2,6 +2,7 @@ use bytes::Bytes;
 
 use fil_actors_runtime::{BURNT_FUNDS_ACTOR_ADDR, EAM_ACTOR_ADDR};
 use fvm_ipld_encoding::{strict_bytes, tuple::*, RawBytes};
+use fvm_shared::sys::SendFlags;
 use fvm_shared::MethodNum;
 use fvm_shared::METHOD_SEND;
 use fvm_shared::{address::Address, econ::TokenAmount};
@@ -118,7 +119,7 @@ fn create_init(
     value: TokenAmount,
 ) -> Result<U256, StatusCode> {
     // send bytecode & params to EAM to generate the address and contract
-    let ret = system.send(&EAM_ACTOR_ADDR, method, params, value);
+    let ret = system.send(&EAM_ACTOR_ADDR, method, params, value, None, SendFlags::default());
 
     // https://github.com/ethereum/go-ethereum/blob/fb75f11e87420ec25ff72f7eeeb741fa8974e87e/core/vm/evm.go#L406-L496
     // Normally EVM will do some checks here to ensure that a contract has the capability

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -202,7 +202,7 @@ pub(super) fn call_actor<RT: Runtime>(
         let address = &bytes[send_data_size..send_data_size + address_size];
         let address = Address::from_bytes(address).map_err(|_| PrecompileError::InvalidInput)?;
 
-        system.send_generalized(
+        system.send(
             &address,
             method,
             RawBytes::from(input_data.to_vec()),

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -146,33 +146,8 @@ impl<'r, RT: Runtime> System<'r, RT> {
         nonce
     }
 
-    /// Send a message, saving and reloading state as necessary.
-    pub fn send(
-        &mut self,
-        to: &Address,
-        method: MethodNum,
-        params: RawBytes,
-        value: TokenAmount,
-    ) -> Result<RawBytes, ActorError> {
-        self.flush()?;
-        let result = self.rt.send(to, method, params, value)?;
-        self.reload()?;
-        Ok(result)
-    }
-
-    /// Send a message in "read-only" mode (for staticcall).
-    pub fn send_read_only(
-        &mut self,
-        to: &Address,
-        method: MethodNum,
-        params: RawBytes,
-    ) -> Result<RawBytes, ActorError> {
-        self.flush()?;
-        self.rt.send_read_only(to, method, params)
-    }
-
     /// Generalized send
-    pub fn send_generalized(
+    pub fn send(
         &mut self,
         to: &Address,
         method: MethodNum,

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -44,7 +44,7 @@ push1 0x00
 push1 0x00
 calldataload
 # gas
-push1 0x00
+push4 0xffffffff
 # do the call
 call
 
@@ -183,11 +183,13 @@ fn test_call() {
     return_data[31] = 0x42;
 
     rt.expect_gas_available(10_000_000_000u64);
-    rt.expect_send(
+    rt.expect_send_generalized(
         f4_target,
         evm::Method::InvokeContract as u64,
         proxy_call_input_data,
         TokenAmount::zero(),
+        Some(0xffffffff),
+        SendFlags::empty(),
         RawBytes::serialize(BytesSer(&return_data)).expect("failed to serialize return data"),
         ExitCode::OK,
     );
@@ -251,11 +253,13 @@ fn test_call_convert_to_send() {
         let mut return_data = vec![0u8; 32];
         return_data[31] = 0x42;
 
-        rt.expect_send(
+        rt.expect_send_generalized(
             target,
             METHOD_SEND,
             proxy_call_input_data,
             TokenAmount::zero(),
+            None,
+            SendFlags::empty(),
             RawBytes::serialize(BytesSer(&return_data)).expect("failed to serialize return data"),
             ExitCode::OK,
         );
@@ -400,7 +404,7 @@ push1 0x00
 push1 0x0e
 
 # gas
-push1 0x00
+push4 0xffffffff
 
 # call_actor must be from delegatecall
 delegatecall
@@ -483,9 +487,10 @@ fn test_callactor_inner(exit_code: ExitCode) {
         0x42,
         proxy_call_input_data,
         TokenAmount::zero(),
+        Some(0xffffffff),
+        send_flags,
         RawBytes::from(return_data),
         exit_code,
-        send_flags,
     );
 
     // invoke

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Error};
 use cid::multihash::Code;
 use cid::Cid;
-use fvm::SyscallResult;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{Cbor, CborStore, RawBytes, DAG_CBOR};
 use fvm_sdk as fvm;
@@ -17,7 +16,6 @@ use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::event::ActorEvent;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
-use fvm_shared::receipt::Receipt;
 use fvm_shared::sector::{
     AggregateSealVerifyProofAndInfos, RegisteredSealProof, ReplicaUpdateInfo, SealVerifyInfo,
     WindowPoStVerifyInfo,
@@ -99,68 +97,6 @@ impl MessageInfo for FvmMessage {
 
     fn gas_premium(&self) -> TokenAmount {
         fvm::message::gas_premium()
-    }
-}
-
-fn handle_send_result(
-    to: &Address,
-    method: MethodNum,
-    res: SyscallResult<Receipt>,
-) -> Result<RawBytes, ActorError> {
-    match res {
-        Ok(ret) => {
-            if ret.exit_code.is_success() {
-                Ok(ret.return_data)
-            } else {
-                // The returned code can't be simply propagated as it may be a system exit code.
-                // TODO: improve propagation once we return a RuntimeError.
-                // Ref https://github.com/filecoin-project/builtin-actors/issues/144
-                let exit_code = match ret.exit_code {
-                    // This means the called actor did something wrong. We can't "make up" a
-                    // reasonable exit code.
-                    ExitCode::SYS_MISSING_RETURN
-                    | ExitCode::SYS_ILLEGAL_INSTRUCTION
-                    | ExitCode::SYS_ILLEGAL_EXIT_CODE => ExitCode::USR_UNSPECIFIED,
-                    // We don't expect any other system errors.
-                    code if code.is_system_error() => ExitCode::USR_ASSERTION_FAILED,
-                    // Otherwise, pass it through.
-                    code => code,
-                };
-                Err(ActorError::unchecked_with_data(
-                    exit_code,
-                    format!("send to {} method {} aborted with code {}", to, method, ret.exit_code),
-                    ret.return_data,
-                ))
-            }
-        }
-        Err(err) => Err(match err {
-            // Some of these errors are from operations in the Runtime or SDK layer
-            // before or after the underlying VM send syscall.
-            ErrorNumber::NotFound => {
-                // This means that the receiving actor doesn't exist.
-                // TODO: we can't reasonably determine the correct "exit code" here.
-                actor_error!(unspecified; "receiver not found")
-            }
-            ErrorNumber::InsufficientFunds => {
-                // This means that the send failed because we have insufficient funds. We will
-                // get a _syscall error_, not an exit code, because the target actor will not
-                // run (and therefore will not exit).
-                actor_error!(insufficient_funds; "not enough funds")
-            }
-            ErrorNumber::LimitExceeded => {
-                // This means we've exceeded the recursion limit.
-                // TODO: Define a better exit code.
-                actor_error!(assertion_failed; "recursion limit exceeded")
-            }
-            ErrorNumber::ReadOnly => ActorError::unchecked(
-                ExitCode::USR_READ_ONLY,
-                "attempted to mutate state while in readonly mode".into(),
-            ),
-            err => {
-                // We don't expect any other syscall exit codes.
-                actor_error!(assertion_failed; "unexpected error: {}", err)
-            }
-        }),
     }
 }
 
@@ -361,39 +297,6 @@ where
         &self.blockstore
     }
 
-    fn send(
-        &self,
-        to: &Address,
-        method: MethodNum,
-        params: RawBytes,
-        value: TokenAmount,
-    ) -> Result<RawBytes, ActorError> {
-        if self.in_transaction {
-            return Err(actor_error!(assertion_failed; "send is not allowed during transaction"));
-        }
-        handle_send_result(
-            to,
-            method,
-            fvm::send::send(to, method, params, value, None, SendFlags::default()),
-        )
-    }
-
-    fn send_read_only(
-        &self,
-        to: &Address,
-        method: MethodNum,
-        params: RawBytes,
-    ) -> Result<RawBytes, ActorError> {
-        if self.in_transaction {
-            return Err(actor_error!(assertion_failed; "send is not allowed during transaction"));
-        }
-        handle_send_result(
-            to,
-            method,
-            fvm::send::send(to, method, params, TokenAmount::default(), None, SendFlags::READ_ONLY),
-        )
-    }
-
     fn send_generalized(
         &self,
         to: &Address,
@@ -406,7 +309,65 @@ where
         if self.in_transaction {
             return Err(actor_error!(assertion_failed; "send is not allowed during transaction"));
         }
-        handle_send_result(to, method, fvm::send::send(to, method, params, value, gas_limit, flags))
+
+        match fvm::send::send(to, method, params, value, gas_limit, flags) {
+            Ok(ret) => {
+                if ret.exit_code.is_success() {
+                    Ok(ret.return_data)
+                } else {
+                    // The returned code can't be simply propagated as it may be a system exit code.
+                    // TODO: improve propagation once we return a RuntimeError.
+                    // Ref https://github.com/filecoin-project/builtin-actors/issues/144
+                    let exit_code = match ret.exit_code {
+                        // This means the called actor did something wrong. We can't "make up" a
+                        // reasonable exit code.
+                        ExitCode::SYS_MISSING_RETURN
+                        | ExitCode::SYS_ILLEGAL_INSTRUCTION
+                        | ExitCode::SYS_ILLEGAL_EXIT_CODE => ExitCode::USR_UNSPECIFIED,
+                        // We don't expect any other system errors.
+                        code if code.is_system_error() => ExitCode::USR_ASSERTION_FAILED,
+                        // Otherwise, pass it through.
+                        code => code,
+                    };
+                    Err(ActorError::unchecked_with_data(
+                        exit_code,
+                        format!(
+                            "send to {} method {} aborted with code {}",
+                            to, method, ret.exit_code
+                        ),
+                        ret.return_data,
+                    ))
+                }
+            }
+            Err(err) => Err(match err {
+                // Some of these errors are from operations in the Runtime or SDK layer
+                // before or after the underlying VM send syscall.
+                ErrorNumber::NotFound => {
+                    // This means that the receiving actor doesn't exist.
+                    // TODO: we can't reasonably determine the correct "exit code" here.
+                    actor_error!(unspecified; "receiver not found")
+                }
+                ErrorNumber::InsufficientFunds => {
+                    // This means that the send failed because we have insufficient funds. We will
+                    // get a _syscall error_, not an exit code, because the target actor will not
+                    // run (and therefore will not exit).
+                    actor_error!(insufficient_funds; "not enough funds")
+                }
+                ErrorNumber::LimitExceeded => {
+                    // This means we've exceeded the recursion limit.
+                    // TODO: Define a better exit code.
+                    actor_error!(assertion_failed; "recursion limit exceeded")
+                }
+                ErrorNumber::ReadOnly => ActorError::unchecked(
+                    ExitCode::USR_READ_ONLY,
+                    "attempted to mutate state while in readonly mode".into(),
+                ),
+                err => {
+                    // We don't expect any other syscall exit codes.
+                    actor_error!(assertion_failed; "unexpected error: {}", err)
+                }
+            }),
+        }
     }
 
     fn new_actor_address(&mut self) -> Result<Address, ActorError> {

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -188,21 +188,9 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
         method: MethodNum,
         params: RawBytes,
         value: TokenAmount,
-    ) -> Result<RawBytes, ActorError>;
-
-    /// Like [`Runtime::send`] except that neither the called actor nor any recursively called actor
-    /// can make any state changes or emit any events. Specifically:
-    ///
-    /// - Value transfers are rejected.
-    /// - Events are discarded.
-    /// - State changes are rejected when the called actor attempts to update its state-root.
-    /// - Actor deletion is forbidden.
-    fn send_read_only(
-        &self,
-        to: &Address,
-        method: MethodNum,
-        params: RawBytes,
-    ) -> Result<RawBytes, ActorError>;
+    ) -> Result<RawBytes, ActorError> {
+        self.send_generalized(to, method, params, value, None, SendFlags::empty())
+    }
 
     /// Generailizes [`Runtime::send`] and [`Runtime::send_read_only`] to allow the caller to
     /// specify a gas limit and send flags.


### PR DESCRIPTION
This removes the send_read_only variant and makes the simplified `send` variant just call `send_generalized.