### PR TITLE
fix: correctly handle "0" in EVM call gas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.16"
+version = "3.0.0-alpha.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7016663436cc9e98b68bbdee40a2a333efa22eb984a1d2099a51d73b9cb2fd7a"
+checksum = "5d6f88e45b7984efbc2add1c98ca24155a454a21513d4c1d9ee40a1a109d4181"
 dependencies = [
  "cid 0.8.6",
  "fvm_ipld_encoding",

--- a/actors/embryo/Cargo.toml
+++ b/actors/embryo/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fvm_sdk = { version = "3.0.0-alpha.16", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.17", optional = true }
 fvm_shared = { version = "3.0.0-alpha.14", optional = true }
 
 [features]

--- a/actors/evm/src/interpreter/precompiles/evm.rs
+++ b/actors/evm/src/interpreter/precompiles/evm.rs
@@ -334,7 +334,7 @@ mod tests {
 
     impl Default for PrecompileContext {
         fn default() -> Self {
-            Self { call_type: CallKind::Call, gas_limit: None }
+            Self { call_type: CallKind::Call, gas_limit: u64::MAX }
         }
     }
 

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -207,7 +207,7 @@ pub(super) fn call_actor<RT: Runtime>(
             method,
             RawBytes::from(input_data.to_vec()),
             TokenAmount::from(&value),
-            ctx.gas_limit,
+            Some(ctx.gas_limit),
             flags,
         )
     };

--- a/actors/evm/src/interpreter/precompiles/mod.rs
+++ b/actors/evm/src/interpreter/precompiles/mod.rs
@@ -105,7 +105,7 @@ impl From<PrecompileError> for StatusCode {
 #[derive(Debug, PartialEq, Eq)]
 pub struct PrecompileContext {
     pub call_type: CallKind,
-    pub gas_limit: Option<u64>,
+    pub gas_limit: u64,
 }
 
 /// Native Type of a given contract

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -251,7 +251,6 @@ fn test_call_convert_to_send() {
         let mut return_data = vec![0u8; 32];
         return_data[31] = 0x42;
 
-        rt.expect_gas_available(10_000_000_000u64);
         rt.expect_send(
             target,
             METHOD_SEND,
@@ -293,7 +292,6 @@ fn test_call_convert_to_send2() {
     // we don't expected return data
     let return_data = vec![];
 
-    rt.expect_gas_available(10_000_000_000u64);
     rt.expect_send(
         target,
         METHOD_SEND,
@@ -334,7 +332,6 @@ fn test_call_convert_to_send3() {
     // we don't expected return data
     let return_data = vec![];
 
-    rt.expect_gas_available(10_000_000_000u64);
     rt.expect_send(
         target,
         METHOD_SEND,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -34,7 +34,7 @@ paste = "1.0.9"
 sha2 = "0.10"
 
 # fil-actor
-fvm_sdk = { version = "3.0.0-alpha.16", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.17", optional = true }
 
 # test_util
 rand = { version = "0.8.5", default-features = false, optional = true }


### PR DESCRIPTION
1. Update the FVM's SDK to the version that treats 0 as 0 instead of infinity.
2. Correctly set the gas limit to infinity if we're demoting a call to METHOD_SEND.
3. If the user passes 0 gas in the EVM, leave it at 0 (except when demoting to METHOD_SEND).

Tests:

1. We need integration tests in the FVM (or somewhere, at least).
2. Part of this will be tested in https://github.com/filecoin-project/builtin-actors/pull/923 now that we're actually checking the passed gas limits.