### PR TITLE
placeholder: drop deps on FVM SDK and shared

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,10 +2021,6 @@ dependencies = [
 [[package]]
 name = "fil_actor_placeholder"
 version = "10.0.0-alpha.1"
-dependencies = [
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
-]
 
 [[package]]
 name = "fil_actor_power"

--- a/actors/placeholder/Cargo.toml
+++ b/actors/placeholder/Cargo.toml
@@ -12,9 +12,5 @@ keywords = ["filecoin", "web3", "wasm"]
 ## cdylib is necessary for Wasm build
 crate-type = ["cdylib", "lib"]
 
-[dependencies]
-fvm_sdk = { version = "3.0.0-alpha.22", optional = true }
-fvm_shared = { version = "3.0.0-alpha.17", optional = true }
-
 [features]
-fil-actor = ["fvm_sdk", "fvm_shared"]
+fil-actor = []


### PR DESCRIPTION
No longer needed after #1112 