### PR TITLE
EVM: Refactor FVM precompiles

### DIFF
--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -9,8 +9,8 @@ use crate::interpreter::{instructions::call::CallKind, precompiles::NativeType, 
 use super::{parameter::ParameterReader, PrecompileContext, PrecompileError, PrecompileResult};
 
 /// Read right padded BE encoded low u64 ID address from a u256 word.
-/// Returns variant of [`BuiltinType`] encoded as a u256 word.
-/// Returns nothing inputs >2^65
+/// - Reverts if the input is greater than `MAX::u64`.
+/// - Returns variant of [`BuiltinType`] encoded as a u256 word.
 pub(super) fn get_actor_type<RT: Runtime>(
     system: &mut System<RT>,
     input: &[u8],

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -162,11 +162,11 @@ pub(super) fn resolve_address<RT: Runtime>(
 ///
 /// Returns (also solidity ABI encoded):
 ///
-/// `[int256 exit_code, uint codec, uint offset, uint size, []bytes <actor return value>]`
-/// ```
+/// ```text
 /// i256  exit_code
 /// u64   codec
 /// bytes return_value
+/// ```
 ///
 /// for exit_code:
 /// - negative values are system errors
@@ -195,11 +195,11 @@ pub(super) fn call_actor<RT: Runtime>(
 ///
 /// Returns (also solidity ABI encoded):
 ///
-/// `[int256 exit_code, uint codec, uint offset, uint size, []bytes <actor return value>]`
-/// ```
+/// ```text
 /// i256  exit_code
 /// u64   codec
 /// bytes return_value
+/// ```
 ///
 /// for exit_code:
 /// - negative values are system errors

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -157,7 +157,7 @@ pub(super) fn resolve_address<RT: Runtime>(
 /// u256  value
 /// u64   flags (1 for read-only, 0 otherwise)
 /// u64   codec (0x71 for "dag-cbor", or `0` for "nothing")
-/// u64   input (must be empty if the codec is 0x0)
+/// bytes params (must be empty if the codec is 0x0)
 /// ```
 ///
 /// Returns (also solidity ABI encoded):
@@ -190,7 +190,7 @@ pub(super) fn call_actor<RT: Runtime>(
 /// u256  value
 /// u64   flags (1 for read-only, 0 otherwise)
 /// u64   codec (0x71 for "dag-cbor", or `0` for "nothing")
-/// u64   input (must be empty if the codec is 0x0)
+/// bytes params (must be empty if the codec is 0x0)
 /// ```
 ///
 /// Returns (also solidity ABI encoded):

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -130,7 +130,7 @@ pub(super) fn resolve_address<RT: Runtime>(
     input: &[u8],
     _: PrecompileContext,
 ) -> PrecompileResult {
-    let addr = match Address::from_bytes(&input) {
+    let addr = match Address::from_bytes(input) {
         Ok(o) => o,
         Err(e) => {
             log::debug!(target: "evm", "Address parsing failed: {e}");

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -299,7 +299,7 @@ pub(super) fn call_actor_shared<RT: Runtime>(
         // Pad out to the next increment of 32 bytes for solidity compatibility.
         let offset = output.len() % 32;
         if offset > 0 {
-            output.resize(output.len() - offset - 32, 0);
+            output.resize(output.len() - offset + 32, 0);
         }
         output
     };

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -152,12 +152,12 @@ pub(super) fn resolve_address<RT: Runtime>(
 /// Parameters are encoded according to the solidity ABI, with no function selector:
 ///
 /// ```text
-/// bytes address
 /// u64   method
 /// u256  value
 /// u64   flags (1 for read-only, 0 otherwise)
 /// u64   codec (0x71 for "dag-cbor", or `0` for "nothing")
 /// bytes params (must be empty if the codec is 0x0)
+/// bytes address
 /// ```
 ///
 /// Returns (also solidity ABI encoded):
@@ -185,12 +185,12 @@ pub(super) fn call_actor<RT: Runtime>(
 /// Parameters are encoded according to the solidity ABI, with no function selector:
 ///
 /// ```text
-/// u64   actor_id
 /// u64   method
 /// u256  value
 /// u64   flags (1 for read-only, 0 otherwise)
 /// u64   codec (0x71 for "dag-cbor", or `0` for "nothing")
 /// bytes params (must be empty if the codec is 0x0)
+/// u64   actor_id
 /// ```
 ///
 /// Returns (also solidity ABI encoded):

--- a/actors/evm/src/interpreter/precompiles/parameter.rs
+++ b/actors/evm/src/interpreter/precompiles/parameter.rs
@@ -84,12 +84,22 @@ impl_param_int!(u16 i16 u32 i32 u64 i64);
 /// Provides a nice API interface for reading Parameters from input. This API treats the input as if
 /// it is followed by infinite zeros.
 pub(super) struct ParameterReader<'a> {
+    full: &'a [u8],
     slice: &'a [u8],
 }
 
 impl<'a> ParameterReader<'a> {
     pub(super) fn new(slice: &'a [u8]) -> Self {
-        ParameterReader { slice }
+        ParameterReader { full: slice, slice }
+    }
+
+    /// Seek to an offset from the beginning of the input.
+    pub fn seek(&mut self, offset: usize) {
+        if offset > self.full.len() {
+            self.slice = &[];
+        } else {
+            self.slice = &self.full[offset..];
+        }
     }
 
     /// Drop a fixed number of bytes, and return an error if said bytes are not zeros.

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -291,7 +291,7 @@ fn test_native_actor_type() {
 fn resolve_address_contract() -> Vec<u8> {
     let init = "";
     let body = r#"
-    
+
 # get call payload size
 calldatasize
 # store payload to mem 0x00
@@ -405,12 +405,7 @@ fn test_resolve_delegated() {
 
     fn test_resolve(rt: &mut MockRuntime, addr: FILAddress, expected: Vec<u8>) {
         rt.expect_gas_available(10_000_000_000u64);
-        let input = {
-            let addr = addr.to_bytes();
-            let mut v = U256::from(addr.len()).to_bytes().to_vec();
-            v.extend_from_slice(&addr);
-            v
-        };
+        let input = addr.to_bytes();
         let result = util::invoke_contract(rt, &input);
         rt.verify();
         assert_eq!(expected, &result[1..]);
@@ -424,44 +419,6 @@ fn test_resolve_delegated() {
     test_resolve(&mut rt, bls, id_to_vec(&bls_target));
     // not found
     test_resolve(&mut rt, unbound_del, vec![]);
-
-    // valid with extra padding
-    rt.expect_gas_available(10_000_000_000u64);
-    let input = {
-        let addr = evm_del.to_bytes();
-        // address length to read
-        let mut v = U256::from(addr.len()).to_bytes().to_vec();
-        // address itself
-        v.extend_from_slice(&addr);
-        // extra padding
-        v.extend_from_slice(&[0; 10]);
-        v
-    };
-    let result = util::invoke_contract(&mut rt, &input);
-    rt.verify();
-    assert_eq!(id_to_vec(&evm_target), &result[1..]);
-    assert_eq!(1, result[0]);
-    rt.reset();
-
-    // valid but needs padding
-    rt.expect_gas_available(10_000_000_000u64);
-    let input = {
-        // EVM f4 but subaddress len is 12 bytes
-        // FEEDFACECAFEBEEF00000000
-        let addr = FILAddress::new_delegated(10, &util::CONTRACT_ADDRESS[..12]).unwrap();
-        let addr = addr.to_bytes();
-
-        let read_len = addr.len() + 8;
-        let mut v = U256::from(read_len).to_bytes().to_vec();
-        // address itself
-        v.extend_from_slice(&addr);
-        v
-    };
-    let result = util::invoke_contract(&mut rt, &input);
-    rt.verify();
-    assert_eq!(id_to_vec(&evm_target), &result[1..]);
-    assert_eq!(1, result[0]);
-    rt.reset();
 
     // invalid first param fails
     rt.expect_gas_available(10_000_000_000u64);
@@ -523,14 +480,7 @@ fn test_precompile_failure() {
 
     // not found succeeds with empty
     rt.expect_gas_available(10_000_000_000u64);
-    let input = {
-        let addr = FILAddress::new_delegated(111, b"foo").unwrap().to_bytes();
-        // first word is len
-        let mut v = U256::from(addr.len()).to_bytes().to_vec();
-        // then addr
-        v.extend_from_slice(&addr);
-        v
-    };
+    let input = FILAddress::new_delegated(111, b"foo").unwrap().to_bytes();
     let result = util::invoke_contract(&mut rt, &input);
     rt.verify();
     assert_eq!(&[1u8], result.as_slice());


### PR DESCRIPTION
1. Remove the `length` from `resolve_address` (just take bytes).
2. Fix `call_actor` to follow the solidity conventions with respect to offsets and lengths.
3. Add a new `call_actor_id` that takes an ID instead of an address.