### PR TITLE
Runtime: Restrict internal API away from EVM actors

### DIFF
--- a/actors/account/tests/account_actor_test.rs
+++ b/actors/account/tests/account_actor_test.rs
@@ -66,7 +66,7 @@ fn token_receiver() {
     )
     .unwrap();
 
-    rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1000));
+    rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1000));
     rt.expect_validate_caller_any();
     let ret = rt.call::<AccountActor>(
         Method::UniversalReceiverHook as MethodNum,

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -290,7 +290,7 @@ fn exec_restricted_correctly() {
     construct_and_verify(&mut rt);
 
     // set caller to not-builtin
-    rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1000));
+    rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1000));
 
     // cannot call the unexported method num
     let fake_constructor_params =

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -124,7 +124,7 @@ pub fn construct_and_verify(rt: &mut MockRuntime) {
 }
 
 pub fn get_balance(rt: &mut MockRuntime, addr: &Address) -> GetBalanceReturn {
-    rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1234));
+    rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1234));
     rt.expect_validate_caller_any();
     let ret: GetBalanceReturn = rt
         .call::<MarketActor>(Method::GetBalanceExported as u64, &RawBytes::serialize(addr).unwrap())

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -1953,7 +1953,7 @@ fn add_balance_restricted_correctly() {
     rt.set_value(amount);
 
     // set caller to not-builtin
-    rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1234));
+    rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1234));
 
     // cannot call the unexported method num
     expect_abort_contains_message(
@@ -2018,7 +2018,7 @@ fn psd_restricted_correctly() {
     };
 
     // set caller to not-builtin
-    rt.set_caller(make_identity_cid(b"1234"), WORKER_ADDR);
+    rt.set_caller(*EVM_ACTOR_CODE_ID, WORKER_ADDR);
 
     // cannot call the unexported method num
     expect_abort_contains_message(

--- a/actors/miner/tests/change_beneficiary_test.rs
+++ b/actors/miner/tests/change_beneficiary_test.rs
@@ -1,6 +1,6 @@
 use fil_actor_miner::{Actor, BeneficiaryTerm, GetBeneficiaryReturn, Method};
 use fil_actors_runtime::test_utils::{
-    expect_abort, expect_abort_contains_message, make_identity_cid, MockRuntime,
+    expect_abort, expect_abort_contains_message, MockRuntime, EVM_ACTOR_CODE_ID,
 };
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::clock::ChainEpoch;
@@ -8,6 +8,7 @@ use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, MethodNum
 use num_traits::Zero;
 
 mod util;
+
 use util::*;
 
 fn setup() -> (ActorHarness, MockRuntime) {
@@ -450,7 +451,7 @@ fn get_beneficiary_correctly_restricted() {
     let (h, mut rt) = setup();
 
     // set caller to not-builtin
-    rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1000));
+    rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1000));
 
     // cannot call the unexported method num
     expect_abort_contains_message(

--- a/actors/miner/tests/change_owner_address_test.rs
+++ b/actors/miner/tests/change_owner_address_test.rs
@@ -1,13 +1,14 @@
 use fil_actor_miner::{Actor, Method};
 use fil_actors_runtime::test_utils::{
-    expect_abort, expect_abort_contains_message, make_identity_cid, new_bls_addr, MockRuntime,
-    ACCOUNT_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID,
+    expect_abort, expect_abort_contains_message, new_bls_addr, MockRuntime, ACCOUNT_ACTOR_CODE_ID,
+    EVM_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID,
 };
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::{address::Address, error::ExitCode};
 
 mod util;
+
 use util::*;
 
 const NEW_ADDRESS: Address = Address::new_id(1001);
@@ -60,7 +61,7 @@ fn change_owner_address_restricted_correctly() {
     let (h, mut rt) = setup();
 
     let params = &RawBytes::serialize(NEW_ADDRESS).unwrap();
-    rt.set_caller(make_identity_cid(b"1234"), h.owner);
+    rt.set_caller(*EVM_ACTOR_CODE_ID, h.owner);
 
     // fail to call the unexported method
 
@@ -84,7 +85,7 @@ fn change_owner_address_restricted_correctly() {
     // new owner can also call the exported method
 
     rt.expect_validate_caller_addr(vec![NEW_ADDRESS]);
-    rt.set_caller(make_identity_cid(b"1234"), NEW_ADDRESS);
+    rt.set_caller(*EVM_ACTOR_CODE_ID, NEW_ADDRESS);
     rt.call::<Actor>(Method::ChangeOwnerAddressExported as u64, params).unwrap();
 
     rt.verify();

--- a/actors/miner/tests/change_peer_id_test.rs
+++ b/actors/miner/tests/change_peer_id_test.rs
@@ -1,11 +1,12 @@
 use fil_actor_miner::{Actor, ChangePeerIDParams, GetPeerIDReturn, Method};
 use fil_actors_runtime::test_utils::{
-    expect_abort_contains_message, make_identity_cid, MockRuntime,
+    expect_abort_contains_message, MockRuntime, EVM_ACTOR_CODE_ID,
 };
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::error::ExitCode;
 
 mod util;
+
 use util::*;
 
 fn setup() -> (ActorHarness, MockRuntime) {
@@ -38,7 +39,7 @@ fn change_peer_id_restricted_correctly() {
 
     let params = RawBytes::serialize(ChangePeerIDParams { new_id: new_id.clone() }).unwrap();
 
-    rt.set_caller(make_identity_cid(b"1234"), h.worker);
+    rt.set_caller(*EVM_ACTOR_CODE_ID, h.worker);
 
     // fail to call the unexported setter
 

--- a/actors/miner/tests/change_worker_address_test.rs
+++ b/actors/miner/tests/change_worker_address_test.rs
@@ -11,7 +11,8 @@ use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode};
 
 mod util;
-use fil_actors_runtime::test_utils::make_identity_cid;
+
+use fil_actors_runtime::test_utils::EVM_ACTOR_CODE_ID;
 use itertools::Itertools;
 use num_traits::Zero;
 use util::*;
@@ -89,7 +90,7 @@ fn change_and_confirm_worker_address_restricted_correctly() {
     })
     .unwrap();
 
-    rt.set_caller(make_identity_cid(b"1234"), h.owner);
+    rt.set_caller(*EVM_ACTOR_CODE_ID, h.owner);
 
     // fail to call the unexported method
 

--- a/actors/miner/tests/exported_getters.rs
+++ b/actors/miner/tests/exported_getters.rs
@@ -3,7 +3,7 @@ use fil_actor_miner::{
     IsControllingAddressParam, IsControllingAddressReturn, Method,
 };
 use fil_actors_runtime::cbor::serialize;
-use fil_actors_runtime::test_utils::make_identity_cid;
+use fil_actors_runtime::test_utils::EVM_ACTOR_CODE_ID;
 use fil_actors_runtime::INIT_ACTOR_ADDR;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
@@ -28,7 +28,7 @@ fn info_getters() {
     h.construct_and_verify(&mut rt);
 
     // set caller to not-builtin
-    rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1234));
+    rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1234));
 
     // owner is good
     rt.expect_validate_caller_any();

