### PR TITLE
Avoid redundant read/write of allocation/claims HAMT root when unchanged

### DIFF
--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -696,8 +696,8 @@ impl Actor {
 
         // Save new allocations and updated claims.
         let ids = rt.transaction(|st: &mut State, rt| {
-            let ids = st.insert_allocations(rt.store(), client, new_allocs.into_iter())?;
-            st.put_claims(rt.store(), updated_claims.into_iter())?;
+            let ids = st.insert_allocations(rt.store(), client, new_allocs)?;
+            st.put_claims(rt.store(), updated_claims)?;
             Ok(ids)
         })?;
 


### PR DESCRIPTION
This saves 464k gas (4.9%) on a simple transfer making a single allocation an no claims (or vice versa), on an otherwise empty state.

Progress on #1020 