### PR TITLE
fix: don't verify mock runtime when already panicing

### DIFF
--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -1238,7 +1238,7 @@ impl<BS> RuntimePolicy for MockRuntime<BS> {
 // In order to clear the unsatisfied expectations in tests, use MockRuntime#reset().
 impl Drop for Expectations {
     fn drop(&mut self) {
-        if !self.skip_verification_on_drop {
+        if !self.skip_verification_on_drop && !std::thread::panicking() {
             self.verify();
         }
     }


### PR DESCRIPTION
Otherwise, we'll just panic twice and abort.