--- a/actors/miner/tests/miner_actor_test_peer_info.rs
+++ b/actors/miner/tests/miner_actor_test_peer_info.rs
@@ -125,7 +125,7 @@ fn get_and_change_multiaddrs_restricted_correctly() {
         &RawBytes::serialize(ChangeMultiaddrsParams { new_multi_addrs: new_multiaddrs.clone() })
             .unwrap();
 
-    rt.set_caller(make_identity_cid(b"1234"), h.worker);
+    rt.set_caller(*EVM_ACTOR_CODE_ID, h.worker);
 
     // fail to call the unexported setter
 

--- a/actors/miner/tests/repay_debts.rs
+++ b/actors/miner/tests/repay_debts.rs
@@ -1,5 +1,5 @@
 use fil_actor_miner::{locked_reward_from_reward, Actor, Method};
-use fil_actors_runtime::test_utils::{expect_abort_contains_message, make_identity_cid};
+use fil_actors_runtime::test_utils::{expect_abort_contains_message, EVM_ACTOR_CODE_ID};
 use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::bigint::Zero;
@@ -9,6 +9,7 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::METHOD_SEND;
 
 mod util;
+
 use util::*;
 
 const PERIOD_OFFSET: ChainEpoch = 100;
@@ -65,7 +66,7 @@ fn repay_debt_restricted_correctly() {
     st.fee_debt = fee_debt.clone();
     rt.replace_state(&st);
 
-    rt.set_caller(make_identity_cid(b"1234"), h.owner);
+    rt.set_caller(*EVM_ACTOR_CODE_ID, h.owner);
 
     // fail to call the unexported method
     expect_abort_contains_message(

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2552,7 +2552,7 @@ impl ActorHarness {
 
     pub fn get_available_balance(&self, rt: &mut MockRuntime) -> Result<TokenAmount, ActorError> {
         // set caller to non-builtin
-        rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1234));
+        rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1234));
         rt.expect_validate_caller_any();
         let available_balance_ret: GetAvailableBalanceReturn = rt
             .call::<Actor>(Method::GetAvailableBalanceExported as u64, &RawBytes::default())?

--- a/actors/miner/tests/withdraw_balance.rs
+++ b/actors/miner/tests/withdraw_balance.rs
@@ -2,7 +2,7 @@ use fil_actor_miner::{
     Actor, BeneficiaryTerm, Method, WithdrawBalanceParams, WithdrawBalanceReturn,
 };
 use fil_actors_runtime::test_utils::{
-    expect_abort, expect_abort_contains_message, make_identity_cid,
+    expect_abort, expect_abort_contains_message, EVM_ACTOR_CODE_ID,
 };
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
@@ -13,6 +13,7 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::METHOD_SEND;
 
 mod util;
+
 use util::*;
 
 const PERIOD_OFFSET: ChainEpoch = 100;
@@ -45,7 +46,7 @@ fn withdraw_funds_restricted_correctly() {
         &RawBytes::serialize(WithdrawBalanceParams { amount_requested: amount_requested.clone() })
             .unwrap();
 
-    rt.set_caller(make_identity_cid(b"1234"), h.owner);
+    rt.set_caller(*EVM_ACTOR_CODE_ID, h.owner);
 
     // fail to call the unexported method
 

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -770,7 +770,7 @@ fn test_propose_restricted_correctly() {
     h.construct_and_verify(&mut rt, 2, no_unlock_duration, start_epoch, signers);
 
     // set caller to not-builtin
-    rt.set_caller(make_identity_cid(b"102"), Address::new_id(102));
+    rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(102));
     let propose_params = serialize(
         &ProposeParams {
             to: chuck,

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -2,7 +2,7 @@ use fil_actor_power::ext::init::{ExecParams, EXEC_METHOD};
 use fil_actor_power::ext::miner::MinerConstructorParams;
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::test_utils::{
-    expect_abort, expect_abort_contains_message, make_identity_cid, ACCOUNT_ACTOR_CODE_ID,
+    expect_abort, expect_abort_contains_message, ACCOUNT_ACTOR_CODE_ID, EVM_ACTOR_CODE_ID,
     MINER_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID,
 };
 use fil_actors_runtime::{runtime::Policy, INIT_ACTOR_ADDR};
@@ -581,7 +581,7 @@ fn get_network_and_miner_power() {
     rt.replace_state(&state);
 
     // set caller to not-builtin
-    rt.set_caller(make_identity_cid(b"1234"), Address::new_id(1234));
+    rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1234));
 
     rt.expect_validate_caller_any();
     let network_power: NetworkRawPowerReturn = rt
@@ -1460,7 +1460,7 @@ fn create_miner_restricted_correctly() {
     )
     .unwrap();
 
-    rt.set_caller(make_identity_cid(b"1234"), *OWNER);
+    rt.set_caller(*EVM_ACTOR_CODE_ID, *OWNER);
 
     // cannot call the unexported method
     expect_abort_contains_message(

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -400,7 +400,7 @@ mod clients {
             AddVerifiedClientParams { address: *CLIENT, allowance: allowance_client.clone() };
 
         // set caller to not-builtin
-        rt.set_caller(make_identity_cid(b"1234"), *VERIFIER);
+        rt.set_caller(*EVM_ACTOR_CODE_ID, *VERIFIER);
 
         // cannot call the unexported method num
         expect_abort_contains_message(
@@ -513,7 +513,7 @@ mod allocs_claims {
         MINIMUM_VERIFIED_ALLOCATION_TERM,
     };
     use fil_actors_runtime::test_utils::{
-        expect_abort_contains_message, make_identity_cid, ACCOUNT_ACTOR_CODE_ID,
+        expect_abort_contains_message, ACCOUNT_ACTOR_CODE_ID, EVM_ACTOR_CODE_ID,
     };
     use fil_actors_runtime::FailCode;
     use harness::*;
@@ -987,7 +987,7 @@ mod allocs_claims {
         };
 
         // set caller to not-builtin
-        rt.set_caller(make_identity_cid(b"1234"), Address::new_id(CLIENT1));
+        rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(CLIENT1));
 
         // cannot call the unexported extend method num
         expect_abort_contains_message(


### PR DESCRIPTION
I'm not thrilled about adding another use of `Type`. I'd like to replace this with explicit "is miner" and "is EVM" methods that should be all we need.