### PR TITLE
feat: Partial implementation of FIP-0048 (f4/delegated addresses)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actor_placeholder"
+version = "10.0.0-alpha.1"
+
+[[package]]
 name = "fil_actor_power"
 version = "10.0.0-alpha.1"
 dependencies = [
@@ -855,6 +859,7 @@ dependencies = [
  "fil_actor_miner",
  "fil_actor_multisig",
  "fil_actor_paych",
+ "fil_actor_placeholder",
  "fil_actor_power",
  "fil_actor_reward",
  "fil_actor_system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ fil_actor_market = { version = "10.0.0-alpha.1", path = "./actors/market", featu
 fil_actor_miner = { version = "10.0.0-alpha.1", path = "./actors/miner", features = ["fil-actor"] }
 fil_actor_multisig = { version = "10.0.0-alpha.1", path = "./actors/multisig", features = ["fil-actor"] }
 fil_actor_paych = { version = "10.0.0-alpha.1", path = "./actors/paych", features = ["fil-actor"] }
+fil_actor_placeholder = { version = "10.0.0-alpha.1", path = "./actors/placeholder", features = ["fil-actor"] }
 fil_actor_power = { version = "10.0.0-alpha.1", path = "./actors/power", features = ["fil-actor"] }
 fil_actor_reward = { version = "10.0.0-alpha.1", path = "./actors/reward", features = ["fil-actor"] }
 fil_actor_system = { version = "10.0.0-alpha.1", path = "./actors/system", features = ["fil-actor"] }

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -84,7 +84,11 @@ impl Actor {
         if existing {
             // NOTE: this case should be impossible, but we check it anyways just in case something
             // changes.
-            return Err(ActorError::forbidden("cannot exec over an existing actor".into()));
+            return Err(actor_error!(
+                forbidden,
+                "cannot exec over an existing actor {}",
+                id_address
+            ));
         }
 
         // Create an empty actor

--- a/actors/init/src/state.rs
+++ b/actors/init/src/state.rs
@@ -32,8 +32,7 @@ impl State {
     /// With no delegated address, or if the delegated address is not already mapped,
     /// allocates a new ID address and maps both to it.
     /// If the delegated address is already present, maps the robust address to that actor ID.
-    /// Fails if the robust address is already mapped, providing tombstone.
-    ///
+    /// Fails if the robust address is already mapped. The assignment of an ID to an address is one-time-only, even if the actor at that ID is deleted.
     /// Returns the actor ID and a boolean indicating whether or not the actor already exists.
     pub fn map_addresses_to_id<BS: Blockstore>(
         &mut self,

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -67,7 +67,7 @@ fn repeated_robust_address() {
         // Next id
         let expected_id = 100;
         let expected_id_addr = Address::new_id(expected_id);
-        rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id);
+        rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id, None);
 
         // Expect a send to the multisig actor constructor
         rt.expect_send(
@@ -129,7 +129,7 @@ fn create_2_payment_channels() {
 
         let expected_id = 100 + n;
         let expected_id_addr = Address::new_id(expected_id);
-        rt.expect_create_actor(*PAYCH_ACTOR_CODE_ID, expected_id);
+        rt.expect_create_actor(*PAYCH_ACTOR_CODE_ID, expected_id, None);
 
         let fake_params = ConstructorParams { network_name: String::from("fake_param") };
 
@@ -175,7 +175,7 @@ fn create_storage_miner() {
 
     let expected_id = 100;
     let expected_id_addr = Address::new_id(expected_id);
-    rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id);
+    rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id, None);
 
     let fake_params = ConstructorParams { network_name: String::from("fake_param") };
 
@@ -226,7 +226,7 @@ fn create_multisig_actor() {
     // Next id
     let expected_id = 100;
     let expected_id_addr = Address::new_id(expected_id);
-    rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id);
+    rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id, None);
 
     let fake_params = ConstructorParams { network_name: String::from("fake_param") };
     // Expect a send to the multisig actor constructor
@@ -263,7 +263,7 @@ fn sending_constructor_failure() {
     // Create the next id address
     let expected_id = 100;
     let expected_id_addr = Address::new_id(expected_id);
-    rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id);
+    rt.expect_create_actor(*MINER_ACTOR_CODE_ID, expected_id, None);
 
     let fake_params = ConstructorParams { network_name: String::from("fake_param") };
     rt.expect_send(
@@ -328,7 +328,7 @@ fn exec_restricted_correctly() {
     // Next id
     let expected_id = 100;
     let expected_id_addr = Address::new_id(expected_id);
-    rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id);
+    rt.expect_create_actor(*MULTISIG_ACTOR_CODE_ID, expected_id, None);
 
     // Expect a send to the multisig actor constructor
     rt.expect_send(

--- a/actors/placeholder/Cargo.toml
+++ b/actors/placeholder/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "fil_actor_placeholder"
+description = "Builtin placeholder actor for Filecoin"
+version = "10.0.0-alpha.1"
+license = "MIT OR Apache-2.0"
+authors = ["Protocol Labs", "Filecoin Core Devs"]
+edition = "2021"
+keywords = ["filecoin", "web3", "wasm"]
+
+[lib]
+## lib is necessary for integration tests
+## cdylib is necessary for Wasm build
+crate-type = ["cdylib", "lib"]
+
+[features]
+fil-actor = []

--- a/actors/placeholder/src/lib.rs
+++ b/actors/placeholder/src/lib.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "fil-actor")]
+#[no_mangle]
+pub extern "C" fn invoke(_: u32) -> u32 {
+    0
+}

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -164,6 +164,10 @@ where
         fvm::actor::resolve_address(address)
     }
 
+    fn lookup_delegated_address(&self, id: ActorID) -> Option<Address> {
+        fvm::actor::lookup_delegated_address(id)
+    }
+
     fn get_actor_code_cid(&self, id: &ActorID) -> Option<Cid> {
         fvm::actor::get_actor_code_cid(&Address::new_id(*id))
     }
@@ -344,13 +348,18 @@ where
         Ok(fvm::actor::next_actor_address())
     }
 
-    fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {
+    fn create_actor(
+        &mut self,
+        code_id: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) -> Result<(), ActorError> {
         if self.in_transaction {
             return Err(
                 actor_error!(assertion_failed; "create_actor is not allowed during transaction"),
             );
         }
-        fvm::actor::create_actor(actor_id, &code_id, None).map_err(|e| match e {
+        fvm::actor::create_actor(actor_id, &code_id, predictable_address).map_err(|e| match e {
             ErrorNumber::IllegalArgument => {
                 ActorError::illegal_argument("failed to create actor".into())
             }

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -74,8 +74,8 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// If the argument is an ID address it is returned directly.
     fn resolve_address(&self, address: &Address) -> Option<ActorID>;
 
-    /// Looks-up the "delegated" address of an actor by ID, if any. Returns None if either the
-    /// target actor doesn't exist, or if the target actor doesn't have either an f4 address.
+    /// Looks up the "delegated" address of an actor by ID, if any. Returns None if either the
+    /// target actor doesn't exist, or doesn't have an f4 address.
     fn lookup_delegated_address(&self, id: ActorID) -> Option<Address>;
 
     /// Look up the code ID at an actor address.

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -74,6 +74,10 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// If the argument is an ID address it is returned directly.
     fn resolve_address(&self, address: &Address) -> Option<ActorID>;
 
+    /// Looks-up the "delegated" address of an actor by ID, if any. Returns None if either the
+    /// target actor doesn't exist, or if the target actor doesn't have either an f4 address.
+    fn lookup_delegated_address(&self, id: ActorID) -> Option<Address>;
+
     /// Look up the code ID at an actor address.
     fn get_actor_code_cid(&self, id: &ActorID) -> Option<Cid>;
 
@@ -146,9 +150,14 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// Always an ActorExec address.
     fn new_actor_address(&mut self) -> Result<Address, ActorError>;
 
-    /// Creates an actor with code `codeID` and address `address`, with empty state.
+    /// Creates an actor with code `codeID`, an empty state, id `actor_id`, and an optional predictable address.
     /// May only be called by Init actor.
-    fn create_actor(&mut self, code_id: Cid, address: ActorID) -> Result<(), ActorError>;
+    fn create_actor(
+        &mut self,
+        code_id: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) -> Result<(), ActorError>;
 
     /// Deletes the executing actor from the state tree, transferring any balance to beneficiary.
     /// Aborts if the beneficiary does not exist.

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -57,6 +57,7 @@ lazy_static::lazy_static! {
     pub static ref REWARD_ACTOR_CODE_ID: Cid = make_identity_cid(b"fil/test/reward");
     pub static ref VERIFREG_ACTOR_CODE_ID: Cid = make_identity_cid(b"fil/test/verifiedregistry");
     pub static ref DATACAP_TOKEN_ACTOR_CODE_ID: Cid = make_identity_cid(b"fil/test/datacap");
+    pub static ref PLACEHOLDER_ACTOR_CODE_ID: Cid = make_identity_cid(b"fil/test/placeholder");
     pub static ref ACTOR_TYPES: BTreeMap<Cid, Type> = {
         let mut map = BTreeMap::new();
         map.insert(*SYSTEM_ACTOR_CODE_ID, Type::System);
@@ -111,6 +112,8 @@ pub struct MockRuntime<BS = MemoryBlockstore> {
     pub miner: Address,
     pub base_fee: TokenAmount,
     pub id_addresses: HashMap<Address, Address>,
+    pub delegated_addresses: HashMap<Address, Address>,
+    pub delegated_addresses_source: HashMap<Address, Address>,
     pub actor_code_cids: HashMap<Address, Cid>,
     pub new_actor_addr: Option<Address>,
     pub receiver: Address,
@@ -270,6 +273,8 @@ impl<BS> MockRuntime<BS> {
             miner: Address::new_id(0),
             base_fee: Default::default(),
             id_addresses: Default::default(),
+            delegated_addresses: Default::default(),
+            delegated_addresses_source: Default::default(),
             actor_code_cids: Default::default(),
             new_actor_addr: Default::default(),
             receiver: Address::new_id(0),
@@ -290,10 +295,11 @@ impl<BS> MockRuntime<BS> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct ExpectCreateActor {
     pub code_id: Cid,
     pub actor_id: ActorID,
+    pub predictable_address: Option<Address>,
 }
 
 #[derive(Clone, Debug)]
@@ -458,6 +464,17 @@ impl<BS: Blockstore> MockRuntime<BS> {
         self.id_addresses.insert(source, target);
     }
 
+    pub fn add_delegated_address(&mut self, source: Address, target: Address) {
+        assert_eq!(
+            target.protocol(),
+            Protocol::Delegated,
+            "target must use Delegated address protocol"
+        );
+        assert_eq!(source.protocol(), Protocol::ID, "source must use ID address protocol");
+        self.delegated_addresses.insert(source, target);
+        self.delegated_addresses_source.insert(target, source);
+    }
+
     pub fn call<A: ActorCode>(
         &mut self,
         method_num: MethodNum,
@@ -566,8 +583,13 @@ impl<BS: Blockstore> MockRuntime<BS> {
     }
 
     #[allow(dead_code)]
-    pub fn expect_create_actor(&mut self, code_id: Cid, actor_id: ActorID) {
-        let a = ExpectCreateActor { code_id, actor_id };
+    pub fn expect_create_actor(
+        &mut self,
+        code_id: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) {
+        let a = ExpectCreateActor { code_id, actor_id, predictable_address };
         self.expectations.borrow_mut().expect_create_actor = Some(a);
     }
 
@@ -788,6 +810,12 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         if let &Payload::ID(id) = address.payload() {
             return Some(id);
         }
+        if Protocol::Delegated == address.protocol() {
+            return self
+                .delegated_addresses_source
+                .get(address)
+                .and_then(|a| self.resolve_address(a));
+        }
 
         match self.get_id_address(address) {
             None => None,
@@ -798,6 +826,11 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
                 None
             }
         }
+    }
+
+    fn lookup_delegated_address(&self, id: ActorID) -> Option<Address> {
+        self.require_in_call();
+        self.delegated_addresses.get(&Address::new_id(id)).copied()
     }
 
     fn get_actor_code_cid(&self, id: &ActorID) -> Option<Cid> {
@@ -966,7 +999,12 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         Ok(ret)
     }
 
-    fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {
+    fn create_actor(
+        &mut self,
+        code_id: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) -> Result<(), ActorError> {
         self.require_in_call();
         if self.in_transaction {
             return Err(actor_error!(assertion_failed; "side-effect within transaction"));
@@ -978,7 +1016,12 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
             .take()
             .expect("unexpected call to create actor");
 
-        assert!(expect_create_actor.code_id == code_id && expect_create_actor.actor_id == actor_id, "unexpected actor being created, expected code: {:?} address: {:?}, actual code: {:?} address: {:?}", expect_create_actor.code_id, expect_create_actor.actor_id, code_id, actor_id);
+        assert_eq!(
+            expect_create_actor,
+            ExpectCreateActor { code_id, actor_id, predictable_address },
+            "unexpected actor being created"
+        );
+        self.set_address_actor_type(Address::new_id(actor_id), code_id);
         Ok(())
     }
 

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -64,6 +64,10 @@ pub struct Actor {
     pub call_seq_num: u64,
     /// Token balance of the actor
     pub balance: TokenAmount,
+    /// The actor's "predictable" address, if assigned.
+    ///
+    /// This field is set on actor creation and never modified.
+    pub address: Option<Address>,
 }
 
 /// A specialization of a map of ID-addresses to actor heads.

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -35,8 +35,8 @@ use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{CborStore, RawBytes};
 use fvm_ipld_hamt::{BytesKey, Hamt, Sha256};
+use fvm_shared::address::Address;
 use fvm_shared::address::Payload;
-use fvm_shared::address::{Address, Protocol};
 use fvm_shared::bigint::Zero;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
@@ -140,17 +140,23 @@ impl<'bs> VM<'bs> {
         let sys_st = SystemState::new(store).unwrap();
         let sys_head = v.put_store(&sys_st);
         let sys_value = faucet_total.clone(); // delegate faucet funds to system so we can construct faucet by sending to bls addr
-        v.set_actor(SYSTEM_ACTOR_ADDR, actor(*SYSTEM_ACTOR_CODE_ID, sys_head, 0, sys_value));
+        v.set_actor(SYSTEM_ACTOR_ADDR, actor(*SYSTEM_ACTOR_CODE_ID, sys_head, 0, sys_value, None));
 
         // init
         let init_st = InitState::new(store, "integration-test".to_string()).unwrap();
         let init_head = v.put_store(&init_st);
-        v.set_actor(INIT_ACTOR_ADDR, actor(*INIT_ACTOR_CODE_ID, init_head, 0, TokenAmount::zero()));
+        v.set_actor(
+            INIT_ACTOR_ADDR,
+            actor(*INIT_ACTOR_CODE_ID, init_head, 0, TokenAmount::zero(), None),
+        );
 
         // reward
 
         let reward_head = v.put_store(&RewardState::new(StoragePower::zero()));
-        v.set_actor(REWARD_ACTOR_ADDR, actor(*REWARD_ACTOR_CODE_ID, reward_head, 0, reward_total));
+        v.set_actor(
+            REWARD_ACTOR_ADDR,
+            actor(*REWARD_ACTOR_CODE_ID, reward_head, 0, reward_total, None),
+        );
 
         // cron
         let builtin_entries = vec![
@@ -164,20 +170,23 @@ impl<'bs> VM<'bs> {
             },
         ];
         let cron_head = v.put_store(&CronState { entries: builtin_entries });
-        v.set_actor(CRON_ACTOR_ADDR, actor(*CRON_ACTOR_CODE_ID, cron_head, 0, TokenAmount::zero()));
+        v.set_actor(
+            CRON_ACTOR_ADDR,
+            actor(*CRON_ACTOR_CODE_ID, cron_head, 0, TokenAmount::zero(), None),
+        );
 
         // power
         let power_head = v.put_store(&PowerState::new(&v.store).unwrap());
         v.set_actor(
             STORAGE_POWER_ACTOR_ADDR,
-            actor(*POWER_ACTOR_CODE_ID, power_head, 0, TokenAmount::zero()),
+            actor(*POWER_ACTOR_CODE_ID, power_head, 0, TokenAmount::zero(), None),
         );
 
         // market
         let market_head = v.put_store(&MarketState::new(&v.store).unwrap());
         v.set_actor(
             STORAGE_MARKET_ACTOR_ADDR,
-            actor(*MARKET_ACTOR_CODE_ID, market_head, 0, TokenAmount::zero()),
+            actor(*MARKET_ACTOR_CODE_ID, market_head, 0, TokenAmount::zero(), None),
         );
 
         // verifreg
@@ -226,7 +235,7 @@ impl<'bs> VM<'bs> {
         let verifreg_head = v.put_store(&VerifRegState::new(&v.store, root_msig_addr).unwrap());
         v.set_actor(
             VERIFIED_REGISTRY_ACTOR_ADDR,
-            actor(*VERIFREG_ACTOR_CODE_ID, verifreg_head, 0, TokenAmount::zero()),
+            actor(*VERIFREG_ACTOR_CODE_ID, verifreg_head, 0, TokenAmount::zero(), None),
         );
 
         // datacap
@@ -234,14 +243,14 @@ impl<'bs> VM<'bs> {
             v.put_store(&DataCapState::new(&v.store, VERIFIED_REGISTRY_ACTOR_ADDR).unwrap());
         v.set_actor(
             DATACAP_TOKEN_ACTOR_ADDR,
-            actor(*DATACAP_TOKEN_ACTOR_CODE_ID, datacap_head, 0, TokenAmount::zero()),
+            actor(*DATACAP_TOKEN_ACTOR_CODE_ID, datacap_head, 0, TokenAmount::zero(), None),
         );
 
         // burnt funds
         let burnt_funds_head = v.put_store(&AccountState { address: BURNT_FUNDS_ACTOR_ADDR });
         v.set_actor(
             BURNT_FUNDS_ACTOR_ADDR,
-            actor(*ACCOUNT_ACTOR_CODE_ID, burnt_funds_head, 0, TokenAmount::zero()),
+            actor(*ACCOUNT_ACTOR_CODE_ID, burnt_funds_head, 0, TokenAmount::zero(), None),
         );
 
         // create a faucet with 1 billion FIL for setting up test accounts
@@ -571,19 +580,28 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
                 return Ok((act, a));
             }
         };
+
         // Address does not yet exist, create it
-        let protocol = target.protocol();
-        match protocol {
-            Protocol::Actor | Protocol::ID => {
+        let is_account = match target.payload() {
+            Payload::Secp256k1(_) | Payload::BLS(_) => true,
+            Payload::Delegated(da)
+            // Validate that there's an actor at the target ID (we don't care what is there,
+            // just that something is there).
+            if self.v.get_actor(Address::new_id(da.namespace())).is_some() =>
+                {
+                    false
+                }
+            _ => {
                 return Err(ActorError::unchecked(
                     ExitCode::SYS_INVALID_RECEIVER,
-                    format!("cannot create account for address {} type {}", target, protocol),
+                    format!("cannot create account for address {} type {}", target, target.protocol()),
                 ));
             }
-            _ => (),
-        }
+        };
+
         let mut st = self.v.get_state::<InitState>(INIT_ACTOR_ADDR).unwrap();
-        let target_id = st.map_address_to_new_id(self.v.store, target).unwrap();
+        let (target_id, existing) = st.map_addresses_to_id(self.v.store, target, None).unwrap();
+        assert!(!existing, "should never have existing actor when no f4 address is specified");
         let target_id_addr = Address::new_id(target_id);
         let mut init_actor = self.v.get_actor(INIT_ACTOR_ADDR).unwrap();
         init_actor.head = self.v.store.put_cbor(&st, Code::Blake2b256).unwrap();
@@ -606,13 +624,17 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
                 policy: self.policy,
                 subinvocations: RefCell::new(vec![]),
             };
-            new_ctx.create_actor(*ACCOUNT_ACTOR_CODE_ID, target_id).unwrap();
-            let res = new_ctx.invoke();
-            let invoc = new_ctx.gather_trace(res);
-            RefMut::map(self.subinvocations.borrow_mut(), |subinvocs| {
-                subinvocs.push(invoc);
-                subinvocs
-            });
+            if is_account {
+                new_ctx.create_actor(*ACCOUNT_ACTOR_CODE_ID, target_id, None).unwrap();
+                let res = new_ctx.invoke();
+                let invoc = new_ctx.gather_trace(res);
+                RefMut::map(self.subinvocations.borrow_mut(), |subinvocs| {
+                    subinvocs.push(invoc);
+                    subinvocs
+                });
+            } else {
+                new_ctx.create_actor(*PLACEHOLDER_ACTOR_CODE_ID, target_id, Some(*target)).unwrap();
+            }
         }
 
         Ok((self.v.get_actor(target_id_addr).unwrap(), target_id_addr))
@@ -704,7 +726,12 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
 impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
     type Blockstore = &'bs MemoryBlockstore;
 
-    fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {
+    fn create_actor(
+        &mut self,
+        code_id: Cid,
+        actor_id: ActorID,
+        predictable_address: Option<Address>,
+    ) -> Result<(), ActorError> {
         match NON_SINGLETON_CODES.get(&code_id) {
             Some(_) => (),
             None => {
@@ -721,7 +748,7 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
                 "attempt to create new actor at existing address".to_string(),
             ));
         }
-        let a = actor(code_id, EMPTY_ARR_CID, 0, TokenAmount::zero());
+        let a = actor(code_id, EMPTY_ARR_CID, 0, TokenAmount::zero(), predictable_address);
         self.v.set_actor(addr, a);
         Ok(())
     }
@@ -816,6 +843,10 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
             None => None,
             Some(act) => Some(act.code),
         }
+    }
+
+    fn lookup_delegated_address(&self, id: ActorID) -> Option<Address> {
+        self.v.get_actor(Address::new_id(id)).and_then(|act| act.predictable_address)
     }
 
     fn send(
@@ -1082,10 +1113,17 @@ pub struct Actor {
     pub head: Cid,
     pub call_seq_num: u64,
     pub balance: TokenAmount,
+    pub predictable_address: Option<Address>,
 }
 
-pub fn actor(code: Cid, head: Cid, seq: u64, bal: TokenAmount) -> Actor {
-    Actor { code, head, call_seq_num: seq, balance: bal }
+pub fn actor(
+    code: Cid,
+    head: Cid,
+    call_seq_num: u64,
+    balance: TokenAmount,
+    predictable_address: Option<Address>,
+) -> Actor {
+    Actor { code, head, call_seq_num, balance, predictable_address }
 }
 
 #[derive(Clone)]

--- a/test_vm/tests/test_vm_test.rs
+++ b/test_vm/tests/test_vm_test.rs
@@ -25,14 +25,20 @@ fn state_control() {
         make_identity_cid(b"a1-head"),
         42,
         TokenAmount::from_atto(10u8),
+        None,
     );
     v.set_actor(addr1, a1.clone());
     let out = v.get_actor(addr1).unwrap();
     assert_eq!(out, a1);
     let check = v.checkpoint();
 
-    let a2 =
-        actor(*PAYCH_ACTOR_CODE_ID, make_identity_cid(b"a2-head"), 88, TokenAmount::from_atto(1u8));
+    let a2 = actor(
+        *PAYCH_ACTOR_CODE_ID,
+        make_identity_cid(b"a2-head"),
+        88,
+        TokenAmount::from_atto(1u8),
+        None,
+    );
     v.set_actor(addr2, a2.clone());
     assert_eq!(v.get_actor(addr2).unwrap(), a2);
     // rollback removes a2 but not a1


### PR DESCRIPTION
Extracted from `next`.

This is a partial implementation of [FIP-0048](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0048.md). This PR:

- updates to the new `Actor` object, that includes an Optional field for Predictable addresses
- introduces the new `Placeholder` actor that has no state and accepts all calls 
- updates the init actor to store f4 addresses in its map
- adds a new `lookup_delegated_address` syscall to retrieve an actor's f4 address

It does NOT introduce the new Exec4 method specified in FIP-0048, as that method requires implementation of the Ethereum Address Manager actor. That will be included in a future PR.
