### PR TITLE
EVM: Burn value sent to addresses reserved by the system

### DIFF
--- a/actors/eam/src/lib.rs
+++ b/actors/eam/src/lib.rs
@@ -92,10 +92,15 @@ impl EthAddress {
         self.0 == [0; 20]
     }
 
+    #[inline]
+    fn is_burn(&self) -> bool {
+        self.0 == hex_literal::hex!("000000000000000000000000000000000000dead")
+    }
+
     /// Returns true if the EthAddress is "reserved" (cannot be assigned by the EAM).
     #[inline]
     fn is_reserved(&self) -> bool {
-        self.is_precompile() || self.is_id() || self.is_null()
+        self.is_precompile() || self.is_id() || self.is_null() || self.is_burn()
     }
 }
 

--- a/actors/evm/src/interpreter/address.rs
+++ b/actors/evm/src/interpreter/address.rs
@@ -146,8 +146,8 @@ impl AsRef<[u8]> for EthAddress {
 mod tests {
     use fvm_shared::address::Address;
 
-    use crate::interpreter::StatusCode;
     use crate::interpreter::address::EthAddress;
+    use crate::interpreter::StatusCode;
     use crate::U256;
 
     const TYPE_PADDING: &[u8] = &[0; 12]; // padding (12 bytes)
@@ -247,7 +247,7 @@ mod tests {
         let addr = EthAddress(hex_literal::hex!("fe000000000000000000000000000000000000aa"));
         let _ = Address::try_from(addr).expect_err("can't convert precompile into f4!");
         assert!(addr.is_reserved());
-        
+
         let addr = EthAddress(hex_literal::hex!("00000000000000000000000000000000000000aa"));
         let _ = Address::try_from(addr).expect_err("can't convert precompile into f4!");
         assert!(addr.is_reserved());

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -198,7 +198,7 @@ pub fn call_generic<RT: Runtime>(
                     Ok(res) => {
                         // log error if we get something unexpected, but otherwise do nothing
                         if res.exit_code != ExitCode::OK || res.return_data.is_some() {
-                            log::error!( 
+                            log::error!(
                                 target: "evm",
                                 "Unexpected return from reserved address {:?}: {:?}",
                                 dst,

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -3,9 +3,9 @@
 use fil_actors_runtime::EAM_ACTOR_ID;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::BytesDe;
-use fvm_shared::{address::Address, sys::SendFlags, IPLD_RAW, METHOD_SEND};
+use fvm_shared::{address::Address, error::ExitCode, sys::SendFlags, IPLD_RAW, METHOD_SEND};
 
-use crate::interpreter::{precompiles::{is_reserved_precompile_address, PrecompileContext}, address::ETH_NULL_ADDRESS};
+use crate::interpreter::precompiles::PrecompileContext;
 
 use super::ext::{get_contract_type, get_evm_bytecode_cid, ContractType};
 
@@ -178,54 +178,78 @@ pub fn call_generic<RT: Runtime>(
 
         let dst: EthAddress = dst.into();
         if dst.is_reserved() {
-
-            // value sends to a reserved address will go through even though they don't exist since it is expected to burn
+            // value sent to a reserved address will succeed even though they don't exist since it is expected to burn
             if !value.is_zero() {
                 // construct manually to skip checks done normally
                 let send_dst = Address::new_delegated(EAM_ACTOR_ID, &dst.0)
-                // replace with null address if failed somehow
-                    .unwrap_or_else(ETH_NULL_ADDRESS.try_into().expect("Eth null address must always be a valid f4 address"));
+                    // use null address if construction failed somehow
+                    .unwrap_or_else(|_| EthAddress::null_f4_address());
 
-                system
-                    .rt
-                    .send_generalized(
-                        &send_dst,
-                        0,
-                        None,
-                        TokenAmount::from(&value),
-                        None,
-                        SendFlags::empty(),
-                    )
-                    // ignore any exit code or return value, this is gross
-                    .map(|_| (1, vec![]))
-                    .unwrap_or((0, vec![]));
-            }
-
-            let context =
-                PrecompileContext { call_type: kind, gas_limit: effective_gas_limit(system, gas) };
-                
-            match precompiles::Precompiles::call_precompile(system, &dst, input_data, context) {
-                Some(res) => {
-                    if log::log_enabled!(log::Level::Info) {
-                        // log input to the precompile, but make sure we dont log _too_ much.
-                        let mut input_hex = hex::encode(input_data);
-                        input_hex.truncate(512);
-                        log::info!(target: "evm", "Call Precompile:\n\taddress: {:x?}\n\tcontext: {:?}\n\tinput: {}", dst, context, input_hex);
-                    }
-
-                    match res {
-                        Ok(return_data) => (1, return_data),
-                        Err(err) => {
-                            log::error!(target: "evm", "Precompile failed: error {:?}", err);
-                            // precompile failed, exit with reverted and no output
-                            (0, vec![])
+                let burn_amount = TokenAmount::from(&value);
+                let send_result = system.rt.send_generalized(
+                    &send_dst,
+                    0,
+                    None,
+                    burn_amount,
+                    None,
+                    SendFlags::empty(),
+                );
+                match send_result {
+                    Ok(res) => {
+                        // log error if we get something unexpected, but otherwise do nothing
+                        if res.exit_code != ExitCode::OK || res.return_data.is_some() {
+                            log::error!( 
+                                target: "evm",
+                                "Unexpected return from reserved address {:?}: {:?}",
+                                dst,
+                                res
+                            )
                         }
                     }
+                    Err(e) => {
+                        return Err(ActorError::assertion_failed(format!(
+                            "Failed to burn {} attoFIL sent to precompile address {:?}: {}",
+                            TokenAmount::from(&value),
+                            dst,
+                            e
+                        ))
+                        .into())
+                    }
                 }
-                None => {
-                    log::warn!(target: "evm", "Non-existing precompile address: {:?}", dst);
-                    (0, vec![])
+            }
+
+            if precompiles::Precompiles::<RT>::is_precompile(&dst) {
+                let context = PrecompileContext {
+                    call_type: kind,
+                    gas_limit: effective_gas_limit(system, gas),
+                };
+
+                match precompiles::Precompiles::call_precompile(system, &dst, input_data, context) {
+                    Some(res) => {
+                        if log::log_enabled!(log::Level::Info) {
+                            // log input to the precompile, but make sure we dont log _too_ much.
+                            let mut input_hex = hex::encode(input_data);
+                            input_hex.truncate(512);
+                            log::info!(target: "evm", "Call Precompile:\n\taddress: {:x?}\n\tcontext: {:?}\n\tinput: {}", dst, context, input_hex);
+                        }
+
+                        match res {
+                            Ok(return_data) => (1, return_data),
+                            Err(err) => {
+                                log::error!(target: "evm", "Precompile failed: error {:?}", err);
+                                // precompile failed, exit with reverted and no output
+                                (0, vec![])
+                            }
+                        }
+                    }
+                    None => {
+                        log::warn!(target: "evm", "Non-existing precompile address: {:?}", dst);
+                        (0, vec![])
+                    }
                 }
+            } else {
+                // non-precompile reserved addresses always return nothing successfully
+                (1, vec![])
             }
         } else {
             let call_result = match kind {


### PR DESCRIPTION
This adds the eth burn address (000000000000000000000000000000000000dead) to reserved addresses

There are two implementations of what reserved addresses are, it is horrible and it sucks.

