### PR TITLE
EVM: Make solidity's "transfer" execute code

### DIFF
--- a/actors/evm/src/interpreter/uints.rs
+++ b/actors/evm/src/interpreter/uints.rs
@@ -94,6 +94,12 @@ impl From<&TokenAmount> for U256 {
     }
 }
 
+impl From<TokenAmount> for U256 {
+    fn from(amount: TokenAmount) -> U256 {
+        U256::from(&amount)
+    }
+}
+
 impl From<U256> for arith::U256 {
     fn from(src: U256) -> arith::U256 {
         arith::U256::from(src.0)
@@ -112,6 +118,12 @@ impl From<&U256> for TokenAmount {
         let mut bits = [0u8; 32];
         ui.to_big_endian(&mut bits);
         TokenAmount::from_atto(BigInt::from_bytes_be(fvm_shared::bigint::Sign::Plus, &bits))
+    }
+}
+
+impl From<U256> for TokenAmount {
+    fn from(ui: U256) -> TokenAmount {
+        TokenAmount::from(&ui)
     }
 }
 


### PR DESCRIPTION
See https://github.com/filecoin-project/ref-fvm/issues/1569 for context.

This PR has two commits:

1. The first commit simplifies the call implementation given the recent changes to the placeholder and account actors. However, it removes any and all gas limit on calls that _look_ like they were triggered by a Solidity `.transfer` (otherwise, these calls would fail).
2. The second commit applies an actual gas limit on transfers. Unfortunately, we have to play quite a few games to make these gas limits "reliable". The EVM doesn't have this problem because _it_ applies gas limits lower down the stack (after automatically creating actors, etc.), but, IMO, that makes gas limits strictly less useful.

The question is: Do we want the second commit? Or can we just leave it unrestricted and document it?