### PR TITLE
EVM: Fix resolve address errors

### DIFF
--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -148,7 +148,7 @@ pub(super) fn resolve_address<RT: Runtime>(
         Ok(o) => o,
         Err(e) => {
             log::debug!(target: "evm", "Address parsing failed: {e}");
-            return Err(PrecompileError::InvalidInput);
+            return Err(PrecompileError::InvalidInput)
         }
     };
     Ok(system

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -148,7 +148,7 @@ pub(super) fn resolve_address<RT: Runtime>(
         Ok(o) => o,
         Err(e) => {
             log::debug!(target: "evm", "Address parsing failed: {e}");
-            return Err(PrecompileError::InvalidInput)
+            return Err(PrecompileError::InvalidInput);
         }
     };
     Ok(system

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -148,7 +148,7 @@ pub(super) fn resolve_address<RT: Runtime>(
         Ok(o) => o,
         Err(e) => {
             log::debug!(target: "evm", "Address parsing failed: {e}");
-            return Ok(Vec::new())
+            return Err(PrecompileError::InvalidInput);
         }
     };
     Ok(system

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -146,12 +146,18 @@ pub(super) fn resolve_address<RT: Runtime>(
     let len = input_params.next_param_padded::<u32>()? as usize;
     let addr = match Address::from_bytes(&read_right_pad(input_params.remaining_slice(), len)) {
         Ok(o) => o,
-        Err(_) => return Ok(Vec::new()),
+        Err(e) => {
+            log::debug!(target: "evm", "Address parsing failed: {e}");
+            return Ok(Vec::new())
+        }
     };
     Ok(system
         .rt
         .resolve_address(&addr)
-        .map(|a| U256::from(a).to_bytes().to_vec())
+        .map(|a| {
+            log::debug!(target: "evm", "{addr} resolved to {a}");
+            U256::from(a).to_bytes().to_vec()
+        })
         .unwrap_or_default())
 }
 

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -296,7 +296,15 @@ fn test_precompile_failure() {
 
     // not found succeeds with empty
     rt.expect_gas_available(10_000_000_000u64);
-    let result = util::invoke_contract(&mut rt, &U256::from(111).to_bytes());
+    let input = {
+        let addr = FILAddress::new_delegated(111, b"foo").unwrap().to_bytes();
+        // first word is len
+        let mut v = U256::from(addr.len()).to_bytes().to_vec();
+        // then addr
+        v.extend_from_slice(&addr);
+        v
+    };
+    let result = util::invoke_contract(&mut rt, &input);
     rt.verify();
     assert_eq!(&[1u8], result.as_slice());
     rt.reset();


### PR DESCRIPTION
This will log a more helpful reason than just empty vec. also add some logging. Split out from #1016 but not dependent on it.

This also caught that one of the failure tests was not failing with what it said it was. That is also fixed in this. 