### PR TITLE
EVM: unit tests: Control Flow, Call Context, Call

### DIFF
--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -271,7 +271,8 @@ impl<'r, 'a, RT: Runtime + 'r> Machine<'r, 'a, RT> {
     }
 
     #[inline(always)]
-    fn step(&mut self) -> Result<(), ActorError> {
+    // Note: pub only for unit test steps.
+    pub(crate) fn step(&mut self) -> Result<(), ActorError> {
         let op = self.bytecode[self.pc];
         unsafe { Self::JMPTABLE[op as usize](self) }
     }

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -158,6 +158,7 @@ pub fn jumpi(bytecode: &Bytecode, pc: usize, dest: U256, test: U256) -> Result<u
 
 #[cfg(test)]
 mod tests {
+    use crate::do_test;
     use crate::interpreter::test_util;
     use crate::interpreter::U256;
 
@@ -173,18 +174,20 @@ mod tests {
 
     #[test]
     fn test_pc() {
-        let mut rt = test_util::rt();
-        let mut env = test_util::env(
-            &mut rt,
+        do_test!(
+            rt,
+            env,
+            m,
             vec![
                 0x58, // PC
                 0x5b, // JMPDEST -- noop
             ],
+            {
+                let result = m.step();
+                assert!(result.is_ok(), "execution stop failed");
+                assert_eq!(m.state.stack.pop().unwrap(), U256::zero());
+                assert_eq!(m.pc, 1, "pc has advanced");
+            }
         );
-        let mut m = test_util::machine(&mut env);
-        let result = m.step();
-        assert!(result.is_ok(), "execution stop failed");
-        assert_eq!(m.state.stack.pop().unwrap(), U256::zero());
-        assert_eq!(m.pc, 1, "pc has advanced");
     }
 }

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -158,186 +158,155 @@ pub fn jumpi(bytecode: &Bytecode, pc: usize, dest: U256, test: U256) -> Result<u
 
 #[cfg(test)]
 mod tests {
-    use crate::do_test;
+    use crate::evm_unit_test;
     use crate::interpreter::U256;
     use crate::EVM_CONTRACT_BAD_JUMPDEST;
 
     #[test]
     fn test_jump() {
-        do_test!(
-            rt,
-            m,
-            vec![
-                0x56, // JUMP
-                0x5b, // JMPDEST -- noop
-                0x5b, // JMPDEST -- noop
-                0x5b, // JMPDEST -- noop
-                0x5b, // JMPDEST -- noop
-            ],
-            {
-                m.state.stack.push(U256::from(2)).unwrap();
-                let result = m.step();
-                assert!(result.is_ok(), "execution step failed");
-                assert_eq!(m.state.stack.len(), 0);
-                assert_eq!(m.pc, 3, "pc has not advanced to 3");
+        evm_unit_test! {
+            (rt, m) {
+                JUMP;
+                JUMPDEST;
+                JUMPDEST;
+                JUMPDEST;
+                JUMPDEST;
             }
-        );
+            m.state.stack.push(U256::from(2)).unwrap();
+            let result = m.step();
+            assert!(result.is_ok(), "execution step failed");
+            assert_eq!(m.state.stack.len(), 0);
+            assert_eq!(m.pc, 3, "pc has not advanced to 3");
+        };
     }
 
     #[test]
     fn test_jump_err() {
-        do_test!(
-            rt,
-            m,
-            vec![
-                0x56, // JUMP
-                0x63, // PUSH4 -- garbage
-                0x01, // garbage
-                0x02, // garbage
-                0x03, // garbage
-                0x04, // garbage
-            ],
-            {
-                m.state.stack.push(U256::from(2)).unwrap();
-                let result = m.step();
-                assert_eq!(m.state.stack.len(), 0);
-                assert!(result.is_err(), "execution step succeeded");
-                assert_eq!(result.err().unwrap().exit_code(), EVM_CONTRACT_BAD_JUMPDEST);
+        evm_unit_test!(
+            (rt, m) {
+                JUMP; // JUMP
+                PUSH4; // PUSH4 -- garbage
+                0x01; // garbage
+                0x02; // garbage
+                0x03; // garbage
+                0x04; // garbage
             }
+            m.state.stack.push(U256::from(2)).unwrap();
+            let result = m.step();
+            assert_eq!(m.state.stack.len(), 0);
+            assert!(result.is_err(), "execution step succeeded");
+            assert_eq!(result.err().unwrap().exit_code(), EVM_CONTRACT_BAD_JUMPDEST);
         );
     }
 
     #[test]
     fn test_jump_err2() {
-        do_test!(
-            rt,
-            m,
-            vec![
-                0x56, // JUMP
-                0x63, // PUSH4 -- garbage
-                0x01, // garbage
-                0x02, // garbage
-                0x03, // garbage
-                0x04, // garbage
-            ],
-            {
-                m.state.stack.push(U256::from(123)).unwrap();
-                let result = m.step();
-                assert_eq!(m.state.stack.len(), 0);
-                assert!(result.is_err(), "execution step succeeded");
-                assert_eq!(result.err().unwrap().exit_code(), EVM_CONTRACT_BAD_JUMPDEST);
+        evm_unit_test! {
+            (rt, m) {
+                JUMP;  // JUMP
+                PUSH4; // PUSH4 -- garbage
+                0x01;  // garbage
+                0x02;  // garbage
+                0x03;  // garbage
+                0x04;  // garbage
             }
-        );
+
+            m.state.stack.push(U256::from(123)).unwrap();
+            let result = m.step();
+            assert_eq!(m.state.stack.len(), 0);
+            assert!(result.is_err(), "execution step succeeded");
+            assert_eq!(result.err().unwrap().exit_code(), EVM_CONTRACT_BAD_JUMPDEST);
+        };
     }
 
     #[test]
     fn test_jump_err3() {
-        do_test!(
-            rt,
-            m,
-            vec![
-                0x56, // JUMP
-                0x63, // PUSH4 -- garbage
-                0x5b, // garbage
-                0x5b, // garbage
-                0x5b, // garbage
-                0x5b, // garbage
-            ],
-            {
-                m.state.stack.push(U256::from(2)).unwrap();
-                let result = m.step();
-                assert_eq!(m.state.stack.len(), 0);
-                assert!(result.is_err(), "execution step succeeded");
-                assert_eq!(result.err().unwrap().exit_code(), EVM_CONTRACT_BAD_JUMPDEST);
+        evm_unit_test! {
+            (rt, m) {
+                JUMP;
+                PUSH4;
+                JUMPDEST;
+                JUMPDEST;
+                JUMPDEST;
+                JUMPDEST;
             }
-        );
+            m.state.stack.push(U256::from(2)).unwrap();
+            let result = m.step();
+            assert_eq!(m.state.stack.len(), 0);
+            assert!(result.is_err(), "execution step succeeded");
+            assert_eq!(result.err().unwrap().exit_code(), EVM_CONTRACT_BAD_JUMPDEST);
+        };
     }
 
     #[test]
     fn test_jumpi_t() {
-        do_test!(
-            rt,
-            m,
-            vec![
-                0x57, // JUMPI
-                0x5b, // JMPDEST -- noop
-                0x5b, // JMPDEST -- noop
-                0x5b, // JMPDEST -- noop
-                0x5b, // JMPDEST -- noop
-            ],
-            {
-                m.state.stack.push(U256::from(1)).unwrap();
-                m.state.stack.push(U256::from(2)).unwrap();
-                let result = m.step();
-                assert!(result.is_ok(), "execution step failed");
-                assert_eq!(m.state.stack.len(), 0);
-                assert_eq!(m.pc, 3, "pc has not advanced to 3");
+        evm_unit_test! {
+            (rt, m) {
+                JUMPI;
+                JUMPDEST;
+                JUMPDEST;
+                JUMPDEST;
+                JUMPDEST;
             }
-        );
+            m.state.stack.push(U256::from(1)).unwrap();
+            m.state.stack.push(U256::from(2)).unwrap();
+            let result = m.step();
+            assert!(result.is_ok(), "execution step failed");
+            assert_eq!(m.state.stack.len(), 0);
+            assert_eq!(m.pc, 3, "pc has not advanced to 3");
+        }
     }
 
     #[test]
     fn test_jumpi_f() {
-        do_test!(
-            rt,
-            m,
-            vec![
-                0x57, // JUMPI
-                0x5b, // JMPDEST -- noop
-                0x5b, // JMPDEST -- noop
-                0x5b, // JMPDEST -- noop
-                0x5b, // JMPDEST -- noop
-            ],
-            {
-                m.state.stack.push(U256::from(0)).unwrap();
-                m.state.stack.push(U256::from(2)).unwrap();
-                let result = m.step();
-                assert!(result.is_ok(), "execution step failed");
-                assert_eq!(m.state.stack.len(), 0);
-                assert_eq!(m.pc, 1, "pc has not advanced to 1");
+        evm_unit_test! {
+            (rt, m) {
+                JUMPI;
+                JUMPDEST;
+                JUMPDEST;
+                JUMPDEST;
+                JUMPDEST;
             }
-        );
+            m.state.stack.push(U256::from(0)).unwrap();
+            m.state.stack.push(U256::from(2)).unwrap();
+            let result = m.step();
+            assert!(result.is_ok(), "execution step failed");
+            assert_eq!(m.state.stack.len(), 0);
+            assert_eq!(m.pc, 1, "pc has not advanced to 1");
+        };
     }
 
     #[test]
     fn test_jumpi_err() {
-        do_test!(
-            rt,
-            m,
-            vec![
-                0x57, // JUMPI
-                0x5b, // JMPDEST -- noop
-                0x5b, // JMPDEST -- noop
-                0x5b, // JMPDEST -- noop
-                0x5b, // JMPDEST -- noop
-            ],
-            {
-                m.state.stack.push(U256::from(1)).unwrap();
-                m.state.stack.push(U256::from(123)).unwrap();
-                let result = m.step();
-                assert_eq!(m.state.stack.len(), 0);
-                assert!(result.is_err(), "execution step succeeded");
-                assert_eq!(result.err().unwrap().exit_code(), EVM_CONTRACT_BAD_JUMPDEST);
+        evm_unit_test! {
+            (rt, m) {
+                JUMPI;
+                JUMPDEST;
+                JUMPDEST;
+                JUMPDEST;
+                JUMPDEST;
             }
-        );
+            m.state.stack.push(U256::from(1)).unwrap();
+            m.state.stack.push(U256::from(123)).unwrap();
+            let result = m.step();
+            assert_eq!(m.state.stack.len(), 0);
+            assert!(result.is_err(), "execution step succeeded");
+            assert_eq!(result.err().unwrap().exit_code(), EVM_CONTRACT_BAD_JUMPDEST);
+        };
     }
 
     #[test]
     fn test_pc() {
-        do_test!(
-            rt,
-            m,
-            vec![
-                0x58, // PC
-                0x5b, // JMPDEST -- noop
-            ],
-            {
-                let result = m.step();
-                assert!(result.is_ok(), "execution step failed");
-                assert_eq!(m.state.stack.len(), 1);
-                assert_eq!(m.state.stack.pop().unwrap(), U256::zero());
-                assert_eq!(m.pc, 1, "pc has not advanced to 1");
+        evm_unit_test! {
+            (rt, m) {
+                PC;
+                JUMPDEST;
             }
-        );
+            let result = m.step();
+            assert!(result.is_ok(), "execution step failed");
+            assert_eq!(m.state.stack.len(), 1);
+            assert_eq!(m.state.stack.pop().unwrap(), U256::zero());
+            assert_eq!(m.pc, 1, "pc has not advanced to 1");
+        }
     }
 }

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -200,6 +200,7 @@ mod tests {
             {
                 m.state.stack.push(U256::from(2)).unwrap();
                 let result = m.step();
+                assert_eq!(m.state.stack.len(), 0);
                 assert!(result.is_err(), "execution step succeeded");
                 assert_eq!(result.err().unwrap().exit_code(), EVM_CONTRACT_BAD_JUMPDEST);
             }
@@ -222,6 +223,7 @@ mod tests {
             {
                 m.state.stack.push(U256::from(123)).unwrap();
                 let result = m.step();
+                assert_eq!(m.state.stack.len(), 0);
                 assert!(result.is_err(), "execution step succeeded");
                 assert_eq!(result.err().unwrap().exit_code(), EVM_CONTRACT_BAD_JUMPDEST);
             }
@@ -244,6 +246,7 @@ mod tests {
             {
                 m.state.stack.push(U256::from(2)).unwrap();
                 let result = m.step();
+                assert_eq!(m.state.stack.len(), 0);
                 assert!(result.is_err(), "execution step succeeded");
                 assert_eq!(result.err().unwrap().exit_code(), EVM_CONTRACT_BAD_JUMPDEST);
             }
@@ -252,17 +255,71 @@ mod tests {
 
     #[test]
     fn test_jumpi_t() {
-        // TODO
-    }
-
-    #[test]
-    fn test_jumpi_err() {
-        // TODO
+        do_test!(
+            rt,
+            m,
+            vec![
+                0x57, // JUMPI
+                0x5b, // JMPDEST -- noop
+                0x5b, // JMPDEST -- noop
+                0x5b, // JMPDEST -- noop
+                0x5b, // JMPDEST -- noop
+            ],
+            {
+                m.state.stack.push(U256::from(1)).unwrap();
+                m.state.stack.push(U256::from(2)).unwrap();
+                let result = m.step();
+                assert!(result.is_ok(), "execution step failed");
+                assert_eq!(m.state.stack.len(), 0);
+                assert_eq!(m.pc, 3, "pc has not advanced to 3");
+            }
+        );
     }
 
     #[test]
     fn test_jumpi_f() {
-        // TODO
+        do_test!(
+            rt,
+            m,
+            vec![
+                0x57, // JUMPI
+                0x5b, // JMPDEST -- noop
+                0x5b, // JMPDEST -- noop
+                0x5b, // JMPDEST -- noop
+                0x5b, // JMPDEST -- noop
+            ],
+            {
+                m.state.stack.push(U256::from(0)).unwrap();
+                m.state.stack.push(U256::from(2)).unwrap();
+                let result = m.step();
+                assert!(result.is_ok(), "execution step failed");
+                assert_eq!(m.state.stack.len(), 0);
+                assert_eq!(m.pc, 1, "pc has not advanced to 1");
+            }
+        );
+    }
+
+    #[test]
+    fn test_jumpi_err() {
+        do_test!(
+            rt,
+            m,
+            vec![
+                0x57, // JUMPI
+                0x5b, // JMPDEST -- noop
+                0x5b, // JMPDEST -- noop
+                0x5b, // JMPDEST -- noop
+                0x5b, // JMPDEST -- noop
+            ],
+            {
+                m.state.stack.push(U256::from(1)).unwrap();
+                m.state.stack.push(U256::from(123)).unwrap();
+                let result = m.step();
+                assert_eq!(m.state.stack.len(), 0);
+                assert!(result.is_err(), "execution step succeeded");
+                assert_eq!(result.err().unwrap().exit_code(), EVM_CONTRACT_BAD_JUMPDEST);
+            }
+        );
     }
 
     #[test]

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -155,3 +155,36 @@ pub fn jumpi(bytecode: &Bytecode, pc: usize, dest: U256, test: U256) -> Result<u
         Ok(pc + 1)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::interpreter::test_util;
+    use crate::interpreter::U256;
+
+    #[test]
+    fn test_jump() {
+        // toDO
+    }
+
+    #[test]
+    fn test_jumpi() {
+        // TODO
+    }
+
+    #[test]
+    fn test_pc() {
+        let mut rt = test_util::rt();
+        let mut env = test_util::env(
+            &mut rt,
+            vec![
+                0x58, // PC
+                0x5b, // JMPDEST -- noop
+            ],
+        );
+        let mut m = test_util::machine(&mut env);
+        let result = m.step();
+        assert!(result.is_ok(), "execution stop failed");
+        assert_eq!(m.state.stack.pop().unwrap(), U256::zero());
+        assert_eq!(m.pc, 1, "pc has advanced");
+    }
+}

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -159,7 +159,6 @@ pub fn jumpi(bytecode: &Bytecode, pc: usize, dest: U256, test: U256) -> Result<u
 #[cfg(test)]
 mod tests {
     use crate::do_test;
-    use crate::interpreter::test_util;
     use crate::interpreter::U256;
 
     #[test]
@@ -176,7 +175,6 @@ mod tests {
     fn test_pc() {
         do_test!(
             rt,
-            env,
             m,
             vec![
                 0x58, // PC

--- a/actors/evm/src/interpreter/mod.rs
+++ b/actors/evm/src/interpreter/mod.rs
@@ -9,6 +9,9 @@ pub mod stack;
 pub mod system;
 pub mod uints;
 
+#[cfg(test)]
+pub mod test_util;
+
 pub use {
     bytecode::Bytecode,
     execution::{execute, ExecutionState},

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -119,7 +119,7 @@ pub struct System<'r, RT: Runtime> {
 }
 
 impl<'r, RT: Runtime> System<'r, RT> {
-    fn new(rt: &'r mut RT, readonly: bool) -> Self
+    pub(crate) fn new(rt: &'r mut RT, readonly: bool) -> Self
     where
         RT::Blockstore: Clone,
     {

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -1,0 +1,52 @@
+#![cfg(test)]
+
+use fil_actors_runtime::test_utils::*;
+use fvm_shared::econ::TokenAmount;
+
+use crate::interpreter::address::*;
+use crate::interpreter::bytecode::*;
+use crate::interpreter::execution::*;
+use crate::interpreter::output::*;
+use crate::interpreter::system::*;
+
+use bytes::Bytes;
+
+pub type TestSystem<'r> = System<'r, MockRuntime>;
+pub type TestMachine<'a, 'r> = Machine<'a, 'r, MockRuntime>;
+
+pub struct TestEnv<'r> {
+    pub system: TestSystem<'r>,
+    pub state: ExecutionState,
+    pub bytecode: Bytecode,
+}
+
+pub struct Tester<'a, 'r> {
+    pub m: TestMachine<'a, 'r>,
+    pub env: TestEnv<'r>,
+}
+
+pub fn rt() -> MockRuntime {
+    MockRuntime::default()
+}
+
+pub fn env<'r>(rt: &'r mut MockRuntime, code: Vec<u8>) -> TestEnv<'r> {
+    let system = TestSystem::new(rt, false);
+    let state = ExecutionState::new(
+        EthAddress::from_id(1000),
+        EthAddress::from_id(1000),
+        TokenAmount::from_atto(0),
+        Bytes::default(),
+    );
+    let bytecode = Bytecode::new(code);
+    TestEnv { system, state, bytecode }
+}
+
+pub fn machine<'a, 'r>(env: &'a mut TestEnv<'r>) -> TestMachine<'a, 'r> {
+    TestMachine {
+        system: &mut env.system,
+        state: &mut env.state,
+        bytecode: &env.bytecode,
+        pc: 0,
+        output: Output::default(),
+    }
+}

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -1,8 +1,18 @@
 #![cfg(test)]
 
 #[macro_export]
-macro_rules! do_test {
-    ($rt:ident, $machine:ident, $code:expr, $body:block) => {
+macro_rules! evm_instruction {
+    ($i:ident) => {
+        $crate::interpreter::execution::opcodes::$i
+    };
+    ($i:literal) => {
+        $i
+    };
+}
+
+#[macro_export]
+macro_rules! evm_unit_test {
+    (($rt:ident, $machine:ident) { $($inst:tt;)* } $($body:tt)*) => {
         use ::fil_actors_runtime::test_utils::MockRuntime;
         use ::fvm_shared::econ::TokenAmount;
         use $crate::interpreter::{execution::Machine, system::System, Output};
@@ -16,8 +26,10 @@ macro_rules! do_test {
             Bytes::default(),
         );
 
+        let code = vec![$($crate::evm_instruction!($inst)),*];
+
         let mut system = System::new(&mut $rt, false);
-        let bytecode = Bytecode::new($code);
+        let bytecode = Bytecode::new(code);
         let mut $machine = Machine {
             system: &mut system,
             state: &mut state,
@@ -26,6 +38,6 @@ macro_rules! do_test {
             output: Output::default(),
         };
 
-        $body
+        $($body)*
     };
 }

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -1,62 +1,31 @@
 #![cfg(test)]
 
-use fil_actors_runtime::test_utils::*;
-use fvm_shared::econ::TokenAmount;
-
-use crate::interpreter::address::*;
-use crate::interpreter::bytecode::*;
-use crate::interpreter::execution::*;
-use crate::interpreter::output::*;
-use crate::interpreter::system::*;
-
-use bytes::Bytes;
-
-pub type TestSystem<'r> = System<'r, MockRuntime>;
-pub type TestMachine<'a, 'r> = Machine<'a, 'r, MockRuntime>;
-
-pub struct TestEnv<'r> {
-    pub system: TestSystem<'r>,
-    pub state: ExecutionState,
-    pub bytecode: Bytecode,
-}
-
-pub struct Tester<'a, 'r> {
-    pub m: TestMachine<'a, 'r>,
-    pub env: TestEnv<'r>,
-}
-
-pub fn rt() -> MockRuntime {
-    MockRuntime::default()
-}
-
-pub fn env<'r>(rt: &'r mut MockRuntime, code: Vec<u8>) -> TestEnv<'r> {
-    let system = TestSystem::new(rt, false);
-    let state = ExecutionState::new(
-        EthAddress::from_id(1000),
-        EthAddress::from_id(1000),
-        TokenAmount::from_atto(0),
-        Bytes::default(),
-    );
-    let bytecode = Bytecode::new(code);
-    TestEnv { system, state, bytecode }
-}
-
-pub fn machine<'a, 'r>(env: &'a mut TestEnv<'r>) -> TestMachine<'a, 'r> {
-    TestMachine {
-        system: &mut env.system,
-        state: &mut env.state,
-        bytecode: &env.bytecode,
-        pc: 0,
-        output: Output::default(),
-    }
-}
-
 #[macro_export]
 macro_rules! do_test {
-    ($rt:ident, $env:ident, $m:ident, $code:expr, $body:block) => {
-        let mut $rt = test_util::rt();
-        let mut $env = test_util::env(&mut $rt, $code);
-        let mut $m = test_util::machine(&mut $env);
+    ($rt:ident, $machine:ident, $code:expr, $body:block) => {
+        use ::fil_actors_runtime::test_utils::MockRuntime;
+        use ::fvm_shared::econ::TokenAmount;
+        use $crate::interpreter::{execution::Machine, system::System, Output};
+        use $crate::{Bytecode, Bytes, EthAddress, ExecutionState};
+
+        let mut $rt = MockRuntime::default();
+        let mut state = ExecutionState::new(
+            EthAddress::from_id(1000),
+            EthAddress::from_id(1000),
+            TokenAmount::from_atto(0),
+            Bytes::default(),
+        );
+
+        let mut system = System::new(&mut $rt, false);
+        let bytecode = Bytecode::new($code);
+        let mut $machine = Machine {
+            system: &mut system,
+            state: &mut state,
+            bytecode: &bytecode,
+            pc: 0,
+            output: Output::default(),
+        };
+
         $body
     };
 }

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 #[macro_export]
 macro_rules! evm_instruction {
     ($i:ident) => {

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -50,3 +50,13 @@ pub fn machine<'a, 'r>(env: &'a mut TestEnv<'r>) -> TestMachine<'a, 'r> {
         output: Output::default(),
     }
 }
+
+#[macro_export]
+macro_rules! do_test {
+    ($rt:ident, $env:ident, $m:ident, $code:expr, $body:block) => {
+        let mut $rt = test_util::rt();
+        let mut $env = test_util::env(&mut $rt, $code);
+        let mut $m = test_util::machine(&mut $env);
+        $body
+    };
+}


### PR DESCRIPTION
Unit Test Macro and a bunch of Unit Tests
- Closes https://github.com/filecoin-project/ref-fvm/issues/1544
  - [X] `JUMP`
  - [X] `JUMPI`
  - [X] `PC`
- Closes https://github.com/filecoin-project/ref-fvm/issues/1545
  - [ ] `CALLVALUE`
  - [ ] `CALLDATALOAD`
  - [ ] `CALLDATASIZE`
  - [ ] `CALLDATACOPY`
  - [ ] `RETURNDATASIZE`
  - [ ] `RETURNDATACOPY`
- Closes https://github.com/filecoin-project/ref-fvm/issues/1546
  - [ ] `CALL`
  - [ ] `DELEGATECALL`
  - [ ] `STATICCALL`
  - [ ] `RETURN`
  - [ ] `REVERT`
  - [ ] `INVALID`