### PR TITLE
Use is_controlling_address in actors

### DIFF
--- a/actors/market/src/ext.rs
+++ b/actors/market/src/ext.rs
@@ -26,12 +26,26 @@ pub mod miner {
     use super::*;
 
     pub const CONTROL_ADDRESSES_METHOD: u64 = 2;
+    pub const IS_CONTROLLING_ADDRESS_EXPORTED: u64 =
+        frc42_dispatch::method_hash!("IsControllingAddress");
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct GetControlAddressesReturnParams {
         pub owner: Address,
         pub worker: Address,
         pub control_addresses: Vec<Address>,
+    }
+
+    #[derive(Serialize_tuple, Deserialize_tuple)]
+    #[serde(transparent)]
+    pub struct IsControllingAddressReturn {
+        pub is_controlling: bool,
+    }
+
+    #[derive(Serialize_tuple, Deserialize_tuple)]
+    #[serde(transparent)]
+    pub struct IsControllingAddressParam {
+        pub address: Address,
     }
 }
 

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -210,15 +210,14 @@ impl Actor {
             ));
         }
 
-        let (_, worker, controllers) = request_miner_control_addrs(rt, provider_id)?;
         let caller = rt.message().caller();
-        let mut caller_ok = caller == worker;
-        for controller in controllers.iter() {
-            if caller_ok {
-                break;
-            }
-            caller_ok = caller == *controller;
-        }
+        let res: ext::miner::IsControllingAddressReturn = deserialize_block(rt.send(
+            &Address::new_id(provider_id),
+            ext::miner::IS_CONTROLLING_ADDRESS_EXPORTED,
+            IpldBlock::serialize_cbor(&ext::miner::IsControllingAddressParam { address: caller })?,
+            TokenAmount::zero(),
+        )?)?;
+        let caller_ok = res.is_controlling;
         if !caller_ok {
             return Err(actor_error!(
                 forbidden,

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -211,14 +211,13 @@ impl Actor {
         }
 
         let caller = rt.message().caller();
-        let res: ext::miner::IsControllingAddressReturn = deserialize_block(rt.send(
+        let caller_status: ext::miner::IsControllingAddressReturn = deserialize_block(rt.send(
             &Address::new_id(provider_id),
             ext::miner::IS_CONTROLLING_ADDRESS_EXPORTED,
             IpldBlock::serialize_cbor(&ext::miner::IsControllingAddressParam { address: caller })?,
             TokenAmount::zero(),
         )?)?;
-        let caller_ok = res.is_controlling;
-        if !caller_ok {
+        if !caller_status.is_controlling {
             return Err(actor_error!(
                 forbidden,
                 "caller {} is not worker or control address of provider {}",

--- a/actors/market/tests/cron_tick_timedout_deals.rs
+++ b/actors/market/tests/cron_tick_timedout_deals.rs
@@ -86,7 +86,7 @@ fn publishing_timed_out_deal_again_should_work_after_cron_tick_as_it_should_no_l
         ClientDealProposal { proposal: deal_proposal2.clone(), client_signature: sig };
     let params = PublishStorageDealsParams { deals: vec![client_deal_proposal] };
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
     expect_query_network_info(&mut rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     let auth_param = IpldBlock::serialize_cbor(&AuthenticateMessageParams {

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -166,6 +166,34 @@ pub fn expect_provider_control_address(
     expect_get_control_addresses(rt, provider, owner, worker, vec![])
 }
 
+pub fn expect_get_is_control_addresses(
+    rt: &mut MockRuntime,
+    provider: Address,
+    caller: Address,
+    is_controlling: bool,
+) {
+    let result = ext::miner::IsControllingAddressReturn { is_controlling };
+
+    rt.expect_send(
+        provider,
+        ext::miner::IS_CONTROLLING_ADDRESS_EXPORTED,
+        IpldBlock::serialize_cbor(&ext::miner::IsControllingAddressParam { address: caller })
+            .unwrap(),
+        TokenAmount::zero(),
+        IpldBlock::serialize_cbor(&result).unwrap(),
+        ExitCode::OK,
+    )
+}
+
+pub fn expect_provider_is_control_address(
+    rt: &mut MockRuntime,
+    provider: Address,
+    caller: Address,
+    is_controlling: bool,
+) {
+    expect_get_is_control_addresses(rt, provider, caller, is_controlling)
+}
+
 pub fn add_provider_funds(rt: &mut MockRuntime, amount: TokenAmount, addrs: &MinerAddresses) {
     rt.set_value(amount.clone());
     rt.set_address_actor_type(addrs.provider, *MINER_ACTOR_CODE_ID);
@@ -441,17 +469,14 @@ pub fn publish_deals(
     let st: State = rt.get_state();
     let next_deal_id = st.next_id;
     rt.expect_validate_caller_any();
+    let return_value = ext::miner::IsControllingAddressReturn { is_controlling: true };
     rt.expect_send(
         addrs.provider,
-        ext::miner::CONTROL_ADDRESSES_METHOD,
-        None,
+        ext::miner::IS_CONTROLLING_ADDRESS_EXPORTED,
+        IpldBlock::serialize_cbor(&ext::miner::IsControllingAddressParam { address: rt.caller })
+            .unwrap(),
         TokenAmount::zero(),
-        IpldBlock::serialize_cbor(&GetControlAddressesReturnParams {
-            owner: addrs.owner,
-            worker: addrs.worker,
-            control_addresses: addrs.control.clone(),
-        })
-        .unwrap(),
+        IpldBlock::serialize_cbor(&return_value).unwrap(),
         ExitCode::OK,
     );
 
@@ -624,12 +649,7 @@ pub fn publish_deals_expect_abort(
     expected_exit_code: ExitCode,
 ) {
     rt.expect_validate_caller_any();
-    expect_provider_control_address(
-        rt,
-        miner_addresses.provider,
-        miner_addresses.owner,
-        miner_addresses.worker,
-    );
+    expect_provider_is_control_address(rt, miner_addresses.provider, WORKER_ADDR, true);
 
     let deal_serialized =
         RawBytes::serialize(proposal.clone()).expect("Failed to marshal deal proposal");
@@ -807,7 +827,7 @@ where
     post_setup(&mut rt, &mut deal_proposal);
 
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
     expect_query_network_info(&mut rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
 

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -166,7 +166,7 @@ pub fn expect_provider_control_address(
     expect_get_control_addresses(rt, provider, owner, worker, vec![])
 }
 
-pub fn expect_get_is_control_addresses(
+pub fn expect_provider_is_control_address(
     rt: &mut MockRuntime,
     provider: Address,
     caller: Address,
@@ -183,15 +183,6 @@ pub fn expect_get_is_control_addresses(
         IpldBlock::serialize_cbor(&result).unwrap(),
         ExitCode::OK,
     )
-}
-
-pub fn expect_provider_is_control_address(
-    rt: &mut MockRuntime,
-    provider: Address,
-    caller: Address,
-    is_controlling: bool,
-) {
-    expect_get_is_control_addresses(rt, provider, caller, is_controlling)
 }
 
 pub fn add_provider_funds(rt: &mut MockRuntime, amount: TokenAmount, addrs: &MinerAddresses) {

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -842,7 +842,7 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     rt.expect_validate_caller_any();
 
-    expect_provider_control_address(&mut rt, provider_resolved, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_is_control_address(&mut rt, provider_resolved, WORKER_ADDR, true);
     expect_query_network_info(&mut rt);
 
     //  create a client proposal with a valid signature
@@ -1526,7 +1526,7 @@ fn cannot_publish_the_same_deal_twice_before_a_cron_tick() {
         deals: vec![ClientDealProposal { proposal: d2.clone(), client_signature: sig }],
     };
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
     expect_query_network_info(&mut rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
 
@@ -1941,7 +1941,7 @@ fn insufficient_client_balance_in_a_batch() {
     };
 
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
     expect_query_network_info(&mut rt);
 
     let authenticate_param1 = IpldBlock::serialize_cbor(&AuthenticateMessageParams {
@@ -2075,7 +2075,7 @@ fn insufficient_provider_balance_in_a_batch() {
     };
 
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
     expect_query_network_info(&mut rt);
 
     let authenticate_param1 = IpldBlock::serialize_cbor(&AuthenticateMessageParams {
@@ -2235,7 +2235,7 @@ fn psd_restricted_correctly() {
     .unwrap();
 
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
     expect_query_network_info(&mut rt);
 
     rt.expect_send(

--- a/actors/market/tests/publish_storage_deals_failures.rs
+++ b/actors/market/tests/publish_storage_deals_failures.rs
@@ -256,7 +256,7 @@ fn fail_when_provider_has_some_funds_but_not_enough_for_a_deal() {
     };
 
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
     expect_query_network_info(&mut rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
 
@@ -319,7 +319,7 @@ fn fail_when_deals_have_different_providers() {
     };
 
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
     expect_query_network_info(&mut rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     let authenticate_param1 = IpldBlock::serialize_cbor(&AuthenticateMessageParams {
@@ -437,7 +437,7 @@ fn caller_is_not_the_same_as_the_worker_address_for_miner() {
     };
 
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, Address::new_id(999), false);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(999));
     expect_abort(
         ExitCode::USR_FORBIDDEN,

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -1127,7 +1127,7 @@ pub fn market_publish_deal(
     let mut expect_publish_invocs = vec![
         ExpectInvocation {
             to: miner_id,
-            method: MinerMethod::ControlAddresses as u64,
+            method: MinerMethod::IsControllingAddressExported as u64,
             ..Default::default()
         },
         ExpectInvocation {

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -539,7 +539,7 @@ fn psd_bad_sig() {
         subinvocs: Some(vec![
             ExpectInvocation {
                 to: a.maddr,
-                method: MinerMethod::ControlAddresses as u64,
+                method: MinerMethod::IsControllingAddressExported as u64,
                 ..Default::default()
             },
             ExpectInvocation {


### PR DESCRIPTION
Replace existing control address accessor with new `is_controlling_address`

Closes #816 