### PR TITLE
use universal (de)serializer for Policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "lazy_static",
  "log",
  "multihash",
+ "num",
  "num-derive",
  "num-traits",
  "paste",
@@ -1482,6 +1483,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1491,6 +1493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1535,6 +1538,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
 fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+num = { version = "0.4", features = ["serde"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof, StoragePower};
 use num_traits::FromPrimitive;
@@ -137,7 +136,6 @@ pub struct Policy {
 
     // --- verifreg policy
     /// Minimum verified deal size
-    #[serde(with = "bigint_ser")]
     pub minimum_verified_allocation_size: StoragePower,
     /// Minimum term for a verified data allocation (epochs)
     pub minimum_verified_allocation_term: i64,
@@ -167,7 +165,6 @@ pub struct Policy {
 
     // --- power ---
     /// Minimum miner consensus power
-    #[serde(with = "bigint_ser")]
     pub minimum_consensus_power: StoragePower,
 }
 


### PR DESCRIPTION
The deserialization of a serialized Policy doesn't work with TOML and JSON. I assume the `fvm_shared::bigint::bigint_ser;` is supposed to be used for binary formats only. See more [here](https://github.com/ChainSafe/fil-actor-states/issues/2).

Given that [it was me](https://github.com/filecoin-project/builtin-actors/commit/7a65393774aea71f9b3cd19c240bc71623ea5a07) who introduced Serialization for this, I believe only Forest wants to use this feature for now so most likely nobody relies on it, especially the network.