### PR TITLE
Include actor name and ID in log prefix

### DIFF
--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -109,6 +109,11 @@ impl Actor {
 
 impl ActorCode for Actor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "Account"
+    }
+
     actor_dispatch! {
         Constructor => constructor,
         PubkeyAddress => pubkey_address,

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -78,6 +78,11 @@ impl Actor {
 
 impl ActorCode for Actor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "Cron"
+    }
+
     actor_dispatch! {
         Constructor => constructor,
         EpochTick => epoch_tick,

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -499,6 +499,11 @@ impl<T> AsActorResult<T> for Result<T, ReceiverHookError> {
 
 impl ActorCode for Actor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "DataCap"
+    }
+
     actor_dispatch! {
         Constructor => constructor,
         MintExported => mint,

--- a/actors/eam/src/lib.rs
+++ b/actors/eam/src/lib.rs
@@ -290,6 +290,11 @@ impl EamActor {
 
 impl ActorCode for EamActor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "EVMAddressManager"
+    }
+
     actor_dispatch_unrestricted! {
         Constructor => constructor,
         Create => create,

--- a/actors/ethaccount/src/lib.rs
+++ b/actors/ethaccount/src/lib.rs
@@ -67,6 +67,11 @@ impl EthAccountActor {
 
 impl ActorCode for EthAccountActor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "EVMAccount"
+    }
+
     actor_dispatch! {
         Constructor => constructor,
         _ => fallback [raw],

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -404,6 +404,11 @@ fn handle_filecoin_method_output(output: &[u8]) -> Result<Option<IpldBlock>, Act
 
 impl ActorCode for EvmContractActor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "EVMContract"
+    }
+
     actor_dispatch_unrestricted! {
         Constructor => constructor,
         InvokeContract => invoke_contract [default_params],

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -166,6 +166,11 @@ impl Actor {
 
 impl ActorCode for Actor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "Init"
+    }
+
     actor_dispatch! {
         Constructor => constructor,
         Exec => exec,

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -1422,6 +1422,11 @@ pub fn deal_id_key(k: DealID) -> BytesKey {
 
 impl ActorCode for Actor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "StorageMarket"
+    }
+
     actor_dispatch! {
         Constructor => constructor,
         AddBalance|AddBalanceExported => add_balance,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -4960,6 +4960,11 @@ fn balance_invariants_broken(e: Error) -> ActorError {
 
 impl ActorCode for Actor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "StorageMiner"
+    }
+
     actor_dispatch! {
         Constructor => constructor,
         ControlAddresses => control_addresses,

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -546,6 +546,11 @@ pub fn compute_proposal_hash(txn: &Transaction, sys: &dyn Primitives) -> anyhow:
 
 impl ActorCode for Actor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "Multisig"
+    }
+
     actor_dispatch! {
       Constructor => constructor,
       Propose => propose,

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -319,6 +319,11 @@ where
 
 impl ActorCode for Actor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "PaymentChannel"
+    }
+
     actor_dispatch! {
         Constructor => constructor,
         UpdateChannelState => update_channel_state,

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -678,6 +678,11 @@ impl Actor {
 
 impl ActorCode for Actor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "StoragePower"
+    }
+
     actor_dispatch! {
         Constructor => constructor,
         CreateMiner|CreateMinerExported => create_miner,

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -217,6 +217,11 @@ impl Actor {
 
 impl ActorCode for Actor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "Reward"
+    }
+
     actor_dispatch! {
         Constructor => constructor,
         AwardBlockReward => award_block_reward,

--- a/actors/system/src/lib.rs
+++ b/actors/system/src/lib.rs
@@ -66,6 +66,11 @@ impl Actor {
 
 impl ActorCode for Actor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "System"
+    }
+
     actor_dispatch! {
         Constructor => constructor,
     }

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -1072,6 +1072,11 @@ fn can_claim_alloc(
 
 impl ActorCode for Actor {
     type Methods = Method;
+
+    fn name() -> &'static str {
+        "VerifiedRegistry"
+    }
+
     actor_dispatch! {
         Constructor => constructor,
         AddVerifier => add_verifier,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = { version = "1.4.0", optional = true }
 unsigned-varint = "0.7.1"
 byteorder = "1.4.3"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-log = "0.4.14"
+log = { version = "0.4.14", features = ["std"] }
 thiserror = "1.0.30"
 anyhow = "1.0.65"
 fvm_sdk = { version = "3.0.0", optional = true }

--- a/runtime/src/runtime/actor_code.rs
+++ b/runtime/src/runtime/actor_code.rs
@@ -10,6 +10,8 @@ use crate::{ActorError, Runtime};
 /// Interface for invoking methods on an Actor
 pub trait ActorCode {
     type Methods;
+    /// A name for the actor type, used in debugging.
+    fn name() -> &'static str;
     /// Invokes method with runtime on the actor's code. Method number will match one
     /// defined by the Actor, and parameters will be serialized and used in execution
     fn invoke_method<RT>(


### PR DESCRIPTION
This is somewhat of an experiment in improving logs, but I think a useful one. Now that the log message formatting is in the built-in actors, we can improve it. I think it's worth landing, but probably isn't the best long term solution here.

```
[TRACE]<Init::1> called exec; params.code_cid: Cid(bafk2bzacechqgn3sj2vlvtjmc4gflanyzto667licltehusfjjd2fgxzxersu)
[TRACE]<Init::1> caller code CID: Cid(bafk2bzacecysql6qcae3ce5qtpcfi4redzthm3zh6yem4ysnpqsyyzt4z4orq)
[TRACE]<Init::1> robust address: Address { network: Mainnet, payload: Actor([37, 45, 230, 183, 58, 234, 176, 63, 50, 214, 200, 206, 15, 67, 199, 165, 229, 227, 169, 138]) }
```

1. The functionality could be pulled into the FVM SDK's `init_logging()` method, with additional parameters for the Logger initialisation
2. Probably better is to move log message formatting into the host/VM instead. Then it's under easy dynamic control of whoever is reading the logs. This would require adding more parameters to the `log` syscall, at least for the actor name (the VM can presumably get the actor ID from its side).

- [x] Land #1019 and rebase