### PR TITLE
EVM: derive copy for precompile enum in tests 

### DIFF
--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -84,7 +84,7 @@ enum PrecompileExit {
 }
 
 #[repr(u8)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum NativePrecompile {
     ResolveAddress = 1,
     LookupDelegatedAddress = 2,


### PR DESCRIPTION
Isn't an issue now, but this will error once we upgrade to >1.65.0 (and I want to use nightly for miri atm)