### PR TITLE
Swallow deal termination error in cron

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -42,8 +42,9 @@ use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, DomainSeparationTag, Policy, Runtime};
 use fil_actors_runtime::{
     actor_dispatch, actor_error, deserialize_block, extract_send_result, ActorContext,
-    ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR,
-    STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR, CRON_ACTOR_ADDR,
+    ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR, INIT_ACTOR_ADDR,
+    REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 pub use monies::*;
@@ -4199,7 +4200,7 @@ fn request_terminate_deals(
         if rt.message().origin() == CRON_ACTOR_ADDR {
             match res {
                 Err(e) => error!("OnSectorsTerminate event failed from cron caller {}", e),
-                _ => (), 
+                _ => (),
             };
         } else {
             res?;

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -42,8 +42,8 @@ use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, DomainSeparationTag, Policy, Runtime};
 use fil_actors_runtime::{
     actor_dispatch, actor_error, deserialize_block, extract_send_result, ActorContext,
-    ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR, INIT_ACTOR_ADDR,
-    REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
+    ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR,
+    STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
     VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_ipld_encoding::ipld_block::IpldBlock;
@@ -4197,11 +4197,10 @@ fn request_terminate_deals(
         ));
         // Intentionally swallow this error to prevent frozen market cron corruption from also freezing this miner cron.
         // This is safe from a malicious caller perspective because this method's callstack should always originate with the trusted system caller.
-        if rt.message().origin() == CRON_ACTOR_ADDR {
-            match res {
-                Err(e) => error!("OnSectorsTerminate event failed from cron caller {}", e),
-                _ => (),
-            };
+        if rt.message().origin() == SYSTEM_ACTOR_ADDR {
+            if let Err(e) = res {
+                error!("OnSectorsTerminate event failed from cron caller {}", e)
+            }
         } else {
             res?;
         }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -4195,8 +4195,8 @@ fn request_terminate_deals(
             })?,
             TokenAmount::zero(),
         ));
-        // Intentionally swallow this error to prevent frozen market cron corruption from also freezing this miner cron.
-        // This is safe from a malicious caller perspective because this method's callstack should always originate with the trusted system caller.
+        // If running in a system / cron context intentionally swallow this error to prevent
+        // frozen market cron corruption from also freezing this miner cron.
         if rt.message().origin() == SYSTEM_ACTOR_ADDR {
             if let Err(e) = res {
                 error!("OnSectorsTerminate event failed from cron caller {}", e)


### PR DESCRIPTION
Today if market cron freezes over in case of programmer error then any miner actors making use of cron to terminate sectors will also freeze.   We should prefer to not do this to make frozen cron easier to recover and less disruptive.  We don't gain much from this.  Any recovery of frozen cron is going to need a migration and that migration should be able to filter out deals that have terminated since market cron froze.  Frozen cron from programmer error isn't esoteric: this is exactly the cause of calibration reset last year.  With FVM approaching and new classes of exploits becoming possible it makes sense to do this hardening.