### PR TITLE
feat: allow all unrestricted method numbers on accounts

### DIFF
--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -1,17 +1,17 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_actor_utils::receiver::UniversalReceiverParams;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::{Address, Protocol};
 use fvm_shared::crypto::signature::SignatureType::{Secp256k1, BLS};
 use fvm_shared::crypto::signature::{Signature, SignatureType};
 use fvm_shared::error::ExitCode;
-use fvm_shared::METHOD_CONSTRUCTOR;
+use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
 use num_derive::FromPrimitive;
 
 use fil_actors_runtime::builtin::singletons::SYSTEM_ACTOR_ADDR;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_dispatch, ActorDowncast};
+use fil_actors_runtime::{actor_dispatch, ActorDowncast, FIRST_EXPORTED_METHOD_NUMBER};
 use fil_actors_runtime::{actor_error, ActorError};
 
 use crate::types::AuthenticateMessageParams;
@@ -34,7 +34,6 @@ pub enum Method {
     // Deprecated in v10
     // AuthenticateMessage = 3,
     AuthenticateMessageExported = frc42_dispatch::method_hash!("AuthenticateMessage"),
-    UniversalReceiverHook = frc42_dispatch::method_hash!("Receive"),
 }
 
 /// Account Actor
@@ -91,13 +90,18 @@ impl Actor {
         Ok(())
     }
 
-    // Always succeeds, accepting any transfers.
-    pub fn universal_receiver_hook(
+    /// Fallback method for unimplemented method numbers.
+    pub fn fallback(
         rt: &mut impl Runtime,
-        _params: UniversalReceiverParams,
-    ) -> Result<(), ActorError> {
+        method: MethodNum,
+        _: Option<IpldBlock>,
+    ) -> Result<Option<IpldBlock>, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
-        Ok(())
+        if method >= FIRST_EXPORTED_METHOD_NUMBER {
+            Ok(None)
+        } else {
+            Err(actor_error!(unhandled_message; "invalid method: {}", method))
+        }
     }
 }
 
@@ -107,6 +111,6 @@ impl ActorCode for Actor {
         Constructor => constructor,
         PubkeyAddress => pubkey_address,
         AuthenticateMessageExported => authenticate_message,
-        UniversalReceiverHook => universal_receiver_hook,
+        _ => fallback [raw],
     }
 }

--- a/actors/account/tests/account_actor_test.rs
+++ b/actors/account/tests/account_actor_test.rs
@@ -76,7 +76,7 @@ fn token_receiver() {
     rt.expect_validate_caller_any();
     let ret = rt
         .call::<AccountActor>(
-            Method::UniversalReceiverHook as MethodNum,
+            frc42_dispatch::method_hash!("Receive"),
             IpldBlock::serialize_cbor(&UniversalReceiverParams {
                 type_: 0,
                 payload: RawBytes::new(vec![1, 2, 3]),

--- a/actors/ethaccount/src/lib.rs
+++ b/actors/ethaccount/src/lib.rs
@@ -1,17 +1,17 @@
 pub mod types;
 
-use fvm_actor_utils::receiver::UniversalReceiverParams;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::{Payload, Protocol};
 use fvm_shared::crypto::hash::SupportedHashes::Keccak256;
 use fvm_shared::error::ExitCode;
-use fvm_shared::METHOD_CONSTRUCTOR;
+use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
 use num_derive::FromPrimitive;
 
 use crate::types::AuthenticateMessageParams;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
     actor_dispatch, actor_error, ActorDowncast, ActorError, AsActorError, EAM_ACTOR_ID,
-    SYSTEM_ACTOR_ADDR,
+    FIRST_EXPORTED_METHOD_NUMBER, SYSTEM_ACTOR_ADDR,
 };
 
 #[cfg(feature = "fil-actor")]
@@ -23,7 +23,6 @@ fil_actors_runtime::wasm_trampoline!(EthAccountActor);
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
     AuthenticateMessageExported = frc42_dispatch::method_hash!("AuthenticateMessage"),
-    UniversalReceiverHook = frc42_dispatch::method_hash!("Receive"),
 }
 
 /// Ethereum Account actor.
@@ -127,12 +126,17 @@ impl EthAccountActor {
     }
 
     // Always succeeds, accepting any transfers.
-    pub fn universal_receiver_hook(
+    pub fn fallback(
         rt: &mut impl Runtime,
-        _params: UniversalReceiverParams,
-    ) -> Result<(), ActorError> {
+        method: MethodNum,
+        _: Option<IpldBlock>,
+    ) -> Result<Option<IpldBlock>, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
-        Ok(())
+        if method >= FIRST_EXPORTED_METHOD_NUMBER {
+            Ok(None)
+        } else {
+            Err(actor_error!(unhandled_message; "invalid method: {}", method))
+        }
     }
 }
 
@@ -141,6 +145,6 @@ impl ActorCode for EthAccountActor {
     actor_dispatch! {
         Constructor => constructor,
         AuthenticateMessageExported => authenticate_message,
-        UniversalReceiverHook => universal_receiver_hook,
+        _ => fallback [raw],
     }
 }

--- a/actors/ethaccount/tests/ethaccount_test.rs
+++ b/actors/ethaccount/tests/ethaccount_test.rs
@@ -36,7 +36,7 @@ fn token_receiver() {
     rt.expect_validate_caller_any();
     let ret = rt
         .call::<EthAccountActor>(
-            Method::UniversalReceiverHook as MethodNum,
+            frc42_dispatch::method_hash!("Receive"),
             IpldBlock::serialize_cbor(&UniversalReceiverParams {
                 type_: 0,
                 payload: RawBytes::new(vec![1, 2, 3]),


### PR DESCRIPTION
This patch implements a "raw" fallback for both account types that simply accepts all methods greater than or equal to the min FRC0042 number.

Alternative to #1081

Fixes https://github.com/filecoin-project/builtin-actors/pull/1076