### PR TITLE
EVM: Add frc-42 method numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ dependencies = [
  "etk-asm",
  "fil_actors_runtime",
  "fixed-hash 0.7.0",
+ "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_kamt",

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "lib"]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
 fvm_ipld_kamt = { version = "0.1.0" }
+frc42_dispatch = "2.0.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5"
 num-traits = "0.2.14"

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -261,7 +261,7 @@ pub fn call_generic<RT: Runtime>(
                             (METHOD_SEND, None)
                         } else {
                             // Otherwise, invoke normally.
-                            (Method::InvokeContract as u64, Some(effective_gas_limit(system, gas)))
+                            (Method::InvokeContractExported as u64, Some(effective_gas_limit(system, gas)))
                         };
                         let params = if input_data.is_empty() {
                             None
@@ -287,7 +287,7 @@ pub fn call_generic<RT: Runtime>(
                             caller: state.caller, };
                         system.send(
                             &system.rt.message().receiver(),
-                            Method::InvokeContractDelegate as u64,
+                            Method::InvokeContractDelegateExported as u64,
                             IpldBlock::serialize_cbor(&params)?,
                             TokenAmount::from(&value),
                             Some(effective_gas_limit(system, gas)),

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -287,7 +287,7 @@ pub fn call_generic<RT: Runtime>(
                             caller: state.caller, };
                         system.send(
                             &system.rt.message().receiver(),
-                            Method::InvokeContractDelegateExported as u64,
+                            Method::InvokeContractDelegate as u64,
                             IpldBlock::serialize_cbor(&params)?,
                             TokenAmount::from(&value),
                             Some(effective_gas_limit(system, gas)),

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -67,7 +67,7 @@ pub fn extcodehash(
     let bytecode_hash: Multihash = system
         .send(
             &addr,
-            crate::Method::GetBytecodeHashExported as u64,
+            crate::Method::GetBytecodeHash as u64,
             Default::default(),
             TokenAmount::zero(),
             None,

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -67,7 +67,7 @@ pub fn extcodehash(
     let bytecode_hash: Multihash = system
         .send(
             &addr,
-            crate::Method::GetBytecodeHash as u64,
+            crate::Method::GetBytecodeHashExported as u64,
             Default::default(),
             TokenAmount::zero(),
             None,
@@ -141,7 +141,7 @@ pub fn get_evm_bytecode_cid(
     Ok(system
         .send(
             addr,
-            crate::Method::GetBytecode as u64,
+            crate::Method::GetBytecodeExported as u64,
             Default::default(),
             TokenAmount::zero(),
             None,

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -59,6 +59,8 @@ pub enum Method {
     // FRC-42 method exports
     InvokeContractExported = frc42_dispatch::method_hash!("InvokeContract"),
     InvokeContractDelegateExported = frc42_dispatch::method_hash!("InvokeContractDelegate"),
+    GetBytecodeExported = frc42_dispatch::method_hash!("GetBytecode"),
+    GetBytecodeHashExported = frc42_dispatch::method_hash!("GetBytecodeHash"),
 }
 
 pub struct EvmContractActor;
@@ -275,6 +277,9 @@ impl ActorCode for EvmContractActor {
         fn is_exported_method(method: u64) -> bool {
             method == Method::InvokeContractDelegateExported as u64
                 || method == Method::InvokeContractExported as u64
+                || method == Method::GetBytecodeExported as u64
+                || method == Method::GetBytecodeHashExported as u64
+
             // TODO bytecode
         }
 
@@ -304,14 +309,13 @@ impl ActorCode for EvmContractActor {
                     }
                 };
                 let value = Self::invoke_contract(rt, &params, None, None)?;
-                log::info!("traceee");
                 Ok(RawBytes::serialize(BytesSer(&value))?)
             }
-            Some(Method::GetBytecode) => {
+            Some(Method::GetBytecode | Method::GetBytecodeExported) => {
                 let cid = Self::bytecode(rt)?;
                 Ok(RawBytes::serialize(cid)?)
             }
-            Some(Method::GetBytecodeHash) => {
+            Some(Method::GetBytecodeHash | Method::GetBytecodeHashExported) => {
                 let multihash = Self::bytecode_hash(rt)?;
                 Ok(RawBytes::serialize(multihash)?)
             }

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -57,10 +57,8 @@ pub enum Method {
     InvokeContractDelegate = 5,
     GetBytecodeHash = 6,
     // FRC-42 method exports
-    InvokeContractExported = frc42_dispatch::method_hash!("InvokeContract"),
-    InvokeContractDelegateExported = frc42_dispatch::method_hash!("InvokeContractDelegate"),
+    InvokeContractExported = frc42_dispatch::method_hash!("InvokeEVM"),
     GetBytecodeExported = frc42_dispatch::method_hash!("GetBytecode"),
-    GetBytecodeHashExported = frc42_dispatch::method_hash!("GetBytecodeHash"),
 }
 
 pub struct EvmContractActor;
@@ -275,12 +273,8 @@ impl ActorCode for EvmContractActor {
         RT::Blockstore: Clone,
     {
         fn is_exported_method(method: u64) -> bool {
-            method == Method::InvokeContractDelegateExported as u64
-                || method == Method::InvokeContractExported as u64
+            method == Method::InvokeContractExported as u64
                 || method == Method::GetBytecodeExported as u64
-                || method == Method::GetBytecodeHashExported as u64
-
-            // TODO bytecode
         }
 
         // We reserve all methods below EVM_MAX_RESERVED (<= 1023) method. This is a _subset_ of
@@ -315,7 +309,7 @@ impl ActorCode for EvmContractActor {
                 let cid = Self::bytecode(rt)?;
                 Ok(RawBytes::serialize(cid)?)
             }
-            Some(Method::GetBytecodeHash | Method::GetBytecodeHashExported) => {
+            Some(Method::GetBytecodeHash) => {
                 let multihash = Self::bytecode_hash(rt)?;
                 Ok(RawBytes::serialize(multihash)?)
             }
@@ -329,7 +323,7 @@ impl ActorCode for EvmContractActor {
                 )?;
                 Ok(RawBytes::serialize(value)?)
             }
-            Some(Method::InvokeContractDelegate | Method::InvokeContractDelegateExported) => {
+            Some(Method::InvokeContractDelegate) => {
                 let params: DelegateCallParams = args
                     .with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
                         "method expects arguments".to_string()

--- a/actors/evm/tests/basic.rs
+++ b/actors/evm/tests/basic.rs
@@ -78,7 +78,7 @@ return
     rt.reset();
     rt.expect_validate_caller_any();
     let returned_bytecode_cid: Cid = rt
-        .call::<evm::EvmContractActor>(evm::Method::GetBytecode as u64, None)
+        .call::<evm::EvmContractActor>(evm::Method::GetBytecodeExported as u64, None)
         .unwrap()
         .deserialize()
         .unwrap();

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -185,7 +185,7 @@ fn test_call() {
     rt.expect_gas_available(10_000_000_000u64);
     rt.expect_send_generalized(
         f4_target,
-        evm::Method::InvokeContract as u64,
+        evm::Method::InvokeContractExported as u64,
         proxy_call_input_data,
         TokenAmount::zero(),
         Some(0xffffffff),

--- a/actors/evm/tests/delegate_call.rs
+++ b/actors/evm/tests/delegate_call.rs
@@ -108,7 +108,7 @@ fn test_delegate_call_caller() {
     rt.expect_gas_available(10_000_000_000u64);
     rt.expect_send_generalized(
         target,
-        Method::GetBytecode as u64,
+        Method::GetBytecodeExported as u64,
         None,
         TokenAmount::zero(),
         None,

--- a/actors/evm/tests/delegate_call.rs
+++ b/actors/evm/tests/delegate_call.rs
@@ -119,7 +119,7 @@ fn test_delegate_call_caller() {
 
     rt.expect_send_generalized(
         target,
-        Method::InvokeContractDelegate as u64,
+        Method::InvokeContractDelegateExported as u64,
         proxy_call_input_data,
         TokenAmount::zero(),
         Some(0xffffffff),

--- a/actors/evm/tests/delegate_call.rs
+++ b/actors/evm/tests/delegate_call.rs
@@ -119,7 +119,7 @@ fn test_delegate_call_caller() {
 
     rt.expect_send_generalized(
         target,
-        Method::InvokeContractDelegateExported as u64,
+        Method::InvokeContractDelegate as u64,
         proxy_call_input_data,
         TokenAmount::zero(),
         Some(0xffffffff),

--- a/actors/evm/tests/env.rs
+++ b/actors/evm/tests/env.rs
@@ -86,7 +86,7 @@ impl TestEnv {
 
         let BytesDe(result) = self
             .runtime
-            .call::<evm::EvmContractActor>(evm::Method::InvokeContract as u64, input)
+            .call::<evm::EvmContractActor>(evm::Method::InvokeContractExported as u64, input)
             .unwrap()
             .deserialize()
             .unwrap();

--- a/actors/evm/tests/ext_opcodes.rs
+++ b/actors/evm/tests/ext_opcodes.rs
@@ -210,7 +210,7 @@ account:
 
     rt.expect_send_generalized(
         evm_target,
-        evm::Method::GetBytecodeHashExported as u64,
+        evm::Method::GetBytecodeHash as u64,
         Default::default(),
         TokenAmount::zero(),
         None,
@@ -259,7 +259,7 @@ fn test_getbytecodehash_method() {
     rt.expect_validate_caller_any();
 
     let res: Multihash = rt
-        .call::<evm::EvmContractActor>(evm::Method::GetBytecodeHashExported as u64, None)
+        .call::<evm::EvmContractActor>(evm::Method::GetBytecodeHash as u64, None)
         .unwrap()
         .deserialize()
         .unwrap();
@@ -430,7 +430,7 @@ init_extsize:
     let mut rt = util::init_construct_and_verify(bytecode, |rt| {
         rt.expect_send_generalized(
             CONTRACT_ID,
-            evm::Method::GetBytecodeHashExported as u64,
+            evm::Method::GetBytecodeHash as u64,
             Default::default(),
             TokenAmount::zero(),
             None,

--- a/actors/evm/tests/ext_opcodes.rs
+++ b/actors/evm/tests/ext_opcodes.rs
@@ -93,7 +93,7 @@ native_account:
     {
         rt.expect_send_generalized(
             evm_contract,
-            evm::Method::GetBytecode as u64,
+            evm::Method::GetBytecodeExported as u64,
             Default::default(),
             TokenAmount::zero(),
             None,
@@ -210,7 +210,7 @@ account:
 
     rt.expect_send_generalized(
         evm_target,
-        evm::Method::GetBytecodeHash as u64,
+        evm::Method::GetBytecodeHashExported as u64,
         Default::default(),
         TokenAmount::zero(),
         None,
@@ -259,7 +259,7 @@ fn test_getbytecodehash_method() {
     rt.expect_validate_caller_any();
 
     let res: Multihash = rt
-        .call::<evm::EvmContractActor>(evm::Method::GetBytecodeHash as u64, None)
+        .call::<evm::EvmContractActor>(evm::Method::GetBytecodeHashExported as u64, None)
         .unwrap()
         .deserialize()
         .unwrap();
@@ -355,7 +355,7 @@ precompile:
 
     rt.expect_send_generalized(
         evm_target,
-        evm::Method::GetBytecode as u64,
+        evm::Method::GetBytecodeExported as u64,
         Default::default(),
         TokenAmount::zero(),
         None,
@@ -430,7 +430,7 @@ init_extsize:
     let mut rt = util::init_construct_and_verify(bytecode, |rt| {
         rt.expect_send_generalized(
             CONTRACT_ID,
-            evm::Method::GetBytecodeHash as u64,
+            evm::Method::GetBytecodeHashExported as u64,
             Default::default(),
             TokenAmount::zero(),
             None,
@@ -445,7 +445,7 @@ init_extsize:
         rt.store.put_keyed(&EMPTY_ARR_CID, &[]).unwrap();
         rt.expect_send_generalized(
             CONTRACT_ID,
-            evm::Method::GetBytecode as u64,
+            evm::Method::GetBytecodeExported as u64,
             Default::default(),
             TokenAmount::zero(),
             None,

--- a/actors/evm/tests/revert.rs
+++ b/actors/evm/tests/revert.rs
@@ -23,7 +23,7 @@ revert
     let mut rt = util::construct_and_verify(contract);
     rt.expect_validate_caller_any();
 
-    let result = rt.call::<evm::EvmContractActor>(evm::Method::InvokeContract as u64, None);
+    let result = rt.call::<evm::EvmContractActor>(evm::Method::InvokeContractExported as u64, None);
     assert!(result.is_err());
     let e = result.unwrap_err();
     assert_eq!(e.exit_code(), evm::EVM_CONTRACT_REVERTED);

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -64,7 +64,7 @@ pub fn invoke_contract(rt: &mut MockRuntime, input_data: &[u8]) -> Vec<u8> {
     rt.expect_validate_caller_any();
     let BytesDe(res) = rt
         .call::<evm::EvmContractActor>(
-            evm::Method::InvokeContract as u64,
+            evm::Method::InvokeContractExported as u64,
             IpldBlock::serialize_cbor(&BytesSer(input_data)).unwrap(),
         )
         .unwrap()
@@ -78,7 +78,7 @@ pub fn invoke_contract_expect_abort(rt: &mut MockRuntime, input_data: &[u8], exp
     rt.expect_validate_caller_any();
     let err = rt
         .call::<evm::EvmContractActor>(
-            evm::Method::InvokeContract as u64,
+            evm::Method::InvokeContractExported as u64,
             IpldBlock::serialize_cbor(&BytesSer(input_data)).unwrap(),
         )
         .expect_err(&format!("expected contract to fail with {}", expect));

--- a/test_vm/tests/evm_test.rs
+++ b/test_vm/tests/evm_test.rs
@@ -65,7 +65,7 @@ fn test_evm_lifecycle() {
             account,
             create_return.robust_address,
             TokenAmount::zero(),
-            fil_actor_evm::Method::InvokeContract as u64,
+            fil_actor_evm::Method::InvokeContractExported as u64,
             Some(ContractParams(contract_params.to_vec())),
         )
         .unwrap();
@@ -169,7 +169,7 @@ fn test_evm_staticcall() {
                 A_act,
                 A_robust_addr,
                 TokenAmount::zero(),
-                fil_actor_evm::Method::InvokeContract as u64,
+                fil_actor_evm::Method::InvokeContractExported as u64,
                 Some(ContractParams(params.to_vec())),
             )
             .unwrap();
@@ -197,7 +197,7 @@ fn test_evm_staticcall() {
                 A_act,
                 A_robust_addr,
                 TokenAmount::zero(),
-                fil_actor_evm::Method::InvokeContract as u64,
+                fil_actor_evm::Method::InvokeContractExported as u64,
                 Some(ContractParams(params.to_vec())),
             )
             .unwrap();
@@ -220,7 +220,7 @@ fn test_evm_staticcall() {
                 A_act,
                 A_robust_addr,
                 TokenAmount::zero(),
-                fil_actor_evm::Method::InvokeContract as u64,
+                fil_actor_evm::Method::InvokeContractExported as u64,
                 Some(ContractParams(params.to_vec())),
             )
             .unwrap();
@@ -250,7 +250,7 @@ fn test_evm_staticcall() {
                 A_act,
                 A_robust_addr,
                 TokenAmount::zero(),
-                fil_actor_evm::Method::InvokeContract as u64,
+                fil_actor_evm::Method::InvokeContractExported as u64,
                 Some(ContractParams(params.to_vec())),
             )
             .unwrap();
@@ -326,7 +326,7 @@ fn test_evm_delegatecall() {
                 A_act,
                 A_robust_addr,
                 TokenAmount::zero(),
-                fil_actor_evm::Method::InvokeContract as u64,
+                fil_actor_evm::Method::InvokeContractExported as u64,
                 Some(ContractParams(params.to_vec())),
             )
             .unwrap();
@@ -354,7 +354,7 @@ fn test_evm_delegatecall() {
                 A_act,
                 A_robust_addr,
                 TokenAmount::zero(),
-                fil_actor_evm::Method::InvokeContract as u64,
+                fil_actor_evm::Method::InvokeContractExported as u64,
                 Some(ContractParams(params.to_vec())),
             )
             .unwrap();
@@ -439,7 +439,7 @@ fn test_evm_staticcall_delegatecall() {
                 A_act,
                 A_robust_addr,
                 TokenAmount::zero(),
-                fil_actor_evm::Method::InvokeContract as u64,
+                fil_actor_evm::Method::InvokeContractExported as u64,
                 Some(ContractParams(params.to_vec())),
             )
             .unwrap();
@@ -470,7 +470,7 @@ fn test_evm_staticcall_delegatecall() {
                 A_act,
                 A_robust_addr,
                 TokenAmount::zero(),
-                fil_actor_evm::Method::InvokeContract as u64,
+                fil_actor_evm::Method::InvokeContractExported as u64,
                 Some(ContractParams(params.to_vec())),
             )
             .unwrap();


### PR DESCRIPTION
Add and use frc-42 method numbers for all externally available methods.