### PR TITLE
chore: update hamt & amt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1",
  "fvm_shared",
  "lazy_static",
  "log",
@@ -632,7 +632,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1",
  "fvm_shared",
  "log",
  "num-derive",
@@ -652,15 +652,15 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "frc46_token",
- "fvm_ipld_amt",
+ "fvm_ipld_amt 0.5.1",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1",
  "fvm_shared",
  "integer-encoding",
  "itertools",
- "libipld-core",
+ "libipld-core 0.13.1",
  "log",
  "multihash",
  "num-derive",
@@ -682,11 +682,11 @@ dependencies = [
  "fil_actor_reward",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_amt",
+ "fvm_ipld_amt 0.5.1",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1",
  "fvm_shared",
  "itertools",
  "lazy_static",
@@ -710,7 +710,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1",
  "fvm_shared",
  "indexmap",
  "integer-encoding",
@@ -729,7 +729,7 @@ dependencies = [
  "derive_builder",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_amt",
+ "fvm_ipld_amt 0.5.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_shared",
@@ -749,7 +749,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1",
  "fvm_shared",
  "indexmap",
  "integer-encoding",
@@ -803,7 +803,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1",
  "fvm_shared",
  "lazy_static",
  "log",
@@ -823,11 +823,11 @@ dependencies = [
  "castaway",
  "cid",
  "derive_builder",
- "fvm_ipld_amt",
+ "fvm_ipld_amt 0.5.1",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1",
  "fvm_sdk",
  "fvm_shared",
  "getrandom",
@@ -967,10 +967,10 @@ dependencies = [
  "cid",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_amt",
+ "fvm_ipld_amt 0.4.2",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.5.1",
  "fvm_sdk",
  "fvm_shared",
  "integer-encoding",
@@ -1121,6 +1121,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fvm_ipld_amt"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e84f16d6927ce342ef86bd20fcc2d5bd498ed33ae6d7a22fea7a1b453488ec88"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.3.2",
+ "itertools",
+ "once_cell",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,7 +1222,27 @@ dependencies = [
  "forest_hash_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "libipld-core",
+ "libipld-core 0.13.1",
+ "multihash",
+ "once_cell",
+ "serde",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_ipld_hamt"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c942494dde990aeac314311bde34c787be99cab7d0836397a75556cbaa2c3e7"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "cid",
+ "forest_hash_utils",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.3.2",
+ "libipld-core 0.14.0",
  "multihash",
  "once_cell",
  "serde",
@@ -1415,6 +1451,21 @@ name = "libipld-core"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdd758764f9680a818af33c31db733eb7c45224715d8816b9dcf0548c75f7c5"
+dependencies = [
+ "anyhow",
+ "cid",
+ "core2",
+ "multibase",
+ "multihash",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "libipld-core"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44790246ec6b7314cba745992c23d479d018073e66d49ae40ae1b64e5dd8eb5"
 dependencies = [
  "anyhow",
  "cid",
@@ -1978,7 +2029,7 @@ dependencies = [
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1",
  "fvm_shared",
  "indexmap",
  "integer-encoding",

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -22,7 +22,7 @@ frc46_token = "3.1.0"
 fvm_actor_utils = "3.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.3"
-fvm_ipld_hamt = "0.5.1"
+fvm_ipld_hamt = "0.6.1"
 fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
 lazy_static = "1.4.0"
 num-derive = "0.3.3"

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "lib"]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.0"
 fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
-fvm_ipld_hamt = "0.5.1"
+fvm_ipld_hamt = "0.6.1"
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -23,7 +23,7 @@ frc46_token = "3.1.0"
 fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.3"
-fvm_ipld_hamt = "0.5.1"
+fvm_ipld_hamt = "0.6.1"
 fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
 integer-encoding = { version = "3.0.3", default-features = false }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
@@ -37,7 +37,7 @@ fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", featu
 fil_actor_power = { path = "../power" }
 fil_actor_reward = { path = "../reward" }
 fil_actor_verifreg = { path = "../verifreg" }
-fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
+fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
 multihash = { version = "0.16.1", default-features = false }
 regex = "1"
 itertools = "0.10"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -18,8 +18,8 @@ fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.0"
 fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
 fvm_ipld_bitfield = "0.5.2"
-fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
-fvm_ipld_hamt = "0.5.1"
+fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
+fvm_ipld_hamt = "0.6.1"
 serde = { version = "1.0.136", features = ["derive"] }
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 num-traits = "0.2.14"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -22,7 +22,7 @@ frc42_dispatch = "3.0.0"
 fvm_actor_utils = "3.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.3"
-fvm_ipld_hamt = "0.5.1"
+fvm_ipld_hamt = "0.6.1"
 fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -27,7 +27,7 @@ fvm_ipld_encoding = "0.2.3"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }
-fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
+fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
 derive_builder = "0.10.2"
 
 [features]

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "lib"]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.0"
 fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
-fvm_ipld_hamt = "0.5.1"
+fvm_ipld_hamt = "0.6.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -23,7 +23,7 @@ frc46_token = "3.1.0"
 fvm_actor_utils = "3.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.3"
-fvm_ipld_hamt = "0.5.1"
+fvm_ipld_hamt = "0.6.1"
 fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
 lazy_static = "1.4.0"
 log = "0.4.14"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 
 [dependencies]
-fvm_ipld_hamt = "0.5.1"
-fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
+fvm_ipld_hamt = "0.6.1"
+fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
 fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
 num = { version = "0.4", features = ["serde"] }
 num-traits = "0.2.14"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -35,7 +35,7 @@ fvm_actor_utils = "3.0.0"
 fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_blockstore = { version = "0.1.1", default-features = false }
 fvm_ipld_encoding = { version = "0.2.3", default-features = false }
-fvm_ipld_hamt = "0.5.1"
+fvm_ipld_hamt = "0.6.1"
 fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }


### PR DESCRIPTION
Replaces #1020. This change avoids flushing unless modified.