### PR TITLE
fix: check for system errors in the eam

### DIFF
--- a/actors/eam/src/lib.rs
+++ b/actors/eam/src/lib.rs
@@ -224,8 +224,7 @@ fn resolve_caller_external(rt: &mut impl Runtime) -> Result<(EthAddress, EthAddr
                 )?;
 
             if !result.exit_code.is_success() {
-                // TODO: rebase on https://github.com/filecoin-project/builtin-actors/pull/1039
-                return Err(ActorError::unchecked(
+                return Err(ActorError::checked(
                     result.exit_code,
                     "failed to retrieve account robust address".to_string(),
                 ));


### PR DESCRIPTION
If we try to exit with a system exit code, we'll get the wrong exit code.