### PR TITLE
fix: remove CallCode

### DIFF
--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -225,7 +225,6 @@ pub mod opcodes {
         // 0xEF Reserved for EIP-3541
         0xf0: CREATE,
         0xf1: CALL,
-        0xf2: CALLCODE,
         0xf3: RETURN,
         0xf4: DELEGATECALL,
         0xf5: CREATE2,

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -17,7 +17,7 @@ use {
     crate::interpreter::ExecutionState,
     crate::interpreter::System,
     crate::interpreter::U256,
-    crate::{DelegateCallParams, Method, EVM_CONTRACT_EXECUTION_ERROR},
+    crate::{DelegateCallParams, Method},
     fil_actors_runtime::runtime::builtins::Type,
     fil_actors_runtime::runtime::Runtime,
     fil_actors_runtime::ActorError,
@@ -30,7 +30,6 @@ pub enum CallKind {
     Call,
     DelegateCall,
     StaticCall,
-    CallCode,
 }
 
 pub fn calldataload(
@@ -108,26 +107,6 @@ pub fn call_call<RT: Runtime>(
         state,
         system,
         CallKind::Call,
-        (gas, dst, value, input_offset, input_size, output_offset, output_size),
-    )
-}
-
-#[inline]
-pub fn call_callcode<RT: Runtime>(
-    state: &mut ExecutionState,
-    system: &mut System<RT>,
-    gas: U256,
-    dst: U256,
-    value: U256,
-    input_offset: U256,
-    input_size: U256,
-    output_offset: U256,
-    output_size: U256,
-) -> Result<U256, StatusCode> {
-    call_generic(
-        state,
-        system,
-        CallKind::CallCode,
         (gas, dst, value, input_offset, input_size, output_offset, output_size),
     )
 }
@@ -311,10 +290,6 @@ pub fn call_generic<RT: Runtime>(
                             .to_string(),
                     )),
                 },
-                CallKind::CallCode => Err(ActorError::unchecked(
-                    EVM_CONTRACT_EXECUTION_ERROR,
-                    "unsupported opcode".to_string(),
-                )),
             };
             let (code, data) = match call_result {
                 Ok(result) => (1, result),

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -344,7 +344,6 @@ def_stdlog! { LOG2(2, (topic1, topic2)) }
 def_stdlog! { LOG3(3, (topic1, topic2, topic3)) }
 def_stdlog! { LOG4(4, (topic1, topic2, topic3, topic4)) }
 def_stdfun! { CALL(gas, dst, value, ioff, isz, ooff, osz) => call::call_call }
-def_stdfun! { CALLCODE(gas, dst, value, ioff, isz, ooff, osz) => call::call_callcode }
 def_stdfun! { DELEGATECALL(gas, dst, ioff, isz, ooff, osz) => call::call_delegatecall }
 def_stdfun! { STATICCALL(gas, dst, ioff, isz, ooff, osz) => call::call_staticcall }
 def_stdfun_code! { CODESIZE() => call::codesize }


### PR DESCRIPTION
It was never implemented and is deprecated. This will now just be treated as an invalid instruction.

fixes https://github.com/filecoin-project/ref-fvm/issues/870