### PR TITLE
EVM: abort if we fail to transfer to the beneficiary on selfdestruct

### DIFF
--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -40,6 +40,7 @@ pub const EVM_CONTRACT_STACK_UNDERFLOW: ExitCode = ExitCode::new(36);
 pub const EVM_CONTRACT_STACK_OVERFLOW: ExitCode = ExitCode::new(37);
 pub const EVM_CONTRACT_ILLEGAL_MEMORY_ACCESS: ExitCode = ExitCode::new(38);
 pub const EVM_CONTRACT_BAD_JUMPDEST: ExitCode = ExitCode::new(39);
+pub const EVM_CONTRACT_SELFDESTRUCT_FAILED: ExitCode = ExitCode::new(40);
 
 const EVM_MAX_RESERVED_METHOD: u64 = 1023;
 pub const NATIVE_METHOD_SIGNATURE: &str = "handle_filecoin_method(uint64,uint64,bytes)";

--- a/actors/evm/tests/selfdestruct.rs
+++ b/actors/evm/tests/selfdestruct.rs
@@ -1,6 +1,6 @@
 use fil_actor_evm::{
     interpreter::{address::EthAddress, U256},
-    EvmContractActor, Method, ResurrectParams, State, Tombstone,
+    EvmContractActor, Method, ResurrectParams, State, Tombstone, EVM_CONTRACT_SELFDESTRUCT_FAILED,
 };
 use fil_actors_runtime::{test_utils::*, EAM_ACTOR_ADDR, INIT_ACTOR_ADDR};
 use fvm_ipld_encoding::{ipld_block::IpldBlock, BytesSer, RawBytes};
@@ -135,7 +135,7 @@ fn test_selfdestruct_missing_beneficiary() {
         )
         .expect_err("call should have failed")
         .exit_code(),
-        ExitCode::USR_UNSPECIFIED,
+        EVM_CONTRACT_SELFDESTRUCT_FAILED,
     );
     let state: State = rt.get_state();
     assert_eq!(state.tombstone, None);

--- a/actors/evm/tests/selfdestruct.rs
+++ b/actors/evm/tests/selfdestruct.rs
@@ -3,8 +3,14 @@ use fil_actor_evm::{
     EvmContractActor, Method, ResurrectParams, State, Tombstone,
 };
 use fil_actors_runtime::{test_utils::*, EAM_ACTOR_ADDR, INIT_ACTOR_ADDR};
-use fvm_ipld_encoding::{ipld_block::IpldBlock, RawBytes};
-use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, MethodNum, METHOD_SEND};
+use fvm_ipld_encoding::{ipld_block::IpldBlock, BytesSer, RawBytes};
+use fvm_shared::{
+    address::Address,
+    econ::TokenAmount,
+    error::{ErrorNumber, ExitCode},
+    sys::SendFlags,
+    MethodNum, METHOD_SEND,
+};
 use num_traits::Zero;
 
 mod util;
@@ -108,18 +114,30 @@ fn test_selfdestruct_missing_beneficiary() {
 
     let solidity_params = hex::decode("35f46994").unwrap();
     rt.expect_validate_caller_any();
-    rt.expect_send(
+    rt.expect_send_generalized(
         beneficiary,
         METHOD_SEND,
         None,
         rt.get_balance(),
         None,
-        ExitCode::SYS_INVALID_RECEIVER,
+        SendFlags::default(),
+        None,
+        ExitCode::OK, // doesn't matter
+        Some(ErrorNumber::NotFound),
     );
 
     // It still works even if the beneficiary doesn't exist.
-    assert!(util::invoke_contract(&mut rt, &solidity_params).is_empty());
+
+    assert_eq!(
+        rt.call::<EvmContractActor>(
+            Method::InvokeContract as u64,
+            IpldBlock::serialize_cbor(&BytesSer(&solidity_params)).unwrap(),
+        )
+        .expect_err("call should have failed")
+        .exit_code(),
+        ExitCode::USR_UNSPECIFIED,
+    );
     let state: State = rt.get_state();
-    assert_eq!(state.tombstone, Some(Tombstone { origin: 100, nonce: 0 }));
+    assert_eq!(state.tombstone, None);
     rt.verify();
 }


### PR DESCRIPTION
This is somewhat of a damned if we do, damned if we don't situation. This operation _can't_ fail in the EVM, but it _can_ fail in the FVM because we implement this with an actual send.

However, this is far from the only instruction that can fail unexpectedly (e.g., EXTCODEHASH).

🤷‍♂️

fixes https://github.com/filecoin-project/ref-fvm/issues/1558