### PR TITLE
[DO NOT MERGE] PoC: feat: disable FEVM

### DIFF
--- a/actors/eam/src/lib.rs
+++ b/actors/eam/src/lib.rs
@@ -9,12 +9,12 @@ use ext::{
     init::{Exec4Params, Exec4Return},
 };
 use fil_actors_runtime::{
-    actor_dispatch_unrestricted, actor_error, deserialize_block, extract_send_result, ActorError,
-    AsActorError, EAM_ACTOR_ID, INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    actor_error, deserialize_block, extract_send_result, ActorError, AsActorError, EAM_ACTOR_ID,
+    INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_shared::{error::ExitCode, sys::SendFlags, ActorID, METHOD_CONSTRUCTOR};
+use fvm_shared::{error::ExitCode, sys::SendFlags, ActorID, MethodNum, METHOD_CONSTRUCTOR};
 use serde::{Deserialize, Serialize};
 
 pub mod ext;
@@ -293,12 +293,23 @@ impl EamActor {
 
 impl ActorCode for EamActor {
     type Methods = Method;
-    actor_dispatch_unrestricted! {
-        Constructor => constructor,
-        Create => create,
-        Create2 => create2,
-        CreateExternal => create_external,
+    fn invoke_method<RT>(
+        _rt: &mut RT,
+        _method: MethodNum,
+        _args: Option<IpldBlock>,
+    ) -> Result<Option<IpldBlock>, ActorError>
+    where
+        RT: Runtime,
+        RT::Blockstore: Clone,
+    {
+        Err(actor_error!(illegal_argument; "EAM has been disabled"))
     }
+    // actor_dispatch_unrestricted! {
+    //     Constructor => constructor,
+    //     Create => create,
+    //     Create2 => create2,
+    //     CreateExternal => create_external,
+    // }
 }
 
 #[cfg(test)]

--- a/actors/ethaccount/src/lib.rs
+++ b/actors/ethaccount/src/lib.rs
@@ -7,7 +7,7 @@ use num_derive::FromPrimitive;
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_dispatch, actor_error, ActorError, EAM_ACTOR_ID, FIRST_EXPORTED_METHOD_NUMBER,
+    actor_error, ActorError, AsActorError, EAM_ACTOR_ID, FIRST_EXPORTED_METHOD_NUMBER,
     SYSTEM_ACTOR_ADDR,
 };
 
@@ -67,8 +67,20 @@ impl EthAccountActor {
 
 impl ActorCode for EthAccountActor {
     type Methods = Method;
-    actor_dispatch! {
-        Constructor => constructor,
-        _ => fallback [raw],
+    fn invoke_method<RT>(
+        _rt: &mut RT,
+        _method: MethodNum,
+        _args: Option<IpldBlock>,
+    ) -> Result<Option<IpldBlock>, ActorError>
+    where
+        RT: Runtime,
+        RT::Blockstore: Clone,
+    {
+        Err(actor_error!(illegal_argument; "EthAccount has been disabled"))
     }
+    // actor_dispatch! {
+    //     Constructor => constructor,
+    //     AuthenticateMessageExported => authenticate_message,
+    //     _ => fallback [raw],
+    // }
 }

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -388,6 +388,9 @@ impl ActorCode for EvmContractActor {
         RT: Runtime,
         RT::Blockstore: Clone,
     {
+        if true {
+            return Err(actor_error!(illegal_argument; "EVM has been disabled"));
+        }
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {
                 Self::constructor(


### PR DESCRIPTION
https://github.com/filecoin-project/ref-fvm/issues/1202
https://github.com/filecoin-project/lotus/issues/9797

I think this is the cleanest way to achieve what we want here. We would need a new actors bundle with this change, and a new network version in clients to ship this out.

With this, we will disable (nearly) all interactions with FEVM functionality including new contract deployments, invocations of existing contracts, etc. The only 2 FEVM-related functionality that can still occur include:

- Sends to the EAM / EthAccounts / Placeholders / EVM contracts
  - I think this is fine, I don't think there'd ever be a case when we'd want to restrict that
- creation of new placeholders, as well as their transformation into EthAccounts
  - I think this is fine, but we can easily disable this too by disallowing f4 addresses as senders / recipients in clients
- sends _from_ EthAccounts
  - Same as previous