### PR TITLE
EVM: Remove StatusCode and return meaningful actor errors

### DIFF
--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code)]
 
+use fil_actors_runtime::ActorError;
 use fvm_shared::econ::TokenAmount;
 
 use super::address::EthAddress;
 use {
     super::instructions,
-    super::StatusCode,
     crate::interpreter::memory::Memory,
     crate::interpreter::stack::Stack,
     crate::interpreter::{Bytecode, Output, System},
@@ -60,7 +60,10 @@ macro_rules! def_opcodes {
         pub const fn jumptable<'r, 'a, RT: Runtime>() -> [Instruction<'r, 'a, RT>; 256] {
             def_ins_raw! {
                 UNDEFINED(_m) {
-                    Err(StatusCode::UndefinedInstruction)
+                    Err(ActorError::unchecked(
+                        crate::EVM_CONTRACT_UNDEFINED_INSTRUCTION,
+                        "undefined instruction".into()
+                    ))
                 }
             }
             $(def_ins_raw! {
@@ -80,7 +83,7 @@ macro_rules! def_opcodes {
 macro_rules! def_ins_raw {
     ($ins:ident ($arg:ident) $body:block) => {
         #[allow(non_snake_case)]
-        unsafe fn $ins<'r, 'a, RT: Runtime>(p: *mut Machine<'r, 'a, RT>) -> Result<(), StatusCode> {
+        unsafe fn $ins<'r, 'a, RT: Runtime>(p: *mut Machine<'r, 'a, RT>) -> Result<(), ActorError> {
             // SAFETY: macro ensures that mut pointer is taken directly from a mutable borrow, used
             // once, then goes out of scope immediately after
             let $arg: &mut Machine<'r, 'a, RT> = &mut *p;
@@ -92,11 +95,11 @@ macro_rules! def_ins_raw {
 pub mod opcodes {
     use super::instructions;
     use super::Machine;
-    use crate::interpreter::StatusCode;
     use fil_actors_runtime::runtime::Runtime;
+    use fil_actors_runtime::ActorError;
 
     pub type Instruction<'r, 'a, RT> =
-        unsafe fn(*mut Machine<'r, 'a, RT>) -> Result<(), StatusCode>;
+        unsafe fn(*mut Machine<'r, 'a, RT>) -> Result<(), ActorError>;
 
     def_opcodes! {
         0x00: STOP,
@@ -255,12 +258,12 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
         Machine { system, state, bytecode, pc: 0, output: Output::default() }
     }
 
-    pub fn execute(mut self) -> Result<Output, StatusCode> {
+    pub fn execute(mut self) -> Result<Output, ActorError> {
         while self.pc < self.bytecode.len() {
             // This is faster than the question mark operator, and speed counts here.
             #[allow(clippy::question_mark)]
             if let Err(e) = self.step() {
-                return Err(e);
+                return Err(e.wrap(format!("ABORT(pc={})", self.pc)));
             }
         }
 
@@ -268,7 +271,7 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
     }
 
     #[inline(always)]
-    fn step(&mut self) -> Result<(), StatusCode> {
+    fn step(&mut self) -> Result<(), ActorError> {
         let op = self.bytecode[self.pc];
         unsafe { Self::JMPTABLE[op as usize](self) }
     }
@@ -280,6 +283,6 @@ pub fn execute(
     bytecode: &Bytecode,
     runtime: &mut ExecutionState,
     system: &mut System<impl Runtime>,
-) -> Result<Output, StatusCode> {
+) -> Result<Output, ActorError> {
     Machine::new(system, runtime, bytecode).execute()
 }

--- a/actors/evm/src/interpreter/instructions/context.rs
+++ b/actors/evm/src/interpreter/instructions/context.rs
@@ -1,7 +1,8 @@
+use fil_actors_runtime::ActorError;
 use fvm_shared::clock::ChainEpoch;
 
 use {
-    crate::interpreter::{ExecutionState, StatusCode, System, U256},
+    crate::interpreter::{ExecutionState, System, U256},
     fil_actors_runtime::runtime::Runtime,
 };
 
@@ -10,7 +11,7 @@ pub fn blockhash(
     _state: &mut ExecutionState,
     system: &System<impl Runtime>,
     bn: U256,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     let result = bn
         .try_into()
         .ok()
@@ -35,7 +36,7 @@ pub fn blockhash(
 }
 
 #[inline]
-pub fn caller(state: &mut ExecutionState, _: &System<impl Runtime>) -> Result<U256, StatusCode> {
+pub fn caller(state: &mut ExecutionState, _: &System<impl Runtime>) -> Result<U256, ActorError> {
     Ok(state.caller.as_evm_word())
 }
 
@@ -43,7 +44,7 @@ pub fn caller(state: &mut ExecutionState, _: &System<impl Runtime>) -> Result<U2
 pub fn address(
     state: &mut ExecutionState,
     _system: &System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     Ok(state.receiver.as_evm_word())
 }
 
@@ -51,7 +52,7 @@ pub fn address(
 pub fn origin(
     _state: &mut ExecutionState,
     system: &System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     let origin_addr = system
         .resolve_ethereum_address(&system.rt.message().origin())
         .expect("failed to resolve origin address");
@@ -62,7 +63,7 @@ pub fn origin(
 pub fn call_value(
     state: &mut ExecutionState,
     _system: &System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     Ok(U256::from(&state.value_received))
 }
 
@@ -70,7 +71,7 @@ pub fn call_value(
 pub fn coinbase(
     _state: &mut ExecutionState,
     _system: &System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     // TODO do we want to return the zero ID address, or just a plain 0?
     Ok(U256::zero())
 }
@@ -79,13 +80,13 @@ pub fn coinbase(
 pub fn gas_price(
     _state: &mut ExecutionState,
     system: &System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     let effective_price = system.rt.base_fee() + system.rt.message().gas_premium();
     Ok(U256::from(&effective_price))
 }
 
 #[inline]
-pub fn gas(_state: &mut ExecutionState, system: &System<impl Runtime>) -> Result<U256, StatusCode> {
+pub fn gas(_state: &mut ExecutionState, system: &System<impl Runtime>) -> Result<U256, ActorError> {
     Ok(U256::from(system.rt.gas_available()))
 }
 
@@ -93,7 +94,7 @@ pub fn gas(_state: &mut ExecutionState, system: &System<impl Runtime>) -> Result
 pub fn timestamp(
     _state: &mut ExecutionState,
     system: &System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     Ok(U256::from(system.rt.tipset_timestamp()))
 }
 
@@ -101,7 +102,7 @@ pub fn timestamp(
 pub fn block_number(
     _state: &mut ExecutionState,
     system: &System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     Ok(U256::from(system.rt.curr_epoch()))
 }
 
@@ -110,7 +111,7 @@ pub fn block_number(
 pub fn prevrandao(
     _state: &mut ExecutionState,
     system: &mut System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     // NOTE: Filecoin beacon randomness is expected to fall outside of the `2^64` reserved range, following PREVRANDAO's assumptions.
     // NOTE: EVM uses previous RANDAO value in this opcode since the _current_ RANDAO for them runs on the beacon chain's state
     //      and wont be finalized till the end of a block. Filecoin's chain randomness is generated _before_ any contract is run, so we instead
@@ -122,7 +123,7 @@ pub fn prevrandao(
 pub fn gas_limit(
     _state: &mut ExecutionState,
     _system: &System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     const BLOCK_GAS_LIMIT: u64 = 10_000_000_000u64;
     Ok(U256::from(BLOCK_GAS_LIMIT))
 }
@@ -131,7 +132,7 @@ pub fn gas_limit(
 pub fn chain_id(
     _state: &mut ExecutionState,
     system: &System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     Ok(U256::from_u64(system.rt.chain_id().into()))
 }
 
@@ -139,6 +140,6 @@ pub fn chain_id(
 pub fn base_fee(
     _state: &mut ExecutionState,
     system: &System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     Ok(U256::from(&system.rt.base_fee()))
 }

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -1,17 +1,21 @@
 use bytes::Bytes;
+use fil_actors_runtime::{ActorError, AsActorError};
 
-use crate::interpreter::{memory::Memory, output::Outcome, Output};
+use crate::{
+    interpreter::{memory::Memory, output::Outcome, Output},
+    EVM_CONTRACT_BAD_JUMPDEST, EVM_CONTRACT_ILLEGAL_MEMORY_ACCESS,
+    EVM_CONTRACT_INVALID_INSTRUCTION,
+};
 
 use {
     super::memory::get_memory_region,
-    crate::interpreter::output::StatusCode,
     crate::interpreter::Bytecode,
     crate::interpreter::{ExecutionState, System, U256},
     fil_actors_runtime::runtime::Runtime,
 };
 
 #[inline]
-pub fn nop(_state: &mut ExecutionState, _system: &System<impl Runtime>) -> Result<(), StatusCode> {
+pub fn nop(_state: &mut ExecutionState, _system: &System<impl Runtime>) -> Result<(), ActorError> {
     Ok(())
 }
 
@@ -19,8 +23,8 @@ pub fn nop(_state: &mut ExecutionState, _system: &System<impl Runtime>) -> Resul
 pub fn invalid(
     _state: &mut ExecutionState,
     _system: &System<impl Runtime>,
-) -> Result<(), StatusCode> {
-    Err(StatusCode::InvalidInstruction)
+) -> Result<(), ActorError> {
+    Err(ActorError::unchecked(EVM_CONTRACT_INVALID_INSTRUCTION, "invalid instruction".into()))
 }
 
 #[inline]
@@ -29,7 +33,7 @@ pub fn ret(
     _system: &System<impl Runtime>,
     offset: U256,
     size: U256,
-) -> Result<Output, StatusCode> {
+) -> Result<Output, ActorError> {
     exit(&mut state.memory, offset, size, Outcome::Return)
 }
 
@@ -39,7 +43,7 @@ pub fn revert(
     _system: &System<impl Runtime>,
     offset: U256,
     size: U256,
-) -> Result<Output, StatusCode> {
+) -> Result<Output, ActorError> {
     exit(&mut state.memory, offset, size, Outcome::Revert)
 }
 
@@ -47,7 +51,7 @@ pub fn revert(
 pub fn stop(
     _state: &mut ExecutionState,
     _system: &System<impl Runtime>,
-) -> Result<Output, StatusCode> {
+) -> Result<Output, ActorError> {
     Ok(Output { return_data: Bytes::new(), outcome: Outcome::Return })
 }
 
@@ -57,11 +61,10 @@ fn exit(
     offset: U256,
     size: U256,
     status: Outcome,
-) -> Result<Output, StatusCode> {
+) -> Result<Output, ActorError> {
     Ok(Output {
         outcome: status,
-        return_data: super::memory::get_memory_region(memory, offset, size)
-            .map_err(|_| StatusCode::InvalidMemoryAccess)?
+        return_data: super::memory::get_memory_region(memory, offset, size)?
             .map(|region| memory[region.offset..region.offset + region.size.get()].to_vec().into())
             .unwrap_or_default(),
     })
@@ -71,7 +74,7 @@ fn exit(
 pub fn returndatasize(
     state: &mut ExecutionState,
     _system: &System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     Ok(U256::from(state.return_data.len()))
 }
 
@@ -82,17 +85,36 @@ pub fn returndatacopy(
     mem_index: U256,
     input_index: U256,
     size: U256,
-) -> Result<(), StatusCode> {
-    let region = get_memory_region(&mut state.memory, mem_index, size)
-        .map_err(|_| StatusCode::InvalidMemoryAccess)?;
+) -> Result<(), ActorError> {
+    let region = get_memory_region(&mut state.memory, mem_index, size)?;
 
-    let src = input_index.try_into().map_err(|_| StatusCode::InvalidMemoryAccess)?;
+    let src: usize = input_index
+        .try_into()
+        .context_code(EVM_CONTRACT_ILLEGAL_MEMORY_ACCESS, "returndatacopy index exceeds max u32")?;
     if src > state.return_data.len() {
-        return Err(StatusCode::InvalidMemoryAccess);
+        return Err(ActorError::unchecked(
+            EVM_CONTRACT_ILLEGAL_MEMORY_ACCESS,
+            format!(
+                "returndatacopy start {} exceeds return-data length {}",
+                src,
+                state.return_data.len()
+            ),
+        ));
     }
 
-    if src + region.as_ref().map(|r| r.size.get()).unwrap_or(0) > state.return_data.len() {
-        return Err(StatusCode::InvalidMemoryAccess);
+    let end = src
+        .checked_add(region.as_ref().map(|r| r.size.get()).unwrap_or(0))
+        .context_code(EVM_CONTRACT_ILLEGAL_MEMORY_ACCESS, "returndatacopy end exceeds max u32")?;
+
+    if end > state.return_data.len() {
+        return Err(ActorError::unchecked(
+            EVM_CONTRACT_ILLEGAL_MEMORY_ACCESS,
+            format!(
+                "returndatacopy end {} exceeds return-data length {}",
+                src,
+                state.return_data.len()
+            ),
+        ));
     }
 
     if let Some(region) = region {
@@ -104,21 +126,28 @@ pub fn returndatacopy(
 }
 
 #[inline]
-pub fn jump(bytecode: &Bytecode, _pc: usize, dest: U256) -> Result<usize, StatusCode> {
-    let dst = dest.try_into().map_err(|_| StatusCode::BadJumpDestination)?;
+pub fn jump(bytecode: &Bytecode, _pc: usize, dest: U256) -> Result<usize, ActorError> {
+    let dst = dest.try_into().context_code(EVM_CONTRACT_BAD_JUMPDEST, "jumpdest exceeds u32")?;
     if !bytecode.valid_jump_destination(dst) {
-        return Err(StatusCode::BadJumpDestination);
+        return Err(ActorError::unchecked(
+            EVM_CONTRACT_BAD_JUMPDEST,
+            format!("jumpdest {dst} is invalid"),
+        ));
     }
     // skip the JMPDEST noop sled
     Ok(dst + 1)
 }
 
 #[inline]
-pub fn jumpi(bytecode: &Bytecode, pc: usize, dest: U256, test: U256) -> Result<usize, StatusCode> {
+pub fn jumpi(bytecode: &Bytecode, pc: usize, dest: U256, test: U256) -> Result<usize, ActorError> {
     if !test.is_zero() {
-        let dst = dest.try_into().map_err(|_| StatusCode::BadJumpDestination)?;
+        let dst =
+            dest.try_into().context_code(EVM_CONTRACT_BAD_JUMPDEST, "jumpdest exceeds u32")?;
         if !bytecode.valid_jump_destination(dst) {
-            return Err(StatusCode::BadJumpDestination);
+            return Err(ActorError::unchecked(
+                EVM_CONTRACT_BAD_JUMPDEST,
+                format!("jumpdest {dst} is invalid"),
+            ));
         }
         // skip the JMPDEST noop sled
         Ok(dst + 1)

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -2,15 +2,16 @@ use crate::interpreter::instructions::memory::copy_to_memory;
 use crate::interpreter::{address::EthAddress, precompiles::Precompiles};
 use crate::{BytecodeHash, U256};
 use cid::Cid;
-use fil_actors_runtime::deserialize_block;
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::ActorError;
+use fil_actors_runtime::{deserialize_block, AsActorError};
 use fvm_ipld_blockstore::Blockstore;
+use fvm_shared::error::ExitCode;
 use fvm_shared::sys::SendFlags;
 use fvm_shared::{address::Address, econ::TokenAmount};
 use num_traits::Zero;
 use {
-    crate::interpreter::{ExecutionState, StatusCode, System},
+    crate::interpreter::{ExecutionState, System},
     fil_actors_runtime::runtime::Runtime,
 };
 
@@ -18,7 +19,7 @@ pub fn extcodesize(
     _state: &mut ExecutionState,
     system: &mut System<impl Runtime>,
     addr: U256,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     // TODO (M2.2) we're fetching the entire block here just to get its size. We should instead use
     //  the ipld::block_stat syscall, but the Runtime nor the Blockstore expose it.
     //  Tracked in https://github.com/filecoin-project/ref-fvm/issues/867
@@ -38,7 +39,7 @@ pub fn extcodehash(
     _state: &mut ExecutionState,
     system: &mut System<impl Runtime>,
     addr: U256,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     let addr = match get_contract_type(system.rt, &addr.into()) {
         ContractType::EVM(a) => a,
         // _Technically_ since we have native "bytecode" set as 0xfe this is valid, though we cant differentiate between different native actors.
@@ -73,7 +74,7 @@ pub fn extcodecopy(
     dest_offset: U256,
     data_offset: U256,
     size: U256,
-) -> Result<(), StatusCode> {
+) -> Result<(), ActorError> {
     let bytecode = match get_contract_type(system.rt, &addr.into()) {
         ContractType::EVM(addr) => get_evm_bytecode(system, &addr)?,
         ContractType::NotFound | ContractType::Account | ContractType::Precompile => Vec::new(),
@@ -133,16 +134,14 @@ pub fn get_evm_bytecode_cid(
 pub fn get_evm_bytecode(
     system: &mut System<impl Runtime>,
     addr: &Address,
-) -> Result<Vec<u8>, StatusCode> {
+) -> Result<Vec<u8>, ActorError> {
     if let Some(cid) = get_evm_bytecode_cid(system, addr)? {
         let raw_bytecode = system
             .rt
             .store()
             .get(&cid) // TODO this is inefficient; should call stat here.
-            .map_err(|e| {
-                StatusCode::InternalError(format!("failed to get bytecode block: {}", &e))
-            })?
-            .ok_or_else(|| ActorError::not_found("bytecode block not found".to_string()))?;
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to get bytecode block")?
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "bytecode block not found")?;
         Ok(raw_bytecode)
     } else {
         Ok(Vec::new())

--- a/actors/evm/src/interpreter/instructions/hash.rs
+++ b/actors/evm/src/interpreter/instructions/hash.rs
@@ -1,6 +1,8 @@
+use fil_actors_runtime::ActorError;
+
 use {
     super::memory::get_memory_region,
-    crate::interpreter::{ExecutionState, StatusCode, System, U256},
+    crate::interpreter::{ExecutionState, System, U256},
     fil_actors_runtime::runtime::Runtime,
     fvm_shared::crypto::hash::SupportedHashes,
 };
@@ -10,9 +12,8 @@ pub fn keccak256(
     system: &System<impl Runtime>,
     index: U256,
     size: U256,
-) -> Result<U256, StatusCode> {
-    let region = get_memory_region(&mut state.memory, index, size) //
-        .map_err(|_| StatusCode::InvalidMemoryAccess)?;
+) -> Result<U256, ActorError> {
+    let region = get_memory_region(&mut state.memory, index, size)?;
 
     let (buf, size) = system.rt.hash_64(
         SupportedHashes::Keccak256,

--- a/actors/evm/src/interpreter/instructions/lifecycle.rs
+++ b/actors/evm/src/interpreter/instructions/lifecycle.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 
 use fil_actors_runtime::deserialize_block;
+use fil_actors_runtime::ActorError;
 use fil_actors_runtime::EAM_ACTOR_ADDR;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::{strict_bytes, tuple::*};
@@ -15,7 +16,7 @@ use crate::interpreter::{address::EthAddress, U256};
 
 use super::memory::{get_memory_region, MemoryRegion};
 use {
-    crate::interpreter::{ExecutionState, StatusCode, System},
+    crate::interpreter::{ExecutionState, System},
     fil_actors_runtime::runtime::Runtime,
 };
 
@@ -51,9 +52,9 @@ pub fn create(
     value: U256,
     offset: U256,
     size: U256,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     if system.readonly {
-        return Err(StatusCode::StaticModeViolation);
+        return Err(ActorError::read_only("create called while read-only".into()));
     }
 
     let ExecutionState { stack: _, memory, .. } = state;
@@ -62,8 +63,7 @@ pub fn create(
     if value > system.rt.current_balance() {
         return Ok(U256::zero());
     }
-    let input_region =
-        get_memory_region(memory, offset, size).map_err(|_| StatusCode::InvalidMemoryAccess)?;
+    let input_region = get_memory_region(memory, offset, size)?;
 
     let input_data = if let Some(MemoryRegion { offset, size }) = input_region {
         &memory[offset..][..size.get()]
@@ -83,9 +83,9 @@ pub fn create2(
     offset: U256,
     size: U256,
     salt: U256,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     if system.readonly {
-        return Err(StatusCode::StaticModeViolation);
+        return Err(ActorError::read_only("create2 called while read-only".into()));
     }
 
     let ExecutionState { stack: _, memory, .. } = state;
@@ -96,8 +96,7 @@ pub fn create2(
         return Ok(U256::zero());
     }
 
-    let input_region =
-        get_memory_region(memory, offset, size).map_err(|_| StatusCode::InvalidMemoryAccess)?;
+    let input_region = get_memory_region(memory, offset, size)?;
 
     // BE encoded array
     let salt: [u8; 32] = salt.into();
@@ -120,7 +119,7 @@ fn create_init(
     params: Option<IpldBlock>,
     method: MethodNum,
     value: TokenAmount,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     // send bytecode & params to EAM to generate the address and contract
     let ret = system.send(&EAM_ACTOR_ADDR, method, params, value, None, SendFlags::default());
 
@@ -157,11 +156,11 @@ pub fn selfdestruct(
     _state: &mut ExecutionState,
     system: &mut System<impl Runtime>,
     beneficiary: U256,
-) -> Result<Output, StatusCode> {
+) -> Result<Output, ActorError> {
     use crate::interpreter::output::Outcome;
 
     if system.readonly {
-        return Err(StatusCode::StaticModeViolation);
+        return Err(ActorError::read_only("selfdestruct called while read-only".into()));
     }
 
     // Try to give funds to the beneficiary. If this fails, we just keep them.

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -16,9 +16,9 @@ pub mod state;
 pub mod storage;
 
 use crate::interpreter::execution::Machine;
-use crate::interpreter::output::StatusCode;
 use crate::interpreter::U256;
 use fil_actors_runtime::runtime::Runtime;
+use fil_actors_runtime::ActorError;
 
 macro_rules! rev {
     ($($args:ident),*) => {
@@ -36,7 +36,7 @@ macro_rules! def_op {
     ($op:ident ($m:ident) => { $($body:tt)* }) => {
         #[allow(non_snake_case)]
         #[inline(always)]
-        pub fn $op<'r, 'a, RT: Runtime + 'a>($m: &mut Machine<'r, 'a, RT> ) -> Result<(), StatusCode> {
+        pub fn $op<'r, 'a, RT: Runtime + 'a>($m: &mut Machine<'r, 'a, RT> ) -> Result<(), ActorError> {
             $($body)*
         }
     }

--- a/actors/evm/src/interpreter/instructions/stack.rs
+++ b/actors/evm/src/interpreter/instructions/stack.rs
@@ -1,7 +1,9 @@
 #![allow(clippy::missing_safety_doc)]
 
-use crate::interpreter::StatusCode;
-use {crate::interpreter::stack::Stack, crate::interpreter::U256};
+use fil_actors_runtime::ActorError;
+
+use crate::interpreter::stack::Stack;
+use crate::interpreter::U256;
 
 macro_rules! be_u64 {
     ($byte:expr) => {$byte as u64};
@@ -16,7 +18,7 @@ macro_rules! be_shift {
 }
 
 #[inline]
-pub(crate) fn push<const LEN: usize>(stack: &mut Stack, code: &[u8]) -> Result<usize, StatusCode> {
+pub(crate) fn push<const LEN: usize>(stack: &mut Stack, code: &[u8]) -> Result<usize, ActorError> {
     if code.len() < LEN {
         // this is a pathological edge case, as the contract will immediately stop execution.
         // we still handle it for correctness sake (and obviously avoid crashing out of bounds)
@@ -46,17 +48,17 @@ pub(crate) fn push<const LEN: usize>(stack: &mut Stack, code: &[u8]) -> Result<u
 }
 
 #[inline]
-pub(crate) fn dup<const HEIGHT: usize>(stack: &mut Stack) -> Result<(), StatusCode> {
+pub(crate) fn dup<const HEIGHT: usize>(stack: &mut Stack) -> Result<(), ActorError> {
     stack.dup(HEIGHT)
 }
 
 #[inline]
-pub(crate) fn swap<const HEIGHT: usize>(stack: &mut Stack) -> Result<(), StatusCode> {
+pub(crate) fn swap<const HEIGHT: usize>(stack: &mut Stack) -> Result<(), ActorError> {
     stack.swap_top(HEIGHT)
 }
 
 #[inline]
-pub(crate) fn pop(stack: &mut Stack) -> Result<(), StatusCode> {
+pub(crate) fn pop(stack: &mut Stack) -> Result<(), ActorError> {
     stack.drop()
 }
 

--- a/actors/evm/src/interpreter/instructions/state.rs
+++ b/actors/evm/src/interpreter/instructions/state.rs
@@ -1,9 +1,10 @@
+use fil_actors_runtime::ActorError;
 use fvm_shared::address::Address;
 
 use crate::U256;
 use {
     crate::interpreter::address::EthAddress,
-    crate::interpreter::{ExecutionState, StatusCode, System},
+    crate::interpreter::{ExecutionState, System},
     fil_actors_runtime::runtime::Runtime,
 };
 
@@ -12,7 +13,7 @@ pub fn balance(
     _state: &mut ExecutionState,
     system: &System<impl Runtime>,
     actor: U256,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     let addr: EthAddress = actor.into();
     let addr: Address = addr.into();
 
@@ -29,7 +30,7 @@ pub fn balance(
 pub fn selfbalance(
     _state: &mut ExecutionState,
     system: &System<impl Runtime>,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     // Returns native FIL balance of the receiver. Value precision is identical to Ethereum, so
     // no conversion needed (atto, 1e18).
     Ok(U256::from(&system.rt.current_balance()))

--- a/actors/evm/src/interpreter/instructions/storage.rs
+++ b/actors/evm/src/interpreter/instructions/storage.rs
@@ -1,5 +1,7 @@
+use fil_actors_runtime::ActorError;
+
 use {
-    crate::interpreter::{ExecutionState, StatusCode, System, U256},
+    crate::interpreter::{ExecutionState, System, U256},
     fil_actors_runtime::runtime::Runtime,
 };
 
@@ -8,7 +10,7 @@ pub fn sload(
     _state: &mut ExecutionState,
     system: &mut System<impl Runtime>,
     location: U256,
-) -> Result<U256, StatusCode> {
+) -> Result<U256, ActorError> {
     // get from storage and place on stack
     system.get_storage(location)
 }
@@ -19,9 +21,9 @@ pub fn sstore(
     system: &mut System<impl Runtime>,
     key: U256,
     value: U256,
-) -> Result<(), StatusCode> {
+) -> Result<(), ActorError> {
     if system.readonly {
-        return Err(StatusCode::StaticModeViolation);
+        return Err(ActorError::read_only("store called while read-only".into()));
     }
 
     system.set_storage(key, value)

--- a/actors/evm/src/interpreter/mod.rs
+++ b/actors/evm/src/interpreter/mod.rs
@@ -12,7 +12,7 @@ pub mod uints;
 pub use {
     bytecode::Bytecode,
     execution::{execute, ExecutionState},
-    output::{Output, StatusCode},
+    output::Output,
     system::System,
     uints::{U256, U512},
 };

--- a/actors/evm/src/interpreter/output.rs
+++ b/actors/evm/src/interpreter/output.rs
@@ -1,5 +1,6 @@
-use fil_actors_runtime::ActorError as RTActorError;
-use {bytes::Bytes, std::fmt::Debug, strum_macros::Display};
+use std::fmt::Debug;
+
+use bytes::Bytes;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum Outcome {
@@ -15,97 +16,4 @@ pub struct Output {
     pub outcome: Outcome,
     /// The return data.
     pub return_data: Bytes,
-}
-
-/// Message status code.
-#[must_use]
-#[derive(Clone, Debug, Display, PartialEq, Eq)]
-pub enum StatusCode {
-    /// The designated INVALID instruction has been hit during execution.
-    ///
-    /// [EIP-141](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-141.md)
-    /// defines the instruction 0xfe as INVALID instruction to indicate execution
-    /// abortion coming from high-level languages. This status code is reported
-    /// in case this INVALID instruction has been encountered.
-    #[strum(serialize = "invalid instruction")]
-    InvalidInstruction,
-
-    /// An argument passed to an instruction does not meet expectations.
-    #[strum(serialize = "invalid argument")]
-    InvalidArgument(String),
-
-    /// An undefined instruction has been encountered.
-    #[strum(serialize = "undefined instruction")]
-    UndefinedInstruction,
-
-    /// The execution has attempted to put more items on the EVM stack
-    /// than the specified limit.
-    #[strum(serialize = "stack overflow")]
-    StackOverflow,
-
-    /// Execution of an opcode has required more items on the EVM stack.
-    #[strum(serialize = "stack underflow")]
-    StackUnderflow,
-
-    /// Execution has violated the jump destination restrictions.
-    #[strum(serialize = "bad jump destination")]
-    BadJumpDestination,
-
-    /// Tried to read outside memory bounds.
-    ///
-    /// An example is RETURNDATACOPY reading past the available buffer.
-    #[strum(serialize = "invalid memory access")]
-    InvalidMemoryAccess,
-
-    /// Call depth has exceeded the limit (if any)
-    #[strum(serialize = "call depth exceeded")]
-    CallDepthExceeded,
-
-    /// Tried to execute an operation which is restricted in static mode.
-    #[strum(serialize = "static mode violation")]
-    StaticModeViolation,
-
-    /// A call to a precompiled or system contract has ended with a failure.
-    ///
-    /// An example: elliptic curve functions handed invalid EC points.
-    #[strum(serialize = "precompile failure")]
-    PrecompileFailure,
-
-    /// Contract validation has failed.
-    #[strum(serialize = "contract validation failure")]
-    ContractValidationFailure,
-
-    /// An argument to a state accessing method has a value outside of the
-    /// accepted range of values.
-    #[strum(serialize = "argument out of range")]
-    ArgumentOutOfRange(String),
-
-    /// The caller does not have enough funds for value transfer.
-    #[strum(serialize = "insufficient balance")]
-    InsufficientBalance,
-
-    /// EVM implementation generic internal error.
-    #[strum(serialize = "internal error")]
-    InternalError(String),
-
-    /// Invalid Address
-    #[strum(serialize = "bad address")]
-    BadAddress(String),
-
-    /// Nested Actor invocation Error
-    #[strum(serialize = "runtime actor error")]
-    ActorError(RTActorError),
-}
-
-// Map ActorError to a generic internal error status code.
-impl From<RTActorError> for StatusCode {
-    fn from(ae: RTActorError) -> Self {
-        Self::ActorError(ae)
-    }
-}
-
-impl From<fvm_ipld_encoding::Error> for StatusCode {
-    fn from(err: fvm_ipld_encoding::Error) -> Self {
-        Self::InternalError(format!("IPLD error: {:?}", &err))
-    }
 }

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code, clippy::missing_safety_doc)]
 
-use crate::interpreter::U256;
+use fil_actors_runtime::{ActorError, AsActorError};
 
-use super::StatusCode;
+use crate::{interpreter::U256, EVM_CONTRACT_STACK_OVERFLOW, EVM_CONTRACT_STACK_UNDERFLOW};
 
 /// Ethereum Yellow Paper (9.1)
 pub const STACK_SIZE: usize = 1024;
@@ -37,9 +37,9 @@ impl Stack {
     }
 
     #[inline(always)]
-    pub fn push(&mut self, value: U256) -> Result<(), StatusCode> {
+    pub fn push(&mut self, value: U256) -> Result<(), ActorError> {
         if self.stack.len() >= STACK_SIZE {
-            Err(StatusCode::StackOverflow)
+            Err(ActorError::unchecked(EVM_CONTRACT_STACK_OVERFLOW, "stack overflow".into()))
         } else {
             self.stack.push(value);
             Ok(())
@@ -47,9 +47,12 @@ impl Stack {
     }
 
     #[inline]
-    pub fn pop_many<const S: usize>(&mut self) -> Result<&[U256; S], StatusCode> {
+    pub fn pop_many<const S: usize>(&mut self) -> Result<&[U256; S], ActorError> {
         if self.len() < S {
-            return Err(StatusCode::StackUnderflow);
+            return Err(ActorError::unchecked(
+                EVM_CONTRACT_STACK_UNDERFLOW,
+                "stack underflow".into(),
+            ));
         }
         let new_len = self.len() - S;
         unsafe {
@@ -66,21 +69,21 @@ impl Stack {
 
     #[inline(always)]
     /// Ensures at least one more item is able to be allocated on the stack.
-    pub fn ensure_one(&self) -> Result<(), StatusCode> {
+    pub fn ensure_one(&self) -> Result<(), ActorError> {
         if self.stack.len() >= STACK_SIZE {
-            Err(StatusCode::StackOverflow)
+            Err(ActorError::unchecked(EVM_CONTRACT_STACK_OVERFLOW, "stack overflow".into()))
         } else {
             Ok(())
         }
     }
 
     #[inline]
-    pub fn dup(&mut self, i: usize) -> Result<(), StatusCode> {
+    pub fn dup(&mut self, i: usize) -> Result<(), ActorError> {
         let len = self.stack.len();
         if len >= STACK_SIZE {
-            Err(StatusCode::StackOverflow)
+            Err(ActorError::unchecked(EVM_CONTRACT_STACK_OVERFLOW, "stack overflow".into()))
         } else if i > len {
-            Err(StatusCode::StackUnderflow)
+            Err(ActorError::unchecked(EVM_CONTRACT_STACK_UNDERFLOW, "stack underflow".into()))
         } else {
             unsafe {
                 // This is safe because we're careful not to alias. We're _basically_ implementing
@@ -96,26 +99,29 @@ impl Stack {
     }
 
     #[inline]
-    pub fn swap_top(&mut self, i: usize) -> Result<(), StatusCode> {
+    pub fn swap_top(&mut self, i: usize) -> Result<(), ActorError> {
         let len = self.stack.len();
         if len <= i {
-            return Err(StatusCode::StackUnderflow);
+            return Err(ActorError::unchecked(
+                EVM_CONTRACT_STACK_UNDERFLOW,
+                "stack underflow".into(),
+            ));
         }
         self.stack.swap(len - i - 1, len - 1);
         Ok(())
     }
 
     #[inline]
-    pub fn pop(&mut self) -> Result<U256, StatusCode> {
-        self.stack.pop().ok_or(StatusCode::StackUnderflow)
+    pub fn pop(&mut self) -> Result<U256, ActorError> {
+        self.stack.pop().context_code(EVM_CONTRACT_STACK_UNDERFLOW, "stack underflow")
     }
 
     #[inline]
-    pub fn drop(&mut self) -> Result<(), StatusCode> {
+    pub fn drop(&mut self) -> Result<(), ActorError> {
         if self.stack.pop().is_some() {
             Ok(())
         } else {
-            Err(StatusCode::StackUnderflow)
+            Err(ActorError::unchecked(EVM_CONTRACT_STACK_UNDERFLOW, "stack underflow".into()))
         }
     }
 }
@@ -157,13 +163,13 @@ fn test_stack_swap() {
 #[test]
 fn test_stack_swap_underflow() {
     let mut stack = Stack::new();
-    assert_eq!(stack.swap_top(1).unwrap_err(), StatusCode::StackUnderflow);
+    assert_eq!(stack.swap_top(1).unwrap_err().exit_code(), EVM_CONTRACT_STACK_UNDERFLOW);
 
     stack.push(1.into()).unwrap();
-    assert_eq!(stack.swap_top(1).unwrap_err(), StatusCode::StackUnderflow);
+    assert_eq!(stack.swap_top(1).unwrap_err().exit_code(), EVM_CONTRACT_STACK_UNDERFLOW);
 
     stack.push(2.into()).unwrap();
-    assert_eq!(stack.swap_top(2).unwrap_err(), StatusCode::StackUnderflow);
+    assert_eq!(stack.swap_top(2).unwrap_err().exit_code(), EVM_CONTRACT_STACK_UNDERFLOW);
 }
 
 #[test]
@@ -182,9 +188,9 @@ fn test_stack_dup() {
 #[test]
 fn test_stack_dup_underflow() {
     let mut stack = Stack::new();
-    assert_eq!(stack.dup(1).unwrap_err(), StatusCode::StackUnderflow);
+    assert_eq!(stack.dup(1).unwrap_err().exit_code(), EVM_CONTRACT_STACK_UNDERFLOW);
     stack.push(1.into()).unwrap();
-    assert_eq!(stack.dup(2).unwrap_err(), StatusCode::StackUnderflow);
+    assert_eq!(stack.dup(2).unwrap_err().exit_code(), EVM_CONTRACT_STACK_UNDERFLOW);
 }
 
 #[test]
@@ -194,8 +200,8 @@ fn test_stack_overflow() {
         stack.push(i.into()).unwrap();
     }
 
-    assert_eq!(stack.push(1024.into()).unwrap_err(), StatusCode::StackOverflow);
-    assert_eq!(stack.dup(1).unwrap_err(), StatusCode::StackOverflow);
+    assert_eq!(stack.push(1024.into()).unwrap_err().exit_code(), EVM_CONTRACT_STACK_OVERFLOW);
+    assert_eq!(stack.dup(1).unwrap_err().exit_code(), EVM_CONTRACT_STACK_OVERFLOW);
     stack.swap_top(1).unwrap();
     assert_eq!(stack.pop().unwrap(), 1022);
 }

--- a/runtime/src/actor_error.rs
+++ b/runtime/src/actor_error.rs
@@ -90,6 +90,9 @@ impl ActorError {
     pub fn assertion_failed(msg: String) -> Self {
         Self { exit_code: ExitCode::USR_ASSERTION_FAILED, msg, data: None }
     }
+    pub fn read_only(msg: String) -> Self {
+        Self { exit_code: ExitCode::USR_READ_ONLY, msg, data: None }
+    }
 
     /// Returns the exit code of the error.
     pub fn exit_code(&self) -> ExitCode {


### PR DESCRIPTION
Remove "StatusCode" as we were just turning those into actor errors anyways. Instead, we return meaningful exit codes:

- 34: Invalid Instruction (assert)
- 35: Undefined Instruction (bad instruction)
- 36: Stack Underflow
- 37: Stack Underflow
- 38: Illegal Memory Access
- 39: Bad Jump Destination

This change also ensures that meaningful error messages get sent through the FVM (although they're not committed on-chain).

fixes #1195