### PR TITLE
Drop Cbor from method params and return types

### DIFF
--- a/actors/account/src/types.rs
+++ b/actors/account/src/types.rs
@@ -1,5 +1,5 @@
+use fvm_ipld_encoding::serde_bytes;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::{serde_bytes, Cbor};
 
 #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct AuthenticateMessageParams {
@@ -8,5 +8,3 @@ pub struct AuthenticateMessageParams {
     #[serde(with = "serde_bytes")]
     pub message: Vec<u8>,
 }
-
-impl Cbor for AuthenticateMessageParams {}

--- a/actors/datacap/src/types.rs
+++ b/actors/datacap/src/types.rs
@@ -1,5 +1,4 @@
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 
@@ -13,12 +12,8 @@ pub struct MintParams {
     pub operators: Vec<Address>,
 }
 
-impl Cbor for MintParams {}
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct DestroyParams {
     pub owner: Address,
     pub amount: TokenAmount,
 }
-
-impl Cbor for DestroyParams {}

--- a/actors/init/src/types.rs
+++ b/actors/init/src/types.rs
@@ -3,7 +3,7 @@
 
 use cid::Cid;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 
 /// Init actor Constructor parameters
@@ -27,6 +27,3 @@ pub struct ExecReturn {
     /// Reorg safe address for actor
     pub robust_address: Address,
 }
-
-impl Cbor for ExecReturn {}
-impl Cbor for ExecParams {}

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -6,7 +6,6 @@ use cid::Cid;
 use fil_actors_runtime::Array;
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::{bigint_ser, BigInt};
 use fvm_shared::clock::ChainEpoch;
@@ -27,8 +26,6 @@ pub struct WithdrawBalanceParams {
     pub provider_or_client: Address,
     pub amount: TokenAmount,
 }
