### PR TITLE
EVM: infallible address conversion

### DIFF
--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -201,10 +201,7 @@ pub fn call_generic<RT: Runtime>(
         } else {
             let call_result = match kind {
                 CallKind::Call | CallKind::StaticCall => {
-                    let dst_addr: Address = dst.try_into().map_err(|_| ActorError::assertion_failed(
-                        "Reached a precompile address when a precompile should've been caught earlier in the system"
-                            .to_string(),
-                    ))?;
+                    let dst_addr: Address = dst.into();
 
                     // Special casing for account/placeholder/non-existent actors: we just do a SEND (method 0)
                     // which allows us to transfer funds (and create placeholders)

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -103,9 +103,8 @@ pub fn get_contract_type<RT: Runtime>(rt: &RT, addr: &EthAddress) -> ContractTyp
         return ContractType::Precompile;
     }
 
-    addr.try_into()
-        .ok() // into filecoin address
-        .and_then(|addr| rt.resolve_address(&addr)) // resolve actor id
+    let addr: Address = addr.into();
+    rt.resolve_address(&addr) // resolve actor id
         .and_then(|id| rt.get_actor_code_cid(&id).map(|cid| (id, cid))) // resolve code cid
         .map(|(id, cid)| match rt.resolve_builtin_actor_type(&cid) {
             // TODO part of current account abstraction hack where placeholders are accounts

--- a/actors/evm/src/interpreter/instructions/lifecycle.rs
+++ b/actors/evm/src/interpreter/instructions/lifecycle.rs
@@ -165,10 +165,10 @@ pub fn selfdestruct(
     }
 
     // Try to give funds to the beneficiary. If this fails, we just keep them.
-    if let Ok(addr) = EthAddress::from(beneficiary).try_into() {
-        let balance = system.rt.current_balance();
-        let _ = system.rt.send(&addr, METHOD_SEND, None, balance);
-    }
+    let beneficiary: EthAddress = beneficiary.into();
+    let beneficiary: Address = beneficiary.into();
+    let balance = system.rt.current_balance();
+    let _ = system.rt.send(&beneficiary, METHOD_SEND, None, balance);
 
     // Now mark ourselves as deleted.
     system.mark_selfdestructed();

--- a/actors/evm/src/interpreter/instructions/state.rs
+++ b/actors/evm/src/interpreter/instructions/state.rs
@@ -13,12 +13,12 @@ pub fn balance(
     system: &System<impl Runtime>,
     actor: U256,
 ) -> Result<U256, StatusCode> {
-    let actor: EthAddress = actor.into();
+    let addr: EthAddress = actor.into();
+    let addr: Address = addr.into();
 
-    let balance = actor
-        .try_into()
-        .ok()
-        .and_then(|addr: Address| system.rt.resolve_address(&addr))
+    let balance = system
+        .rt
+        .resolve_address(&addr)
         .and_then(|id| system.rt.actor_balance(id).as_ref().map(U256::from))
         .unwrap_or_default();
 

--- a/actors/evm/src/interpreter/precompiles/mod.rs
+++ b/actors/evm/src/interpreter/precompiles/mod.rs
@@ -1,6 +1,6 @@
 use std::{marker::PhantomData, num::TryFromIntError};
 
-use fil_actors_runtime::{runtime::Runtime, EAM_ACTOR_ID};
+use fil_actors_runtime::runtime::Runtime;
 use fvm_shared::{address::Address, econ::TokenAmount};
 use substrate_bn::{CurveError, FieldError, GroupError};
 
@@ -111,10 +111,7 @@ impl<RT: Runtime> Precompiles<RT> {
         // This shouldn't be observable as the only precompile with side-effects is the call_actor
         // precompile, and that precompile can only be called with delegatecall.
         if !context.value.is_zero() {
-            // Explicitly construct the precompile addr. We forbid this in the usual try_into for
-            // safety.
-            let fil_addr = Address::new_delegated(EAM_ACTOR_ID, precompile_addr.as_ref())
-                .expect("incorrect address size");
+            let fil_addr: Address = precompile_addr.into();
             system
                 .transfer(&fil_addr, TokenAmount::from(&context.value))
                 .map_err(|_| PrecompileError::TransferFailed)?;


### PR DESCRIPTION
We now allow conversion of all addresses, even precompile ones. Nothing is reserved.

This lets us, e.g., check the balance of a precompile which is technically legal in the EVM.