### PR TITLE
fix: EVM: CALLs to EthAccount should be lowered to bare transfers.

### DIFF
--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -236,7 +236,7 @@ pub fn call_generic<RT: Runtime>(
                         Ok(RawBytes::default())
                     } else {
                         let (method, gas_limit) = if !actor_exists
-                            || matches!(target_actor_type, Some(Type::Placeholder | Type::Account))
+                            || matches!(target_actor_type, Some(Type::Placeholder | Type::Account | Type::EthAccount))
                             // See https://github.com/filecoin-project/ref-fvm/issues/980 for this
                             // hocus pocus
                             || (input_data.is_empty() && ((gas == 0 && value > 0) || (gas == 2300 && value == 0)))
@@ -244,7 +244,7 @@ pub fn call_generic<RT: Runtime>(
                             // We switch to a bare send when:
                             //
                             // 1. The target is a placeholder/account or doesn't exist. Otherwise,
-                            // sendign funds to an account/placeholder would fail when we try to call
+                            // sending funds to an account/placeholder would fail when we try to call
                             // InvokeContract.
                             // 2. The gas wouldn't let code execute anyways. This lets us support
                             // solidity's "transfer" method.

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -122,7 +122,7 @@ pub fn get_contract_type<RT: Runtime>(rt: &RT, addr: U256) -> ContractType {
         .and_then(|id| rt.get_actor_code_cid(&id).map(|cid| (id, cid))) // resolve code cid
         .map(|(id, cid)| match rt.resolve_builtin_actor_type(&cid) {
             // TODO part of current account abstraction hack where placeholders are accounts
-            Some(Type::Account | Type::Placeholder) => ContractType::Account,
+            Some(Type::Account | Type::Placeholder | Type::EthAccount) => ContractType::Account,
             Some(Type::EVM) => ContractType::EVM(Address::new_id(id)),
             // remaining builtin actors are native
             _ => ContractType::Native(cid),


### PR DESCRIPTION
We are in desperate need of integration tests here. Not that it would've helped in this particular case, though.

The impact of this bug is that contracts cannot send value to accounts.