### PR TITLE
Evm unittest fixes

### DIFF
--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -158,8 +158,6 @@ pub fn jumpi(bytecode: &Bytecode, pc: usize, dest: U256, test: U256) -> Result<u
 
 #[cfg(test)]
 mod tests {
-    use fil_actors_runtime::test_utils::MockRuntime;
-
     use crate::do_test;
     use crate::interpreter::U256;
 

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -161,7 +161,6 @@ mod tests {
     use fil_actors_runtime::test_utils::MockRuntime;
 
     use crate::do_test;
-    use crate::interpreter::test_util::Tester;
     use crate::interpreter::U256;
 
     #[test]
@@ -177,7 +176,7 @@ mod tests {
     #[test]
     fn test_pc() {
         do_test!(
-            tester,
+            rt,
             m,
             vec![
                 0x58, // PC

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -177,24 +177,6 @@ mod tests {
 
     #[test]
     fn test_pc() {
-        let v = vec![
-            0x58, // PC
-            0x5b, // JMPDEST -- noop
-        ];
-
-        let mut rt = MockRuntime::default();
-        let mut m = Tester::init(&mut rt);
-        let bytes = Bytecode::new(v);
-        let mut m = m.machine(&bytes);
-
-        let result = m.step();
-        assert!(result.is_ok(), "execution stop failed");
-        assert_eq!(m.state.stack.pop().unwrap(), U256::zero());
-        assert_eq!(m.pc, 1, "pc has advanced");
-    }
-
-    #[test]
-    fn test_pc_() {
         do_test!(
             tester,
             m,

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -162,7 +162,6 @@ mod tests {
 
     use crate::do_test;
     use crate::interpreter::test_util::Tester;
-    use crate::interpreter::Bytecode;
     use crate::interpreter::U256;
 
     #[test]

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -158,8 +158,11 @@ pub fn jumpi(bytecode: &Bytecode, pc: usize, dest: U256, test: U256) -> Result<u
 
 #[cfg(test)]
 mod tests {
+    use fil_actors_runtime::test_utils::MockRuntime;
+
     use crate::do_test;
-    use crate::interpreter::test_util;
+    use crate::interpreter::test_util::Tester;
+    use crate::interpreter::Bytecode;
     use crate::interpreter::U256;
 
     #[test]
@@ -174,9 +177,26 @@ mod tests {
 
     #[test]
     fn test_pc() {
+        let v = vec![
+            0x58, // PC
+            0x5b, // JMPDEST -- noop
+        ];
+
+        let mut rt = MockRuntime::default();
+        let mut m = Tester::init(&mut rt);
+        let bytes = Bytecode::new(v);
+        let mut m = m.machine(&bytes);
+
+        let result = m.step();
+        assert!(result.is_ok(), "execution stop failed");
+        assert_eq!(m.state.stack.pop().unwrap(), U256::zero());
+        assert_eq!(m.pc, 1, "pc has advanced");
+    }
+
+    #[test]
+    fn test_pc_() {
         do_test!(
-            rt,
-            env,
+            tester,
             m,
             vec![
                 0x58, // PC

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -3,9 +3,9 @@
 #[macro_export]
 macro_rules! do_test {
     ($rt:ident, $machine:ident, $code:expr, $body:block) => {
-        use crate::{EthAddress, Bytes, Bytecode, ExecutionState};
-        use crate::interpreter::{system::System, execution::Machine, Output};
         use ::fvm_shared::econ::TokenAmount;
+        use $crate::interpreter::{execution::Machine, system::System, Output};
+        use $crate::{Bytecode, Bytes, EthAddress, ExecutionState};
 
         let mut $rt = MockRuntime::default();
         let mut state = ExecutionState::new(
@@ -25,6 +25,6 @@ macro_rules! do_test {
             output: Output::default(),
         };
 
-        (|| {$body})()
+        $body
     };
 }

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -3,6 +3,7 @@
 #[macro_export]
 macro_rules! do_test {
     ($rt:ident, $machine:ident, $code:expr, $body:block) => {
+        use ::fil_actors_runtime::test_utils::MockRuntime;
         use ::fvm_shared::econ::TokenAmount;
         use $crate::interpreter::{execution::Machine, system::System, Output};
         use $crate::{Bytecode, Bytes, EthAddress, ExecutionState};

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -17,27 +17,28 @@ pub type TestMachine<'machine, 'rt> = Machine<'machine, 'rt, MockRuntime>;
 pub struct Tester<'rt> {
     pub system: TestSystem<'rt>,
     pub state: ExecutionState,
+    pub bytecode: Bytecode,
 }
 
 impl<'rt> Tester<'rt> {
-    pub fn machine<'m>(&'rt mut self, bytecode: &'m Bytecode) -> TestMachine<'m, 'rt> {
+    pub fn machine<'m>(&'rt mut self) -> TestMachine<'m, 'rt> {
         TestMachine {
             system: &mut self.system,
             state: &mut self.state,
-            bytecode,
+            bytecode: &self.bytecode,
             pc: 0,
             output: Output::default(),
         }
     }
 
-    pub fn init(rt: &'rt mut MockRuntime) -> Tester<'rt> {
+    pub fn init(rt: &'rt mut MockRuntime, bytecode: Vec<u8>) -> Tester<'rt> {
         let state = ExecutionState::new(
             EthAddress::from_id(1000),
             EthAddress::from_id(1000),
             TokenAmount::from_atto(0),
             Bytes::default(),
         );
-        Tester { state, system: TestSystem::new(rt, false) }
+        Tester { state, system: TestSystem::new(rt, false), bytecode: Bytecode::new(bytecode) }
     }
 }
 
@@ -45,9 +46,8 @@ impl<'rt> Tester<'rt> {
 macro_rules! do_test {
     ($tester:ident, $machine:ident, $code:expr, $body:block) => {
         let mut rt = MockRuntime::default();
-        let mut $tester = Tester::init(&mut rt);
-        let bytes = Bytecode::new($code);
-        let mut $machine = $tester.machine(&bytes);
+        let mut $tester = Tester::init(&mut rt, $code);
+        let mut $machine = $tester.machine();
 
         $body
     };

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -1,54 +1,30 @@
 #![cfg(test)]
 
-use fil_actors_runtime::test_utils::*;
-use fvm_shared::econ::TokenAmount;
+#[macro_export]
+macro_rules! do_test {
+    ($rt:ident, $machine:ident, $code:expr, $body:block) => {
+        use crate::{EthAddress, Bytes, Bytecode, ExecutionState};
+        use crate::interpreter::{system::System, execution::Machine, Output};
+        use ::fvm_shared::econ::TokenAmount;
 
-use crate::interpreter::address::*;
-use crate::interpreter::bytecode::*;
-use crate::interpreter::execution::*;
-use crate::interpreter::output::*;
-use crate::interpreter::system::*;
-
-use bytes::Bytes;
-
-pub type TestSystem<'rt> = System<'rt, MockRuntime>;
-pub type TestMachine<'machine, 'rt> = Machine<'machine, 'rt, MockRuntime>;
-
-pub struct Tester<'rt> {
-    pub system: TestSystem<'rt>,
-    pub state: ExecutionState,
-    pub bytecode: Bytecode,
-}
-
-impl<'rt> Tester<'rt> {
-    pub fn machine<'m>(&'rt mut self) -> TestMachine<'m, 'rt> {
-        TestMachine {
-            system: &mut self.system,
-            state: &mut self.state,
-            bytecode: &self.bytecode,
-            pc: 0,
-            output: Output::default(),
-        }
-    }
-
-    pub fn init(rt: &'rt mut MockRuntime, bytecode: Vec<u8>) -> Tester<'rt> {
-        let state = ExecutionState::new(
+        let mut $rt = MockRuntime::default();
+        let mut state = ExecutionState::new(
             EthAddress::from_id(1000),
             EthAddress::from_id(1000),
             TokenAmount::from_atto(0),
             Bytes::default(),
         );
-        Tester { state, system: TestSystem::new(rt, false), bytecode: Bytecode::new(bytecode) }
-    }
-}
 
-#[macro_export]
-macro_rules! do_test {
-    ($tester:ident, $machine:ident, $code:expr, $body:block) => {
-        let mut rt = MockRuntime::default();
-        let mut $tester = Tester::init(&mut rt, $code);
-        let mut $machine = $tester.machine();
+        let mut system = System::new(&mut $rt, false);
+        let bytecode = Bytecode::new($code);
+        let mut $machine = Machine {
+            system: &mut system,
+            state: &mut state,
+            bytecode: &bytecode,
+            pc: 0,
+            output: Output::default(),
+        };
 
-        $body
+        (|| {$body})()
     };
 }


### PR DESCRIPTION
There are way to many refrences inside structs to be able to construct this manually (without some nasty hacks), so instead I've just cleaned up the types that had duplicate fields already accessable or not owned. 