### PR TITLE
Miner: Export method to GetPendingOwner

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -239,12 +239,12 @@ impl Actor {
         })
     }
 
-    /// Returns the owner address.
+    /// Returns the owner address, as well as the proposed new owner (if any).
     fn get_owner(rt: &mut impl Runtime) -> Result<GetOwnerReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let state: State = rt.state()?;
-        let owner = get_miner_info(rt.store(), &state)?.owner;
-        Ok(GetOwnerReturn { owner })
+        let info = get_miner_info(rt.store(), &state)?;
+        Ok(GetOwnerReturn { owner: info.owner, proposed: info.pending_owner_address })
     }
 
     /// Returns whether the provided address is "controlling".

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -170,7 +170,8 @@ impl Cbor for SectorClaim {}
 pub struct ExpirationExtension2 {
     pub deadline: u64,
     pub partition: u64,
-    pub sectors: BitField, // IDs of sectors without FIL+ claims
+    // IDs of sectors without FIL+ claims
+    pub sectors: BitField,
     pub sectors_with_claims: Vec<SectorClaim>,
     pub new_expiration: ChainEpoch,
 }
@@ -314,6 +315,7 @@ impl Cbor for PreCommitSectorParams {}
 pub struct PreCommitSectorBatchParams {
     pub sectors: Vec<PreCommitSectorParams>,
 }
+
 impl Cbor for PreCommitSectorBatchParams {}
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize_tuple, Deserialize_tuple)]
@@ -483,10 +485,10 @@ pub struct GetBeneficiaryReturn {
 
 impl Cbor for GetBeneficiaryReturn {}
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
-#[serde(transparent)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct GetOwnerReturn {
     pub owner: Address,
+    pub proposed: Option<Address>,
 }
 
 impl Cbor for GetOwnerReturn {}

--- a/actors/miner/tests/change_owner_address_test.rs
+++ b/actors/miner/tests/change_owner_address_test.rs
@@ -1,4 +1,4 @@
-use fil_actor_miner::{Actor, Method};
+use fil_actor_miner::{Actor, GetOwnerReturn, Method};
 use fil_actors_runtime::test_utils::{
     expect_abort, expect_abort_contains_message, make_identity_cid, new_bls_addr, MockRuntime,
     ACCOUNT_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID,
@@ -40,9 +40,17 @@ fn successful_change() {
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
     h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
 
-    let info = h.get_info(&rt);
-    assert_eq!(h.owner, info.owner);
-    assert_eq!(NEW_ADDRESS, info.pending_owner_address.unwrap());
+    // Set to non-builtin caller to confirm exported correctly
+    rt.set_caller(make_identity_cid(b"1234"), OTHER_ADDRESS);
+    rt.expect_validate_caller_any();
+    let ret: GetOwnerReturn = rt
+        .call::<Actor>(Method::GetOwnerExported as u64, &RawBytes::default())
+        .unwrap()
+        .deserialize()
+        .unwrap();
+
+    assert_eq!(h.owner, ret.owner);
+    assert_eq!(NEW_ADDRESS, ret.proposed.unwrap());
 
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, NEW_ADDRESS);
     h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();


### PR DESCRIPTION
As in the title.

We might want to add analogous methods for pending workers and beneficiaries, but I'd like to hear motivation for them first.