### PR TITLE
EVM: Add a test to successfully resolve an address

### DIFF
--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -141,13 +141,16 @@ pub(super) fn resolve_address<RT: Runtime>(
     input: &[u8],
     _: PrecompileContext,
 ) -> PrecompileResult {
-    let mut input_params = U256Reader::new(input);
+    let input_params = U256Reader::new(input);
 
-    let len = input_params.next_param_padded::<u32>()? as usize;
-    let addr = match Address::from_bytes(&read_right_pad(input_params.remaining_slice(), len)) {
+    let addr = match Address::from_bytes(&read_right_pad(
+        input_params.remaining_slice(),
+        input_params.remaining_len(),
+    )) {
         Ok(o) => o,
         Err(_) => return Ok(Vec::new()),
     };
+
     Ok(system
         .rt
         .resolve_address(&addr)


### PR DESCRIPTION
Mostly for demonstrative purpose.

@wadeAlexC reported that the lookup_delegate -> resolve -> lookup_delegate call wasn't roundtripping, which led to some investigation. 

I'm not sure what (if anything) is actually wrong here, but this PR adds a test that successfully invokes `resolve_address`, as well a patch that I had to make to the precompile to get it to work. I may be misunderstanding (and thus misusing) the system, but something seems funky here?