### PR TITLE
Runtime: Don't convert syscall errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,7 +2256,7 @@ dependencies = [
 [[package]]
 name = "frc42_dispatch"
 version = "3.0.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#9fb649e70b9ba333b1944a4696f2f6bae9f9793e"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#d8a2364f9ea23428ac095c0360211a4696f1a21b"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
@@ -2269,7 +2269,7 @@ dependencies = [
 [[package]]
 name = "frc42_hasher"
 version = "1.3.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#9fb649e70b9ba333b1944a4696f2f6bae9f9793e"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#d8a2364f9ea23428ac095c0360211a4696f1a21b"
 dependencies = [
  "fvm_sdk",
  "fvm_shared",
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "frc42_macros"
 version = "1.0.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#9fb649e70b9ba333b1944a4696f2f6bae9f9793e"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#d8a2364f9ea23428ac095c0360211a4696f1a21b"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "frc46_token"
 version = "3.1.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#9fb649e70b9ba333b1944a4696f2f6bae9f9793e"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#d8a2364f9ea23428ac095c0360211a4696f1a21b"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -2440,7 +2440,7 @@ dependencies = [
 [[package]]
 name = "fvm_actor_utils"
 version = "3.0.0"
-source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#9fb649e70b9ba333b1944a4696f2f6bae9f9793e"
+source = "git+https://github.com/filecoin-project/filecoin-actor-utils?branch=feat/fvm-m2#d8a2364f9ea23428ac095c0360211a4696f1a21b"
 dependencies = [
  "anyhow",
  "cid 0.8.6",
@@ -2568,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.21"
+version = "3.0.0-alpha.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec61bd25838e3b26805506de57e11a51798498e6dec7b3075ec8ab4db6579f5"
+checksum = "d51908aab9e7564fbcb278d78e31c12402b68c70517661780feb29adbb234aaf"
 dependencies = [
  "cid 0.8.6",
  "fvm_ipld_encoding",
@@ -2583,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0-alpha.15"
+version = "3.0.0-alpha.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dea3259a0e147bcd22c5670441c1cbc2452e70763bf6688fb14e96f36cee2c2"
+checksum = "a95666bb2e4b450f1750015a5f6c5da7544e744e295690cb4fcc5ba453283142"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -3968,9 +3968,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -4993,45 +4993,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 frc42_dispatch = "3.0.0"
 fvm_actor_utils = "3.0.0"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -23,7 +23,7 @@ fvm_actor_utils = "3.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.2"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 lazy_static = "1.4.0"
 num-derive = "0.3.3"
 num-traits = "0.2.14"

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -4,14 +4,14 @@ use frc46_token::token::types::{
     TransferFromParams, TransferFromReturn, TransferParams, TransferReturn,
 };
 use frc46_token::token::{Token, TokenError, TOKEN_PRECISION};
-use fvm_actor_utils::messaging::{Messaging, MessagingError, Response};
+use fvm_actor_utils::messaging::{Messaging, MessagingError};
 use fvm_actor_utils::receiver::ReceiverHookError;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
-use fvm_shared::{ActorID, MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND};
+use fvm_shared::{ActorID, MethodNum, Response, METHOD_CONSTRUCTOR, METHOD_SEND};
 use lazy_static::lazy_static;
 use log::info;
 use num_derive::FromPrimitive;

--- a/actors/eam/Cargo.toml
+++ b/actors/eam/Cargo.toml
@@ -24,7 +24,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.2"
 multihash = { version = "0.16.1", default-features = false }
 cid = "0.8.6"
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 hex-literal = "0.3.4"

--- a/actors/ethaccount/Cargo.toml
+++ b/actors/ethaccount/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "lib"]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 serde = { version = "1.0.136", features = ["derive"] }
 fvm_ipld_encoding = "0.3.2"
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 hex-literal = "0.3.4"

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 fvm_ipld_kamt = { version = "0.1.0" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5"

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 frc42_dispatch = "3.0.0"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -24,7 +24,7 @@ fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.2"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 integer-encoding = { version = "3.0.3", default-features = false }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 log = "0.4.14"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.0"
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_amt = { version = "0.5.0", features = ["go-interop"] }
 fvm_ipld_hamt = "0.6.1"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -23,7 +23,7 @@ fvm_actor_utils = "3.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.2"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 num-derive = "0.3.3"

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 frc42_dispatch = "3.0.0"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/placeholder/Cargo.toml
+++ b/actors/placeholder/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fvm_sdk = { version = "3.0.0-alpha.21", optional = true }
-fvm_shared = { version = "3.0.0-alpha.15", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.22", optional = true }
+fvm_shared = { version = "3.0.0-alpha.16", optional = true }
 
 [features]
 fil-actor = ["fvm_sdk", "fvm_shared"]

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 frc42_dispatch = "3.0.0"
 fvm_ipld_hamt = "0.6.1"
 num-traits = "0.2.14"

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -119,11 +119,11 @@ fn create_miner_given_send_to_init_actor_fails_should_fail() {
         IpldBlock::serialize_cbor(&message_params).unwrap(),
         TokenAmount::from_atto(10),
         None,
-        ExitCode::SYS_INSUFFICIENT_FUNDS,
+        ExitCode::USR_INSUFFICIENT_FUNDS,
     );
 
     expect_abort(
-        ExitCode::SYS_INSUFFICIENT_FUNDS,
+        ExitCode::USR_INSUFFICIENT_FUNDS,
         rt.call::<PowerActor>(
             Method::CreateMiner as u64,
             IpldBlock::serialize_cbor(&create_miner_params).unwrap(),

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 fvm_ipld_encoding = "0.3.2"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -24,7 +24,7 @@ fvm_actor_utils = "3.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.2"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 lazy_static = "1.4.0"
 log = "0.4.14"
 num-derive = "0.3.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 [dependencies]
 fvm_ipld_hamt = "0.6.1"
 fvm_ipld_amt = { version = "0.5.0", features = ["go-interop"] }
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 num = { version = "0.4", features = ["serde"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -37,7 +37,7 @@ castaway = "0.2.2"
 sha2 = "0.10"
 
 # fil-actor
-fvm_sdk = { version = "3.0.0-alpha.21", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.22", optional = true }
 
 # test_util
 rand = { version = "0.8.5", default-features = false, optional = true }

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -24,6 +24,7 @@ use fvm_shared::sector::{
 };
 use fvm_shared::sys::SendFlags;
 use fvm_shared::version::NetworkVersion;
+use fvm_shared::Response;
 use fvm_shared::{ActorID, MethodNum};
 use num_traits::FromPrimitive;
 use serde::de::DeserializeOwned;
@@ -318,69 +319,12 @@ where
         value: TokenAmount,
         gas_limit: Option<u64>,
         flags: SendFlags,
-    ) -> Result<Option<IpldBlock>, ActorError> {
+    ) -> Result<Response, ErrorNumber> {
         if self.in_transaction {
-            return Err(actor_error!(assertion_failed; "send is not allowed during transaction"));
+            return Err(ErrorNumber::IllegalOperation);
         }
 
-        match fvm::send::send(to, method, params, value, gas_limit, flags) {
-            Ok(ret) => {
-                if ret.exit_code.is_success() {
-                    Ok(ret.return_data)
-                } else {
-                    // The returned code can't be simply propagated as it may be a system exit code.
-                    // TODO: improve propagation once we return a RuntimeError.
-                    // Ref https://github.com/filecoin-project/builtin-actors/issues/144
-                    let exit_code = match ret.exit_code {
-                        // This means the called actor did something wrong. We can't "make up" a
-                        // reasonable exit code.
-                        ExitCode::SYS_MISSING_RETURN
-                        | ExitCode::SYS_ILLEGAL_INSTRUCTION
-                        | ExitCode::SYS_ILLEGAL_EXIT_CODE => ExitCode::USR_UNSPECIFIED,
-                        // We don't expect any other system errors.
-                        code if code.is_system_error() => ExitCode::USR_ASSERTION_FAILED,
-                        // Otherwise, pass it through.
-                        code => code,
-                    };
-                    Err(ActorError::unchecked_with_data(
-                        exit_code,
-                        format!(
-                            "send to {} method {} aborted with code {}",
-                            to, method, ret.exit_code
-                        ),
-                        ret.return_data,
-                    ))
-                }
-            }
-            Err(err) => Err(match err {
-                // Some of these errors are from operations in the Runtime or SDK layer
-                // before or after the underlying VM send syscall.
-                ErrorNumber::NotFound => {
-                    // This means that the receiving actor doesn't exist.
-                    // TODO: we can't reasonably determine the correct "exit code" here.
-                    actor_error!(unspecified; "receiver not found")
-                }
-                ErrorNumber::InsufficientFunds => {
-                    // This means that the send failed because we have insufficient funds. We will
-                    // get a _syscall error_, not an exit code, because the target actor will not
-                    // run (and therefore will not exit).
-                    actor_error!(insufficient_funds; "not enough funds")
-                }
-                ErrorNumber::LimitExceeded => {
-                    // This means we've exceeded the recursion limit.
-                    // TODO: Define a better exit code.
-                    actor_error!(assertion_failed; "recursion limit exceeded")
-                }
-                ErrorNumber::ReadOnly => ActorError::unchecked(
-                    ExitCode::USR_READ_ONLY,
-                    "attempted to mutate state while in readonly mode".into(),
-                ),
-                err => {
-                    // We don't expect any other syscall exit codes.
-                    actor_error!(assertion_failed; "unexpected error: {}", err)
-                }
-            }),
-        }
+        fvm::send::send(to, method, params, value, gas_limit, flags)
     }
 
     fn new_actor_address(&mut self) -> Result<Address, ActorError> {

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -27,7 +27,7 @@ fil_actor_reward = { version = "10.0.0-alpha.1", path = "../actors/reward"}
 fil_actor_system = { version = "10.0.0-alpha.1", path = "../actors/system"}
 fil_actor_init = { version = "10.0.0-alpha.1", path = "../actors/init"}
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../runtime"}
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 fvm_ipld_encoding = "0.3.2"
 frc46_token = "3.0.0"
 fvm_ipld_blockstore = "0.1.1"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -39,7 +39,7 @@ fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_blockstore = { version = "0.1.1", default-features = false }
 fvm_ipld_encoding = { version = "0.3.2", default-features = false }
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.15", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.16", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 lazy_static = "1.4.0"


### PR DESCRIPTION
https://github.com/filecoin-project/ref-fvm/issues/1020

Open questions:
 
- [x] Is it fine to make the runtime _always_ depend on the SDK? (and less importantly, for test_vm to do so?
  - [x] No, we're just gonna move the relevant types to shared (https://github.com/filecoin-project/ref-fvm/pull/1445)
- [ ] EVM: Is converting the SyscallError into an ActorError at the interpreter's system level fine (for now)? I'm guessing we'll want to actually propagate and handle differently at the callsites (or at least do more nuanced handling here), but that can be deferred so long as this isn't a regression.
- [x] We can reduce the code duplication in the test runtimes by having them do the same thing that the "actual" FVM runtime does (and moving that logic into the trait itself). The only loss is some information in test failures (since ErrorNumbers don't contain message strings).
  - @Stebalien is in favour of making this change, so gonna do that.