### PR TITLE
EVM: test lookup_address

### DIFF
--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -133,8 +133,8 @@ pub(super) fn lookup_delegated_address<RT: Runtime>(
     Ok(ab)
 }
 
-/// Reads a FIL encoded address.
-/// Resolves a FIL encoded address into an ID address.
+/// Reads a FIL (i.e. f0xxx, f4x1xxx) encoded address
+/// Resolves a FIL encoded address into an ID address
 /// Returns BE encoded u256 (return will always be under 2^64). Empty array if nothing found or `InvalidInput` if length was larger 2^32.
 pub(super) fn resolve_address<RT: Runtime>(
     system: &mut System<RT>,

--- a/actors/evm/src/interpreter/precompiles/parameter.rs
+++ b/actors/evm/src/interpreter/precompiles/parameter.rs
@@ -213,3 +213,20 @@ impl<'a, T: Sized + Copy, const CHUNK_SIZE: usize> PaddedChunks<'a, T, CHUNK_SIZ
         self.next().map(|p| Parameter::<V>::from(p).0).ok_or(PrecompileError::IncorrectInputSize)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_assert_zero_bytes() {
+        let mut bytes = [0u8; 32];
+        assert_zero_bytes::<32>(&bytes).unwrap();
+        bytes[31] = 1;
+        assert_zero_bytes::<31>(&bytes).unwrap();
+        assert_zero_bytes::<32>(&bytes).expect_err("expected error from nonzero byte");
+    }
+
+    // remaining slice
+    
+}

--- a/actors/evm/src/interpreter/precompiles/parameter.rs
+++ b/actors/evm/src/interpreter/precompiles/parameter.rs
@@ -228,5 +228,4 @@ mod test {
     }
 
     // remaining slice
-    
 }

--- a/actors/evm/src/interpreter/precompiles/parameter.rs
+++ b/actors/evm/src/interpreter/precompiles/parameter.rs
@@ -226,6 +226,4 @@ mod test {
         assert_zero_bytes::<31>(&bytes).unwrap();
         assert_zero_bytes::<32>(&bytes).expect_err("expected error from nonzero byte");
     }
-
-    // remaining slice
 }

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -1,6 +1,6 @@
 mod asm;
 
-use evm::interpreter::{U256, address::EthAddress};
+use evm::interpreter::{address::EthAddress, U256};
 use fil_actor_evm as evm;
 use fil_actors_runtime::test_utils::{
     MockRuntime, ACCOUNT_ACTOR_CODE_ID, EAM_ACTOR_CODE_ID, EVM_ACTOR_CODE_ID, MINER_ACTOR_CODE_ID,
@@ -248,7 +248,7 @@ push1 0x00
 return
 "#;
 
-        asm::new_contract("native_actor_type", init, body).unwrap()
+        asm::new_contract("native_lookup_delegated_address", init, body).unwrap()
     };
     let mut rt = util::construct_and_verify(bytecode);
 

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -257,6 +257,11 @@ return
     let evm_del = EthAddress(util::CONTRACT_ADDRESS).try_into().unwrap();
     rt.add_delegated_address(evm_target, evm_del);
 
+    // f0 10111 is an actor with a non-evm delegate address
+    let unknown_target = FILAddress::new_id(10111);
+    let unknown_del = FILAddress::new_delegated(1234, "foobarboxy".as_bytes()).unwrap();
+    rt.add_delegated_address(unknown_target, unknown_del);
+
     fn test_reslove(rt: &mut MockRuntime, id: FILAddress, expected: Vec<u8>) {
         rt.expect_gas_available(10_000_000_000u64);
         let result = util::invoke_contract(rt, &id_to_vec(&id));
@@ -266,7 +271,15 @@ return
     }
 
     test_reslove(&mut rt, evm_target, evm_del.to_bytes());
+    test_reslove(&mut rt, unknown_target, unknown_del.to_bytes());
     test_reslove(&mut rt, FILAddress::new_id(11111), Vec::new());
+
+    // invalid input
+    rt.expect_gas_available(10_000_000_000u64);
+    let result = util::invoke_contract(&mut rt, &[0xff; 42]);
+    rt.verify();
+    assert_eq!(Vec::<u8>::new(), result);
+    rt.reset();
 }
 
 #[test]

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -1,6 +1,6 @@
 mod asm;
 
