### PR TITLE
fix: reject (f4) actor redeploy after selfdestruct

### DIFF
--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -12,6 +12,7 @@ use fil_actors_runtime::{
 };
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
+use fvm_shared::error::ExitCode;
 use fvm_shared::{ActorID, MethodNum, METHOD_CONSTRUCTOR};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -146,7 +147,7 @@ impl Actor {
         if existing {
             let code_cid = rt
                 .get_actor_code_cid(&id_address)
-                .context_code(ActorError::USR_FORBIDDEN, "cannot redeploy a deleted actor")?;
+                .context_code(ExitCode::USR_FORBIDDEN, "cannot redeploy a deleted actor")?;
             let embryo_cid = rt.get_code_cid_for_type(Type::Embryo);
             if code_cid != embryo_cid {
                 return Err(ActorError::forbidden(format!(
@@ -247,7 +248,6 @@ impl ActorCode for Actor {
 
 #[cfg(not(feature = "m2-native"))]
 fn can_exec(rt: &impl Runtime, caller: &Cid, exec: &Cid) -> bool {
-    use fil_actors_runtime::runtime::builtins::Type;
     rt.resolve_builtin_actor_type(exec)
         .map(|typ| match typ {
             Type::Multisig | Type::PaymentChannel => true,

--- a/actors/init/src/state.rs
+++ b/actors/init/src/state.rs
@@ -52,7 +52,7 @@ impl State {
     /// If the delegated address is already present, maps the robust address to that actor ID.
     /// Fails if the robust address is already mapped, providing tombstone.
     ///
-    /// Returns the nwe or existing actor ID.
+    /// Returns the actor ID and a boolean indicating whether or not the actor already exists.
     pub fn map_addresses_to_id<BS: Blockstore>(
         &mut self,
         store: &BS,

--- a/actors/init/src/state.rs
+++ b/actors/init/src/state.rs
@@ -58,10 +58,10 @@ impl State {
         store: &BS,
         robust_addr: &Address,
         delegated_addr: Option<&Address>,
-    ) -> Result<ActorID, ActorError> {
+    ) -> Result<(ActorID, bool), ActorError> {
         let mut map = make_map_with_root_and_bitwidth(&self.address_map, store, HAMT_BIT_WIDTH)
             .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load address map")?;
-        let id = if let Some(delegated_addr) = delegated_addr {
+        let (id, existing) = if let Some(delegated_addr) = delegated_addr {
             // If there's a delegated address, either recall the already-mapped actor ID or
             // create and map a new one.
             let delegated_key = delegated_addr.to_bytes().into();
@@ -69,19 +69,19 @@ impl State {
                 .get(&delegated_key)
                 .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to lookup delegated address")?
             {
-                *existing_id
+                (*existing_id, true)
             } else {
                 let new_id = self.next_id;
                 self.next_id += 1;
                 map.set(delegated_key, new_id)
                     .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to map delegated address")?;
-                new_id
+                (new_id, false)
             }
         } else {
             // With no delegated address, always create a new actor ID.
             let new_id = self.next_id;
             self.next_id += 1;
-            new_id
+            (new_id, false)
         };
 
         // Map the robust address to the ID, failing if it's already mapped to anything.
@@ -97,7 +97,7 @@ impl State {
         }
         self.address_map =
             map.flush().context_code(ExitCode::USR_ILLEGAL_STATE, "failed to store address map")?;
-        Ok(id)
+        Ok((id, existing))
     }
 
     /// ResolveAddress resolves an address to an ID-address, if possible.

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -387,6 +387,82 @@ fn call_exec4() {
         .flatten()
         .expect("failed to lookup f4 address");
     assert_eq!(expected_id_addr, resolved_id, "f4 address not assigned to the right actor");
+
+    // Try again and expect it to fail with "forbidden".
+    let unique_address = Address::new_actor(b"test2");
+    rt.new_actor_addr = Some(unique_address);
+    let exec_err =
+        exec4_and_verify(&mut rt, subaddr, *MULTISIG_ACTOR_CODE_ID, &fake_params).unwrap_err();
+
+    assert_eq!(exec_err.exit_code(), ExitCode::USR_FORBIDDEN);
+
+    // Delete and try again, it should still fail.
+    rt.actor_code_cids.remove(&resolved_id);
+    let unique_address = Address::new_actor(b"test2");
+    rt.new_actor_addr = Some(unique_address);
+    let exec_err =
+        exec4_and_verify(&mut rt, subaddr, *MULTISIG_ACTOR_CODE_ID, &fake_params).unwrap_err();
+
+    assert_eq!(exec_err.exit_code(), ExitCode::USR_FORBIDDEN);
+}
+
+// Try turning an embryo into an f4 actor.
+#[test]
+fn call_exec4_embryo() {
+    let mut rt = construct_runtime();
+    construct_and_verify(&mut rt);
+
+    // Assign addresses
+    let unique_address = Address::new_actor(b"test");
+    rt.new_actor_addr = Some(unique_address);
+
+    // Make the f4 addr
+    let subaddr = b"foobar";
+    let f4_addr = Address::new_delegated(EAM_ACTOR_ID, subaddr).unwrap();
+
+    // Register an embryo with the init actor.
+    let expected_id = {
+        let mut state: State = rt.get_state();
+        let (id, existing) = state.map_addresses_to_id(rt.store(), &f4_addr, None).unwrap();
+        assert!(!existing);
+        rt.replace_state(&state);
+        id
+    };
+
+    // Register it in the state-tree.
+    let expected_id_addr = Address::new_id(expected_id);
+    rt.set_address_actor_type(expected_id_addr, *EMBRYO_ACTOR_CODE_ID);
+    rt.add_delegated_address(expected_id_addr, f4_addr);
+
+    // Now try to create it.
+    rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id, Some(f4_addr));
+
+    let fake_params = ConstructorParams { network_name: String::from("fake_param") };
+    // Expect a send to the multisig actor constructor
+    rt.expect_send(
+        expected_id_addr,
+        METHOD_CONSTRUCTOR,
+        RawBytes::serialize(&fake_params).unwrap(),
+        TokenAmount::zero(),
+        RawBytes::default(),
+        ExitCode::OK,
+    );
+
+    // Return should have been successful. Check the returned addresses
+    let exec_ret =
+        exec4_and_verify(&mut rt, subaddr, *MULTISIG_ACTOR_CODE_ID, &fake_params).unwrap();
+
+    assert_eq!(unique_address, exec_ret.robust_address, "Robust address does not macth");
+    assert_eq!(expected_id_addr, exec_ret.id_address, "Id address does not match");
+
+    // Check that we assigned the right f4 address.
+    let init_state: State = rt.get_state();
+    let resolved_id = init_state
+        .resolve_address(rt.store(), &f4_addr)
+        .ok()
+        .flatten()
+        .expect("failed to lookup f4 address");
+    assert_eq!(expected_id_addr, resolved_id, "f4 address not assigned to the right actor");
 }
 
 fn construct_and_verify(rt: &mut MockRuntime) {

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -1202,6 +1202,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
             ExpectCreateActor { code_id, actor_id, predictable_address },
             "unexpected actor being created"
         );
+        self.set_address_actor_type(Address::new_id(actor_id), code_id);
         Ok(())
     }
 

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -640,7 +640,8 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
         }
 
         let mut st = self.v.get_state::<InitState>(INIT_ACTOR_ADDR).unwrap();
-        let target_id = st.map_addresses_to_id(self.v.store, target, None).unwrap();
+        let (target_id, existing) = st.map_addresses_to_id(self.v.store, target, None).unwrap();
+        assert!(!existing, "should never have existing actor when no f4 address is specified");
         let target_id_addr = Address::new_id(target_id);
         let mut init_actor = self.v.get_actor(INIT_ACTOR_ADDR).unwrap();
         init_actor.head = self.v.store.put_cbor(&st, Code::Blake2b256).unwrap();


### PR DESCRIPTION
We could also reject this in the FVM, but then we'd have to tell the FVM that we're re-assigning an existing ID address.

The downside of this method is that it's _slightly_ more expensive (we have to make multiple syscalls instead of one).

The benefit is that it makes auditing and testing this code _much_ simpler. Before, we were enforcing half the constraints in the FVM, and the other half in the init actor, which is why we had into this bug in the first place.

fixes https://github.com/filecoin-project/ref-fvm/issues/1175