### PR TITLE
Test and fix fip 47 implementation

### DIFF
--- a/actors/miner/src/deadline_state.rs
+++ b/actors/miner/src/deadline_state.rs
@@ -359,9 +359,7 @@ impl Deadline {
         self.early_terminations |= &new_early_terminations;
 
         // Update live sector count.
-        let on_time_count = all_expirations.on_time_sectors.len();
-        let early_count = all_expirations.faulty_sectors.len();
-        self.live_sectors -= on_time_count + early_count;
+        self.live_sectors -= all_expirations.len();
 
         self.faulty_power -= &all_expirations.faulty_power;
         Ok(all_expirations)

--- a/actors/miner/src/expiration_queue.rs
+++ b/actors/miner/src/expiration_queue.rs
@@ -236,39 +236,6 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
         Ok((sector_numbers, total_power, total_pledge))
     }
 
-    /// Reschedules some sectors to a new (quantized) expiration epoch.
-    /// The sectors being rescheduled are assumed to be not faulty, and hence are removed from and re-scheduled for on-time
-    /// rather than early expiration.
-    /// The sectors' power and pledge are assumed not to change, despite the new expiration.
-    pub fn reschedule_expirations(
-        &mut self,
-        new_expiration: ChainEpoch,
-        sectors: &[SectorOnChainInfo],
-        sector_size: SectorSize,
-    ) -> anyhow::Result<()> {
-        if sectors.is_empty() {
-            return Ok(());
-        }
-
-        let (sector_numbers, power, pledge) = self
-            .remove_active_sectors(sectors, sector_size)
-            .map_err(|e| e.downcast_wrap("failed to remove sector expirations"))?;
-
-        // TODO it reschedules always as on time, add a flag?
-        self.add(
-            new_expiration,
-            &sector_numbers,
-            &BitField::new(),
-            &BitField::new(),
-            &power,
-            &PowerPair::zero(),
-            &pledge,
-        )
-        .map_err(|e| e.downcast_wrap("failed to record new sector expirations"))?;
-
-        Ok(())
-    }
-
     /// Re-schedules sectors to expire at an early expiration epoch (quantized), if they wouldn't expire before then anyway.
     /// The sectors must not be currently faulty, so must be registered as expiring on-time rather than early.
     /// The pledge for the now-early sectors is removed from the queue.

--- a/actors/miner/src/expiration_queue.rs
+++ b/actors/miner/src/expiration_queue.rs
@@ -454,33 +454,29 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
                 recovered_power += &power;
             }
 
-            let mut early_unset = Vec::new();
             for sector_number in expiration_set.proof_expiring_sectors.iter() {
                 let sector = match remaining.remove(&sector_number) {
                     Some(s) => s,
                     None => continue,
                 };
-                // If the sector expires early at this epoch, remove it for re-scheduling.
+                // If the sector expires early at this epoch, leave it here but change faulty power to active.
                 // It's not part of the on-time pledge number here.
-                early_unset.push(sector_number);
                 let power = power_for_sector(sector_size, sector);
                 faulty_power_delta -= &power;
-                sectors_rescheduled.push(sector);
+                active_power_delta += &power;
 
                 recovered_power += &power;
             }
 
             // we need to defer the changes as we cannot borrow immutably for iteration
             // and mutably for changes at the same time
-            if !early_unset.is_empty()
-                || !faulty_unset.is_empty()
+            if !faulty_unset.is_empty()
                 || !faulty_power_delta.is_zero()
                 || !active_power_delta.is_zero()
             {
                 expiration_set.active_power += &active_power_delta;
                 expiration_set.faulty_power += &faulty_power_delta;
 
-                expiration_set.proof_expiring_sectors -= BitField::try_from_bits(early_unset)?;
                 expiration_set.faulty_sectors -= BitField::try_from_bits(faulty_unset)?;
                 expiration_set.validate_state()?;
             }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3931,7 +3931,6 @@ fn process_early_terminations(
                     &sectors,
                 );
 
