### PR TITLE
Consolidate Init actor address mapping code

### DIFF
--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -83,7 +83,7 @@ impl Actor {
         // Allocate an ID for this actor.
         // Store mapping of actor addresses to the actor ID.
         let id_address: ActorID = rt.transaction(|s: &mut State, rt| {
-            s.map_address_to_new_id(rt.store(), &robust_address)
+            s.map_addresses_to_id(rt.store(), &robust_address, None)
                 .context("failed to allocate ID address")
         })?;
 
@@ -130,8 +130,8 @@ impl Actor {
         // Allocate an ID for this actor.
         // Store mapping of actor addresses to the actor ID.
         let id_address: ActorID = rt.transaction(|s: &mut State, rt| {
-            s.map_address_to_f4(rt.store(), &robust_address, &delegated_address)
-                .context("constructor failed")
+            s.map_addresses_to_id(rt.store(), &robust_address, Some(&delegated_address))
+                .context("failed to map addresses to ID")
         })?;
 
         // Create an empty actor

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -640,7 +640,7 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
         }
 
         let mut st = self.v.get_state::<InitState>(INIT_ACTOR_ADDR).unwrap();
-        let target_id = st.map_address_to_new_id(self.v.store, target).unwrap();
+        let target_id = st.map_addresses_to_id(self.v.store, target, None).unwrap();
         let target_id_addr = Address::new_id(target_id);
         let mut init_actor = self.v.get_actor(INIT_ACTOR_ADDR).unwrap();
         init_actor.head = self.v.store.put_cbor(&st, Code::Blake2b256).unwrap();


### PR DESCRIPTION
Removes most duplication, and clarifies the logic a bit.