### PR TITLE
Adds log() method to runtime, calling through to the VM syscall

### DIFF
--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -382,6 +382,10 @@ where
     fn base_fee(&self) -> TokenAmount {
         fvm::network::base_fee()
     }
+
+    fn log(&self, msg: String) {
+        fvm::debug::log(msg);
+    }
 }
 
 impl<B> Primitives for FvmRuntime<B>

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -171,7 +171,12 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// `name` provides information about gas charging point
     fn charge_gas(&mut self, name: &'static str, compute: i64);
 
+    /// Returns the gas base fee (cost per unit) for the current epoch.
     fn base_fee(&self) -> TokenAmount;
+
+    /// Logs a message with the VM.
+    /// This message can appear in execution traces.
+    fn log(&self, msg: String);
 }
 
 /// Message information available to the actor about executing message.

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -1026,6 +1026,10 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
     fn base_fee(&self) -> TokenAmount {
         self.base_fee.clone()
     }
+
+    fn log(&self, msg: String) {
+        log::log!(msg);
+    }
 }
 
 impl<BS> Primitives for MockRuntime<BS> {

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -942,6 +942,10 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
     fn base_fee(&self) -> TokenAmount {
         TokenAmount::zero()
     }
+
+    fn log(&self, msg: String) {
+        log::log!(msg);
+    }
 }
 
 impl Primitives for VM<'_> {


### PR DESCRIPTION
Context: https://github.com/filecoin-project/ref-fvm/issues/1397

At present the mock runtime just prints the message, but we could accumulate them in the future. No actual log calls are checked in here because they cost gas.