### PR TITLE
Introduce a SendError

### DIFF
--- a/runtime/src/actor_error.rs
+++ b/runtime/src/actor_error.rs
@@ -169,12 +169,16 @@ pub trait ActorContext<T> {
         F: FnOnce() -> C;
 }
 
-impl<T> ActorContext<T> for Result<T, ActorError> {
+impl<T, E> ActorContext<T> for Result<T, E>
+where
+    E: Into<ActorError>,
+{
     fn context<C>(self, context: C) -> Result<T, ActorError>
     where
         C: Display + 'static,
     {
-        self.map_err(|mut err| {
+        self.map_err(|err| {
+            let mut err = err.into();
             err.msg = format!("{}: {}", context, err.msg);
             err
         })
@@ -185,7 +189,8 @@ impl<T> ActorContext<T> for Result<T, ActorError> {
         C: Display + 'static,
         F: FnOnce() -> C,
     {
-        self.map_err(|mut err| {
+        self.map_err(|err| {
+            let mut err = err.into();
             err.msg = format!("{}: {}", f(), err.msg);
             err
         })

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -24,7 +24,7 @@ pub use self::actor_code::*;
 pub use self::policy::*;
 pub use self::randomness::DomainSeparationTag;
 use crate::runtime::builtins::Type;
-use crate::{actor_error, ActorError};
+use crate::{actor_error, ActorError, SendError};
 
 mod actor_code;
 pub mod builtins;
@@ -42,7 +42,6 @@ pub(crate) mod empty;
 
 pub use empty::EMPTY_ARR_CID;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_shared::error::ErrorNumber;
 use fvm_shared::sys::SendFlags;
 use multihash::Code;
 
@@ -162,7 +161,7 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
         value: TokenAmount,
         gas_limit: Option<u64>,
         flags: SendFlags,
-    ) -> Result<Response, ErrorNumber>;
+    ) -> Result<Response, SendError>;
 
     /// Simplified version of [`Runtime::send`] that does not specify a gas limit, nor any send flags.
     fn send_simple(
@@ -171,7 +170,7 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
         method: MethodNum,
         params: Option<IpldBlock>,
         value: TokenAmount,
-    ) -> Result<Response, ErrorNumber> {
+    ) -> Result<Response, SendError> {
         self.send(to, method, params, value, None, SendFlags::empty())
     }
 

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -14,7 +14,6 @@ use fil_actor_power::{Actor as PowerActor, Method as MethodPower, State as Power
 use fil_actor_reward::{Actor as RewardActor, State as RewardState};
 use fil_actor_system::{Actor as SystemActor, State as SystemState};
 use fil_actor_verifreg::{Actor as VerifregActor, State as VerifRegState};
-use fil_actors_runtime::actor_error;
 use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{
@@ -22,6 +21,7 @@ use fil_actors_runtime::runtime::{
     Verifier, EMPTY_ARR_CID,
 };
 use fil_actors_runtime::test_utils::*;
+use fil_actors_runtime::{actor_error, SendError};
 use fil_actors_runtime::{
     ActorError, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR, FIRST_NON_SINGLETON_ADDR, INIT_ACTOR_ADDR,
     REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
@@ -42,7 +42,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::error::{ErrorNumber, ExitCode};
+use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::Randomness;
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
@@ -893,7 +893,7 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
         value: TokenAmount,
         _gas_limit: Option<u64>,
         mut send_flags: SendFlags,
-    ) -> Result<Response, ErrorNumber> {
+    ) -> Result<Response, SendError> {
         // replicate FVM by silently propagating read only flag to subcalls
         if self.read_only() {
             send_flags.set(SendFlags::READ_ONLY, true)


### PR DESCRIPTION
This way the user can directly bubble the send error with the `?` operator.

Unfortunately, I couldn't simplify `extract_send_result` because `Response` isn't implemented in this crate and `ActorError` is, so there's no way to implement `From<Response>` for `Result<T, ActorError>`.