### PR TITLE
EVM: Fix `Memory::grow`

### DIFF
--- a/actors/evm/src/interpreter/instructions/memory.rs
+++ b/actors/evm/src/interpreter/instructions/memory.rs
@@ -44,10 +44,7 @@ pub fn get_memory_region(
         .checked_add(size)
         .context_code(EVM_CONTRACT_ILLEGAL_MEMORY_ACCESS, "new memory size exceeds max u32")?;
 
-    let current_size = mem.len();
-    if new_size as usize > current_size {
-        mem.grow(new_size as usize);
-    }
+    mem.grow(new_size as usize);
 
     Ok(Some(MemoryRegion {
         offset: offset as usize,

--- a/actors/evm/src/interpreter/memory.rs
+++ b/actors/evm/src/interpreter/memory.rs
@@ -5,7 +5,6 @@ use {
 
 use crate::EVM_WORD_SIZE;
 
-// REMOVEME actuall wasm page is 64Kib no?
 const PAGE_SIZE: usize = 4 * 1024;
 
 #[derive(Clone, Debug, Deref, DerefMut)]

--- a/actors/evm/src/interpreter/memory.rs
+++ b/actors/evm/src/interpreter/memory.rs
@@ -3,6 +3,9 @@ use {
     derive_more::{Deref, DerefMut},
 };
 
+use crate::EVM_WORD_SIZE;
+
+// REMOVEME actuall wasm page is 64Kib no?
 const PAGE_SIZE: usize = 4 * 1024;
 
 #[derive(Clone, Debug, Deref, DerefMut)]
@@ -16,16 +19,38 @@ impl Default for Memory {
 
 impl Memory {
     #[inline]
-    /// Resizes memory to `size` length, reserving extra WASM pages as-needed.
-    /// TODO this should be renamed resize since it can also shrink memory.
-    pub fn grow(&mut self, size: usize) {
-        let cap = self.0.capacity();
-        if size > cap {
-            let required_pages = (size + PAGE_SIZE - 1) / PAGE_SIZE;
-            self.0.reserve((PAGE_SIZE * required_pages) - self.0.len());
+    /// Reserve extra pages of memory
+    fn reserve_pages(&mut self, pages: usize) {
+        self.0.reserve((PAGE_SIZE * pages) - self.0.len());
+    }
+
+    #[inline]
+    /// Grows memory to a new size, reserving extra pages as-needed.
+    /// `new_size` may be unaligned.
+    ///
+    /// Do nothing if `new_size` doesn't grow memory.
+    pub fn grow(&mut self, mut new_size: usize) {
+        if new_size <= self.len() {
+            return;
         }
-        debug_assert_eq!(size % 32, 0, "MSIZE depends on memory length being multiple of 32");
-        self.0.resize(size, 0);
+
+        // Align to the next u256.
+        // Guaranteed to not overflow.
+        let alignment = new_size % EVM_WORD_SIZE;
+        if alignment > 0 {
+            new_size += EVM_WORD_SIZE - alignment;
+        }
+
+        // Reserve any new pages.
+        let cap = self.0.capacity();
+        if new_size > cap {
+            let required_pages = (new_size + PAGE_SIZE - 1) / PAGE_SIZE;
+            self.reserve_pages(required_pages);
+        }
+
+        debug_assert_eq!(new_size % 32, 0, "MSIZE depends that memory is aligned to 32 bytes");
+        // Grow to new aligned size.
+        self.0.resize(new_size, 0);
     }
 }
 
@@ -34,11 +59,10 @@ mod tests {
     use super::*;
 
     #[test]
-    #[ignore = "failing because of new assert, replacing grow in new PR"]
     fn grow() {
         let mut mem = Memory::default();
         mem.grow(PAGE_SIZE * 2 + 1);
-        assert_eq!(mem.len(), PAGE_SIZE * 2 + 1);
+        assert_eq!(mem.len(), PAGE_SIZE * 2 + EVM_WORD_SIZE);
         assert_eq!(mem.capacity(), PAGE_SIZE * 3);
     }
 }

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -46,6 +46,8 @@ const EVM_MAX_RESERVED_METHOD: u64 = 1023;
 pub const NATIVE_METHOD_SIGNATURE: &str = "handle_filecoin_method(uint64,uint64,bytes)";
 pub const NATIVE_METHOD_SELECTOR: [u8; 4] = [0x86, 0x8e, 0x10, 0xc4];
 
+const EVM_WORD_SIZE: usize = 32;
+
 #[test]
 fn test_method_selector() {
     // We could just _generate_ this method selector with a proc macro, but this is easier.


### PR DESCRIPTION
do alignment inside the function, and no-op if new_size would shrink memory.