-
                 // estimate ~one deal per sector.
                 let mut deal_ids = Vec::<DealID>::with_capacity(sectors.len());
                 for sector in sectors {
@@ -3942,7 +3941,6 @@ fn process_early_terminations(
                 let params = ext::market::OnMinerSectorsTerminateParams { epoch, deal_ids };
                 deals_to_terminate.push(params);
                 println!("total pledge released at termination: {}", total_initial_pledge);
-
             }
 
             // Pay penalty
@@ -3972,7 +3970,6 @@ fn process_early_terminations(
             println!("total penalty {}", penalty);
             println!("total pledge from vesting penalty: {}", penalty_from_vesting);
             println!("total pledge delta: {}", pledge_delta);
-
 
             Ok((result, more, deals_to_terminate, penalty, pledge_delta))
         })?;

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3965,7 +3965,7 @@ fn process_early_terminations(
                 })?;
 
             penalty = &penalty_from_vesting + penalty_from_balance;
-            pledge_delta -= penalty_from_vesting.clone();
+            pledge_delta -= penalty_from_vesting;
 
             Ok((result, more, deals_to_terminate, penalty, pledge_delta))
         })?;

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -4176,6 +4176,7 @@ fn validate_commitment_expiration(
     let max_lifetime = seal_proof_sector_maximum_lifetime(seal_proof).ok_or_else(|| {
         actor_error!(illegal_argument, "unrecognized seal proof type {:?}", seal_proof)
     })?;
+
     if expiration - activation > max_lifetime {
         return Err(actor_error!(
         illegal_argument,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3931,6 +3931,7 @@ fn process_early_terminations(
                     &sectors,
                 );
 
+
                 // estimate ~one deal per sector.
                 let mut deal_ids = Vec::<DealID>::with_capacity(sectors.len());
                 for sector in sectors {
@@ -3940,6 +3941,8 @@ fn process_early_terminations(
 
                 let params = ext::market::OnMinerSectorsTerminateParams { epoch, deal_ids };
                 deals_to_terminate.push(params);
+                println!("total pledge released at termination: {}", total_initial_pledge);
+
             }
 
             // Pay penalty
@@ -3965,7 +3968,11 @@ fn process_early_terminations(
                 })?;
 
             penalty = &penalty_from_vesting + penalty_from_balance;
-            pledge_delta -= penalty_from_vesting;
+            pledge_delta -= penalty_from_vesting.clone();
+            println!("total penalty {}", penalty);
+            println!("total pledge from vesting penalty: {}", penalty_from_vesting);
+            println!("total pledge delta: {}", pledge_delta);
+
 
             Ok((result, more, deals_to_terminate, penalty, pledge_delta))
         })?;

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3940,7 +3940,6 @@ fn process_early_terminations(
 
                 let params = ext::market::OnMinerSectorsTerminateParams { epoch, deal_ids };
                 deals_to_terminate.push(params);
-                println!("total pledge released at termination: {}", total_initial_pledge);
             }
 
             // Pay penalty
@@ -3967,9 +3966,6 @@ fn process_early_terminations(
 
             penalty = &penalty_from_vesting + penalty_from_balance;
             pledge_delta -= penalty_from_vesting.clone();
-            println!("total penalty {}", penalty);
-            println!("total pledge from vesting penalty: {}", penalty_from_vesting);
-            println!("total pledge delta: {}", pledge_delta);
 
             Ok((result, more, deals_to_terminate, penalty, pledge_delta))
         })?;

--- a/actors/miner/src/partition_state.rs
+++ b/actors/miner/src/partition_state.rs
@@ -361,44 +361,6 @@ impl Partition {
         // No change to unproven power.
     }
 
-    /// RescheduleExpirations moves expiring sectors to the target expiration,
-    /// skipping any sectors it can't find.
-    ///
-    /// The power of the rescheduled sectors is assumed to have not changed since
-    /// initial scheduling.
-    ///
-    /// Note: see the docs on State.RescheduleSectorExpirations for details on why we
-    /// skip sectors/partitions we can't find.
-    pub fn reschedule_expirations<BS: Blockstore>(
-        &mut self,
-        store: &BS,
-        sectors: &Sectors<'_, BS>,
-        new_expiration: ChainEpoch,
-        sector_numbers: &BitField,
-        sector_size: SectorSize,
-        quant: QuantSpec,
-    ) -> anyhow::Result<Vec<SectorOnChainInfo>> {
-        // Ensure these sectors actually belong to this partition.
-        let present = sector_numbers & &self.sectors;
-
-        // Filter out terminated sectors.
-        let live = &present - &self.terminated;
-
-        // Filter out faulty sectors.
-        let active = &live - &self.faults;
-
-        let sector_infos = sectors.load_sector(&active)?;
-        let mut expirations = ExpirationQueue::new(store, &self.expirations_epochs, quant)
-            .map_err(|e| e.downcast_wrap("failed to load sector expirations"))?;
-        expirations.reschedule_expirations(new_expiration, &sector_infos, sector_size)?;
-        self.expirations_epochs = expirations.amt.flush()?;
-
-        // check invariants
-        self.validate_state()?;
-
-        Ok(sector_infos)
-    }
-
     /// Replaces a number of "old" sectors with new ones.
     /// The old sectors must not be faulty or terminated.
     /// If the same sector is both removed and added, this permits rescheduling *with a change in power*.

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -130,12 +130,12 @@ pub struct CheckSectorProvenParams {
     pub sector_number: SectorNumber,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
 pub struct ExtendSectorExpirationParams {
     pub extensions: Vec<ExpirationExtension>,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
 pub struct ExpirationExtension {
     pub deadline: u64,
     pub partition: u64,

--- a/actors/miner/tests/deadline_cron.rs
+++ b/actors/miner/tests/deadline_cron.rs
@@ -134,7 +134,11 @@ fn sector_expires_and_repays_fee_debt() {
             no_enrollment: true,
             expired_sectors_power_delta: Some(power_delta),
             expired_sectors_pledge_delta: initial_pledge.neg(),
-            continued_faults_penalty: PenaltyConfig::new_from_tranches(TokenAmount::zero(), initial_pledge.clone(), TokenAmount::zero()),
+            continued_faults_penalty: PenaltyConfig::new_from_tranches(
+                TokenAmount::zero(),
+                initial_pledge.clone(),
+                TokenAmount::zero(),
+            ),
             ..CronConfig::default()
         },
     );
@@ -216,7 +220,10 @@ fn detects_and_penalizes_faults() {
 
     h.advance_deadline(
         &mut rt,
-        CronConfig { continued_faults_penalty: PenaltyConfig::new(ongoing_penalty), ..Default::default() },
+        CronConfig {
+            continued_faults_penalty: PenaltyConfig::new(ongoing_penalty),
+            ..Default::default()
+        },
     );
 
     // recorded faulty power is unchanged

--- a/actors/miner/tests/deadline_cron.rs
+++ b/actors/miner/tests/deadline_cron.rs
@@ -134,7 +134,6 @@ fn sector_expires_and_repays_fee_debt() {
             no_enrollment: true,
             expired_sectors_power_delta: Some(power_delta),
             expired_sectors_pledge_delta: initial_pledge.neg(),
-            repaid_fee_debt_deprecated: initial_pledge.clone(),
             continued_faults_penalty: PenaltyConfig::new_from_tranches(TokenAmount::zero(), initial_pledge.clone(), TokenAmount::zero()),
             ..CronConfig::default()
         },
@@ -217,7 +216,7 @@ fn detects_and_penalizes_faults() {
 
     h.advance_deadline(
         &mut rt,
-        CronConfig { continued_faults_penalty_deprecated: ongoing_penalty.clone(), continued_faults_penalty: PenaltyConfig::new(ongoing_penalty), ..Default::default() },
+        CronConfig { continued_faults_penalty: PenaltyConfig::new(ongoing_penalty), ..Default::default() },
     );
 
     // recorded faulty power is unchanged

--- a/actors/miner/tests/deadline_cron.rs
+++ b/actors/miner/tests/deadline_cron.rs
@@ -134,7 +134,8 @@ fn sector_expires_and_repays_fee_debt() {
             no_enrollment: true,
             expired_sectors_power_delta: Some(power_delta),
             expired_sectors_pledge_delta: initial_pledge.neg(),
-            repaid_fee_debt: initial_pledge.clone(),
+            repaid_fee_debt_deprecated: initial_pledge.clone(),
+            continued_faults_penalty: PenaltyConfig::new_from_tranches(TokenAmount::zero(), initial_pledge.clone(), TokenAmount::zero()),
             ..CronConfig::default()
         },
     );
@@ -216,7 +217,7 @@ fn detects_and_penalizes_faults() {
 
     h.advance_deadline(
         &mut rt,
-        CronConfig { continued_faults_penalty: ongoing_penalty, ..Default::default() },
+        CronConfig { continued_faults_penalty_deprecated: ongoing_penalty.clone(), continued_faults_penalty: PenaltyConfig::new(ongoing_penalty), ..Default::default() },
     );
 
     // recorded faulty power is unchanged

--- a/actors/miner/tests/declare_faults.rs
+++ b/actors/miner/tests/declare_faults.rs
@@ -60,7 +60,7 @@ fn declare_fault_pays_fee_at_window_post() {
     );
     h.advance_deadline(
         &mut rt,
-        CronConfig { continued_faults_penalty: ongoing_penalty, ..Default::default() },
+        CronConfig { continued_faults_penalty_deprecated: ongoing_penalty.clone(), continued_faults_penalty: PenaltyConfig::new(ongoing_penalty), ..Default::default() },
     );
     h.check_state(&rt);
 }

--- a/actors/miner/tests/declare_faults.rs
+++ b/actors/miner/tests/declare_faults.rs
@@ -60,7 +60,10 @@ fn declare_fault_pays_fee_at_window_post() {
     );
     h.advance_deadline(
         &mut rt,
-        CronConfig { continued_faults_penalty: PenaltyConfig::new(ongoing_penalty), ..Default::default() },
+        CronConfig {
+            continued_faults_penalty: PenaltyConfig::new(ongoing_penalty),
+            ..Default::default()
+        },
     );
     h.check_state(&rt);
 }

--- a/actors/miner/tests/declare_faults.rs
+++ b/actors/miner/tests/declare_faults.rs
@@ -60,7 +60,7 @@ fn declare_fault_pays_fee_at_window_post() {
     );
     h.advance_deadline(
         &mut rt,
-        CronConfig { continued_faults_penalty_deprecated: ongoing_penalty.clone(), continued_faults_penalty: PenaltyConfig::new(ongoing_penalty), ..Default::default() },
+        CronConfig { continued_faults_penalty: PenaltyConfig::new(ongoing_penalty), ..Default::default() },
     );
     h.check_state(&rt);
 }

--- a/actors/miner/tests/declare_recoveries.rs
+++ b/actors/miner/tests/declare_recoveries.rs
@@ -80,7 +80,7 @@ fn recovery_must_pay_back_fee_debt() {
     h.advance_deadline(
         &mut rt,
         CronConfig {
-             // continued faults penalty is all 0s, fee is instead added to debt
+            // continued faults penalty is all 0s, fee is instead added to debt
             ..Default::default()
         },
     );

--- a/actors/miner/tests/declare_recoveries.rs
+++ b/actors/miner/tests/declare_recoveries.rs
@@ -80,7 +80,7 @@ fn recovery_must_pay_back_fee_debt() {
     h.advance_deadline(
         &mut rt,
         CronConfig {
-            continued_faults_penalty: TokenAmount::zero(), // fee is instead added to debt
+             // continued faults penalty is all 0s, fee is instead added to debt
             ..Default::default()
         },
     );

--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -1,4 +1,3 @@
-use anyhow::Chain;
 use fil_actor_market::VerifiedDealInfo;
 use fil_actor_miner::ext::verifreg::Claim as FILPlusClaim;
 use fil_actor_miner::{
@@ -176,8 +175,8 @@ fn proof_extension_validation_checks() {
     };
     expect_abort_contains_message(
         ExitCode::USR_FORBIDDEN,
-        &format!("proof validity beyond {} epochs in the future", rt.policy().max_proof_validity)
-            .to_string(),
+        format!("proof validity beyond {} epochs in the future", rt.policy().max_proof_validity)
+            .as_str(),
         h.refresh_proof_expiration(&mut rt, params),
     );
     rt.reset();
@@ -264,7 +263,7 @@ fn proof_extension_early_sector_terminates_with_penalty() {
     );
 
     // Handle proving deadline. No missed PoSt fees are charged. Termination fee charged. Total power and pledge are lowered.
-    let power = -power_for_sector(h.sector_size, &new_sector.clone());
+    let power = -power_for_sector(h.sector_size, &new_sector);
     let mut cron_config = CronConfig::empty();
     // edge case alert: cron halting will wait until **next** deadline if it needs to process terminations since we check pledge before processing terminations
     cron_config.expected_enrollment = exp_dlinfo.last() + rt.policy.wpost_challenge_window;
@@ -415,8 +414,8 @@ fn rejects_extension_past_max_for_seal_proof(v2: bool) {
             };
 
             h.refresh_proof_expiration(&mut rt, refresh_params).unwrap();
-            sector.proof_expiration = sector.proof_expiration
-                + (rt.policy().max_proof_validity - rt.policy().proof_refresh_window);
+            sector.proof_expiration +=
+                rt.policy().max_proof_validity - rt.policy().proof_refresh_window;
         }
         h.assert_queue_state(
             &mut rt,

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -128,6 +128,12 @@ pub fn setup() -> (ActorHarness, MockRuntime) {
     h.construct_and_verify(&mut rt);
     (h, rt)
 }
+#[allow(dead_code)]
+pub enum ExpirationKind {
+    OnTime,
+    Proof,
+    Fault,
+}
 
 pub struct ActorHarness {
     pub receiver: Address,
@@ -2641,8 +2647,6 @@ impl ActorHarness {
         rt: &mut MockRuntime,
         sector: SectorOnChainInfo,
     ) -> TokenAmount {
-        let state: State = rt.get_state();
-
         let sector_size = sector.seal_proof.sector_size().unwrap();
         let sector_power = qa_power_for_sector(sector_size, &sector);
 
@@ -2658,12 +2662,6 @@ impl ActorHarness {
             0,
         )
     }
-}
-
-pub enum ExpirationKind {
-    OnTime,
-    Proof,
-    Fault,
 }
 
 #[allow(dead_code)]

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -933,7 +933,10 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
                 && expected_msg.method == method
                 && expected_msg.params == params
                 && expected_msg.value == value,
-        );
+            "\nexpected \n    msg to: {}, method: {}, params: {:?}, value: {}\nfound\n    msg to: {}, method: {}, params: {:?}, value: {}",
+             expected_msg.to, expected_msg.method, expected_msg.params, expected_msg.value,
+            to, method, params, value
+            );
 
         {
             let mut balance = self.balance.borrow_mut();


### PR DESCRIPTION
Adding proper tests to the new proof extension mechanism.  

Proof expiration tests
- [x] Extend past proof expiry, refresh proof expiry, extend past new proof expiry, cron expires on time
- [x] Extend past proof expiry, cron expires early 
- [ ] Extend past proof expiry, fault, recover, cron expires early
- [x] Check for basic validation: expiry must be set to 0 in refresh, no refresh before proof expiration window


This required addressing fairly involved technical debt in miner actor test harness.  Less direct changes to testing:
- [x] Better queue state asserting
- [x] Fixing harness send failure asserts to print out useful debug info
- [x] update expiration tests to use a modern seal proof type so we aren't constrained by limited lifetime to be unable to extend past proof expiration.  This required fixing some brittle assumptions in seemingly unrelated expiration tests as well as adapting them to the new proof expiration constraints
- [x] Modularize cron config to make accounting for pledge and penalty expirations more clean
- [x] Use this new modularization to allow asserting on termination processing from miner cron.  The fact that we weren't doing this already from the test harness is worrying given the major complexity and risk associated with miner cron.  



I'm also using this PR to address 3 fixes I deferred for expediency when merging the original branch here.