### PR TITLE
EVM: Rename read right pad for clarity

### DIFF
--- a/actors/evm/src/interpreter/precompiles/evm.rs
+++ b/actors/evm/src/interpreter/precompiles/evm.rs
@@ -11,7 +11,7 @@ use substrate_bn::{pairing_batch, AffineG1, AffineG2, Fq, Fq2, Fr, Group, Gt, G1
 use uint::byteorder::{ByteOrder, LE};
 
 use crate::interpreter::{
-    precompiles::{parameter::read_right_pad, PrecompileError},
+    precompiles::{parameter::right_pad, PrecompileError},
     System, U256,
 };
 
@@ -112,7 +112,7 @@ pub(super) fn modexp<RT: Runtime>(
     input: &[u8],
     _: PrecompileContext,
 ) -> PrecompileResult {
-    let input = read_right_pad(input, 96);
+    let input = right_pad(input, 96);
 
     // Follows go-ethereum by truncating bits to u64, ignoring other all other values in the first 24 bytes.
     // Since we don't have any complexity functions or specific gas measurements of modexp in FEVM,
@@ -140,7 +140,7 @@ pub(super) fn modexp<RT: Runtime>(
         return Ok(Vec::new());
     }
     let input = if input.len() > 96 { &input[96..] } else { &[] };
-    let input = read_right_pad(input, base_len + exponent_len + mod_len);
+    let input = right_pad(input, base_len + exponent_len + mod_len);
 
     let base = BigUint::from_bytes_be(&input[0..base_len]);
     let exponent = BigUint::from_bytes_be(&input[base_len..exponent_len + base_len]);
@@ -194,7 +194,7 @@ pub(super) fn ec_mul<RT: Runtime>(
     input: &[u8],
     _: PrecompileContext,
 ) -> PrecompileResult {
-    let input = read_right_pad(input, 96);
+    let input = right_pad(input, 96);
     let mut input_params: PaddedChunks<u8, 64> = PaddedChunks::new(&input);
     let point = input_params.next_param_padded()?;
 
@@ -346,7 +346,7 @@ mod tests {
             let mut expected = input.clone();
             expected.resize(i, 0);
 
-            let res = read_right_pad(&input, i);
+            let res = right_pad(&input, i);
             assert_eq!(&*res, &expected);
 
             input.push(0);

--- a/actors/evm/src/interpreter/precompiles/evm.rs
+++ b/actors/evm/src/interpreter/precompiles/evm.rs
@@ -349,6 +349,10 @@ mod tests {
             let res = right_pad(&input, i);
             assert_eq!(&*res, &expected);
 
+            let no_padding = b"foo bar boxy                     ".to_vec();
+            let res = right_pad(&no_padding, 12);
+            // do nothing
+            assert_eq!(&res, &no_padding);
             input.push(0);
         }
     }

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -6,7 +6,7 @@ use num_traits::FromPrimitive;
 use crate::interpreter::{
     instructions::call::CallKind,
     precompiles::{
-        parameter::{read_right_pad, Parameter},
+        parameter::{right_pad, Parameter},
         NativeType,
     },
     System, U256,
@@ -23,7 +23,7 @@ pub(super) fn get_actor_type<RT: Runtime>(
     _: PrecompileContext,
 ) -> PrecompileResult {
     // should never panic, pad to 32 bytes then read exactly 32 bytes
-    let id_bytes: [u8; 32] = read_right_pad(input, 32)[..32].as_ref().try_into().unwrap();
+    let id_bytes: [u8; 32] = right_pad(input, 32)[..32].as_ref().try_into().unwrap();
     let id = match Parameter::<u64>::try_from(&id_bytes) {
         Ok(id) => id.0,
         Err(_) => return Ok(Vec::new()),
@@ -98,7 +98,7 @@ pub(super) fn get_randomness<RT: Runtime>(
 
     debug_assert_eq!(input_params.chunks_read(), 4);
 
-    let entropy = read_right_pad(input_params.remaining_slice(), entropy_len as usize);
+    let entropy = right_pad(input_params.remaining_slice(), entropy_len as usize);
 
     let randomness = match randomness_type {
         Some(RandomnessType::Chain) => system
@@ -144,7 +144,7 @@ pub(super) fn resolve_address<RT: Runtime>(
     let mut input_params = U256Reader::new(input);
 
     let len = input_params.next_param_padded::<u32>()? as usize;
-    let addr = match Address::from_bytes(&read_right_pad(input_params.remaining_slice(), len)) {
+    let addr = match Address::from_bytes(&right_pad(input_params.remaining_slice(), len)) {
         Ok(o) => o,
         Err(_) => return Ok(Vec::new()),
     };
@@ -197,7 +197,7 @@ pub(super) fn call_actor<RT: Runtime>(
 
     let result = {
         let start = input_params.remaining_slice();
-        let bytes = read_right_pad(start, send_data_size + address_size);
+        let bytes = right_pad(start, send_data_size + address_size);
 
         let input_data = &bytes[..send_data_size];
         let address = &bytes[send_data_size..send_data_size + address_size];

--- a/actors/evm/src/interpreter/precompiles/parameter.rs
+++ b/actors/evm/src/interpreter/precompiles/parameter.rs
@@ -18,7 +18,7 @@ impl From<GroupError> for PrecompileError {
     }
 }
 
-// It is uncomfortable how much Eth pads everything...
+/// Pad out to len as needed, but does not slice output to len
 pub(super) fn right_pad<'a>(input: impl Into<Cow<'a, [u8]>>, len: usize) -> Cow<'a, [u8]> {
     let mut input: Cow<[u8]> = input.into();
     let input_len = input.len();

--- a/actors/evm/src/interpreter/precompiles/parameter.rs
+++ b/actors/evm/src/interpreter/precompiles/parameter.rs
@@ -19,7 +19,7 @@ impl From<GroupError> for PrecompileError {
 }
 
 // It is uncomfortable how much Eth pads everything...
-pub(super) fn read_right_pad<'a>(input: impl Into<Cow<'a, [u8]>>, len: usize) -> Cow<'a, [u8]> {
+pub(super) fn right_pad<'a>(input: impl Into<Cow<'a, [u8]>>, len: usize) -> Cow<'a, [u8]> {
     let mut input: Cow<[u8]> = input.into();
     let input_len = input.len();
     if len > input_len {


### PR DESCRIPTION
Renamed the padding function for better clarity on it's function to hopefully avoid issue fixed in #1016 in the future. I also double checked its uses to ensure this mistake was unique.