### PR TITLE
EVM: Remove get_actor_type and allow precompile lookup table to have empty slots

### DIFF
--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -48,7 +48,11 @@ pub(super) fn get_actor_type<RT: Runtime>(
         None => NativeType::NonExistent,
     };
 
-    Ok(builtin_type.word_vec())
+    fn word_vec(src: NativeType) -> Vec<u8> {
+        U256::from(src as u32).to_bytes().to_vec()
+    }
+
+    Ok(word_vec(builtin_type))
 }
 
 /// !! DISABLED !!

--- a/actors/evm/src/interpreter/precompiles/mod.rs
+++ b/actors/evm/src/interpreter/precompiles/mod.rs
@@ -49,11 +49,11 @@ pub struct Precompiles<RT>(PhantomData<RT>);
 impl<RT: Runtime> Precompiles<RT> {
     /// FEVM specific precompiles (0xfe prefix)
     const NATIVE_PRECOMPILES: PrecompileTable<RT, 5> = PrecompileTable::init([
-        Some(WrappedFn(resolve_address::<RT>)), // 0xfe00..01 resolve_address
-        Some(WrappedFn(lookup_delegated_address::<RT>)), // 0xfe00..02 lookup_delegated_address
-        Some(WrappedFn(call_actor::<RT>)),      // 0xfe00..03 call_actor
-        None,                                   // DISABLED 0xfe00..04 get_actor_type
-        Some(WrappedFn(call_actor_id::<RT>)),   // 0xfe00..05 call_actor_id
+        Some(WrappedFn(resolve_address::<RT>)),          // 0xfe00..01
+        Some(WrappedFn(lookup_delegated_address::<RT>)), // 0xfe00..02
+        Some(WrappedFn(call_actor::<RT>)),               // 0xfe00..03
+        None,                                            // 0xfe00..04 DISABLED
+        Some(WrappedFn(call_actor_id::<RT>)),            // 0xfe00..05
     ]);
 
     /// EVM specific precompiles

--- a/actors/evm/src/interpreter/precompiles/mod.rs
+++ b/actors/evm/src/interpreter/precompiles/mod.rs
@@ -12,56 +12,24 @@ mod evm;
 mod fvm;
 
 use evm::{blake2f, ec_add, ec_mul, ec_pairing, ec_recover, identity, modexp, ripemd160, sha256};
-use fvm::{call_actor, call_actor_id, get_actor_type, lookup_delegated_address, resolve_address};
+use fvm::{call_actor, call_actor_id, lookup_delegated_address, resolve_address};
 
-// really I'd want to have context as a type parameter, but since the table we generate must have the same types (or dyn) its messy
-type PrecompileFn<RT> = unsafe fn(*mut System<RT>, &[u8], PrecompileContext) -> PrecompileResult;
-
-type NewPrecompileFn<RT> = fn(&mut System<RT>, &[u8], PrecompileContext) -> PrecompileResult;
-
+type PrecompileFn<RT> = fn(&mut System<RT>, &[u8], PrecompileContext) -> PrecompileResult;
 pub type PrecompileResult = Result<Vec<u8>, PrecompileError>;
 
 pub const NATIVE_PRECOMPILE_ADDRESS_PREFIX: u8 = 0xFE;
 
-struct SlotArray<T, const N: usize> ([Option<T>; N]);
-
-type PrecompileTable<RT, const N: usize> = SlotArray<NewPrecompileFn<RT>, N>;
-
-impl<T, const N: usize> SlotArray<T, N> {
-    /// Err(err) if out of range
-    /// Ok(None) for empty slot
-    fn try_get<E>(&self, index: usize, err: E) -> Result<Option<&T>, E> {
-        self.0.get(index).map(|i| i.as_ref()).ok_or(err)
-    }
-
-    const fn init(src: [Option<T>; N]) -> Self {
-        Self(src)
-    }
-}
+struct PrecompileTable<RT: Runtime, const N: usize> ([Option<PrecompileFn<RT>>; N]);
 
 impl<RT: Runtime, const N: usize> PrecompileTable<RT, N> {
-    /// Tries to lookup Precompile, None if empty slot or out of bounds
-    fn get(&self, index: usize) -> Option<NewPrecompileFn<RT>> {
-        self.try_get(index, ()).ok().flatten().map(|f| *f)
+    /// Tries to lookup Precompile, None if empty slot or out of bounds.
+    /// Last byte of precompile address - 1 is the index.
+    fn get(&self, index: usize) -> Option<PrecompileFn<RT>> {
+        self.0.get(index).map(|i| i.as_ref()).flatten().map(|f| *f)
     }
-}
 
-macro_rules! precompiles {
-    ($($precompile:ident,)*) => {
-        pub(super) mod trampolines {
-            use fil_actors_runtime::runtime::Runtime;
-            use crate::System;
-            use super::{PrecompileContext, PrecompileResult};
-            $(
-                #[inline(always)]
-                pub unsafe fn $precompile<RT: Runtime>(s: *mut System<RT>, inp: &[u8], ctx: PrecompileContext) -> PrecompileResult {
-                    super::$precompile(&mut *s, inp, ctx)
-                }
-            )*
-        }
-        [
-            $(trampolines::$precompile,)*
-        ]
+    fn init(src: [Option<PrecompileFn<RT>>; N]) -> Self {
+        Self(src)
     }
 }
 
@@ -89,31 +57,6 @@ fn n_gen_native_precompiles<RT: Runtime>() -> PrecompileTable<RT, 5> {
     ])
 }
 
-/// Generates a list of precompile smart contracts, index + 1 is the address.
-const fn gen_evm_precompiles<RT: Runtime>() -> [PrecompileFn<RT>; 9] {
-    precompiles! {
-        ec_recover, // 0x01 ecrecover
-        sha256,     // 0x02 SHA2-256
-        ripemd160,  // 0x03 ripemd160
-        identity,   // 0x04 identity
-        modexp,     // 0x05 modexp
-        ec_add,     // 0x06 ecAdd
-        ec_mul,     // 0x07 ecMul
-        ec_pairing, // 0x08 ecPairing
-        blake2f,    // 0x09 blake2f
-    }
-}
-
-const fn gen_native_precompiles<RT: Runtime>() -> [PrecompileFn<RT>; 5] {
-    precompiles! {
-        resolve_address,            // 0xfe00..01 resolve_address
-        lookup_delegated_address,   // 0xfe00..02 lookup_delegated_address
-        call_actor,                 // 0xfe00..03 call_actor
-        get_actor_type,             // 0xfe00..04 get_actor_type
-        call_actor_id,              // 0xfe00..05 call_actor_id
-    }
-}
-
 pub fn is_reserved_precompile_address(addr: &EthAddress) -> bool {
     let [prefix, middle @ .., index] = addr.0;
     (prefix == 0x00 || prefix == NATIVE_PRECOMPILE_ADDRESS_PREFIX)
@@ -128,7 +71,7 @@ impl<RT: Runtime> Precompiles<RT> {
     const EVM_PRECOMPILES: Lazy<PrecompileTable<RT, 9>> = Lazy::new(|| n_gen_evm_precompiles());
     const NATIVE_PRECOMPILES: Lazy<PrecompileTable<RT, 5>> = Lazy::new(|| n_gen_native_precompiles());
 
-    fn lookup_precompile(addr: &EthAddress) -> Option<NewPrecompileFn<RT>> {
+    fn lookup_precompile(addr: &EthAddress) -> Option<PrecompileFn<RT>> {
         let [prefix, _m @ .., index] = addr.0;
         if is_reserved_precompile_address(addr) {
             let index = index as usize - 1;
@@ -237,12 +180,6 @@ pub enum NativeType {
     StorageProvider = 4,
     EVMContract = 5,
     OtherTypes = 6,
-}
-
-impl NativeType {
-    fn word_vec(self) -> Vec<u8> {
-        U256::from(self as u32).to_bytes().to_vec()
-    }
 }
 
 #[cfg(test)]

--- a/actors/evm/src/interpreter/precompiles/mod.rs
+++ b/actors/evm/src/interpreter/precompiles/mod.rs
@@ -43,7 +43,7 @@ impl<RT: Runtime> Precompiles<RT> {
         Some(resolve_address::<RT>),          // 0xfe00..01
         Some(lookup_delegated_address::<RT>), // 0xfe00..02
         Some(call_actor::<RT>),               // 0xfe00..03
-        None,                                            // 0xfe00..04 DISABLED
+        None,                                 // 0xfe00..04 DISABLED
         Some(call_actor_id::<RT>),            // 0xfe00..05
     ]);
 

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -73,7 +73,7 @@ fn tester_bytecode() -> Vec<u8> {
 }
 
 #[test]
-#[ignore = "removing this later PR"]
+#[ignore = "this precompile disabled"]
 fn test_native_actor_type() {
     use evm::interpreter::precompiles::NativeType;
 

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -73,6 +73,7 @@ fn tester_bytecode() -> Vec<u8> {
 }
 
 #[test]
+#[ignore = "removing this later PR"]
 fn test_native_actor_type() {
     use evm::interpreter::precompiles::NativeType;
 


### PR DESCRIPTION
also removes the unsafe we had laying around :)

unfortunately this will add a _small_ runtime cost on first call to a precompile every time an actor is initialized, but its a simple array init of fn pointers. `mem::size_of` said the evm precompile table is currently 72 bytes - which is really nothing compared to the 32 byte words we are tossing around.