### PR TITLE
EVM: Flush state before calling send in Ext opcodes 

### DIFF
--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -275,7 +275,7 @@ pub fn call_generic<RT: Runtime>(
                 CallKind::DelegateCall => match get_contract_type(system.rt, dst) {
                     ContractType::EVM(dst_addr) => {
                         // If we're calling an actual EVM actor, get its code.
-                        let code = get_evm_bytecode_cid(system.rt, &dst_addr)?;
+                        let code = get_evm_bytecode_cid(system, &dst_addr)?;
 
                         // and then invoke self with delegate; readonly context is sticky
                         let params = DelegateCallParams { code, input: input_data.into(),

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -5,6 +5,7 @@ use cid::Cid;
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::ActorError;
 use fvm_ipld_blockstore::Blockstore;
+use fvm_shared::sys::SendFlags;
 use fvm_shared::{address::Address, econ::TokenAmount};
 use multihash::Multihash;
 use num_traits::Zero;
@@ -23,7 +24,7 @@ const EMPTY_EVM_HASH: [u8; 32] =
 
 pub fn extcodesize(
     _state: &mut ExecutionState,
-    system: &System<impl Runtime>,
+    system: &mut System<impl Runtime>,
     addr: U256,
 ) -> Result<U256, StatusCode> {
     // TODO (M2.2) we're fetching the entire block here just to get its size. We should instead use
@@ -31,7 +32,7 @@ pub fn extcodesize(
     //  Tracked in https://github.com/filecoin-project/ref-fvm/issues/867
     let len = match get_contract_type(system.rt, addr) {
         ContractType::EVM(addr) => {
-            get_evm_bytecode(system.rt, &addr).map(|bytecode| bytecode.len())?
+            get_evm_bytecode(system, &addr).map(|bytecode| bytecode.len())?
         }
         ContractType::Native(_) => 1,
         // account, not found, and precompiles are 0 size
@@ -43,7 +44,7 @@ pub fn extcodesize(
 
 pub fn extcodehash(
     _state: &mut ExecutionState,
-    system: &System<impl Runtime>,
+    system: &mut System<impl Runtime>,
     addr: U256,
 ) -> Result<U256, StatusCode> {
     let addr = match get_contract_type(system.rt, addr) {
@@ -63,12 +64,13 @@ pub fn extcodehash(
 
     // multihash { keccak256(bytecode) }
     let bytecode_hash: Multihash = system
-        .rt
         .send(
             &addr,
             crate::Method::GetBytecodeHash as u64,
             Default::default(),
             TokenAmount::zero(),
+            None,
+            SendFlags::READ_ONLY,
         )?
         .deserialize()?;
 
@@ -81,14 +83,14 @@ pub fn extcodehash(
 
 pub fn extcodecopy(
     state: &mut ExecutionState,
-    system: &System<impl Runtime>,
+    system: &mut System<impl Runtime>,
     addr: U256,
     dest_offset: U256,
     data_offset: U256,
     size: U256,
 ) -> Result<(), StatusCode> {
     let bytecode = match get_contract_type(system.rt, addr) {
-        ContractType::EVM(addr) => get_evm_bytecode(system.rt, &addr)?,
+        ContractType::EVM(addr) => get_evm_bytecode(system, &addr)?,
         ContractType::NotFound | ContractType::Account | ContractType::Precompile => Vec::new(),
         // calling EXTCODECOPY on native actors results with a single byte 0xFE which solidtiy uses for its `assert`/`throw` methods
         // and in general invalid EVM bytecode
@@ -130,15 +132,15 @@ pub fn get_contract_type<RT: Runtime>(rt: &RT, addr: U256) -> ContractType {
         .unwrap_or(ContractType::NotFound)
 }
 
-pub fn get_evm_bytecode_cid(rt: &impl Runtime, addr: &Address) -> Result<Cid, ActorError> {
-    Ok(rt
-        .send(addr, crate::Method::GetBytecode as u64, Default::default(), TokenAmount::zero())?
+pub fn get_evm_bytecode_cid(system: &mut System<impl Runtime>, addr: &Address) -> Result<Cid, ActorError> {
+    Ok(system
+        .send(addr, crate::Method::GetBytecode as u64, Default::default(), TokenAmount::zero(), None, SendFlags::READ_ONLY)?
         .deserialize()?)
 }
 
-pub fn get_evm_bytecode(rt: &impl Runtime, addr: &Address) -> Result<Vec<u8>, StatusCode> {
-    let cid = get_evm_bytecode_cid(rt, addr)?;
-    let raw_bytecode = rt
+pub fn get_evm_bytecode(system: &mut System<impl Runtime>, addr: &Address) -> Result<Vec<u8>, StatusCode> {
+    let cid = get_evm_bytecode_cid(system, addr)?;
+    let raw_bytecode = system.rt
         .store()
         .get(&cid) // TODO this is inefficient; should call stat here.
         .map_err(|e| StatusCode::InternalError(format!("failed to get bytecode block: {}", &e)))?

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -5,6 +5,7 @@ use cid::Cid;
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::ActorError;
 use fvm_ipld_blockstore::Blockstore;
+use fvm_shared::crypto::hash::SupportedHashes;
 use fvm_shared::sys::SendFlags;
 use fvm_shared::{address::Address, econ::TokenAmount};
 use multihash::Multihash;
@@ -15,11 +16,11 @@ use {
 };
 
 /// Keccak256 hash of `[0xfe]`, "native bytecode"
-const NATIVE_BYTECODE_HASH: [u8; 32] =
+pub const NATIVE_BYTECODE_HASH: [u8; 32] =
     hex_literal::hex!("bcc90f2d6dada5b18e155c17a1c0a55920aae94f39857d39d0d8ed07ae8f228b");
 
 /// Keccak256 hash of `[]`, empty bytecode
-const EMPTY_EVM_HASH: [u8; 32] =
+pub const EMPTY_EVM_HASH: [u8; 32] =
     hex_literal::hex!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
 
 pub fn extcodesize(
@@ -75,6 +76,7 @@ pub fn extcodehash(
         .deserialize()?;
 
     let digest = bytecode_hash.digest();
+    debug_assert_eq!(SupportedHashes::Keccak256 as u64, bytecode_hash.code());
 
     // Take the first 32 bytes of the Multihash
     let digest_len = digest.len().min(32);

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -132,15 +132,29 @@ pub fn get_contract_type<RT: Runtime>(rt: &RT, addr: U256) -> ContractType {
         .unwrap_or(ContractType::NotFound)
 }
 
-pub fn get_evm_bytecode_cid(system: &mut System<impl Runtime>, addr: &Address) -> Result<Cid, ActorError> {
+pub fn get_evm_bytecode_cid(
+    system: &mut System<impl Runtime>,
+    addr: &Address,
+) -> Result<Cid, ActorError> {
     Ok(system
-        .send(addr, crate::Method::GetBytecode as u64, Default::default(), TokenAmount::zero(), None, SendFlags::READ_ONLY)?
+        .send(
+            addr,
+            crate::Method::GetBytecode as u64,
+            Default::default(),
+            TokenAmount::zero(),
+            None,
+            SendFlags::READ_ONLY,
+        )?
         .deserialize()?)
 }
 
-pub fn get_evm_bytecode(system: &mut System<impl Runtime>, addr: &Address) -> Result<Vec<u8>, StatusCode> {
+pub fn get_evm_bytecode(
+    system: &mut System<impl Runtime>,
+    addr: &Address,
+) -> Result<Vec<u8>, StatusCode> {
     let cid = get_evm_bytecode_cid(system, addr)?;
-    let raw_bytecode = system.rt
+    let raw_bytecode = system
+        .rt
         .store()
         .get(&cid) // TODO this is inefficient; should call stat here.
         .map_err(|e| StatusCode::InternalError(format!("failed to get bytecode block: {}", &e)))?

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -303,8 +303,8 @@ impl ActorCode for EvmContractActor {
                 Ok(RawBytes::serialize(cid)?)
             }
             Some(Method::GetBytecodeHash) => {
-                let cid = Self::bytecode_hash(rt)?;
-                Ok(RawBytes::serialize(cid)?)
+                let multihash = Self::bytecode_hash(rt)?;
+                Ok(RawBytes::serialize(multihash)?)
             }
             Some(Method::GetStorageAt) => {
                 let value = Self::storage_at(

--- a/actors/evm/tests/delegate_call.rs
+++ b/actors/evm/tests/delegate_call.rs
@@ -106,11 +106,13 @@ fn test_delegate_call_caller() {
     let return_data = U256::from(0x42);
 
     rt.expect_gas_available(10_000_000_000u64);
-    rt.expect_send(
+    rt.expect_send_generalized(
         target,
         Method::GetBytecode as u64,
         None,
         TokenAmount::zero(),
+        None,
+        SendFlags::READ_ONLY,
         RawBytes::serialize(EMPTY_ARR_CID).expect("failed to serialize bytecode hash"),
         ExitCode::OK,
     );

--- a/actors/evm/tests/ext_opcodes.rs
+++ b/actors/evm/tests/ext_opcodes.rs
@@ -14,6 +14,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 
 mod util;
+use fvm_shared::sys::SendFlags;
 use util::DUMMY_ACTOR_CODE_ID;
 
 #[test]
@@ -89,11 +90,13 @@ native_account:
     let method = util::dispatch_num_word(0);
     let expected = U256::from(0x04);
     {
-        rt.expect_send(
+        rt.expect_send_generalized(
             evm_contract,
             evm::Method::GetBytecode as u64,
             Default::default(),
             TokenAmount::zero(),
+            None,
+            SendFlags::READ_ONLY,
             RawBytes::serialize(&bytecode_cid).unwrap(),
             ExitCode::OK,
         );
@@ -204,11 +207,13 @@ account:
     )
     .unwrap();
 
-    rt.expect_send(
+    rt.expect_send_generalized(
         evm_target,
         evm::Method::GetBytecodeHash as u64,
         Default::default(),
         TokenAmount::zero(),
+        None,
+        SendFlags::READ_ONLY,
         RawBytes::serialize(&bytecode_hash).unwrap(),
         ExitCode::OK,
     );
@@ -347,11 +352,13 @@ precompile:
     let other_bytecode = vec![0x01, 0x02, 0x03, 0x04];
     rt.store.put_keyed(&bytecode_cid, other_bytecode.as_slice()).unwrap();
 
-    rt.expect_send(
+    rt.expect_send_generalized(
         evm_target,
         evm::Method::GetBytecode as u64,
         Default::default(),
         TokenAmount::zero(),
+        None,
+        SendFlags::READ_ONLY,
         RawBytes::serialize(&bytecode_cid).unwrap(),
         ExitCode::OK,
     );

--- a/actors/evm/tests/ext_opcodes.rs
+++ b/actors/evm/tests/ext_opcodes.rs
@@ -1,15 +1,14 @@
 mod asm;
 
 use cid::Cid;
-use evm::interpreter::U256;
-use evm::interpreter::address::EthAddress;
 use evm::interpreter::instructions::ext::EMPTY_EVM_HASH;
+use evm::interpreter::U256;
 use fil_actor_evm as evm;
 use fil_actors_runtime::runtime::{Primitives, Runtime, EMPTY_ARR_CID};
 use fil_actors_runtime::test_utils::*;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::{RawBytes, BytesSer};
-use fvm_shared::address::{Address as FILAddress, DelegatedAddress};
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::Address as FILAddress;
 use fvm_shared::bigint::Zero;
 use fvm_shared::crypto::hash::SupportedHashes;
 use fvm_shared::econ::TokenAmount;
@@ -17,7 +16,7 @@ use fvm_shared::error::ExitCode;
 
 mod util;
 use fvm_shared::sys::SendFlags;
-use util::{DUMMY_ACTOR_CODE_ID, CONTRACT_ID};
+use util::{CONTRACT_ID, DUMMY_ACTOR_CODE_ID};
 
 #[test]
 fn test_extcodesize() {
@@ -436,7 +435,10 @@ init_extsize:
             TokenAmount::zero(),
             None,
             SendFlags::READ_ONLY,
-            RawBytes::serialize(Multihash::wrap(SupportedHashes::Keccak256 as u64, &EMPTY_EVM_HASH).unwrap()).unwrap(),
+            RawBytes::serialize(
+                Multihash::wrap(SupportedHashes::Keccak256 as u64, &EMPTY_EVM_HASH).unwrap(),
+            )
+            .unwrap(),
             ExitCode::OK,
         );
 

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -15,6 +15,7 @@ pub fn construct_and_verify(initcode: Vec<u8>) -> MockRuntime {
 pub const CONTRACT_ADDRESS: [u8; 20] =
     hex_literal::hex!("FEEDFACECAFEBEEF000000000000000000000000");
 
+#[allow(unused)]
 pub const CONTRACT_ID: Address = Address::new_id(0);
 
 pub fn init_construct_and_verify<F: FnOnce(&mut MockRuntime)>(
@@ -34,7 +35,6 @@ pub fn init_construct_and_verify<F: FnOnce(&mut MockRuntime)>(
         Address::new_delegated(EAM_ACTOR_ID, &CONTRACT_ADDRESS).unwrap(),
     );
     rt.set_address_actor_type(Address::new_id(0), *EVM_ACTOR_CODE_ID);
-
 
     let params = evm::ConstructorParams {
         creator: EthAddress::from_id(fil_actors_runtime::EAM_ACTOR_ADDR.id().unwrap()),

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -15,6 +15,8 @@ pub fn construct_and_verify(initcode: Vec<u8>) -> MockRuntime {
 pub const CONTRACT_ADDRESS: [u8; 20] =
     hex_literal::hex!("FEEDFACECAFEBEEF000000000000000000000000");
 
+pub const CONTRACT_ID: Address = Address::new_id(0);
+
 pub fn init_construct_and_verify<F: FnOnce(&mut MockRuntime)>(
     initcode: Vec<u8>,
     initrt: F,
@@ -31,6 +33,8 @@ pub fn init_construct_and_verify<F: FnOnce(&mut MockRuntime)>(
         Address::new_id(0),
         Address::new_delegated(EAM_ACTOR_ID, &CONTRACT_ADDRESS).unwrap(),
     );
+    rt.set_address_actor_type(Address::new_id(0), *EVM_ACTOR_CODE_ID);
+
 
     let params = evm::ConstructorParams {
         creator: EthAddress::from_id(fil_actors_runtime::EAM_ACTOR_ADDR.id().unwrap()),


### PR DESCRIPTION
This is needed since ext* opcodes can/will be called during initcode.
Calling ext* on self during initcode must have _some_ state flushed, system.send will flush empty bytecode hashes to state before send for us so get_bytecode and code hash work properly then.

This _could_ be potentially unexpected behavior depending on what EVM does for these opcodes during initcode, since it may consider self as non-existent and return zeros. This also introduces the idea that self "exists" during initcode despite the potential for the constructor to fail and not _actually_ exist.

**Note:** This PR changes Ext opcodes to use readonly sends since those methods we call in them should never change state.