### PR TITLE
EVM:  dont panic on invalid precompile address

### DIFF
--- a/actors/evm/src/interpreter/address.rs
+++ b/actors/evm/src/interpreter/address.rs
@@ -40,7 +40,7 @@ impl TryFrom<EthAddress> for Address {
 impl TryFrom<&EthAddress> for Address {
     type Error = StatusCode;
     fn try_from(addr: &EthAddress) -> Result<Self, Self::Error> {
-        if is_reserved_precompile_address(addr.0) {
+        if is_reserved_precompile_address(&addr.as_evm_word()) {
             return Err(StatusCode::BadAddress(format!(
                 "Cannot convert a precompile address: {:?} to an f4 address",
                 addr

--- a/actors/evm/src/interpreter/address.rs
+++ b/actors/evm/src/interpreter/address.rs
@@ -40,7 +40,7 @@ impl TryFrom<EthAddress> for Address {
 impl TryFrom<&EthAddress> for Address {
     type Error = StatusCode;
     fn try_from(addr: &EthAddress) -> Result<Self, Self::Error> {
-        if is_reserved_precompile_address(&addr.as_evm_word()) {
+        if is_reserved_precompile_address(addr) {
             return Err(StatusCode::BadAddress(format!(
                 "Cannot convert a precompile address: {:?} to an f4 address",
                 addr

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -196,28 +196,31 @@ pub fn call_generic<RT: Runtime>(
             &[]
         };
 
-        if is_reserved_precompile_address(&dst) {
+        if is_reserved_precompile_address(&dst.into()) {
             let context =
                 PrecompileContext { call_type: kind, gas_limit: effective_gas_limit(system, gas) };
-            if log::log_enabled!(log::Level::Info) {
-                // log input to the precompile, but make sure we dont log _too_ much.
-                let mut input_hex = hex::encode(input_data);
-                input_hex.truncate(512);
-                log::info!(target: "evm", "Call Precompile:\n\taddress: {:x?}\n\tcontext: {:?}\n\tinput: {}", EthAddress::try_from(dst).unwrap_or(EthAddress([0xff; 20])), context, input_hex);
-            }
+            match precompiles::Precompiles::call_precompile(system, dst, input_data, context) {
+                Some(res) => {
+                    if log::log_enabled!(log::Level::Info) {
+                        // log input to the precompile, but make sure we dont log _too_ much.
+                        let mut input_hex = hex::encode(input_data);
+                        input_hex.truncate(512);
+                        log::info!(target: "evm", "Call Precompile:\n\taddress: {:x?}\n\tcontext: {:?}\n\tinput: {}", EthAddress::try_from(dst).unwrap_or(EthAddress([0xff; 20])), context, input_hex);
+                    }
 
-            if precompiles::Precompiles::<RT>::is_precompile(&dst) {
-                match precompiles::Precompiles::call_precompile(system, dst, input_data, context) {
-                    Ok(return_data) => (1, return_data),
-                    Err(err) => {
-                        log::error!(target: "evm", "Precompile failed: error {:?}", err);
-                        // precompile failed, exit with reverted and no output
-                        (0, vec![])
+                    match res {
+                        Ok(return_data) => (1, return_data),
+                        Err(err) => {
+                            log::error!(target: "evm", "Precompile failed: error {:?}", err);
+                            // precompile failed, exit with reverted and no output
+                            (0, vec![])
+                        }
                     }
                 }
-            } else {
-                // Invalid precompile address, but within reserved precompile range.
-                (0, vec![])
+                None => {
+                    log::warn!(target: "evm", "Non-existing precompile address: {:?}", EthAddress::from(dst));
+                    (0, vec![])
+                }
             }
         } else {
             let call_result = match kind {

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -100,7 +100,7 @@ pub fn get_contract_type<RT: Runtime>(rt: &RT, addr: U256) -> ContractType {
     let addr: EthAddress = addr.into();
     // precompiles cant be resolved by the FVM
     // addresses passed in precompile range will be returned as NotFound; EAM asserts that no actors can be deployed in the precompile reserved range
-    if Precompiles::<RT>::is_precompile(&addr.as_evm_word()) {
+    if Precompiles::<RT>::is_precompile(addr.as_evm_word()) {
         return ContractType::Precompile;
     }
 

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -99,6 +99,7 @@ pub enum ContractType {
 pub fn get_contract_type<RT: Runtime>(rt: &RT, addr: U256) -> ContractType {
     let addr: EthAddress = addr.into();
     // precompiles cant be resolved by the FVM
+    // addresses passed in precompile range will be returned as NotFound; EAM asserts that no actors can be deployed in the precompile reserved range
     if Precompiles::<RT>::is_precompile(&addr.as_evm_word()) {
         return ContractType::Precompile;
     }

--- a/actors/evm/src/interpreter/uints.rs
+++ b/actors/evm/src/interpreter/uints.rs
@@ -66,12 +66,6 @@ impl U256 {
         buf
     }
 
-    /// Returns bottom 20 bytes
-    pub fn to_address_bytes(&self) -> [u8; 20] {
-        // unrwap will never panic, 32 - 12 = 20
-        self.to_bytes()[12..].try_into().unwrap()
-    }
-
     /// Returns the low 64 bits, saturating the value to u64 max if it is larger
     pub fn to_u64_saturating(&self) -> u64 {
         if self.bits() > 64 {

--- a/actors/evm/src/interpreter/uints.rs
+++ b/actors/evm/src/interpreter/uints.rs
@@ -66,6 +66,12 @@ impl U256 {
         buf
     }
 
+    /// Returns bottom 20 bytes
+    pub fn to_address_bytes(&self) -> [u8; 20] {
+        // unrwap will never panic, 32 - 12 = 20
+        self.to_bytes()[12..].try_into().unwrap()
+    }
+
     /// Returns the low 64 bits, saturating the value to u64 max if it is larger
     pub fn to_u64_saturating(&self) -> u64 {
         if self.bits() > 64 {


### PR DESCRIPTION
This:
- Checks if address is in reserved precompile range, _then_ will try to resolve the exact one, otherwise return fail and no return value
- No longer panics in call/staticcall if precompile was found, instead return an ActorError
- Documents behavior of get_contract_type (used by delagatecall) if precompile address is not a valid precompile, but still within precompile range. 