### PR TITLE
feat: runtime: Add send_generalized

### DIFF
--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_dispatch, actor_error, ActorError, SYSTEM_ACTOR_ADDR};
+use fil_actors_runtime::{
+    actor_dispatch, actor_error, extract_send_result, ActorError, SYSTEM_ACTOR_ADDR,
+};
 
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::econ::TokenAmount;
@@ -56,7 +58,12 @@ impl Actor {
         let st: State = rt.state()?;
         for entry in st.entries {
             // Intentionally ignore any error when calling cron methods
-            let res = rt.send(&entry.receiver, entry.method_num, None, TokenAmount::zero());
+            let res = extract_send_result(rt.send_simple(
+                &entry.receiver,
+                entry.method_num,
+                None,
+                TokenAmount::zero(),
+            ));
             if let Err(e) = res {
                 log::error!(
                     "cron failed to send entry to {}, send error code {}",

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -21,7 +21,8 @@ use num_derive::FromPrimitive;
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_dispatch, actor_error, ActorContext, ActorError, AsActorError, SYSTEM_ACTOR_ADDR,
+    actor_dispatch, actor_error, extract_send_result, ActorContext, ActorError, AsActorError,
+    SYSTEM_ACTOR_ADDR,
 };
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 
@@ -406,7 +407,7 @@ where
         value: TokenAmount,
     ) -> Result<Response, ErrorNumber> {
         // The Runtime discards some of the information from the syscall :-(
-        let res = self.rt.send(to, method, params, value);
+        let res = extract_send_result(self.rt.send_simple(to, method, params, value));
 
         let rec = match res {
             Ok(ret) => Response { exit_code: ExitCode::OK, return_data: ret },

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -6,7 +6,7 @@ use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 
 use fil_actors_runtime::{
-    actor_dispatch, actor_error, ActorContext, ActorError, SYSTEM_ACTOR_ADDR,
+    actor_dispatch, actor_error, extract_send_result, ActorContext, ActorError, SYSTEM_ACTOR_ADDR,
 };
 use fvm_shared::address::Address;
 use fvm_shared::{ActorID, METHOD_CONSTRUCTOR};
@@ -95,12 +95,12 @@ impl Actor {
         rt.create_actor(params.code_cid, id_address, None)?;
 
         // Invoke constructor
-        rt.send(
+        extract_send_result(rt.send_simple(
             &Address::new_id(id_address),
             METHOD_CONSTRUCTOR,
             params.constructor_params.into(),
             rt.message().value_received(),
-        )
+        ))
         .context("constructor failed")?;
 
         Ok(ExecReturn { id_address: Address::new_id(id_address), robust_address })

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -41,9 +41,9 @@ use fil_actors_runtime::cbor::{serialize, serialize_vec};
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, DomainSeparationTag, Policy, Runtime};
 use fil_actors_runtime::{
-    actor_dispatch, actor_error, deserialize_block, ActorContext, ActorDowncast, ActorError,
-    BURNT_FUNDS_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
-    STORAGE_POWER_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+    actor_dispatch, actor_error, deserialize_block, extract_send_result, ActorContext,
+    ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR,
+    STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 pub use monies::*;
@@ -1649,7 +1649,9 @@ impl Actor {
 
         request_update_power(rt, power_delta)?;
         if !to_reward.is_zero() {
-            if let Err(e) = rt.send(&reporter, METHOD_SEND, None, to_reward.clone()) {
+            if let Err(e) =
+                extract_send_result(rt.send_simple(&reporter, METHOD_SEND, None, to_reward.clone()))
+            {
                 error!("failed to send reward: {}", e);
                 to_burn += to_reward;
             }
@@ -2078,12 +2080,12 @@ impl Actor {
             precommit.info.unsealed_cid,
         )?;
 
-        rt.send(
+        extract_send_result(rt.send_simple(
             &STORAGE_POWER_ACTOR_ADDR,
             ext::power::SUBMIT_POREP_FOR_BULK_VERIFY_METHOD,
             IpldBlock::serialize_cbor(&svi)?,
             TokenAmount::zero(),
-        )?;
+        ))?;
 
         Ok(())
     }
@@ -3178,7 +3180,9 @@ impl Actor {
             Ok((burn_amount, reward_amount))
         })?;
 
-        if let Err(e) = rt.send(&reporter, METHOD_SEND, None, reward_amount) {
+        if let Err(e) =
+            extract_send_result(rt.send_simple(&reporter, METHOD_SEND, None, reward_amount))
+        {
             error!("failed to send reward: {}", e);
         }
 
@@ -3277,7 +3281,12 @@ impl Actor {
             })?;
 
         if amount_withdrawn.is_positive() {
-            rt.send(&info.beneficiary, METHOD_SEND, None, amount_withdrawn.clone())?;
+            extract_send_result(rt.send_simple(
+                &info.beneficiary,
+                METHOD_SEND,
+                None,
+                amount_withdrawn.clone(),
+            ))?;
         }
 
         burn_funds(rt, fee_to_burn)?;
@@ -4137,12 +4146,12 @@ fn enroll_cron_event(
     let payload = serialize(&cb, "cron payload")?;
     let ser_params =
         IpldBlock::serialize_cbor(&ext::power::EnrollCronEventParams { event_epoch, payload })?;
-    rt.send(
+    extract_send_result(rt.send_simple(
         &STORAGE_POWER_ACTOR_ADDR,
         ext::power::ENROLL_CRON_EVENT_METHOD,
         ser_params,
         TokenAmount::zero(),
-    )?;
+    ))?;
 
     Ok(())
 }
@@ -4154,7 +4163,7 @@ fn request_update_power(rt: &mut impl Runtime, delta: PowerPair) -> Result<(), A
 
     let delta_clone = delta.clone();
 
-    rt.send(
+    extract_send_result(rt.send_simple(
         &STORAGE_POWER_ACTOR_ADDR,
         ext::power::UPDATE_CLAIMED_POWER_METHOD,
         IpldBlock::serialize_cbor(&ext::power::UpdateClaimedPowerParams {
@@ -4162,7 +4171,7 @@ fn request_update_power(rt: &mut impl Runtime, delta: PowerPair) -> Result<(), A
             quality_adjusted_delta: delta.qa,
         })?,
         TokenAmount::zero(),
-    )
+    ))
     .map_err(|e| e.wrap(format!("failed to update power with {:?}", delta_clone)))?;
 
     Ok(())
@@ -4176,7 +4185,7 @@ fn request_terminate_deals(
     const MAX_LENGTH: usize = 8192;
 
     for chunk in deal_ids.chunks(MAX_LENGTH) {
-        rt.send(
+        extract_send_result(rt.send_simple(
             &STORAGE_MARKET_ACTOR_ADDR,
             ext::market::ON_MINER_SECTORS_TERMINATE_METHOD,
             IpldBlock::serialize_cbor(&ext::market::OnMinerSectorsTerminateParamsRef {
@@ -4184,7 +4193,7 @@ fn request_terminate_deals(
                 deal_ids: chunk,
             })?,
             TokenAmount::zero(),
-        )?;
+        ))?;
     }
 
     Ok(())
@@ -4310,12 +4319,12 @@ fn request_deal_data(
         });
     }
 
-    deserialize_block(rt.send(
+    deserialize_block(extract_send_result(rt.send_simple(
         &STORAGE_MARKET_ACTOR_ADDR,
         ext::market::VERIFY_DEALS_FOR_ACTIVATION_METHOD,
         IpldBlock::serialize_cbor(&ext::market::VerifyDealsForActivationParamsRef { sectors })?,
         TokenAmount::zero(),
-    )?)
+    ))?)
 }
 
 /// Requests the current epoch target block reward from the reward actor.
@@ -4324,12 +4333,12 @@ fn request_current_epoch_block_reward(
     rt: &mut impl Runtime,
 ) -> Result<ThisEpochRewardReturn, ActorError> {
     deserialize_block(
-        rt.send(
+        extract_send_result(rt.send_simple(
             &REWARD_ACTOR_ADDR,
             ext::reward::THIS_EPOCH_REWARD_METHOD,
             Default::default(),
             TokenAmount::zero(),
-        )
+        ))
         .map_err(|e| e.wrap("failed to check epoch baseline power"))?,
     )
 }
@@ -4339,12 +4348,12 @@ fn request_current_total_power(
     rt: &mut impl Runtime,
 ) -> Result<ext::power::CurrentTotalPowerReturn, ActorError> {
     deserialize_block(
-        rt.send(
+        extract_send_result(rt.send_simple(
             &STORAGE_POWER_ACTOR_ADDR,
             ext::power::CURRENT_TOTAL_POWER_METHOD,
             Default::default(),
             TokenAmount::zero(),
-        )
+        ))
         .map_err(|e| e.wrap("failed to check current power"))?,
     )
 }
@@ -4368,12 +4377,12 @@ fn resolve_worker_address(rt: &mut impl Runtime, raw: Address) -> Result<ActorID
     }
 
     if raw.protocol() != Protocol::BLS {
-        let pub_key: Address = deserialize_block(rt.send(
+        let pub_key: Address = deserialize_block(extract_send_result(rt.send_simple(
             &Address::new_id(resolved),
             ext::account::PUBKEY_ADDRESS_METHOD,
             None,
             TokenAmount::zero(),
-        )?)?;
+        ))?)?;
         if pub_key.protocol() != Protocol::BLS {
             return Err(actor_error!(
                 illegal_argument,
@@ -4389,7 +4398,7 @@ fn resolve_worker_address(rt: &mut impl Runtime, raw: Address) -> Result<ActorID
 fn burn_funds(rt: &mut impl Runtime, amount: TokenAmount) -> Result<(), ActorError> {
     log::debug!("storage provder {} burning {}", rt.message().receiver(), amount);
     if amount.is_positive() {
-        rt.send(&BURNT_FUNDS_ACTOR_ADDR, METHOD_SEND, None, amount)?;
+        extract_send_result(rt.send_simple(&BURNT_FUNDS_ACTOR_ADDR, METHOD_SEND, None, amount))?;
     }
     Ok(())
 }
@@ -4399,12 +4408,12 @@ fn notify_pledge_changed(
     pledge_delta: &TokenAmount,
 ) -> Result<(), ActorError> {
     if !pledge_delta.is_zero() {
-        rt.send(
+        extract_send_result(rt.send_simple(
             &STORAGE_POWER_ACTOR_ADDR,
             ext::power::UPDATE_PLEDGE_TOTAL_METHOD,
             IpldBlock::serialize_cbor(pledge_delta)?,
             TokenAmount::zero(),
-        )?;
+        ))?;
     }
     Ok(())
 }
@@ -4417,12 +4426,13 @@ fn get_claims(
         provider: rt.message().receiver().id().unwrap(),
         claim_ids: ids.clone(),
     };
-    let claims_ret: ext::verifreg::GetClaimsReturn = deserialize_block(rt.send(
-        &VERIFIED_REGISTRY_ACTOR_ADDR,
-        ext::verifreg::GET_CLAIMS_METHOD as u64,
-        IpldBlock::serialize_cbor(&params)?,
-        TokenAmount::zero(),
-    )?)?;
+    let claims_ret: ext::verifreg::GetClaimsReturn =
+        deserialize_block(extract_send_result(rt.send_simple(
+            &VERIFIED_REGISTRY_ACTOR_ADDR,
+            ext::verifreg::GET_CLAIMS_METHOD as u64,
+            IpldBlock::serialize_cbor(&params)?,
+            TokenAmount::zero(),
+        ))?)?;
     if (claims_ret.batch_info.success_count as usize) < ids.len() {
         return Err(actor_error!(illegal_argument, "invalid claims"));
     }
@@ -4869,12 +4879,12 @@ fn activate_deals_and_claim_allocations(
         return Ok(Some(ext::market::DealSpaces::default()));
     }
     // Check (and activate) storage deals associated to sector. Abort if checks failed.
-    let activate_raw = rt.send(
+    let activate_raw = extract_send_result(rt.send_simple(
         &STORAGE_MARKET_ACTOR_ADDR,
         ext::market::ACTIVATE_DEALS_METHOD,
         IpldBlock::serialize_cbor(&ext::market::ActivateDealsParams { deal_ids, sector_expiry })?,
         TokenAmount::zero(),
-    );
+    ));
     let activate_res: ext::market::ActivateDealsResult = match activate_raw {
         Ok(res) => deserialize_block(res)?,
         Err(e) => {
@@ -4903,7 +4913,7 @@ fn activate_deals_and_claim_allocations(
         })
         .collect();
 
-    let claim_raw = rt.send(
+    let claim_raw = extract_send_result(rt.send_simple(
         &VERIFIED_REGISTRY_ACTOR_ADDR,
         ext::verifreg::CLAIM_ALLOCATIONS_METHOD,
         IpldBlock::serialize_cbor(&ext::verifreg::ClaimAllocationsParams {
@@ -4911,7 +4921,7 @@ fn activate_deals_and_claim_allocations(
             all_or_nothing: true,
         })?,
         TokenAmount::zero(),
-    );
+    ));
     let claim_res: ext::verifreg::ClaimAllocationsReturn = match claim_raw {
         Ok(res) => deserialize_block(res)?,
         Err(e) => {

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -16,8 +16,8 @@ use num_traits::Zero;
 use fil_actors_runtime::cbor::serialize_vec;
 use fil_actors_runtime::runtime::{ActorCode, Primitives, Runtime};
 use fil_actors_runtime::{
-    actor_dispatch, actor_error, make_empty_map, make_map_with_root, resolve_to_actor_id,
-    ActorContext, ActorError, AsActorError, Map, INIT_ACTOR_ADDR,
+    actor_dispatch, actor_error, extract_send_result, make_empty_map, make_map_with_root,
+    resolve_to_actor_id, ActorContext, ActorError, AsActorError, Map, INIT_ACTOR_ADDR,
 };
 
 pub use self::state::*;
@@ -472,7 +472,12 @@ fn execute_transaction_if_approved(
     if threshold_met {
         st.check_available(rt.current_balance(), &txn.value, rt.curr_epoch())?;
 
-        match rt.send(&txn.to, txn.method, txn.params.clone().into(), txn.value.clone()) {
+        match extract_send_result(rt.send_simple(
+            &txn.to,
+            txn.method,
+            txn.params.clone().into(),
+            txn.value.clone(),
+        )) {
             Ok(Some(r)) => {
                 out = RawBytes::new(r.data);
             }

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -119,11 +119,11 @@ fn create_miner_given_send_to_init_actor_fails_should_fail() {
         IpldBlock::serialize_cbor(&message_params).unwrap(),
         TokenAmount::from_atto(10),
         None,
-        ExitCode::SYS_INSUFFICIENT_FUNDS,
+        ExitCode::USR_INSUFFICIENT_FUNDS,
     );
 
     expect_abort(
-        ExitCode::SYS_INSUFFICIENT_FUNDS,
+        ExitCode::USR_INSUFFICIENT_FUNDS,
         rt.call::<PowerActor>(
             Method::CreateMiner as u64,
             IpldBlock::serialize_cbor(&create_miner_params).unwrap(),

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -23,9 +23,10 @@ use fil_actors_runtime::cbor::deserialize;
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Policy, Runtime};
 use fil_actors_runtime::{
-    actor_dispatch, actor_error, deserialize_block, make_map_with_root_and_bitwidth,
-    resolve_to_actor_id, ActorDowncast, ActorError, BatchReturn, Map, DATACAP_TOKEN_ACTOR_ADDR,
-    STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+    actor_dispatch, actor_error, deserialize_block, extract_send_result,
+    make_map_with_root_and_bitwidth, resolve_to_actor_id, ActorDowncast, ActorError, BatchReturn,
+    Map, DATACAP_TOKEN_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fil_actors_runtime::{ActorContext, AsActorError, BatchReturnGen};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
@@ -722,12 +723,12 @@ fn is_verifier(rt: &impl Runtime, st: &State, address: Address) -> Result<bool, 
 fn balance(rt: &mut impl Runtime, owner: &Address) -> Result<DataCap, ActorError> {
     let params = IpldBlock::serialize_cbor(owner)?;
     let x: TokenAmount = deserialize_block(
-        rt.send(
+        extract_send_result(rt.send_simple(
             &DATACAP_TOKEN_ACTOR_ADDR,
             ext::datacap::Method::Balance as u64,
             params,
             TokenAmount::zero(),
-        )
+        ))
         .context(format!("failed to query datacap balance of {}", owner))?,
     )?;
     Ok(tokens_to_datacap(&x))
@@ -742,12 +743,12 @@ fn mint(
 ) -> Result<(), ActorError> {
     let token_amt = datacap_to_tokens(amount);
     let params = MintParams { to: *to, amount: token_amt, operators };
-    rt.send(
+    extract_send_result(rt.send_simple(
         &DATACAP_TOKEN_ACTOR_ADDR,
         ext::datacap::Method::Mint as u64,
         IpldBlock::serialize_cbor(&params)?,
         TokenAmount::zero(),
-    )
+    ))
     .context(format!("failed to send mint {:?} to datacap", params))?;
     Ok(())
 }
@@ -760,12 +761,12 @@ fn burn(rt: &mut impl Runtime, amount: &DataCap) -> Result<(), ActorError> {
 
     let token_amt = datacap_to_tokens(amount);
     let params = BurnParams { amount: token_amt };
-    rt.send(
+    extract_send_result(rt.send_simple(
         &DATACAP_TOKEN_ACTOR_ADDR,
         ext::datacap::Method::Burn as u64,
         IpldBlock::serialize_cbor(&params)?,
         TokenAmount::zero(),
-    )
+    ))
     .context(format!("failed to send burn {:?} to datacap", params))?;
     // The burn return value gives the new balance, but it's dropped here.
     // This also allows the check for zero burns inside this method.
@@ -779,12 +780,12 @@ fn destroy(rt: &mut impl Runtime, owner: &Address, amount: &DataCap) -> Result<(
     }
     let token_amt = datacap_to_tokens(amount);
     let params = DestroyParams { owner: *owner, amount: token_amt };
-    rt.send(
+    extract_send_result(rt.send_simple(
         &DATACAP_TOKEN_ACTOR_ADDR,
         ext::datacap::Method::Destroy as u64,
         IpldBlock::serialize_cbor(&params)?,
         TokenAmount::zero(),
-    )
+    ))
     .context(format!("failed to send destroy {:?} to datacap", params))?;
     Ok(())
 }
@@ -797,12 +798,12 @@ fn transfer(rt: &mut impl Runtime, to: ActorID, amount: &DataCap) -> Result<(), 
         amount: token_amt,
         operator_data: Default::default(),
     };
-    rt.send(
+    extract_send_result(rt.send_simple(
         &DATACAP_TOKEN_ACTOR_ADDR,
         ext::datacap::Method::Transfer as u64,
         IpldBlock::serialize_cbor(&params)?,
         TokenAmount::zero(),
-    )
+    ))
     .context(format!("failed to send transfer to datacap {:?}", params))?;
     Ok(())
 }
@@ -875,7 +876,7 @@ fn remove_data_cap_request_is_valid(
 
     let payload = [SIGNATURE_DOMAIN_SEPARATION_REMOVE_DATA_CAP, b.bytes()].concat();
 
-    rt.send(
+    extract_send_result(rt.send_simple(
         &request.verifier,
         ext::account::AUTHENTICATE_MESSAGE_METHOD,
         IpldBlock::serialize_cbor(&ext::account::AuthenticateMessageParams {
@@ -883,7 +884,7 @@ fn remove_data_cap_request_is_valid(
             message: payload,
         })?,
         TokenAmount::zero(),
-    )
+    ))
     .map_err(|e| e.wrap("proposal authentication failed"))?;
     Ok(())
 }

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{actor_error, ActorContext, ActorError};
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
 use fvm_shared::METHOD_SEND;
 use fvm_shared::{ActorID, MethodNum};
@@ -25,8 +26,13 @@ pub fn resolve_to_actor_id(
     }
 
     // send 0 balance to the account so an ID address for it is created and then try to resolve
-    rt.send(address, METHOD_SEND, Default::default(), Default::default())
-        .with_context(|| format!("failed to send zero balance to address {}", address))?;
+    extract_send_result(rt.send_simple(
+        address,
+        METHOD_SEND,
+        Default::default(),
+        Default::default(),
+    ))
+    .with_context(|| format!("failed to send zero balance to address {}", address))?;
 
     if let Some(id) = rt.resolve_address(address) {
         return Ok(id);
@@ -55,7 +61,7 @@ where
         None => {
             return Err(
                 actor_error!(forbidden; "no code for caller {} of method {}", caller, method),
-            )
+            );
         }
         Some(code_cid) => {
             let builtin_type = rt.resolve_builtin_actor_type(&code_cid);
@@ -67,4 +73,48 @@ where
         }
     }
     Ok(())
+}
+
+pub fn extract_send_result(
+    res: Result<fvm_shared::Response, fvm_shared::error::ErrorNumber>,
+) -> Result<Option<IpldBlock>, ActorError> {
+    match res {
+        Ok(ret) => {
+            if ret.exit_code.is_success() {
+                Ok(ret.return_data)
+            } else {
+                Err(ActorError::checked(
+                    ret.exit_code,
+                    format!("send aborted with code {}", ret.exit_code),
+                    ret.return_data,
+                ))
+            }
+        }
+        Err(err) => Err(match err {
+            // Some of these errors are from operations in the Runtime or SDK layer
+            // before or after the underlying VM send syscall.
+            fvm_shared::error::ErrorNumber::NotFound => {
+                // This means that the receiving actor doesn't exist.
+                actor_error!(unspecified; "receiver not found")
+            }
+            fvm_shared::error::ErrorNumber::InsufficientFunds => {
+                // This means that the send failed because we have insufficient funds. We will
+                // get a _syscall error_, not an exit code, because the target actor will not
+                // run (and therefore will not exit).
+                actor_error!(insufficient_funds; "not enough funds")
+            }
+            fvm_shared::error::ErrorNumber::LimitExceeded => {
+                // This means we've exceeded the recursion limit.
+                actor_error!(assertion_failed; "recursion limit exceeded")
+            }
+            fvm_shared::error::ErrorNumber::ReadOnly => ActorError::unchecked(
+                fvm_shared::error::ExitCode::USR_READ_ONLY,
+                "attempted to mutate state while in readonly mode".into(),
+            ),
+            err => {
+                // We don't expect any other syscall exit codes.
+                actor_error!(assertion_failed; "unexpected error: {}", err)
+            }
+        }),
+    }
 }

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -302,6 +302,8 @@ where
         flags: SendFlags,
     ) -> Result<Response, ErrorNumber> {
         if self.in_transaction {
+            // Note: It's slightly improper to call this ErrorNumber::IllegalOperation,
+            // since the error arises before getting to the VM.
             return Err(ErrorNumber::IllegalOperation);
         }
 

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -292,7 +292,7 @@ where
         &self.blockstore
     }
 
-    fn send_generalized(
+    fn send(
         &self,
         to: &Address,
         method: MethodNum,

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -21,7 +21,7 @@ use fvm_shared::sector::{
 };
 use fvm_shared::sys::SendFlags;
 use fvm_shared::version::NetworkVersion;
-use fvm_shared::{ActorID, MethodNum};
+use fvm_shared::{ActorID, MethodNum, Response};
 use num_traits::FromPrimitive;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -292,56 +292,20 @@ where
         &self.blockstore
     }
 
-    fn send(
+    fn send_generalized(
         &self,
         to: &Address,
         method: MethodNum,
         params: Option<IpldBlock>,
         value: TokenAmount,
-    ) -> Result<Option<IpldBlock>, ActorError> {
+        gas_limit: Option<u64>,
+        flags: SendFlags,
+    ) -> Result<Response, ErrorNumber> {
         if self.in_transaction {
-            return Err(actor_error!(assertion_failed; "send is not allowed during transaction"));
+            return Err(ErrorNumber::IllegalOperation);
         }
-        match fvm::send::send(to, method, params, value, None, SendFlags::empty()) {
-            Ok(ret) => {
-                if ret.exit_code.is_success() {
-                    Ok(ret.return_data)
-                } else {
-                    Err(ActorError::checked(
-                        ret.exit_code,
-                        format!(
-                            "send to {} method {} aborted with code {}",
-                            to, method, ret.exit_code
-                        ),
-                        ret.return_data,
-                    ))
-                }
-            }
-            Err(err) => Err(match err {
-                // Some of these errors are from operations in the Runtime or SDK layer
-                // before or after the underlying VM send syscall.
-                ErrorNumber::NotFound => {
-                    // This means that the receiving actor doesn't exist.
-                    // TODO: we can't reasonably determine the correct "exit code" here.
-                    actor_error!(unspecified; "receiver not found")
-                }
-                ErrorNumber::InsufficientFunds => {
-                    // This means that the send failed because we have insufficient funds. We will
-                    // get a _syscall error_, not an exit code, because the target actor will not
-                    // run (and therefore will not exit).
-                    actor_error!(insufficient_funds; "not enough funds")
-                }
-                ErrorNumber::LimitExceeded => {
-                    // This means we've exceeded the recursion limit.
-                    // TODO: Define a better exit code.
-                    actor_error!(assertion_failed; "recursion limit exceeded")
-                }
-                err => {
-                    // We don't expect any other syscall exit codes.
-                    actor_error!(assertion_failed; "unexpected error: {}", err)
-                }
-            }),
-        }
+
+        fvm::send::send(to, method, params, value, gas_limit, flags)
     }
 
     fn new_actor_address(&mut self) -> Result<Address, ActorError> {

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -15,7 +15,7 @@ use fvm_shared::sector::{
     WindowPoStVerifyInfo,
 };
 use fvm_shared::version::NetworkVersion;
-use fvm_shared::{ActorID, MethodNum};
+use fvm_shared::{ActorID, MethodNum, Response};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -23,7 +23,7 @@ pub use self::actor_code::*;
 pub use self::policy::*;
 pub use self::randomness::DomainSeparationTag;
 use crate::runtime::builtins::Type;
-use crate::ActorError;
+use crate::{actor_error, ActorError};
 
 mod actor_code;
 pub mod builtins;
@@ -41,6 +41,8 @@ pub(crate) mod empty;
 
 pub use empty::EMPTY_ARR_CID;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fvm_shared::error::{ErrorNumber, ExitCode};
+use fvm_shared::sys::SendFlags;
 
 /// Runtime is the VM's internal runtime object.
 /// this is everything that is accessible to actors, beyond parameters.
@@ -142,7 +144,63 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
         method: MethodNum,
         params: Option<IpldBlock>,
         value: TokenAmount,
-    ) -> Result<Option<IpldBlock>, ActorError>;
+    ) -> Result<Option<IpldBlock>, ActorError> {
+        match self.send_generalized(to, method, params, value, None, SendFlags::empty()) {
+            Ok(ret) => {
+                if ret.exit_code.is_success() {
+                    Ok(ret.return_data)
+                } else {
+                    Err(ActorError::checked(
+                        ret.exit_code,
+                        format!(
+                            "send to {} method {} aborted with code {}",
+                            to, method, ret.exit_code
+                        ),
+                        ret.return_data,
+                    ))
+                }
+            }
+            Err(err) => Err(match err {
+                // Some of these errors are from operations in the Runtime or SDK layer
+                // before or after the underlying VM send syscall.
+                ErrorNumber::NotFound => {
+                    // This means that the receiving actor doesn't exist.
+                    // TODO: we can't reasonably determine the correct "exit code" here.
+                    actor_error!(unspecified; "receiver not found")
+                }
+                ErrorNumber::InsufficientFunds => {
+                    // This means that the send failed because we have insufficient funds. We will
+                    // get a _syscall error_, not an exit code, because the target actor will not
+                    // run (and therefore will not exit).
+                    actor_error!(insufficient_funds; "not enough funds")
+                }
+                ErrorNumber::LimitExceeded => {
+                    // This means we've exceeded the recursion limit.
+                    // TODO: Define a better exit code.
+                    actor_error!(assertion_failed; "recursion limit exceeded")
+                }
+                ErrorNumber::ReadOnly => ActorError::unchecked(
+                    ExitCode::USR_READ_ONLY,
+                    "attempted to mutate state while in readonly mode".into(),
+                ),
+                err => {
+                    // We don't expect any other syscall exit codes.
+                    actor_error!(assertion_failed; "unexpected error: {}", err)
+                }
+            }),
+        }
+    }
+
+    /// Generalization of [`Runtime::send`] that allows the caller to specify a gas limit and send flags.
+    fn send_generalized(
+        &self,
+        to: &Address,
+        method: MethodNum,
+        params: Option<IpldBlock>,
+        value: TokenAmount,
+        gas_limit: Option<u64>,
+        flags: SendFlags,
+    ) -> Result<Response, ErrorNumber>;
 
     /// Computes an address for a new actor. The returned address is intended to uniquely refer to
     /// the actor even in the event of a chain re-org (whereas an ID-address might refer to a

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -23,7 +23,7 @@ pub use self::actor_code::*;
 pub use self::policy::*;
 pub use self::randomness::DomainSeparationTag;
 use crate::runtime::builtins::Type;
-use crate::{actor_error, ActorError};
+use crate::ActorError;
 
 mod actor_code;
 pub mod builtins;
@@ -41,7 +41,7 @@ pub(crate) mod empty;
 
 pub use empty::EMPTY_ARR_CID;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_shared::error::{ErrorNumber, ExitCode};
+use fvm_shared::error::ErrorNumber;
 use fvm_shared::sys::SendFlags;
 
 /// Runtime is the VM's internal runtime object.
@@ -135,64 +135,7 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// Sends a message to another actor, returning the exit code and return value envelope.
     /// If the invoked method does not return successfully, its state changes
     /// (and that of any messages it sent in turn) will be rolled back.
-    /// Note that the current return type cannot distinguish between a successful invocation
-    /// that returns an error code, and an error originating from the syscall prior to
-    /// invoking the target actor/method.
     fn send(
-        &self,
-        to: &Address,
-        method: MethodNum,
-        params: Option<IpldBlock>,
-        value: TokenAmount,
-    ) -> Result<Option<IpldBlock>, ActorError> {
-        match self.send_generalized(to, method, params, value, None, SendFlags::empty()) {
-            Ok(ret) => {
-                if ret.exit_code.is_success() {
-                    Ok(ret.return_data)
-                } else {
-                    Err(ActorError::checked(
-                        ret.exit_code,
-                        format!(
-                            "send to {} method {} aborted with code {}",
-                            to, method, ret.exit_code
-                        ),
-                        ret.return_data,
-                    ))
-                }
-            }
-            Err(err) => Err(match err {
-                // Some of these errors are from operations in the Runtime or SDK layer
-                // before or after the underlying VM send syscall.
-                ErrorNumber::NotFound => {
-                    // This means that the receiving actor doesn't exist.
-                    // TODO: we can't reasonably determine the correct "exit code" here.
-                    actor_error!(unspecified; "receiver not found")
-                }
-                ErrorNumber::InsufficientFunds => {
-                    // This means that the send failed because we have insufficient funds. We will
-                    // get a _syscall error_, not an exit code, because the target actor will not
-                    // run (and therefore will not exit).
-                    actor_error!(insufficient_funds; "not enough funds")
-                }
-                ErrorNumber::LimitExceeded => {
-                    // This means we've exceeded the recursion limit.
-                    // TODO: Define a better exit code.
-                    actor_error!(assertion_failed; "recursion limit exceeded")
-                }
-                ErrorNumber::ReadOnly => ActorError::unchecked(
-                    ExitCode::USR_READ_ONLY,
-                    "attempted to mutate state while in readonly mode".into(),
-                ),
-                err => {
-                    // We don't expect any other syscall exit codes.
-                    actor_error!(assertion_failed; "unexpected error: {}", err)
-                }
-            }),
-        }
-    }
-
-    /// Generalization of [`Runtime::send`] that allows the caller to specify a gas limit and send flags.
-    fn send_generalized(
         &self,
         to: &Address,
         method: MethodNum,
@@ -201,6 +144,17 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
         gas_limit: Option<u64>,
         flags: SendFlags,
     ) -> Result<Response, ErrorNumber>;
+
+    /// Simplified version of [`Runtime::send`] that does not specify a gas limit, nor any send flags.
+    fn send_simple(
+        &self,
+        to: &Address,
+        method: MethodNum,
+        params: Option<IpldBlock>,
+        value: TokenAmount,
+    ) -> Result<Response, ErrorNumber> {
+        self.send(to, method, params, value, None, SendFlags::empty())
+    }
 
     /// Computes an address for a new actor. The returned address is intended to uniquely refer to
     /// the actor even in the event of a chain re-org (whereas an ID-address might refer to a

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -945,7 +945,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         &self.store
     }
 
-    fn send_generalized(
+    fn send(
         &self,
         to: &Address,
         method: MethodNum,

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -578,10 +578,10 @@ impl<BS: Blockstore> MockRuntime<BS> {
             method,
             params,
             value,
+            gas_limit: None,
+            send_flags: SendFlags::default(),
             send_return,
             exit_code,
-            send_flags: SendFlags::default(),
-            gas_limit: None,
             send_error: None,
         })
     }

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -885,7 +885,7 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
         self.v.get_actor(Address::new_id(id)).and_then(|act| act.predictable_address)
     }
 
-    fn send_generalized(
+    fn send(
         &self,
         to: &Address,
         method: MethodNum,


### PR DESCRIPTION
Extracted from `next`. Needs:

- [x] #1118 

This PR adds a new `send_generalized` method to the `Runtime`. The key differences between `send` and `send_generalized` are that:

- `send_generalized` can take an optional `gas_limit` that restricts the total gas usage of the send
- `send_generalized` can carry optional `SendFlags` -- currently the only `SendFlag` the FVM supports is `READ_ONLY`
- `send_generalized` segregates failures arising from the syscall prior to target invocation (returned as an `ErrorNumber`) and those arising from the invocation itself (returned as an `ExitCode`).

This PR is a pre-factor necessary for landing the changes involved in the FEVM FIPs -- it introduces new functionality, but doesn't start to _use_ it anywhere.