### PR TITLE
feat: runtime: Add read_only getter

### DIFF
--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -353,6 +353,10 @@ where
     fn base_fee(&self) -> TokenAmount {
         fvm::network::base_fee()
     }
+
+    fn read_only(&self) -> bool {
+        fvm::vm::read_only()
+    }
 }
 
 impl<B> Primitives for FvmRuntime<B>

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -199,6 +199,10 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
 
     /// Returns the gas base fee (cost per unit) for the current epoch.
     fn base_fee(&self) -> TokenAmount;
+
+    /// Returns true if the call is read_only.
+    /// All state updates, including actor creation and balance transfers, are rejected in read_only calls.
+    fn read_only(&self) -> bool;
 }
 
 /// Message information available to the actor about executing message.

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -1068,6 +1068,11 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
     fn base_fee(&self) -> TokenAmount {
         self.base_fee.clone()
     }
+
+    fn read_only(&self) -> bool {
+        // Unsupported for unit tests
+        unimplemented!()
+    }
 }
 
 impl<BS> Primitives for MockRuntime<BS> {


### PR DESCRIPTION
Extracted from `next`.  Needs:

- [x] #1118 
- [ ] #1126 

This PR simply introduces a getter to the `Runtime` to indicate whether an invocation is in `READ_ONLY` mode, and updates the test framework to consider this status as part of execution.

This PR is a pre-factor necessary for landing the changes involved in the FEVM FIPs -- it introduces new functionality, but doesn't start to _use_ it anywhere.