### PR TITLE
EVM: Bubble up syscall errors from runtime

### DIFF
--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -183,6 +183,8 @@ pub(super) fn call_actor_shared<RT: Runtime>(
         )
     };
 
+    log::debug!("{:?}", result);
+
     // ------ Build Output -------
 
     let output = {

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -186,12 +186,12 @@ pub(super) fn call_actor_shared<RT: Runtime>(
     // ------ Build Output -------
 
     let output = {
-        // negative values are syscall errors
+        // negative values are syscall/system errors
         // positive values are user/actor errors
         // success is 0
         let (exit_code, data) = match result {
             Err(syscall_err) => {
-                let exit_code = U256::from(syscall_err.exit_code().value());
+                let exit_code = U256::from(syscall_err.value());
                 (exit_code.i256_neg(), None)
             }
             Ok(ret) => match ret {

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -173,7 +173,14 @@ pub(super) fn call_actor_shared<RT: Runtime>(
             0 if params.is_empty() => None,
             _ => return Err(PrecompileError::InvalidInput),
         };
-        system.send(&address, method, params, TokenAmount::from(&value), Some(ctx.gas_limit), flags)
+        system.send_raw(
+            &address,
+            method,
+            params,
+            TokenAmount::from(&value),
+            Some(ctx.gas_limit),
+            flags,
+        )
     };
 
     // ------ Build Output -------
@@ -183,16 +190,19 @@ pub(super) fn call_actor_shared<RT: Runtime>(
         // positive values are user/actor errors
         // success is 0
         let (exit_code, data) = match result {
-            Err(mut ae) => {
-                // TODO handle revert
-                // TODO https://github.com/filecoin-project/ref-fvm/issues/1020
-                // put error number from call into revert
-                let exit_code = U256::from(ae.exit_code().value());
-
-                // no return only exit code
-                (exit_code, ae.take_data())
+            Err(syscall_err) => {
+                let exit_code = U256::from(syscall_err.exit_code().value());
+                (exit_code.i256_neg(), None)
             }
-            Ok(ret) => (U256::zero(), ret),
+            Ok(ret) => match ret {
+                Err(exit) => {
+                    // put error number from call into revert
+                    let exit_code = U256::from(exit.exit_code.value());
+                    // exit with any return data
+                    (exit_code, exit.return_data)
+                }
+                Ok(ret) => (U256::zero(), ret),
+            },
         };
 
         let ret_blk = data.unwrap_or(IpldBlock { codec: 0, data: vec![] });

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -183,8 +183,6 @@ pub(super) fn call_actor_shared<RT: Runtime>(
         )
     };
 
-    log::debug!("{:?}", result);
-
     // ------ Build Output -------
 
     let output = {

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -254,18 +254,14 @@ impl<'r, RT: Runtime> System<'r, RT> {
             .send_generalized(to, method, params, value, gas_limit, send_flags)
             .map_err(|err| {
                 let exit = ExitCode::new(err as u32);
-                ActorError::checked(exit, format!("send failed: {}", err))
+                ActorError::unchecked(exit, format!("send failed: {}", err))
             })?;
 
         if !send_flags.read_only() {
             self.reload()?;
         }
 
-        Ok(if !result.exit_code.is_success() {
-            Err(result)
-        } else {
-            Ok(result.return_data)
-        })
+        Ok(if !result.exit_code.is_success() { Err(result) } else { Ok(result.return_data) })
     }
 
     /// Flush the actor state (bytecode, nonce, and slots).

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -1074,14 +1074,6 @@ impl From<CallActorReturn> for Vec<u8> {
     }
 }
 
-#[test]
-fn aaab() {
-    let a = "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffb000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000";
-    let a = hex::decode(a).unwrap();
-    let a = CallActorReturn::from(a.as_slice());
-    println!("{:?}", a);
-}
-
 impl From<&[u8]> for CallActorReturn {
     fn from(src: &[u8]) -> Self {
         fn assert_zero_bytes<const S: usize>(src: &[u8]) {


### PR DESCRIPTION
- Update call_actor precompiles to finally return system errors as negative
- add for the ability to test for syscall errors in the mock runtime