### PR TITLE
Verifreg to use ActorID

### DIFF
--- a/actors/market/src/ext.rs
+++ b/actors/market/src/ext.rs
@@ -40,13 +40,14 @@ pub mod verifreg {
     use fil_actors_runtime::BatchReturn;
     use fvm_shared::clock::ChainEpoch;
     use fvm_shared::piece::PaddedPieceSize;
+    use fvm_shared::ActorID;
 
     pub type AllocationID = u64;
     pub type ClaimID = u64;
 
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
     pub struct AllocationRequest {
-        pub provider: Address,
+        pub provider: ActorID,
         pub data: Cid,
         pub size: PaddedPieceSize,
         pub term_min: ChainEpoch,
@@ -56,7 +57,7 @@ pub mod verifreg {
 
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
     pub struct ClaimExtensionRequest {
-        pub provider: Address,
+        pub provider: ActorID,
         pub claim: ClaimID,
         pub term_max: ChainEpoch,
     }

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -867,6 +867,7 @@ pub fn validate_and_return_deal_space<BS: Blockstore>(
 }
 
 fn alloc_request_for_deal(
+    // Deal proposal must have ID addresses
     deal: &ClientDealProposal,
     policy: &Policy,
     curr_epoch: ChainEpoch,

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -879,7 +879,7 @@ fn alloc_request_for_deal(
     let alloc_expiration =
         min(deal.proposal.start_epoch, curr_epoch + policy.maximum_verified_allocation_expiration);
     ext::verifreg::AllocationRequest {
-        provider: deal.proposal.provider,
+        provider: deal.proposal.provider.id().unwrap(),
         data: deal.proposal.piece_cid,
         size: deal.proposal.piece_size,
         term_min: alloc_term_min,

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -493,7 +493,7 @@ pub fn publish_deals(
             let curr_epoch = rt.epoch;
             let alloc_req = ext::verifreg::AllocationRequests {
                 allocations: vec![AllocationRequest {
-                    provider: deal.provider,
+                    provider: deal.provider.id().unwrap(),
                     data: deal.piece_cid,
                     size: deal.piece_size,
                     term_min: deal.end_epoch - deal.start_epoch,

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -865,7 +865,7 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
     // Data cap transfer is requested using the resolved address (not that it matters).
     let alloc_req = ext::verifreg::AllocationRequests {
         allocations: vec![AllocationRequest {
-            provider: provider_resolved,
+            provider: provider_resolved.id().unwrap(),
             data: deal.piece_cid,
             size: deal.piece_size,
             term_min: deal.end_epoch - deal.start_epoch,

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -648,16 +648,9 @@ impl Actor {
         let mut updated_claims = Vec::<(ClaimID, Claim)>::new();
         let mut extension_total = DataCap::zero();
         for req in &reqs.extensions {
-            // Note: we don't check the client address here, by design.
-            // Any client can spend datacap to extend an existing claim.
-            let provider_id = rt
-                .resolve_address(&req.provider)
-                .with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
-                    format!("failed to resolve provider address {}", req.provider)
-                })?;
-            let claim = state::get_claim(&mut claims, provider_id, req.claim)?
+            let claim = state::get_claim(&mut claims, req.provider, req.claim)?
                 .with_context_code(ExitCode::USR_NOT_FOUND, || {
-                    format!("no claim {} for provider {}", req.claim, provider_id)
+                    format!("no claim {} for provider {}", req.claim, req.provider)
                 })?;
             let policy = rt.policy();
 

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -628,12 +628,9 @@ impl Actor {
         let mut new_allocs = Vec::with_capacity(reqs.allocations.len());
         for req in &reqs.allocations {
             validate_new_allocation(req, rt.policy(), curr_epoch)?;
-            // Require the provider for new allocations to be a miner actor.
-            // This doesn't matter much, but is more ergonomic to fail rather than lock up datacap.
-            let provider_id = resolve_miner_id(rt, &req.provider)?;
             new_allocs.push(Allocation {
                 client,
-                provider: provider_id,
+                provider: req.provider,
                 data: req.data,
                 size: req.size,
                 term_min: req.term_min,

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -1006,31 +1006,6 @@ fn validate_claim_extension(
     Ok(())
 }
 
-// Checks that an address corresponsds to a miner actor.
-fn resolve_miner_id(rt: &mut impl Runtime, addr: &Address) -> Result<ActorID, ActorError> {
-    let id = rt.resolve_address(addr).with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
-        format!("failed to resolve provider address {}", addr)
-    })?;
-    let code_cid =
-        rt.get_actor_code_cid(&id).with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
-            format!("no code CID for provider {}", addr)
-        })?;
-    let provider_type = rt
-        .resolve_builtin_actor_type(&code_cid)
-        .with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
-            format!("provider code {} must be built-in miner actor", code_cid)
-        })?;
-    if provider_type != Type::Miner {
-        return Err(actor_error!(
-            illegal_argument,
-            "allocation provider {} must be a miner actor, was {:?}",
-            addr,
-            provider_type
-        ));
-    }
-    Ok(id)
-}
-
 fn can_claim_alloc(
     claim_alloc: &SectorAllocationClaim,
     provider: ActorID,

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -180,7 +180,7 @@ impl Cbor for AllocationRequest {}
 // A request to extend the term of an existing claim with datacap tokens.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ClaimExtensionRequest {
-    pub provider: Address,
+    pub provider: ActorID,
     pub claim: ClaimID,
     pub term_max: ChainEpoch,
 }

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -168,7 +168,7 @@ pub type ExtendClaimTermsReturn = BatchReturn;
 // See Allocation state for description of field semantics.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct AllocationRequest {
-    pub provider: Address,
+    pub provider: ActorID,
     pub data: Cid,
     pub size: PaddedPieceSize,
     pub term_min: ChainEpoch,

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -448,7 +448,7 @@ pub fn make_alloc(data_id: &str, client: ActorID, provider: ActorID, size: u64) 
 // Creates an allocation request for fixed data with default terms.
 pub fn make_alloc_req(rt: &MockRuntime, provider: ActorID, size: u64) -> AllocationRequest {
     AllocationRequest {
-        provider: Address::new_id(provider),
+        provider,
         data: make_piece_cid("1234".as_bytes()),
         size: PaddedPieceSize(size),
         term_min: MINIMUM_VERIFIED_ALLOCATION_TERM,
@@ -469,7 +469,7 @@ pub fn make_extension_req(
 pub fn alloc_from_req(client: ActorID, req: &AllocationRequest) -> Allocation {
     Allocation {
         client,
-        provider: req.provider.id().unwrap(),
+        provider: req.provider,
         data: req.data,
         size: req.size,
         term_min: req.term_min,

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -462,7 +462,7 @@ pub fn make_extension_req(
     claim: ClaimID,
     term_max: ChainEpoch,
 ) -> ClaimExtensionRequest {
-    ClaimExtensionRequest { provider: Address::new_id(provider), claim, term_max }
+    ClaimExtensionRequest { provider, claim, term_max }
 }
 
 // Creates the expected allocation from a request.

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -1123,7 +1123,12 @@ mod datacap {
 
         let reqs = vec![make_alloc_req(&rt, PROVIDER1, SIZE)];
         let payload = make_receiver_hook_token_payload(CLIENT1, reqs, vec![], SIZE);
-        h.receive_tokens(&mut rt, payload, BatchReturn::ok(1), BATCH_EMPTY, vec![1], 0).unwrap();
+        expect_abort_contains_message(
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            format!("allocation provider {} must be a miner actor", provider1.id().unwrap())
+                .as_str(),
+            h.receive_tokens(&mut rt, payload, BatchReturn::ok(1), BATCH_EMPTY, vec![1], 0),
+        );
         h.check_state(&rt);
     }
 

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -1123,11 +1123,7 @@ mod datacap {
 
         let reqs = vec![make_alloc_req(&rt, PROVIDER1, SIZE)];
         let payload = make_receiver_hook_token_payload(CLIENT1, reqs, vec![], SIZE);
-        expect_abort_contains_message(
-            ExitCode::USR_ILLEGAL_ARGUMENT,
-            format!("allocation provider {} must be a miner actor", provider1).as_str(),
-            h.receive_tokens(&mut rt, payload, BatchReturn::ok(1), BATCH_EMPTY, vec![1], 0),
-        );
+        h.receive_tokens(&mut rt, payload, BatchReturn::ok(1), BATCH_EMPTY, vec![1], 0).unwrap();
         h.check_state(&rt);
     }
 

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -991,7 +991,11 @@ pub fn datacap_extend_claim(
 ) {
     let payload = AllocationRequests {
         allocations: vec![],
-        extensions: vec![ClaimExtensionRequest { provider, claim, term_max: new_term }],
+        extensions: vec![ClaimExtensionRequest {
+            provider: provider.id().unwrap(),
+            claim,
+            term_max: new_term,
+        }],
     };
     let token_amount = TokenAmount::from_whole(size);
     let operator_data = serialize(&payload, "allocation requests").unwrap();
@@ -1142,7 +1146,7 @@ pub fn market_publish_deal(
 
         let alloc_reqs = AllocationRequests {
             allocations: vec![AllocationRequest {
-                provider: miner_id,
+                provider: miner_id.id().unwrap(),
                 data: deal.piece_cid,
                 size: deal.piece_size,
                 term_min: deal_term,

--- a/test_vm/tests/datacap_tests.rs
+++ b/test_vm/tests/datacap_tests.rs
@@ -75,7 +75,7 @@ fn datacap_transfer_scenario() {
     );
 
     let alloc = AllocationRequest {
-        provider: maddr,
+        provider: maddr.id().unwrap(),
         data: make_piece_cid("datacap-test-alloc".as_bytes()),
         size: PaddedPieceSize(MINIMUM_VERIFIED_ALLOCATION_SIZE as u64),
         term_min: policy.minimum_verified_allocation_term,


### PR DESCRIPTION
Changes:

- Verifreg AllocationRequest to use ActorID
- Verifreg ClaimExtensionRequest to use ActorID
- [Remove unused fn resolve_miner_id](https://github.com/filecoin-project/builtin-actors/commit/98bce0813cfdbcb5b63b72e78e58b56508269e0c)
- [Fix receive_alloc_requires_miner_actor test](https://github.com/filecoin-project/builtin-actors/commit/a7b0013bd340dc22029754faad92814949aa7527)

Closes #869 