### PR TITLE
Fix caller check in EVM/EAM constructors

### DIFF
--- a/actors/eam/src/lib.rs
+++ b/actors/eam/src/lib.rs
@@ -12,7 +12,7 @@ use {
         actor_error, cbor,
         runtime::builtins::Type,
         runtime::{ActorCode, Runtime},
-        ActorError, EAM_ACTOR_ID, INIT_ACTOR_ADDR,
+        ActorError, EAM_ACTOR_ID, INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
     },
     fvm_ipld_encoding::{strict_bytes, tuple::*, RawBytes},
     fvm_shared::{
@@ -195,7 +195,7 @@ impl EamActor {
                 "The Ethereum Address Manager must be deployed at {EAM_ACTOR_ID}, was deployed at {actor_id}"
             )));
         }
-        rt.validate_immediate_caller_type(std::iter::once(&Type::Init))
+        rt.validate_immediate_caller_is(iter::once(&SYSTEM_ACTOR_ADDR))
     }
 
     /// Create a new contract per the EVM's CREATE rules.

--- a/actors/eam/tests/create.rs
+++ b/actors/eam/tests/create.rs
@@ -3,12 +3,11 @@ use eam::{
     compute_address_create, Create2Params, CreateParams, EthAddress, EvmConstructorParams, Return,
 };
 use fil_actor_eam as eam;
-use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::Primitives;
 use fil_actors_runtime::test_utils::{
-    expect_empty, MockRuntime, EVM_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID,
+    expect_empty, MockRuntime, EVM_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID,
 };
-use fil_actors_runtime::INIT_ACTOR_ADDR;
+use fil_actors_runtime::{INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR};
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
@@ -159,9 +158,9 @@ pub fn construct_and_verify() -> MockRuntime {
     let mut rt = MockRuntime { receiver: Address::new_id(10), ..Default::default() };
 
     // construct EAM singleton actor
-    rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
+    rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
 
-    rt.expect_validate_caller_type(vec![Type::Init]);
+    rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
 
     let result =
         rt.call::<eam::EamActor>(eam::Method::Constructor as u64, &RawBytes::default()).unwrap();

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use fil_actors_runtime::{actor_error, runtime::builtins::Type, AsActorError, EAM_ACTOR_ID};
+use fil_actors_runtime::{actor_error, AsActorError, EAM_ACTOR_ID, INIT_ACTOR_ADDR};
 use fvm_ipld_encoding::{strict_bytes, BytesDe, BytesSer, DAG_CBOR};
 use fvm_shared::address::{Address, Payload};
 use interpreter::{address::EthAddress, system::load_bytecode};
@@ -65,11 +65,7 @@ impl EvmContractActor {
         RT: Runtime,
         RT::Blockstore: Clone,
     {
-        // TODO ideally we would be checking that we are constructed by the EAM actor,
-        //   but instead we check for init and then assert that we have a delegated address.
-        //   https://github.com/filecoin-project/ref-fvm/issues/746
-        // rt.validate_immediate_caller_is(vec![&EAM_ACTOR_ADDR])?;
-        rt.validate_immediate_caller_type(iter::once(&Type::Init))?;
+        rt.validate_immediate_caller_is(iter::once(&INIT_ACTOR_ADDR))?;
 
         // Assert we are constructed with a delegated address from the EAM
         let receiver = rt.message().receiver();

--- a/actors/evm/tests/env.rs
+++ b/actors/evm/tests/env.rs
@@ -6,8 +6,8 @@ use ethers::{
 use evm::interpreter::address::EthAddress;
 use fil_actor_evm as evm;
 use fil_actors_runtime::{
-    runtime::builtins::Type,
     test_utils::{MockRuntime, EVM_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID},
+    INIT_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::tracking::{BSStats, TrackingBlockstore};
 use fvm_ipld_blockstore::MemoryBlockstore;
@@ -48,8 +48,8 @@ impl TestEnv {
             initcode: hex::decode(contract_hex).unwrap().into(),
         };
         // invoke constructor
-        self.runtime.expect_validate_caller_type(vec![Type::Init]);
-        self.runtime.caller_type = *INIT_ACTOR_CODE_ID;
+        self.runtime.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
+        self.runtime.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
 
         self.runtime.set_origin(self.evm_address);
         // first actor created is 0

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -1,9 +1,7 @@
 use cid::Cid;
 use evm::interpreter::{address::EthAddress, StatusCode};
 use fil_actor_evm as evm;
-use fil_actors_runtime::{
-    runtime::builtins::Type, test_utils::*, ActorError, EAM_ACTOR_ID, INIT_ACTOR_ADDR,
-};
+use fil_actors_runtime::{test_utils::*, ActorError, EAM_ACTOR_ID, INIT_ACTOR_ADDR};
 use fvm_ipld_encoding::{BytesDe, BytesSer, RawBytes};
 use fvm_shared::{address::Address, IDENTITY_HASH, IPLD_RAW};
 use lazy_static::lazy_static;
@@ -24,7 +22,7 @@ pub fn init_construct_and_verify<F: FnOnce(&mut MockRuntime)>(
 
     // construct EVM actor
     rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
-    rt.expect_validate_caller_type(vec![Type::Init]);
+    rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
     initrt(&mut rt);
 
     // first actor created is 0


### PR DESCRIPTION
Changes constructor caller checks to use singleton identity checks rather than actor type checks; this is towards our general goal of removing the use of `Type` from the built-in actors altogether.

Fixes EAM singleton to check its caller is the System actor, consistent with all other built-in actors. This actor is not constructed via `Init::Exec`.