### PR TITLE
Update to FVM SDK 3.0.0-alpha.22, shared 3.0.0-alpha.17, ipld_encoding 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,8 +551,8 @@ dependencies = [
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0-alpha.17",
  "num-derive",
  "num-traits",
  "serde",
@@ -571,7 +571,7 @@ dependencies = [
  "futures",
  "fvm_ipld_blockstore",
  "fvm_ipld_car",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
@@ -583,8 +583,8 @@ version = "10.0.0-alpha.1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0-alpha.17",
  "log",
  "num-derive",
  "num-traits",
@@ -601,9 +601,9 @@ dependencies = [
  "frc46_token",
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 3.0.0-alpha.17",
  "lazy_static",
  "log",
  "num-derive",
@@ -620,9 +620,9 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 3.0.0-alpha.17",
  "log",
  "num-derive",
  "num-traits",
@@ -644,9 +644,9 @@ dependencies = [
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 3.0.0-alpha.17",
  "integer-encoding",
  "itertools",
  "libipld-core 0.13.1",
@@ -674,9 +674,9 @@ dependencies = [
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 3.0.0-alpha.17",
  "itertools",
  "lazy_static",
  "log",
@@ -698,9 +698,9 @@ dependencies = [
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 3.0.0-alpha.17",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -720,8 +720,8 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_amt",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0-alpha.17",
  "num-derive",
  "num-traits",
  "serde",
@@ -737,9 +737,9 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 3.0.0-alpha.17",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -755,8 +755,8 @@ version = "10.0.0-alpha.1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0-alpha.17",
  "lazy_static",
  "log",
  "num",
@@ -773,8 +773,8 @@ dependencies = [
  "cid",
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0-alpha.17",
  "num-derive",
  "num-traits",
  "serde",
@@ -791,9 +791,9 @@ dependencies = [
  "frc46_token",
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 3.0.0-alpha.17",
  "lazy_static",
  "log",
  "num-derive",
@@ -815,10 +815,10 @@ dependencies = [
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_sdk",
- "fvm_shared",
+ "fvm_sdk 3.0.0-alpha.22",
+ "fvm_shared 3.0.0-alpha.17",
  "getrandom",
  "hex",
  "indexmap",
@@ -885,8 +885,8 @@ dependencies = [
  "fil_actors_runtime",
  "frc46_token",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0-alpha.17",
  "num-derive",
  "num-traits",
  "serde",
@@ -910,31 +910,34 @@ dependencies = [
 
 [[package]]
 name = "frc42_dispatch"
-version = "3.0.0"
-source = "git+https://github.com/helix-onchain/filecoin?branch=main#2ce589f689dcd41109e6b2cbb718ac7b3f5b6334"
+version = "3.0.1-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4831f9a09043a3796e88dd6683f5c1ded58bfbb6dbde95708ee675cf3c6b157b"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
- "fvm_ipld_encoding",
- "fvm_sdk",
- "fvm_shared",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_sdk 3.0.0-alpha.22",
+ "fvm_shared 3.0.0-alpha.17",
  "thiserror",
 ]
 
 [[package]]
 name = "frc42_hasher"
 version = "1.3.0"
-source = "git+https://github.com/helix-onchain/filecoin?branch=main#2ce589f689dcd41109e6b2cbb718ac7b3f5b6334"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cf52e60a67e9ad15cd4909ef8c8e45ab3744015dbb603efd8dfbdbfc7ce95b7"
 dependencies = [
- "fvm_sdk",
- "fvm_shared",
+ "fvm_sdk 2.2.0",
+ "fvm_shared 2.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "frc42_macros"
 version = "1.0.0"
-source = "git+https://github.com/helix-onchain/filecoin?branch=main#2ce589f689dcd41109e6b2cbb718ac7b3f5b6334"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c343356c3652593452cc1cfe95535a915261342e2a4c13bb8388ca29b259a400"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
@@ -945,8 +948,9 @@ dependencies = [
 
 [[package]]
 name = "frc46_token"
-version = "3.1.0"
-source = "git+https://github.com/helix-onchain/filecoin?branch=main#2ce589f689dcd41109e6b2cbb718ac7b3f5b6334"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361570ac004ff4c032db36985790b39a7c3e30c039dcc98661155227eba378f4"
 dependencies = [
  "anyhow",
  "cid",
@@ -954,10 +958,10 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_amt",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_sdk",
- "fvm_shared",
+ "fvm_sdk 3.0.0-alpha.22",
+ "fvm_shared 3.0.0-alpha.17",
  "integer-encoding",
  "num-traits",
  "serde",
@@ -1071,16 +1075,17 @@ dependencies = [
 
 [[package]]
 name = "fvm_actor_utils"
-version = "3.0.0"
-source = "git+https://github.com/helix-onchain/filecoin?branch=main#2ce589f689dcd41109e6b2cbb718ac7b3f5b6334"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a584440086c6900c43b131b326751aeb45e1ec547fbf62299db61d8eeb060f8"
 dependencies = [
  "anyhow",
  "cid",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
- "fvm_sdk",
- "fvm_shared",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_sdk 3.0.0-alpha.22",
+ "fvm_shared 3.0.0-alpha.17",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -1096,7 +1101,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "itertools",
  "once_cell",
  "serde",
@@ -1109,7 +1114,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
 dependencies = [
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "serde",
  "thiserror",
  "unsigned-varint",
@@ -1135,9 +1140,27 @@ dependencies = [
  "cid",
  "futures",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "integer-encoding",
  "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_ipld_encoding"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa1ff5ba581625ab38cf2829fbd04ac232c6277466fdbe0270b42dcb976902d5"
+dependencies = [
+ "anyhow",
+ "cid",
+ "cs_serde_bytes",
+ "fvm_ipld_blockstore",
+ "multihash",
+ "serde",
+ "serde_ipld_dagcbor",
+ "serde_repr",
+ "serde_tuple",
  "thiserror",
 ]
 
@@ -1169,7 +1192,7 @@ dependencies = [
  "cid",
  "forest_hash_utils",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "libipld-core 0.14.0",
  "multihash",
  "once_cell",
@@ -1180,17 +1203,61 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb46d7b26e1609de1a3b7470cbd190d78f2d01fdf1b317f741bdd3ac8f59825e"
+dependencies = [
+ "cid",
+ "fvm_ipld_encoding 0.2.3",
+ "fvm_shared 2.0.0",
+ "lazy_static",
+ "log",
+ "num-traits",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_sdk"
 version = "3.0.0-alpha.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51908aab9e7564fbcb278d78e31c12402b68c70517661780feb29adbb234aaf"
 dependencies = [
  "cid",
- "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0-alpha.17",
  "lazy_static",
  "log",
  "num-traits",
  "thiserror",
+]
+
+[[package]]
+name = "fvm_shared"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7d1de62b7b74909d6e4816de83c4e6b46017bba9a31bb0de82b6b26b11cf74"
+dependencies = [
+ "anyhow",
+ "blake2b_simd",
+ "byteorder",
+ "cid",
+ "cs_serde_bytes",
+ "data-encoding",
+ "data-encoding-macro",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.2.3",
+ "lazy_static",
+ "log",
+ "multihash",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "serde_repr",
+ "serde_tuple",
+ "thiserror",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -1207,7 +1274,7 @@ dependencies = [
  "data-encoding",
  "data-encoding-macro",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "lazy_static",
  "log",
  "multihash",
@@ -1956,9 +2023,9 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_shared 3.0.0-alpha.17",
  "indexmap",
  "integer-encoding",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,9 +133,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -155,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-waker"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
+checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
 
 [[package]]
 name = "atty"
@@ -260,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"
@@ -355,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -562,7 +551,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -571,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_bundler"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0550a13a20decf920aeeb630a648b13174af5acf6b513895996ff1cd09393d"
+checksum = "4a3138c84b845e64c6ad0c50ef299f954d979bd265c8b74509a22b9d1b8107e0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -582,7 +571,7 @@ dependencies = [
  "futures",
  "fvm_ipld_blockstore",
  "fvm_ipld_car",
- "fvm_ipld_encoding 0.3.2",
+ "fvm_ipld_encoding",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
@@ -594,7 +583,7 @@ version = "10.0.0-alpha.1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "log",
  "num-derive",
@@ -612,8 +601,8 @@ dependencies = [
  "frc46_token",
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt 0.6.1",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
  "fvm_shared",
  "lazy_static",
  "log",
@@ -631,8 +620,8 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt 0.6.1",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
  "fvm_shared",
  "log",
  "num-derive",
@@ -652,11 +641,11 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "frc46_token",
- "fvm_ipld_amt 0.5.1",
+ "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt 0.6.1",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
  "fvm_shared",
  "integer-encoding",
  "itertools",
@@ -682,11 +671,11 @@ dependencies = [
  "fil_actor_reward",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_amt 0.5.1",
+ "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt 0.6.1",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
  "fvm_shared",
  "itertools",
  "lazy_static",
@@ -709,8 +698,8 @@ dependencies = [
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt 0.6.1",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
  "fvm_shared",
  "indexmap",
  "integer-encoding",
@@ -729,9 +718,9 @@ dependencies = [
  "derive_builder",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_amt 0.5.1",
+ "fvm_ipld_amt",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -748,8 +737,8 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt 0.6.1",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
  "fvm_shared",
  "indexmap",
  "integer-encoding",
@@ -766,7 +755,7 @@ version = "10.0.0-alpha.1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "lazy_static",
  "log",
@@ -784,7 +773,7 @@ dependencies = [
  "cid",
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -802,8 +791,8 @@ dependencies = [
  "frc46_token",
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt 0.6.1",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
  "fvm_shared",
  "lazy_static",
  "log",
@@ -823,11 +812,11 @@ dependencies = [
  "castaway",
  "cid",
  "derive_builder",
- "fvm_ipld_amt 0.5.1",
+ "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt 0.6.1",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
  "fvm_sdk",
  "fvm_shared",
  "getrandom",
@@ -896,7 +885,7 @@ dependencies = [
  "fil_actors_runtime",
  "frc46_token",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -922,12 +911,11 @@ dependencies = [
 [[package]]
 name = "frc42_dispatch"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a093747f6447d7528cf37b87b8ab9879c7417e960d2ea1ac523890eb3a924e2a"
+source = "git+https://github.com/helix-onchain/filecoin?branch=main#2ce589f689dcd41109e6b2cbb718ac7b3f5b6334"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
- "fvm_ipld_encoding 0.2.3",
+ "fvm_ipld_encoding",
  "fvm_sdk",
  "fvm_shared",
  "thiserror",
@@ -936,8 +924,7 @@ dependencies = [
 [[package]]
 name = "frc42_hasher"
 version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf52e60a67e9ad15cd4909ef8c8e45ab3744015dbb603efd8dfbdbfc7ce95b7"
+source = "git+https://github.com/helix-onchain/filecoin?branch=main#2ce589f689dcd41109e6b2cbb718ac7b3f5b6334"
 dependencies = [
  "fvm_sdk",
  "fvm_shared",
@@ -947,8 +934,7 @@ dependencies = [
 [[package]]
 name = "frc42_macros"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c343356c3652593452cc1cfe95535a915261342e2a4c13bb8388ca29b259a400"
+source = "git+https://github.com/helix-onchain/filecoin?branch=main#2ce589f689dcd41109e6b2cbb718ac7b3f5b6334"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
@@ -960,17 +946,16 @@ dependencies = [
 [[package]]
 name = "frc46_token"
 version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112bdb7d37e58715087146b19465f59374e8cffd81561a8d20dbdb1eb2c75fbe"
+source = "git+https://github.com/helix-onchain/filecoin?branch=main#2ce589f689dcd41109e6b2cbb718ac7b3f5b6334"
 dependencies = [
  "anyhow",
  "cid",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_amt 0.4.2",
+ "fvm_ipld_amt",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt 0.5.1",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
  "fvm_sdk",
  "fvm_shared",
  "integer-encoding",
@@ -1087,36 +1072,18 @@ dependencies = [
 [[package]]
 name = "fvm_actor_utils"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a11cab1852eb6f381cc11ebcfa6b2c84d3df5b5603ab6c79d6b02761718da77"
+source = "git+https://github.com/helix-onchain/filecoin?branch=main#2ce589f689dcd41109e6b2cbb718ac7b3f5b6334"
 dependencies = [
  "anyhow",
  "cid",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
+ "fvm_ipld_encoding",
  "fvm_sdk",
  "fvm_shared",
  "num-traits",
  "serde",
  "serde_tuple",
- "thiserror",
-]
-
-[[package]]
-name = "fvm_ipld_amt"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d09e5aa7de45452676d18fcb70b750acd65faae7a4fe18fe784b4c85f869fb"
-dependencies = [
- "ahash",
- "anyhow",
- "cid",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "itertools",
- "once_cell",
- "serde",
  "thiserror",
 ]
 
@@ -1129,7 +1096,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.3.2",
+ "fvm_ipld_encoding",
  "itertools",
  "once_cell",
  "serde",
@@ -1142,7 +1109,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
 dependencies = [
- "fvm_ipld_encoding 0.3.2",
+ "fvm_ipld_encoding",
  "serde",
  "thiserror",
  "unsigned-varint",
@@ -1168,7 +1135,7 @@ dependencies = [
  "cid",
  "futures",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.3.2",
+ "fvm_ipld_encoding",
  "integer-encoding",
  "serde",
  "thiserror",
@@ -1176,27 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_encoding"
-version = "0.2.3"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1ff5ba581625ab38cf2829fbd04ac232c6277466fdbe0270b42dcb976902d5"
-dependencies = [
- "anyhow",
- "cid",
- "cs_serde_bytes",
- "fvm_ipld_blockstore",
- "multihash",
- "serde",
- "serde_ipld_dagcbor",
- "serde_repr",
- "serde_tuple",
- "thiserror",
-]
-
-[[package]]
-name = "fvm_ipld_encoding"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189214585b1dc3c2a92682aa175cce1991c1a09542e5338c400d00c15b706142"
+checksum = "f0816a2a6df4853de08a723d261110d56a121aa313bc570fe9d248f0a4bc5288"
 dependencies = [
  "anyhow",
  "cid",
@@ -1206,27 +1155,6 @@ dependencies = [
  "serde_ipld_dagcbor",
  "serde_repr",
  "serde_tuple",
- "thiserror",
-]
-
-[[package]]
-name = "fvm_ipld_hamt"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b5c939897aa1bfd63e7cb9c458ba10689371af3278ff20d66c6f8ca152c6c0"
-dependencies = [
- "anyhow",
- "byteorder",
- "cid",
- "cs_serde_bytes",
- "forest_hash_utils",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "libipld-core 0.13.1",
- "multihash",
- "once_cell",
- "serde",
- "sha2",
  "thiserror",
 ]
 
@@ -1241,7 +1169,7 @@ dependencies = [
  "cid",
  "forest_hash_utils",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.3.2",
+ "fvm_ipld_encoding",
  "libipld-core 0.14.0",
  "multihash",
  "once_cell",
@@ -1252,12 +1180,12 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "2.2.0"
+version = "3.0.0-alpha.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb46d7b26e1609de1a3b7470cbd190d78f2d01fdf1b317f741bdd3ac8f59825e"
+checksum = "d51908aab9e7564fbcb278d78e31c12402b68c70517661780feb29adbb234aaf"
 dependencies = [
  "cid",
- "fvm_ipld_encoding 0.2.3",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "lazy_static",
  "log",
@@ -1267,19 +1195,19 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "2.0.0"
+version = "3.0.0-alpha.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7d1de62b7b74909d6e4816de83c4e6b46017bba9a31bb0de82b6b26b11cf74"
+checksum = "3779876441e390f414161474701404b5641e02a5b9acfece9b212f6d24e482e1"
 dependencies = [
  "anyhow",
+ "bitflags",
  "blake2b_simd",
  "byteorder",
  "cid",
- "cs_serde_bytes",
  "data-encoding",
  "data-encoding-macro",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
+ "fvm_ipld_encoding",
  "lazy_static",
  "log",
  "multihash",
@@ -1319,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c4a8d6391675c6b2ee1a6c8d06e8e2d03605c44cec1270675985a4c2a5500b"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1565,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
  "serde",
@@ -1719,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -1973,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -2028,8 +1956,8 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt 0.6.1",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
  "fvm_shared",
  "indexmap",
  "integer-encoding",
@@ -2074,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -2266,42 +2194,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,9 +61,9 @@ members = [
 #fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
 #fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
 #fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-fvm_actor_utils = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
-frc42_dispatch = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
-frc46_token = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
+#fvm_actor_utils = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
+#frc42_dispatch = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
+#frc46_token = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
 
 ## Uncomment when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ fil_actor_system = { version = "10.0.0-alpha.1", path = "./actors/system", featu
 fil_actor_verifreg = { version = "10.0.0-alpha.1", path = "./actors/verifreg", features = ["fil-actor"] }
 
 [build-dependencies]
-fil_actor_bundler = "4.0.0"
+fil_actor_bundler = "5.0.0"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "runtime" }
 num-traits = "0.2.15"
@@ -53,17 +53,17 @@ members = [
      "test_vm",
 ]
 
-#[patch.crates-io]
-#fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm" }
-#fvm_actor_utils = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
-#frc42_dispatch = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
-#frc46_token = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
+[patch.crates-io]
+#fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+fvm_actor_utils = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
+frc42_dispatch = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
+frc46_token = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
 
 ## Uncomment when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-frc42_dispatch = "3.0.0"
-fvm_actor_utils = "3.0.0"
+frc42_dispatch = "3.0.1-alpha.1"
+fvm_actor_utils = "4.0.0"
 fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -16,12 +16,12 @@ crate-type = ["cdylib", "lib"]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.0"
 fvm_actor_utils = "3.0.0"
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.3"
+fvm_ipld_encoding = "0.3.3"
 anyhow = "1.0.65"
 
 [dev-dependencies]

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -15,13 +15,13 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"
 serde = { version = "1.0.136", features = ["derive"] }
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.3"
+fvm_ipld_encoding = "0.3.3"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -17,9 +17,9 @@ crate-type = ["cdylib", "lib"]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime"}
 
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.0.0"
-frc46_token = "3.1.0"
-fvm_actor_utils = "3.0.0"
+frc42_dispatch = "3.0.1-alpha.1"
+frc46_token = "4.0.0"
+fvm_actor_utils = "4.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -21,9 +21,9 @@ frc42_dispatch = "3.0.0"
 frc46_token = "3.1.0"
 fvm_actor_utils = "3.0.0"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.3"
+fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 lazy_static = "1.4.0"
 num-derive = "0.3.3"
 num-traits = "0.2.14"

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-frc42_dispatch = "3.0.0"
+frc42_dispatch = "3.0.1-alpha.1"
 fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.0"
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
@@ -25,7 +25,7 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 anyhow = "1.0.65"
 log = "0.4.14"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.3"
+fvm_ipld_encoding = "0.3.3"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -22,9 +22,9 @@ frc42_dispatch = "3.0.0"
 frc46_token = "3.1.0"
 fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.3"
+fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 integer-encoding = { version = "3.0.3", default-features = false }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 log = "0.4.14"

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -18,8 +18,8 @@ fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime"}
 
 anyhow = "1.0.65"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.0.0"
-frc46_token = "3.1.0"
+frc42_dispatch = "3.0.1-alpha.1"
+frc46_token = "4.0.0"
 fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.0"
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
 fvm_ipld_hamt = "0.6.1"
@@ -30,7 +30,7 @@ byteorder = "1.4.3"
 anyhow = "1.0.65"
 itertools = "0.10.3"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.3"
+fvm_ipld_encoding = "0.3.3"
 multihash = { version = "0.16.2", default-features = false }
 
 [dev-dependencies]

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-frc42_dispatch = "3.0.0"
+frc42_dispatch = "3.0.1-alpha.1"
 fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -1207,7 +1207,7 @@ pub struct AdvanceDeadlineResult {
 }
 
 /// Static information about miner
-#[derive(Debug, PartialEq, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct MinerInfo {
     /// Account that owns this miner
     /// - Income and returned collateral are paid to this address

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -486,7 +486,7 @@ pub struct GetPeerIDReturn {
     pub peer_id: Vec<u8>,
 }
 
-#[derive(Debug, Default, PartialEq, Clone, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct GetMultiaddrsReturn {
     pub multi_addrs: Vec<BytesDe>,
 }

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -21,9 +21,9 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 frc42_dispatch = "3.0.0"
 fvm_actor_utils = "3.0.0"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.3"
+fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 num-derive = "0.3.3"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -18,8 +18,8 @@ fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime"}
 
 anyhow = "1.0.65"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.0.0"
-fvm_actor_utils = "3.0.0"
+frc42_dispatch = "3.0.1-alpha.1"
+fvm_actor_utils = "4.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -9,7 +9,7 @@ use fil_actors_runtime::test_utils::*;
 use fil_actors_runtime::{INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR};
 use fvm_actor_utils::receiver::UniversalReceiverParams;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::{RawBytes, CBOR};
 use fvm_shared::address::{Address, BLS_PUB_LEN};
 
 use fvm_ipld_encoding::ipld_block::IpldBlock;
@@ -2376,5 +2376,5 @@ fn token_receiver() {
 }
 
 fn to_ipld_block(p: RawBytes) -> Option<IpldBlock> {
-    Some(IpldBlock { codec: DAG_CBOR, data: p.to_vec() })
+    Some(IpldBlock { codec: CBOR, data: p.to_vec() })
 }

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-frc42_dispatch = "3.0.0"
+frc42_dispatch = "3.0.1-alpha.1"
 fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -16,14 +16,14 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.0"
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 anyhow = "1.0.65"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.3"
+fvm_ipld_encoding = "0.3.3"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.0"
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -28,7 +28,7 @@ lazy_static = "1.4.0"
 serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.65"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.3"
+fvm_ipld_encoding = "0.3.3"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-frc42_dispatch = "3.0.0"
+frc42_dispatch = "3.0.1-alpha.1"
 fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 num-traits = "0.2.14"

--- a/actors/power/src/types.rs
+++ b/actors/power/src/types.rs
@@ -26,7 +26,7 @@ pub const CRON_QUEUE_HAMT_BITWIDTH: u32 = 6;
 pub const CRON_QUEUE_AMT_BITWIDTH: u32 = 6;
 pub const PROOF_VALIDATION_BATCH_AMT_BITWIDTH: u32 = 4;
 
-#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, PartialEq)]
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
 pub struct CreateMinerParams {
     pub owner: Address,
     pub worker: Address,
@@ -64,7 +64,7 @@ pub struct UpdatePledgeTotalParams {
     pub pledge_delta: TokenAmount,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, PartialEq)]
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
 pub struct CurrentTotalPowerReturn {
     #[serde(with = "bigint_ser")]
     pub raw_byte_power: StoragePower,

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -15,14 +15,14 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"
 lazy_static = "1.4.0"
 serde = { version = "1.0.136", features = ["derive"] }
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.3"
+fvm_ipld_encoding = "0.3.3"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
-fvm_ipld_encoding = "0.2.3"
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_ipld_encoding = "0.3.3"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"
 anyhow = "1.0.65"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -18,9 +18,9 @@ fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime"}
 
 anyhow = "1.0.65"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.0.0"
-frc46_token = "3.1.0"
-fvm_actor_utils = "3.0.0"
+frc42_dispatch = "3.0.1-alpha.1"
+frc46_token = "4.0.0"
+fvm_actor_utils = "4.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -22,9 +22,9 @@ frc42_dispatch = "3.0.0"
 frc46_token = "3.1.0"
 fvm_actor_utils = "3.0.0"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.3"
+fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 lazy_static = "1.4.0"
 log = "0.4.14"
 num-derive = "0.3.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 [dependencies]
 fvm_ipld_hamt = "0.6.1"
 fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 num = { version = "0.4", features = ["serde"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -28,10 +28,10 @@ thiserror = "1.0.30"
 getrandom = { version = "0.2.5", features = ["js"] }
 hex = { version = "0.4.3", optional = true }
 anyhow = "1.0.65"
-fvm_sdk = { version = "2.2.0", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.22", optional = true }
 blake2b_simd = "1.0"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.3"
+fvm_ipld_encoding = "0.3.3"
 fvm_ipld_bitfield = "0.5.2"
 multihash = { version = "0.16.1", default-features = false }
 rand = "0.8.5"

--- a/runtime/src/actor_error.rs
+++ b/runtime/src/actor_error.rs
@@ -112,12 +112,28 @@ impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
     }
 }
 
-/// Converts a no-state error into an an actor error with the appropriate exit code (illegal actor).
+/// Converts a state-read error into an an actor error with the appropriate exit code (illegal actor).
 /// This facilitates propagation.
 #[cfg(feature = "fil-actor")]
-impl From<fvm_sdk::error::NoStateError> for ActorError {
-    fn from(e: fvm_sdk::error::NoStateError) -> Self {
-        Self { exit_code: ExitCode::USR_ILLEGAL_STATE, msg: e.to_string(), data: None }
+impl From<fvm_sdk::error::StateReadError> for ActorError {
+    fn from(e: fvm_sdk::error::StateReadError) -> Self {
+        Self { exit_code: ExitCode::USR_ILLEGAL_STATE, data: None, msg: e.to_string() }
+    }
+}
+
+/// Converts a state update error into an an actor error with the appropriate exit code.
+/// This facilitates propagation.
+#[cfg(feature = "fil-actor")]
+impl From<fvm_sdk::error::StateUpdateError> for ActorError {
+    fn from(e: fvm_sdk::error::StateUpdateError) -> Self {
+        Self {
+            exit_code: match e {
+                fvm_sdk::error::StateUpdateError::ActorDeleted => ExitCode::USR_ILLEGAL_STATE,
+                fvm_sdk::error::StateUpdateError::ReadOnly => ExitCode::USR_READ_ONLY,
+            },
+            data: None,
+            msg: e.to_string(),
+        }
     }
 }
 

--- a/runtime/src/runtime/hash_algorithm.rs
+++ b/runtime/src/runtime/hash_algorithm.rs
@@ -35,12 +35,7 @@ impl HashAlgorithm for FvmHashSha256 {
         let mut hasher = RuntimeHasherWrapper::default();
         key.hash(&mut hasher);
 
-        // TODO :: Enable this when moving to
-        // fvm_sdk 3.0.0-alpha.2,
-        // looks like fvm_sdk 2.0.0-alpha.3 doesn't support `hash_into()` api
-        // fvm::crypto::hash_into(SupportedHashes::Sha2_256, &hasher.0, &mut rval_digest);
-
-        rval_digest.copy_from_slice(&fvm::crypto::hash(SupportedHashes::Sha2_256, &hasher.0));
+        fvm::crypto::hash_into(SupportedHashes::Sha2_256, &hasher.0, &mut rval_digest);
 
         rval_digest
     }

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -105,6 +105,12 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// Loads a readonly copy of the state of the receiver into the argument.
     fn state<T: DeserializeOwned>(&self) -> Result<T, ActorError>;
 
+    /// Gets the state-root.
+    fn get_state_root(&self) -> Result<Cid, ActorError>;
+
+    /// Sets the state-root.
+    fn set_state_root(&mut self, root: &Cid) -> Result<(), ActorError>;
+
     /// Loads a mutable copy of the state of the receiver, passes it to `f`,
     /// and after `f` completes puts the state object back to the store and sets it as
     /// the receiver's state root.

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -27,7 +27,7 @@ fil_actor_reward = { version = "10.0.0-alpha.1", path = "../actors/reward"}
 fil_actor_system = { version = "10.0.0-alpha.1", path = "../actors/system"}
 fil_actor_init = { version = "10.0.0-alpha.1", path = "../actors/init"}
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../runtime"}
-frc46_token = "3.1.0"
+frc46_token = "4.0.0"
 fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_blockstore = "0.1.1"

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -28,8 +28,8 @@ fil_actor_system = { version = "10.0.0-alpha.1", path = "../actors/system"}
 fil_actor_init = { version = "10.0.0-alpha.1", path = "../actors/init"}
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../runtime"}
 frc46_token = "3.1.0"
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
-fvm_ipld_encoding = "0.2.3"
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_ipld_encoding = "0.3.3"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"
 anyhow = "1.0.65"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -34,9 +34,9 @@ frc46_token = "3.1.0"
 fvm_actor_utils = "3.0.0"
 fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_blockstore = { version = "0.1.1", default-features = false }
-fvm_ipld_encoding = { version = "0.2.3", default-features = false }
+fvm_ipld_encoding = { version = "0.3.3", default-features = false }
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "2.0.0-alpha.2", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 lazy_static = "1.4.0"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -30,8 +30,8 @@ anyhow = "1.0.65"
 bimap = { version = "0.6.2" }
 blake2b_simd = "1.0"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc46_token = "3.1.0"
-fvm_actor_utils = "3.0.0"
+frc46_token = "4.0.0"
+fvm_actor_utils = "4.0.0"
 fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_blockstore = { version = "0.1.1", default-features = false }
 fvm_ipld_encoding = { version = "0.3.3", default-features = false }

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -892,6 +892,25 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
         }
     }
 
+    fn get_state_root(&self) -> Result<Cid, ActorError> {
+        Ok(self.v.get_actor(self.to()).unwrap().head)
+    }
+
+    fn set_state_root(&mut self, root: &Cid) -> Result<(), ActorError> {
+        let maybe_act = self.v.get_actor(self.to());
+        match maybe_act {
+            None => Err(ActorError::unchecked(
+                ExitCode::SYS_ASSERTION_FAILED,
+                "actor does not exist".to_string(),
+            )),
+            Some(mut act) => {
+                act.head = *root;
+                self.v.set_actor(self.to(), act);
+                Ok(())
+            }
+        }
+    }
+
     fn state<T: DeserializeOwned>(&self) -> Result<T, ActorError> {
         Ok(self.v.get_state::<T>(self.to()).unwrap())
     }


### PR DESCRIPTION
This is a pre-factor that updates this repo to rely on FVM3 deps, without introducing or supporting any FEVM functionality. The new crates themselves do include some FEVM changes:
- hyperspace support (I'm hoping this is okay, it's just a testnet)
- The f4 address scheme, which is in FIP-0048, which has been Accepted as of today

Most of the changes here result from integrating the latest changes in the https://github.com/helix-onchain/filecoin repo.

Needs:

- [x] https://github.com/helix-onchain/filecoin/pull/187
- [x] https://github.com/filecoin-project/builtin-actors-bundler/pull/12