-use evm::interpreter::U256;
+use evm::interpreter::{address::EthAddress, U256};
 use fil_actor_evm as evm;
 use fil_actors_runtime::test_utils::{
     MockRuntime, ACCOUNT_ACTOR_CODE_ID, EAM_ACTOR_CODE_ID, EVM_ACTOR_CODE_ID, MINER_ACTOR_CODE_ID,
@@ -108,7 +108,7 @@ push1 0x00
 return
 "#;
 
-        asm::new_contract("native_precompiles", init, body).unwrap()
+        asm::new_contract("native_actor_type", init, body).unwrap()
     };
 
     use evm::interpreter::precompiles::NativeType;
@@ -138,10 +138,6 @@ return
     // f0 104 is a multisig
     let other_target = FILAddress::new_id(104);
     rt.set_address_actor_type(other_target, *MULTISIG_ACTOR_CODE_ID);
-
-    fn id_to_vec(src: &FILAddress) -> Vec<u8> {
-        U256::from(src.id().unwrap()).to_bytes().to_vec()
-    }
 
     fn test_type(rt: &mut MockRuntime, id: FILAddress, expected: NativeType) {
         rt.expect_gas_available(10_000_000_000u64);

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -9,6 +9,7 @@ use fil_actors_runtime::test_utils::{
 use fvm_shared::address::Address as FILAddress;
 
 mod util;
+use util::id_to_vec;
 
 #[allow(dead_code)]
 pub fn magic_precompile_contract() -> Vec<u8> {
@@ -157,9 +158,10 @@ return
 
     // invalid format address
     rt.expect_gas_available(10_000_000_000u64);
-    let result = util::invoke_contract(&mut rt, &[0xff; 64]);
+    let _result = util::invoke_contract(&mut rt, &[0xff; 64]);
     rt.verify();
-    assert!(result.is_empty());
+    // TODO re-enable when precompile return value is fixed !! (soon)
+    // assert!(result.is_empty());
     rt.reset();
 }
 

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -1,6 +1,6 @@
 mod asm;
 
-use evm::interpreter::{address::EthAddress, U256};
+use evm::interpreter::U256;
 use fil_actor_evm as evm;
 use fil_actors_runtime::test_utils::{
     MockRuntime, ACCOUNT_ACTOR_CODE_ID, EAM_ACTOR_CODE_ID, EVM_ACTOR_CODE_ID, MINER_ACTOR_CODE_ID,

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -158,10 +158,9 @@ return
 
     // invalid format address
     rt.expect_gas_available(10_000_000_000u64);
-    let _result = util::invoke_contract(&mut rt, &[0xff; 64]);
+    let result = util::invoke_contract(&mut rt, &[0xff; 64]);
     rt.verify();
-    // TODO re-enable when precompile return value is fixed !! (soon)
-    // assert!(result.is_empty());
+    assert!(result.is_empty());
     rt.reset();
 }
 

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -81,7 +81,7 @@ pub fn invoke_contract_expect_abort(rt: &mut MockRuntime, input_data: &[u8], exp
             evm::Method::InvokeContract as u64,
             IpldBlock::serialize_cbor(&BytesSer(input_data)).unwrap(),
         )
-        .expect_err(&format!("expected contract to fail with {}", expect));
+        .expect_err(&format!("expected contract to fail with {:?}", expect));
     rt.verify();
     // REMOVEME so this is jank... (just copies err creation from execute in lib.rs)
     assert_eq!(err, ActorError::unspecified(format!("EVM execution error: {expect:?}")))

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -1,4 +1,5 @@
 use cid::Cid;
+use evm::interpreter::U256;
 use evm::interpreter::{address::EthAddress, StatusCode};
 use fil_actor_evm as evm;
 use fil_actors_runtime::{
@@ -92,6 +93,11 @@ pub fn dispatch_num_word(method_num: u8) -> [u8; 32] {
     let mut word = [0u8; 32];
     word[3] = method_num;
     word
+}
+
+#[allow(dead_code)]
+pub fn id_to_vec(src: &Address) -> Vec<u8> {
+    U256::from(src.id().unwrap()).to_bytes().to_vec()
 }
 
 lazy_static! {


### PR DESCRIPTION
Adds a test for lookup_address, and assert_zero_bytes.

tests in https://github.com/filecoin-project/builtin-actors/pull/977 was originally part of this PR but split out to get it merged before carbonado.r1 

fixes [#1390](https://github.com/filecoin-project/ref-fvm/issues/1390)