-
-impl Cbor for WithdrawBalanceParams {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 #[serde(transparent)]
@@ -53,8 +50,6 @@ pub struct OnMinerSectorsTerminateParamsRef<'a> {
 pub struct PublishStorageDealsParams {
     pub deals: Vec<ClientDealProposal>,
 }
-
-impl Cbor for PublishStorageDealsParams {}
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug)]
 pub struct PublishStorageDealsReturn {

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -4,7 +4,7 @@
 use cid::Cid;
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::{serde_bytes, BytesDe, Cbor};
+use fvm_ipld_encoding::{serde_bytes, BytesDe};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
@@ -119,16 +119,12 @@ pub struct SubmitWindowedPoStParams {
     pub chain_commit_rand: Randomness,
 }
 
-impl Cbor for SubmitWindowedPoStParams {}
-
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ProveCommitSectorParams {
     pub sector_number: SectorNumber,
     #[serde(with = "serde_bytes")]
     pub proof: Vec<u8>,
 }
-
-impl Cbor for ProveCommitSectorParams {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct CheckSectorProvenParams {
@@ -139,8 +135,6 @@ pub struct CheckSectorProvenParams {
 pub struct ExtendSectorExpirationParams {
     pub extensions: Vec<ExpirationExtension>,
 }
-
-impl Cbor for ExtendSectorExpirationParams {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ExpirationExtension {
@@ -155,16 +149,12 @@ pub struct ExtendSectorExpiration2Params {
     pub extensions: Vec<ExpirationExtension2>,
 }
 
-impl Cbor for ExtendSectorExpiration2Params {}
-
 #[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct SectorClaim {
     pub sector_number: SectorNumber,
     pub maintain_claims: Vec<ClaimID>,
     pub drop_claims: Vec<ClaimID>,
 }
-
-impl Cbor for SectorClaim {}
 
 #[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct ExpirationExtension2 {
@@ -174,8 +164,6 @@ pub struct ExpirationExtension2 {
     pub sectors_with_claims: Vec<SectorClaim>,
     pub new_expiration: ChainEpoch,
 }
-
-impl Cbor for ExpirationExtension2 {}
 
 // From is straightforward when there are no claim bearing sectors
 impl From<&ExpirationExtension> for ExpirationExtension2 {
@@ -194,8 +182,6 @@ impl From<&ExpirationExtension> for ExpirationExtension2 {
 pub struct TerminateSectorsParams {
     pub terminations: Vec<TerminationDeclaration>,
 }
-
-impl Cbor for TerminateSectorsParams {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct TerminationDeclaration {
@@ -234,8 +220,6 @@ pub struct DeclareFaultsRecoveredParams {
     pub recoveries: Vec<RecoveryDeclaration>,
 }
 
-impl Cbor for DeclareFaultsRecoveredParams {}
-
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct RecoveryDeclaration {
     /// The deadline to which the recovered sectors are assigned, in range [0..WPoStPeriodDeadlines)
@@ -245,8 +229,6 @@ pub struct RecoveryDeclaration {
     /// Sectors in the partition being declared recovered.
     pub sectors: BitField,
 }
-
-impl Cbor for RecoveryDeclaration {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct CompactPartitionsParams {
@@ -273,8 +255,6 @@ pub struct ReportConsensusFaultParams {
 pub struct WithdrawBalanceParams {
     pub amount_requested: TokenAmount,
 }
-
-impl Cbor for WithdrawBalanceParams {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 #[serde(transparent)]
@@ -308,20 +288,15 @@ pub struct PreCommitSectorParams {
     pub replace_sector_number: SectorNumber,
 }
 
-impl Cbor for PreCommitSectorParams {}
-
 #[derive(Debug, PartialEq, Eq, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct PreCommitSectorBatchParams {
     pub sectors: Vec<PreCommitSectorParams>,
 }
-impl Cbor for PreCommitSectorBatchParams {}
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct PreCommitSectorBatchParams2 {
     pub sectors: Vec<SectorPreCommitInfo>,
 }
-
-impl Cbor for PreCommitSectorBatchParams2 {}
 
 #[derive(Debug, Default, PartialEq, Eq, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct SectorPreCommitInfo {
@@ -392,15 +367,11 @@ pub struct ApplyRewardParams {
     pub penalty: TokenAmount,
 }
 
-impl Cbor for DisputeWindowedPoStParams {}
-
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize_tuple, Deserialize_tuple)]
 pub struct DisputeWindowedPoStParams {
     pub deadline: u64,
     pub post_index: u64, // only one is allowed at a time to avoid loading too many sector infos.
 }
-
-impl Cbor for ProveCommitAggregateParams {}
 
 #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct ProveCommitAggregateParams {
@@ -426,8 +397,6 @@ pub struct ProveReplicaUpdatesParams {
     pub updates: Vec<ReplicaUpdate>,
 }
 
-impl Cbor for ProveReplicaUpdatesParams {}
-
 #[derive(Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ReplicaUpdate2 {
     pub sector_number: SectorNumber,
@@ -446,8 +415,6 @@ pub struct ProveReplicaUpdatesParams2 {
     pub updates: Vec<ReplicaUpdate2>,
 }
 
-impl Cbor for ProveReplicaUpdatesParams2 {}
-
 #[derive(Debug, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct ChangeBeneficiaryParams {
     pub new_beneficiary: Address,
@@ -465,20 +432,14 @@ impl ChangeBeneficiaryParams {
     }
 }
 
-impl Cbor for ChangeBeneficiaryParams {}
-
 #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct ActiveBeneficiary {
     pub beneficiary: Address,
     pub term: BeneficiaryTerm,
 }
 
-impl Cbor for ActiveBeneficiary {}
-
 #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct GetBeneficiaryReturn {
     pub active: ActiveBeneficiary,
     pub proposed: Option<PendingBeneficiaryChange>,
 }
-
-impl Cbor for GetBeneficiaryReturn {}

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -626,7 +626,7 @@ impl ActorHarness {
         rt: &mut MockRuntime,
         sectors: &[SectorPreCommitInfo],
         method: MethodNum,
-        param: impl Cbor,
+        param: impl Serialize,
         first_for_miner: bool,
         base_fee: &TokenAmount,
     ) -> Result<RawBytes, ActorError> {

--- a/actors/multisig/src/types.rs
+++ b/actors/multisig/src/types.rs
@@ -4,7 +4,7 @@
 use std::fmt::Display;
 
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::{serde_bytes, Cbor, RawBytes};
+use fvm_ipld_encoding::{serde_bytes, RawBytes};
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
 
@@ -96,9 +96,6 @@ pub struct ProposeReturn {
     pub ret: RawBytes,
 }
 
-impl Cbor for ProposeParams {}
-impl Cbor for ProposeReturn {}
-
 /// Parameters for approve and cancel multisig functions.
 #[derive(Clone, PartialEq, Eq, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct TxnIDParams {
@@ -122,9 +119,6 @@ pub struct ApproveReturn {
     pub ret: RawBytes,
 }
 
-impl Cbor for TxnIDParams {}
-impl Cbor for ApproveReturn {}
-
 /// Add signer params.
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct AddSignerParams {
@@ -139,16 +133,12 @@ pub struct RemoveSignerParams {
     pub decrease: bool,
 }
 
-impl Cbor for RemoveSignerParams {}
-
 /// Swap signer multisig method params
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct SwapSignerParams {
     pub from: Address,
     pub to: Address,
 }
-
-impl Cbor for SwapSignerParams {}
 
 /// Propose method call parameters
 #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/power/src/types.rs
+++ b/actors/power/src/types.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::{serde_bytes, BytesDe, Cbor, RawBytes};
+use fvm_ipld_encoding::{serde_bytes, BytesDe, RawBytes};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
@@ -32,7 +32,6 @@ pub struct CreateMinerParams {
     pub peer: Vec<u8>,
     pub multiaddrs: Vec<BytesDe>,
 }
-impl Cbor for CreateMinerParams {}
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct CreateMinerReturn {

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -4,7 +4,6 @@
 use cid::Cid;
 use fil_actors_runtime::BatchReturn;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::{bigint_ser, BigInt};
 use fvm_shared::clock::ChainEpoch;
@@ -26,8 +25,6 @@ pub struct VerifierParams {
     pub allowance: DataCap,
 }
 
-impl Cbor for VerifierParams {}
-
 pub type AddVerifierParams = VerifierParams;
 
 pub type AddVerifierClientParams = VerifierParams;
@@ -37,8 +34,6 @@ pub type AddVerifierClientParams = VerifierParams;
 pub type DataCap = StoragePower;
 
 pub const SIGNATURE_DOMAIN_SEPARATION_REMOVE_DATA_CAP: &[u8] = b"fil_removedatacap:";
-
-impl Cbor for RemoveDataCapParams {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct RemoveDataCapParams {
@@ -54,8 +49,6 @@ pub struct RemoveDataCapRequest {
     pub verifier: Address,
     pub signature: Signature,
 }
-
-impl Cbor for RemoveDataCapReturn {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct RemoveDataCapReturn {
@@ -103,7 +96,6 @@ pub struct RemoveExpiredAllocationsParams {
     // Empty means remove all eligible expired allocations.
     pub allocation_ids: Vec<AllocationID>,
 }
-impl Cbor for RemoveExpiredAllocationsParams {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct RemoveExpiredAllocationsReturn {
@@ -115,7 +107,6 @@ pub struct RemoveExpiredAllocationsReturn {
     #[serde(with = "bigint_ser")]
     pub datacap_recovered: DataCap,
 }
-impl Cbor for RemoveExpiredAllocationsReturn {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct SectorAllocationClaim {
@@ -126,14 +117,12 @@ pub struct SectorAllocationClaim {
     pub sector: SectorNumber,
     pub sector_expiry: ChainEpoch,
 }
-impl Cbor for SectorAllocationClaim {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ClaimAllocationsParams {
     pub sectors: Vec<SectorAllocationClaim>,
     pub all_or_nothing: bool,
 }
-impl Cbor for ClaimAllocationsParams {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ClaimAllocationsReturn {
@@ -142,21 +131,17 @@ pub struct ClaimAllocationsReturn {
     pub claimed_space: BigInt,
 }
 
-impl Cbor for ClaimAllocationsReturn {}
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ClaimTerm {
     pub provider: ActorID,
     pub claim_id: ClaimID,
     pub term_max: ChainEpoch,
 }
-impl Cbor for ClaimTerm {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ExtendClaimTermsParams {
     pub terms: Vec<ClaimTerm>,
 }
-impl Cbor for ExtendClaimTermsParams {}
 
 pub type ExtendClaimTermsReturn = BatchReturn;
 
@@ -175,7 +160,6 @@ pub struct AllocationRequest {
     pub term_max: ChainEpoch,
     pub expiration: ChainEpoch,
 }
-impl Cbor for AllocationRequest {}
 
 // A request to extend the term of an existing claim with datacap tokens.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
@@ -184,7 +168,6 @@ pub struct ClaimExtensionRequest {
     pub claim: ClaimID,
     pub term_max: ChainEpoch,
 }
-impl Cbor for ClaimExtensionRequest {}
 
 /// Operator-data payload for a datacap token transfer receiver hook specifying an allocation.
 /// The implied client is the sender of the datacap.
@@ -193,7 +176,6 @@ pub struct AllocationRequests {
     pub allocations: Vec<AllocationRequest>,
     pub extensions: Vec<ClaimExtensionRequest>,
 }
-impl Cbor for AllocationRequests {}
 
 /// Recipient data payload in response to a datacap token transfer.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
@@ -205,21 +187,18 @@ pub struct AllocationsResponse {
     // IDs of new allocations created.
     pub new_allocations: Vec<AllocationID>,
 }
-impl Cbor for AllocationsResponse {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct GetClaimsParams {
     pub provider: ActorID,
     pub claim_ids: Vec<ClaimID>,
 }
-impl Cbor for GetClaimsParams {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct GetClaimsReturn {
     pub batch_info: BatchReturn,
     pub claims: Vec<Claim>,
 }
-impl Cbor for GetClaimsReturn {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct RemoveExpiredClaimsParams {
@@ -229,7 +208,6 @@ pub struct RemoveExpiredClaimsParams {
     // Empty means remove all eligible expired claims.
     pub claim_ids: Vec<ClaimID>,
 }
-impl Cbor for RemoveExpiredClaimsParams {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct RemoveExpiredClaimsReturn {
@@ -238,4 +216,3 @@ pub struct RemoveExpiredClaimsReturn {
     // Results for each processed claim.
     pub results: BatchReturn,
 }
-impl Cbor for RemoveExpiredClaimsReturn {}

--- a/test_vm/tests/account_authenticate_message_test.rs
+++ b/test_vm/tests/account_authenticate_message_test.rs
@@ -33,7 +33,7 @@ fn account_authenticate_message() {
         addr,
         TokenAmount::zero(),
         AuthenticateMessage as u64,
-        authenticate_message_params,
+        Some(authenticate_message_params),
     );
 
     // Bad, bad sig! message fails
@@ -45,7 +45,7 @@ fn account_authenticate_message() {
         addr,
         TokenAmount::zero(),
         AuthenticateMessage as u64,
-        authenticate_message_params,
+        Some(authenticate_message_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 }

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -150,7 +150,7 @@ fn batch_onboarding(v2: bool) {
         CRON_ACTOR_ADDR,
         TokenAmount::zero(),
         CronMethod::EpochTick as u64,
-        RawBytes::default(),
+        None::<RawBytes>,
     );
 
     v.expect_state_invariants(

--- a/test_vm/tests/change_beneficiary_test.rs
+++ b/test_vm/tests/change_beneficiary_test.rs
@@ -147,7 +147,7 @@ fn change_beneficiary_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::ChangeBeneficiary as u64,
-        ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(0), 0),
+        Some(ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(0), 0)),
         ExitCode::USR_FORBIDDEN,
     );
 
@@ -162,7 +162,7 @@ fn change_beneficiary_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::ChangeBeneficiary as u64,
-        ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(100), 400),
+        Some(ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(100), 400)),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
@@ -172,7 +172,7 @@ fn change_beneficiary_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::ChangeBeneficiary as u64,
-        ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(80), 500),
+        Some(ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(80), 500)),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
@@ -182,7 +182,7 @@ fn change_beneficiary_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::ChangeBeneficiary as u64,
-        ChangeBeneficiaryParams::new(addr, TokenAmount::from_atto(80), 500),
+        Some(ChangeBeneficiaryParams::new(addr, TokenAmount::from_atto(80), 500)),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
@@ -193,7 +193,7 @@ fn change_beneficiary_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::ChangeBeneficiary as u64,
-        beneficiary_change_proposal.clone(),
+        Some(beneficiary_change_proposal.clone()),
         ExitCode::USR_FORBIDDEN,
     );
     change_beneficiary(&v, beneficiary, miner_id, &beneficiary_change_proposal);
@@ -205,7 +205,7 @@ fn change_beneficiary_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::ChangeBeneficiary as u64,
-        ChangeBeneficiaryParams::new(owner, TokenAmount::from_atto(80), 0),
+        Some(ChangeBeneficiaryParams::new(owner, TokenAmount::from_atto(80), 0)),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     apply_code(
@@ -214,7 +214,7 @@ fn change_beneficiary_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::ChangeBeneficiary as u64,
-        ChangeBeneficiaryParams::new(owner, TokenAmount::from_atto(0), 100),
+        Some(ChangeBeneficiaryParams::new(owner, TokenAmount::from_atto(0), 100)),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 

--- a/test_vm/tests/change_owner_test.rs
+++ b/test_vm/tests/change_owner_test.rs
@@ -114,7 +114,7 @@ fn change_owner_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::ChangeOwnerAddress as u64,
-        new_owner,
+        Some(new_owner),
         ExitCode::USR_FORBIDDEN,
     );
 
@@ -126,7 +126,7 @@ fn change_owner_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::ChangeOwnerAddress as u64,
-        addr,
+        Some(addr),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     // only pending can confirm
@@ -136,7 +136,7 @@ fn change_owner_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::ChangeOwnerAddress as u64,
-        new_owner,
+        Some(new_owner),
         ExitCode::USR_FORBIDDEN,
     );
     //only miner can change proposal
@@ -146,7 +146,7 @@ fn change_owner_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::ChangeOwnerAddress as u64,
-        addr,
+        Some(addr),
         ExitCode::USR_FORBIDDEN,
     );
 

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -77,7 +77,7 @@ fn setup(store: &'_ MemoryBlockstore) -> (VM<'_>, MinerInfo, SectorInfo) {
         robust_addr,
         TokenAmount::zero(),
         MinerMethod::ProveCommitSector as u64,
-        prove_params,
+        Some(prove_params),
     );
     ExpectInvocation {
         to: id_addr,
@@ -97,7 +97,7 @@ fn setup(store: &'_ MemoryBlockstore) -> (VM<'_>, MinerInfo, SectorInfo) {
             CRON_ACTOR_ADDR,
             TokenAmount::zero(),
             CronMethod::EpochTick as u64,
-            RawBytes::default(),
+            None::<RawBytes>,
         )
         .unwrap();
     assert_eq!(ExitCode::OK, res.code);
@@ -217,7 +217,7 @@ fn skip_sector() {
         miner_info.miner_id,
         TokenAmount::zero(),
         MinerMethod::SubmitWindowedPoSt as u64,
-        params,
+        Some(params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
@@ -249,7 +249,7 @@ fn missed_first_post_deadline() {
         CRON_ACTOR_ADDR,
         TokenAmount::zero(),
         CronMethod::EpochTick as u64,
-        RawBytes::default(),
+        None::<RawBytes>,
     );
 
     ExpectInvocation {
@@ -354,7 +354,7 @@ fn overdue_precommit() {
         CRON_ACTOR_ADDR,
         TokenAmount::zero(),
         CronMethod::EpochTick as u64,
-        RawBytes::default(),
+        None::<RawBytes>,
     );
 
     ExpectInvocation {
@@ -483,7 +483,7 @@ fn aggregate_bad_sector_number() {
         robust_addr,
         TokenAmount::zero(),
         MinerMethod::ProveCommitAggregate as u64,
-        prove_params,
+        Some(prove_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     ExpectInvocation {
@@ -562,7 +562,7 @@ fn aggregate_size_limits() {
         robust_addr,
         TokenAmount::zero(),
         MinerMethod::ProveCommitAggregate as u64,
-        prove_params,
+        Some(prove_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     ExpectInvocation {
@@ -589,7 +589,7 @@ fn aggregate_size_limits() {
         robust_addr,
         TokenAmount::zero(),
         MinerMethod::ProveCommitAggregate as u64,
-        prove_params,
+        Some(prove_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     ExpectInvocation {
@@ -617,7 +617,7 @@ fn aggregate_size_limits() {
         robust_addr,
         TokenAmount::zero(),
         MinerMethod::ProveCommitAggregate as u64,
-        prove_params,
+        Some(prove_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     ExpectInvocation {
@@ -693,7 +693,7 @@ fn aggregate_bad_sender() {
         robust_addr,
         TokenAmount::zero(),
         MinerMethod::ProveCommitAggregate as u64,
-        prove_params,
+        Some(prove_params),
         ExitCode::USR_FORBIDDEN,
     );
     ExpectInvocation {
@@ -800,7 +800,7 @@ fn aggregate_one_precommit_expires() {
         robust_addr,
         TokenAmount::zero(),
         MinerMethod::ProveCommitAggregate as u64,
-        prove_params,
+        Some(prove_params),
     );
     ExpectInvocation {
         to: id_addr,

--- a/test_vm/tests/datacap_tests.rs
+++ b/test_vm/tests/datacap_tests.rs
@@ -49,7 +49,7 @@ fn datacap_transfer_scenario() {
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
         DataCapMethod::Mint as u64,
-        mint_params.clone(),
+        Some(mint_params.clone()),
         ExitCode::USR_FORBIDDEN,
     );
 
@@ -60,7 +60,7 @@ fn datacap_transfer_scenario() {
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
         DataCapMethod::Mint as u64,
-        mint_params,
+        Some(mint_params),
     );
 
     // confirm allowance was set to infinity
@@ -71,7 +71,7 @@ fn datacap_transfer_scenario() {
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
         DataCapMethod::Allowance as u64,
-        GetAllowanceParams { owner: client, operator },
+        Some(GetAllowanceParams { owner: client, operator }),
     );
 
     let alloc = AllocationRequest {
@@ -117,7 +117,7 @@ fn datacap_transfer_scenario() {
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
         DataCapMethod::TransferFrom as u64,
-        params_piece_too_small,
+        Some(params_piece_too_small),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
@@ -131,7 +131,7 @@ fn datacap_transfer_scenario() {
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
         DataCapMethod::TransferFrom as u64,
-        params_mismatched_datacap,
+        Some(params_mismatched_datacap),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
@@ -150,7 +150,7 @@ fn datacap_transfer_scenario() {
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
         DataCapMethod::TransferFrom as u64,
-        params_bad_term,
+        Some(params_bad_term),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
@@ -163,7 +163,7 @@ fn datacap_transfer_scenario() {
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
         DataCapMethod::TransferFrom as u64,
-        clone_params(&params_bad_receiver),
+        Some(clone_params(&params_bad_receiver)),
         ExitCode::USR_FORBIDDEN, // ExitCode(19) because non-operator has insufficient allowance
     );
 
@@ -174,7 +174,7 @@ fn datacap_transfer_scenario() {
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
         DataCapMethod::TransferFrom as u64,
-        clone_params(&transfer_from_params),
+        Some(clone_params(&transfer_from_params)),
         ExitCode::USR_INSUFFICIENT_FUNDS, // ExitCode(19) because non-operator has insufficient allowance
     );
 
@@ -184,7 +184,7 @@ fn datacap_transfer_scenario() {
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
         DataCapMethod::TransferFrom as u64,
-        clone_params(&transfer_from_params),
+        Some(clone_params(&transfer_from_params)),
     );
 
     // Datacap already spent, not enough left
@@ -194,7 +194,7 @@ fn datacap_transfer_scenario() {
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
         DataCapMethod::TransferFrom as u64,
-        transfer_from_params,
+        Some(transfer_from_params),
         ExitCode::USR_INSUFFICIENT_FUNDS,
     );
 }
@@ -213,7 +213,7 @@ fn call_name_symbol() {
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
         DataCapMethod::Name as u64,
-        RawBytes::default(),
+        None::<RawBytes>,
     )
     .deserialize()
     .unwrap();
@@ -225,7 +225,7 @@ fn call_name_symbol() {
         DATACAP_TOKEN_ACTOR_ADDR,
         TokenAmount::zero(),
         DataCapMethod::Symbol as u64,
-        RawBytes::default(),
+        None::<RawBytes>,
     )
     .deserialize()
     .unwrap();

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -62,7 +62,14 @@ fn extend(
                     new_expiration,
                 }],
             };
-            apply_ok(v, worker, maddr, TokenAmount::zero(), extension_method, extension_params);
+            apply_ok(
+                v,
+                worker,
+                maddr,
+                TokenAmount::zero(),
+                extension_method,
+                Some(extension_params),
+            );
         }
         true => {
             let extension_params = ExtendSectorExpiration2Params {
@@ -74,7 +81,14 @@ fn extend(
                     sectors_with_claims: vec![],
                 }],
             };
-            apply_ok(v, worker, maddr, TokenAmount::zero(), extension_method, extension_params);
+            apply_ok(
+                v,
+                worker,
+                maddr,
+                TokenAmount::zero(),
+                extension_method,
+                Some(extension_params),
+            );
         }
     };
 

--- a/test_vm/tests/market_miner_withdrawal_test.rs
+++ b/test_vm/tests/market_miner_withdrawal_test.rs
@@ -132,7 +132,7 @@ mod miner_tests {
             m_addr,
             TokenAmount::zero(),
             MinerMethod::WithdrawBalance as u64,
-            params,
+            Some(params),
             ExitCode::USR_FORBIDDEN,
         );
     }
@@ -165,7 +165,7 @@ fn assert_add_collateral_and_withdraw(
     if collateral.is_positive() {
         match a_type {
             x if x == *MINER_ACTOR_CODE_ID => {
-                apply_ok(v, caller, escrow, collateral.clone(), METHOD_SEND, RawBytes::default())
+                apply_ok(v, caller, escrow, collateral.clone(), METHOD_SEND, None::<RawBytes>)
             }
             x if x == *MARKET_ACTOR_CODE_ID => apply_ok(
                 v,
@@ -173,7 +173,7 @@ fn assert_add_collateral_and_withdraw(
                 escrow,
                 collateral.clone(),
                 MarketMethod::AddBalance as u64,
-                caller,
+                Some(caller),
             ),
             _ => panic!("unreachable"),
         };
@@ -192,7 +192,7 @@ fn assert_add_collateral_and_withdraw(
                 escrow,
                 TokenAmount::zero(),
                 MinerMethod::WithdrawBalance as u64,
-                params,
+                Some(params),
             )
             .deserialize()
             .unwrap()
@@ -206,7 +206,7 @@ fn assert_add_collateral_and_withdraw(
                 escrow,
                 TokenAmount::zero(),
                 MarketMethod::WithdrawBalance as u64,
-                params,
+                Some(params),
             )
             .deserialize()
             .unwrap()

--- a/test_vm/tests/multisig_test.rs
+++ b/test_vm/tests/multisig_test.rs
@@ -44,7 +44,7 @@ fn test_proposal_hash() {
         msig_addr,
         fil_delta.clone(),
         MsigMethod::Propose as u64,
-        propose_send_sys_params,
+        Some(propose_send_sys_params),
     );
 
     let wrong_tx = Transaction {
@@ -62,7 +62,7 @@ fn test_proposal_hash() {
         msig_addr,
         TokenAmount::zero(),
         MsigMethod::Approve as u64,
-        wrong_approval_params,
+        Some(wrong_approval_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
@@ -82,7 +82,7 @@ fn test_proposal_hash() {
         msig_addr,
         TokenAmount::zero(),
         MsigMethod::Approve as u64,
-        correct_approval_params,
+        Some(correct_approval_params),
     );
     let expect = ExpectInvocation {
         to: msig_addr,
@@ -124,7 +124,7 @@ fn test_delete_self() {
             msig_addr,
             TokenAmount::zero(),
             MsigMethod::Propose as u64,
-            propose_remove_params,
+            Some(propose_remove_params),
         );
 
         // approval goes through
@@ -139,7 +139,7 @@ fn test_delete_self() {
                 msig_addr,
                 TokenAmount::zero(),
                 MsigMethod::Approve as u64,
-                approve_remove_signer.clone(),
+                Some(approve_remove_signer.clone()),
             );
         }
 
@@ -151,7 +151,7 @@ fn test_delete_self() {
                 msig_addr,
                 TokenAmount::zero(),
                 MsigMethod::Approve as u64,
-                approve_remove_signer,
+                Some(approve_remove_signer),
                 ExitCode::USR_NOT_FOUND,
             );
         }
@@ -193,7 +193,7 @@ fn swap_self_1_of_2() {
         msig_addr,
         TokenAmount::zero(),
         MsigMethod::Propose as u64,
-        propose_swap_signer_params,
+        Some(propose_swap_signer_params),
     );
     let st = v.get_state::<MsigState>(msig_addr).unwrap();
     assert_eq!(vec![bob, chuck], st.signers);
@@ -225,7 +225,7 @@ fn swap_self_2_of_3() {
         msig_addr,
         TokenAmount::zero(),
         MsigMethod::Propose as u64,
-        propose_swap_signer_params,
+        Some(propose_swap_signer_params),
     );
 
     // approval goes through
@@ -236,7 +236,7 @@ fn swap_self_2_of_3() {
         msig_addr,
         TokenAmount::zero(),
         MsigMethod::Approve as u64,
-        approve_swap_signer_params,
+        Some(approve_swap_signer_params),
     );
     let st = v.get_state::<MsigState>(msig_addr).unwrap();
     assert_eq!(vec![bob, chuck, dinesh], st.signers);
@@ -257,7 +257,7 @@ fn swap_self_2_of_3() {
         msig_addr,
         TokenAmount::zero(),
         MsigMethod::Propose as u64,
-        propose_swap_signer_params,
+        Some(propose_swap_signer_params),
     );
     let approve_swap_signer_params = TxnIDParams { id: TxnID(1), proposal_hash: vec![] };
     apply_ok(
@@ -266,7 +266,7 @@ fn swap_self_2_of_3() {
         msig_addr,
         TokenAmount::zero(),
         MsigMethod::Approve as u64,
-        approve_swap_signer_params,
+        Some(approve_swap_signer_params),
     );
     let st = v.get_state::<MsigState>(msig_addr).unwrap();
     assert_eq!(vec![bob, chuck, alice], st.signers);
@@ -291,10 +291,10 @@ fn create_msig(v: &VM, signers: Vec<Address>, threshold: u64) -> Address {
         INIT_ACTOR_ADDR,
         TokenAmount::zero(),
         fil_actor_init::Method::Exec as u64,
-        fil_actor_init::ExecParams {
+        Some(fil_actor_init::ExecParams {
             code_cid: *MULTISIG_ACTOR_CODE_ID,
             constructor_params: msig_ctor_params,
-        },
+        }),
     )
     .deserialize()
     .unwrap();

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -36,7 +36,7 @@ fn create_miner_test() {
         owner,
         TokenAmount::from_atto(10_000u32),
         METHOD_SEND,
-        RawBytes::default(),
+        None::<RawBytes>,
     )
     .unwrap();
     let multiaddrs = vec![BytesDe("multiaddr".as_bytes().to_vec())];
@@ -55,7 +55,7 @@ fn create_miner_test() {
             STORAGE_POWER_ACTOR_ADDR,
             TokenAmount::from_atto(1000u32),
             PowerMethod::CreateMiner as u64,
-            params.clone(),
+            Some(params.clone()),
         )
         .unwrap();
 
@@ -139,7 +139,7 @@ fn test_cron_tick() {
         robust_addr,
         TokenAmount::zero(),
         MinerMethod::PreCommitSector as u64,
-        precommit_params,
+        Some(precommit_params),
     );
 
     // find epoch of miner's next cron task (precommit:1, enrollCron:2)
@@ -155,7 +155,7 @@ fn test_cron_tick() {
         STORAGE_POWER_ACTOR_ADDR,
         TokenAmount::zero(),
         PowerMethod::OnEpochTickEnd as u64,
-        RawBytes::default(),
+        None::<RawBytes>,
     );
 
     // expect miner call to be missing
@@ -192,7 +192,7 @@ fn test_cron_tick() {
         STORAGE_POWER_ACTOR_ADDR,
         TokenAmount::zero(),
         PowerMethod::OnEpochTickEnd as u64,
-        RawBytes::default(),
+        None::<RawBytes>,
     );
 
     let sub_invocs = vec![

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -84,7 +84,7 @@ fn setup(store: &'_ MemoryBlockstore) -> (VM<'_>, Addrs, ChainEpoch) {
         VERIFIED_REGISTRY_ACTOR_ADDR,
         TokenAmount::zero(),
         VerifregMethod::AddVerifiedClient as u64,
-        add_client_params,
+        Some(add_client_params),
     );
 
     let client_collateral = TokenAmount::from_whole(100);
@@ -94,7 +94,7 @@ fn setup(store: &'_ MemoryBlockstore) -> (VM<'_>, Addrs, ChainEpoch) {
         STORAGE_MARKET_ACTOR_ADDR,
         client_collateral.clone(),
         MarketMethod::AddBalance as u64,
-        client1,
+        Some(client1),
     );
     apply_ok(
         &v,
@@ -102,7 +102,7 @@ fn setup(store: &'_ MemoryBlockstore) -> (VM<'_>, Addrs, ChainEpoch) {
         STORAGE_MARKET_ACTOR_ADDR,
         client_collateral.clone(),
         MarketMethod::AddBalance as u64,
-        client2,
+        Some(client2),
     );
     apply_ok(
         &v,
@@ -110,7 +110,7 @@ fn setup(store: &'_ MemoryBlockstore) -> (VM<'_>, Addrs, ChainEpoch) {
         STORAGE_MARKET_ACTOR_ADDR,
         client_collateral,
         MarketMethod::AddBalance as u64,
-        verified_client,
+        Some(verified_client),
     );
 
     let miner_collateral = TokenAmount::from_whole(100);
@@ -120,7 +120,7 @@ fn setup(store: &'_ MemoryBlockstore) -> (VM<'_>, Addrs, ChainEpoch) {
         STORAGE_MARKET_ACTOR_ADDR,
         miner_collateral,
         MarketMethod::AddBalance as u64,
-        maddr,
+        Some(maddr),
     );
 
     let deal_start =
@@ -242,7 +242,7 @@ fn psd_not_enought_client_lockup_for_batch() {
         STORAGE_MARKET_ACTOR_ADDR,
         one_lifetime_cost,
         MarketMethod::AddBalance as u64,
-        a.cheap_client,
+        Some(a.cheap_client),
     );
 
     let mut batcher =
@@ -282,7 +282,7 @@ fn psd_not_enough_provider_lockup_for_batch() {
         STORAGE_MARKET_ACTOR_ADDR,
         default_provider_collateral,
         MarketMethod::AddBalance as u64,
-        cheap_maddr,
+        Some(cheap_maddr),
     );
     let mut batcher = DealBatcher::new(
         &v,
@@ -405,7 +405,7 @@ fn psd_random_assortment_of_failures() {
         STORAGE_MARKET_ACTOR_ADDR,
         one_lifetime_cost,
         MarketMethod::AddBalance as u64,
-        a.cheap_client,
+        Some(a.cheap_client),
     );
     let broke_client = create_accounts_seeded(&v, 1, TokenAmount::zero(), 555)[0];
 
@@ -527,7 +527,7 @@ fn psd_bad_sig() {
             STORAGE_MARKET_ACTOR_ADDR,
             TokenAmount::zero(),
             MarketMethod::PublishStorageDeals as u64,
-            publish_params,
+            Some(publish_params),
         )
         .unwrap();
     assert_eq!(ExitCode::USR_ILLEGAL_ARGUMENT, ret.code);
@@ -713,7 +713,7 @@ impl<'bs> DealBatcher<'bs> {
             STORAGE_MARKET_ACTOR_ADDR,
             TokenAmount::zero(),
             MarketMethod::PublishStorageDeals as u64,
-            publish_params,
+            Some(publish_params),
         )
         .deserialize()
         .unwrap();
@@ -740,7 +740,7 @@ impl<'bs> DealBatcher<'bs> {
                 STORAGE_MARKET_ACTOR_ADDR,
                 TokenAmount::zero(),
                 MarketMethod::PublishStorageDeals as u64,
-                publish_params,
+                Some(publish_params),
             )
             .unwrap();
         assert_eq!(ExitCode::USR_ILLEGAL_ARGUMENT, ret.code);

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -285,7 +285,7 @@ fn prove_replica_update_multi_dline() {
         maddr,
         TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates as u64,
-        ProveReplicaUpdatesParams { updates: vec![replica_update_1, replica_update_2] },
+        Some(ProveReplicaUpdatesParams { updates: vec![replica_update_1, replica_update_2] }),
     )
     .deserialize()
     .unwrap();
@@ -354,7 +354,7 @@ fn immutable_deadline_failure() {
         robust,
         TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates as u64,
-        ProveReplicaUpdatesParams { updates: vec![replica_update] },
+        Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     v.assert_state_invariants();
@@ -408,7 +408,7 @@ fn unhealthy_sector_failure() {
         robust,
         TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates as u64,
-        ProveReplicaUpdatesParams { updates: vec![replica_update] },
+        Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     v.expect_state_invariants(
@@ -455,7 +455,7 @@ fn terminated_sector_failure() {
         maddr,
         TokenAmount::zero(),
         MinerMethod::TerminateSectors as u64,
-        terminate_parms,
+        Some(terminate_parms),
     );
 
     // replicaUpdate the sector
@@ -475,7 +475,7 @@ fn terminated_sector_failure() {
         robust,
         TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates as u64,
-        ProveReplicaUpdatesParams { updates: vec![replica_update] },
+        Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     v.assert_state_invariants();
@@ -528,7 +528,7 @@ fn bad_batch_size_failure() {
         robust,
         TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates as u64,
-        ProveReplicaUpdatesParams { updates },
+        Some(ProveReplicaUpdatesParams { updates }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     v.assert_state_invariants();
@@ -547,7 +547,7 @@ fn no_dispute_after_upgrade() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::DisputeWindowedPoSt as u64,
-        dispute_params,
+        Some(dispute_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     v.assert_state_invariants();
@@ -578,7 +578,7 @@ fn upgrade_bad_post_dispute() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::DisputeWindowedPoSt as u64,
-        dispute_params,
+        Some(dispute_params),
     );
     v.assert_state_invariants();
 }
@@ -633,7 +633,7 @@ fn bad_post_upgrade_dispute() {
         robust,
         TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates as u64,
-        ProveReplicaUpdatesParams { updates: vec![replica_update] },
+        Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
     )
     .deserialize()
     .unwrap();
@@ -655,7 +655,7 @@ fn bad_post_upgrade_dispute() {
         maddr,
         TokenAmount::zero(),
         MinerMethod::DisputeWindowedPoSt as u64,
-        dispute_params,
+        Some(dispute_params),
     );
     v.assert_state_invariants();
 }
@@ -682,7 +682,7 @@ fn terminate_after_upgrade() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::TerminateSectors as u64,
-        terminate_params,
+        Some(terminate_params),
     );
 
     // expect power, market and miner to be in base state
@@ -734,7 +734,7 @@ fn extend_after_upgrade() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::ExtendSectorExpiration as u64,
-        extension_params,
+        Some(extension_params),
     );
 
     let miner_state = v.get_state::<MinerState>(miner_id).unwrap();
@@ -794,7 +794,7 @@ fn wrong_deadline_index_failure() {
         robust,
         TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates as u64,
-        ProveReplicaUpdatesParams { updates },
+        Some(ProveReplicaUpdatesParams { updates }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
@@ -851,7 +851,7 @@ fn wrong_partition_index_failure() {
         robust,
         TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates as u64,
-        ProveReplicaUpdatesParams { updates },
+        Some(ProveReplicaUpdatesParams { updates }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
@@ -911,7 +911,7 @@ fn deal_included_in_multiple_sectors_failure() {
         CRON_ACTOR_ADDR,
         TokenAmount::zero(),
         CronMethod::EpochTick as u64,
-        RawBytes::default(),
+        None::<RawBytes>,
     );
 
     // advance to proving period and submit post
@@ -970,7 +970,7 @@ fn deal_included_in_multiple_sectors_failure() {
         maddr,
         TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates as u64,
-        ProveReplicaUpdatesParams { updates: vec![replica_update_1, replica_update_2] },
+        Some(ProveReplicaUpdatesParams { updates: vec![replica_update_1, replica_update_2] }),
     )
     .deserialize()
     .unwrap();
@@ -1046,7 +1046,7 @@ fn replica_update_verified_deal() {
         robust,
         TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates2 as u64,
-        ProveReplicaUpdatesParams2 { updates: vec![replica_update] },
+        Some(ProveReplicaUpdatesParams2 { updates: vec![replica_update] }),
     )
     .deserialize()
     .unwrap();
@@ -1171,7 +1171,7 @@ fn replica_update_verified_deal_max_term_violated() {
         robust,
         TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates2 as u64,
-        ProveReplicaUpdatesParams2 { updates: vec![replica_update] },
+        Some(ProveReplicaUpdatesParams2 { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 }
@@ -1220,7 +1220,7 @@ fn create_miner_and_upgrade_sector(
             robust,
             TokenAmount::zero(),
             MinerMethod::ProveReplicaUpdates as u64,
-            ProveReplicaUpdatesParams { updates: vec![replica_update] },
+            Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         )
     } else {
         let replica_update = ReplicaUpdate2 {
@@ -1239,7 +1239,7 @@ fn create_miner_and_upgrade_sector(
             robust,
             TokenAmount::zero(),
             MinerMethod::ProveReplicaUpdates2 as u64,
-            ProveReplicaUpdatesParams2 { updates: vec![replica_update] },
+            Some(ProveReplicaUpdatesParams2 { updates: vec![replica_update] }),
         )
     }
     .deserialize()
@@ -1287,7 +1287,7 @@ fn create_sector(
         maddr,
         TokenAmount::zero(),
         MinerMethod::ProveCommitSector as u64,
-        prove_commit_params,
+        Some(prove_commit_params),
     );
     let res = v
         .apply_message(
@@ -1295,7 +1295,7 @@ fn create_sector(
             CRON_ACTOR_ADDR,
             TokenAmount::zero(),
             CronMethod::EpochTick as u64,
-            RawBytes::default(),
+            None::<RawBytes>,
         )
         .unwrap();
     assert_eq!(ExitCode::OK, res.code);
@@ -1367,7 +1367,7 @@ fn create_deals_frac(
         STORAGE_MARKET_ACTOR_ADDR,
         collateral.clone(),
         MarketMethod::AddBalance as u64,
-        client,
+        Some(client),
     );
     apply_ok(
         v,
@@ -1375,7 +1375,7 @@ fn create_deals_frac(
         STORAGE_MARKET_ACTOR_ADDR,
         collateral,
         MarketMethod::AddBalance as u64,
-        maddr,
+        Some(maddr),
     );
 
     let mut ids = Vec::<DealID>::new();

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -68,7 +68,7 @@ fn terminate_sectors() {
         VERIFIED_REGISTRY_ACTOR_ADDR,
         TokenAmount::zero(),
         VerifregMethod::AddVerifiedClient as u64,
-        add_client_params,
+        Some(add_client_params),
     );
 
     // add market collateral
@@ -79,7 +79,7 @@ fn terminate_sectors() {
         STORAGE_MARKET_ACTOR_ADDR,
         collateral.clone(),
         MarketMethod::AddBalance as u64,
-        unverified_client,
+        Some(unverified_client),
     );
     apply_ok(
         &v,
@@ -87,7 +87,7 @@ fn terminate_sectors() {
         STORAGE_MARKET_ACTOR_ADDR,
         collateral,
         MarketMethod::AddBalance as u64,
-        verified_client,
+        Some(verified_client),
     );
 
     let miner_collateral = TokenAmount::from_whole(64);
@@ -97,7 +97,7 @@ fn terminate_sectors() {
         STORAGE_MARKET_ACTOR_ADDR,
         miner_collateral.clone(),
         MarketMethod::AddBalance as u64,
-        miner_id_addr,
+        Some(miner_id_addr),
     );
 
     // create 3 deals, some verified and some not
@@ -152,7 +152,7 @@ fn terminate_sectors() {
             CRON_ACTOR_ADDR,
             TokenAmount::zero(),
             CronMethod::EpochTick as u64,
-            RawBytes::default(),
+            None::<RawBytes>,
         )
         .unwrap();
     assert_eq!(ExitCode::OK, res.code);
@@ -170,7 +170,7 @@ fn terminate_sectors() {
         miner_robust_addr,
         TokenAmount::zero(),
         MinerMethod::PreCommitSector as u64,
-        PreCommitSectorParams {
+        Some(PreCommitSectorParams {
             seal_proof,
             sector_number,
             sealed_cid,
@@ -178,7 +178,7 @@ fn terminate_sectors() {
             deal_ids: deal_ids.clone(),
             expiration: v.get_epoch() + 220 * EPOCHS_IN_DAY,
             ..Default::default()
-        },
+        }),
     );
     let prove_time = v.get_epoch() + Policy::default().pre_commit_challenge_delay + 1;
     let v = advance_by_deadline_to_epoch(v, miner_id_addr, prove_time).0;
@@ -191,7 +191,7 @@ fn terminate_sectors() {
         miner_robust_addr,
         TokenAmount::zero(),
         MinerMethod::ProveCommitSector as u64,
-        prove_params,
+        Some(prove_params),
     );
     let res = v
         .apply_message(
@@ -199,7 +199,7 @@ fn terminate_sectors() {
             CRON_ACTOR_ADDR,
             TokenAmount::zero(),
             CronMethod::EpochTick as u64,
-            RawBytes::default(),
+            None::<RawBytes>,
         )
         .unwrap();
     assert_eq!(ExitCode::OK, res.code);
@@ -216,7 +216,7 @@ fn terminate_sectors() {
         CRON_ACTOR_ADDR,
         TokenAmount::zero(),
         CronMethod::EpochTick as u64,
-        RawBytes::default(),
+        None::<RawBytes>,
     )
     .unwrap();
     assert_eq!(ExitCode::OK, res.code);
@@ -248,13 +248,13 @@ fn terminate_sectors() {
         miner_robust_addr,
         TokenAmount::zero(),
         MinerMethod::TerminateSectors as u64,
-        TerminateSectorsParams {
+        Some(TerminateSectorsParams {
             terminations: vec![TerminationDeclaration {
                 deadline: d_idx,
                 partition: p_idx,
                 sectors: make_bitfield(&[sector_number]),
             }],
-        },
+        }),
     );
     ExpectInvocation {
         to: miner_id_addr,
@@ -332,7 +332,10 @@ fn terminate_sectors() {
         STORAGE_MARKET_ACTOR_ADDR,
         TokenAmount::zero(),
         MarketMethod::WithdrawBalance as u64,
-        WithdrawBalanceParams { provider_or_client: verified_client, amount: withdrawal.clone() },
+        Some(WithdrawBalanceParams {
+            provider_or_client: verified_client,
+            amount: withdrawal.clone(),
+        }),
     );
     ExpectInvocation {
         to: STORAGE_MARKET_ACTOR_ADDR,
@@ -353,7 +356,7 @@ fn terminate_sectors() {
         STORAGE_MARKET_ACTOR_ADDR,
         TokenAmount::zero(),
         MarketMethod::WithdrawBalance as u64,
-        WithdrawBalanceParams { provider_or_client: miner_id_addr, amount: miner_collateral },
+        Some(WithdrawBalanceParams { provider_or_client: miner_id_addr, amount: miner_collateral }),
     );
 
     let value_withdrawn = v.take_invocations().last().unwrap().subinvocations[1].msg.value();

--- a/test_vm/tests/test_vm_test.rs
+++ b/test_vm/tests/test_vm_test.rs
@@ -67,7 +67,7 @@ fn test_sent() {
         addr1,
         TokenAmount::from_atto(42u8),
         METHOD_SEND,
-        RawBytes::default(),
+        None::<RawBytes>,
     )
     .unwrap();
     let expect_id_addr1 = Address::new_id(FIRST_TEST_USER_ADDR);
@@ -75,25 +75,25 @@ fn test_sent() {
 
     // send from this account actor to another uninit account actor
     let addr2 = Address::new_bls(&[2; fvm_shared::address::BLS_PUB_LEN]).unwrap();
-    v.apply_message(addr1, addr2, TokenAmount::from_atto(41u8), METHOD_SEND, RawBytes::default())
+    v.apply_message(addr1, addr2, TokenAmount::from_atto(41u8), METHOD_SEND, None::<RawBytes>)
         .unwrap();
     let expect_id_addr2 = Address::new_id(FIRST_TEST_USER_ADDR + 1);
     assert_account_actor(0, TokenAmount::from_atto(41u8), addr2, &v, expect_id_addr2);
 
     // send between two initialized account actors
-    v.apply_message(addr2, addr1, TokenAmount::from_atto(41u8), METHOD_SEND, RawBytes::default())
+    v.apply_message(addr2, addr1, TokenAmount::from_atto(41u8), METHOD_SEND, None::<RawBytes>)
         .unwrap();
     assert_account_actor(1, TokenAmount::from_atto(42u8), addr1, &v, expect_id_addr1);
     assert_account_actor(1, TokenAmount::zero(), addr2, &v, expect_id_addr2);
 
     // self send is noop
-    v.apply_message(addr1, addr1, TokenAmount::from_atto(1u8), METHOD_SEND, RawBytes::default())
+    v.apply_message(addr1, addr1, TokenAmount::from_atto(1u8), METHOD_SEND, None::<RawBytes>)
         .unwrap();
     assert_account_actor(2, TokenAmount::from_atto(42u8), addr1, &v, expect_id_addr1);
 
     // fail with insufficient funds
     let mres = v
-        .apply_message(addr2, addr1, TokenAmount::from_atto(1u8), METHOD_SEND, RawBytes::default())
+        .apply_message(addr2, addr1, TokenAmount::from_atto(1u8), METHOD_SEND, None::<RawBytes>)
         .unwrap();
     assert_eq!(ExitCode::SYS_INSUFFICIENT_FUNDS, mres.code);
     assert_account_actor(2, TokenAmount::from_atto(42u8), addr1, &v, expect_id_addr1);
@@ -106,7 +106,7 @@ fn test_sent() {
             Address::new_id(88),
             TokenAmount::from_atto(1u8),
             METHOD_SEND,
-            RawBytes::default(),
+            None::<RawBytes>,
         )
         .unwrap();
     assert_eq!(ExitCode::SYS_INVALID_RECEIVER, mres.code);

--- a/test_vm/tests/verified_claim_test.rs
+++ b/test_vm/tests/verified_claim_test.rs
@@ -325,7 +325,7 @@ fn verified_claim_scenario() {
         VERIFIED_REGISTRY_ACTOR_ADDR,
         TokenAmount::zero(),
         VerifregMethod::RemoveExpiredClaims as u64,
-        cleanup_claims,
+        Some(cleanup_claims),
     );
     let ret: RemoveExpiredClaimsReturn = deserialize(&ret_raw, "balance of return value").unwrap();
     assert_eq!(vec![claim_id], ret.considered);

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -59,7 +59,7 @@ fn remove_datacap_simple_successful_path() {
         VERIFIED_REGISTRY_ACTOR_ADDR,
         TokenAmount::zero(),
         VerifregMethod::AddVerifiedClient as u64,
-        add_verified_client_params.clone(),
+        Some(add_verified_client_params.clone()),
     );
 
     ExpectInvocation {
@@ -152,7 +152,7 @@ fn remove_datacap_simple_successful_path() {
         VERIFIED_REGISTRY_ACTOR_ADDR,
         TokenAmount::zero(),
         VerifregMethod::RemoveVerifiedClientDataCap as u64,
-        remove_datacap_params.clone(),
+        Some(remove_datacap_params.clone()),
     )
     .deserialize()
     .unwrap();
@@ -231,7 +231,7 @@ fn remove_datacap_simple_successful_path() {
         VERIFIED_REGISTRY_ACTOR_ADDR,
         TokenAmount::zero(),
         VerifregMethod::RemoveVerifiedClientDataCap as u64,
-        remove_datacap_params.clone(),
+        Some(remove_datacap_params.clone()),
     )
     .deserialize()
     .unwrap();
@@ -318,7 +318,7 @@ fn remove_datacap_fails_on_verifreg() {
         VERIFIED_REGISTRY_ACTOR_ADDR,
         TokenAmount::zero(),
         VerifregMethod::RemoveVerifiedClientDataCap as u64,
-        remove_datacap_params,
+        Some(remove_datacap_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 

--- a/test_vm/tests/withdraw_balance_test.rs
+++ b/test_vm/tests/withdraw_balance_test.rs
@@ -83,7 +83,7 @@ fn withdraw_balance_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::WithdrawBalance as u64,
-        WithdrawBalanceParams { amount_requested: withdraw_amount },
+        Some(WithdrawBalanceParams { amount_requested: withdraw_amount }),
         ExitCode::USR_FORBIDDEN,
     );
     assert_eq!(balance_before_withdraw, v.get_actor(beneficiary).unwrap().balance);
@@ -100,7 +100,7 @@ fn withdraw_balance_fail() {
         miner_id,
         TokenAmount::zero(),
         MinerMethod::WithdrawBalance as u64,
-        WithdrawBalanceParams { amount_requested: withdraw_amount.clone() },
+        Some(WithdrawBalanceParams { amount_requested: withdraw_amount.clone() }),
         ExitCode::USR_FORBIDDEN,
     );
     assert_eq!(balance_before_withdraw, v.get_actor(addr).unwrap().balance);


### PR DESCRIPTION
Fixes #700 

- Changes the test_vm's apply methods to take an `Option<serde::Serialize>` as params. `None` is serialized as `RawBytes::default()`, `Some(p)` is serialized as CBOR.
- Drop the `impl Cbor` for all method params & returns types.