### PR TITLE
EVM: Factor out shared crate & reorg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,7 @@ dependencies = [
  "derive_more",
  "ethers 1.0.2",
  "etk-asm",
+ "fil_actors_evm_shared",
  "fil_actors_runtime",
  "fixed-hash 0.7.0",
  "frc42_dispatch",
@@ -1899,7 +1900,6 @@ dependencies = [
  "strum",
  "strum_macros",
  "substrate-bn",
- "uint",
 ]
 
 [[package]]
@@ -2094,6 +2094,18 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "fil_actors_evm_shared"
+version = "10.0.0-alpha.1"
+dependencies = [
+ "fil_actors_runtime",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0-alpha.17",
+ "hex",
+ "serde",
+ "uint",
 ]
 
 [[package]]
@@ -4552,6 +4564,7 @@ dependencies = [
  "fil_actor_reward",
  "fil_actor_system",
  "fil_actor_verifreg",
+ "fil_actors_evm_shared",
  "fil_actors_runtime",
  "fil_builtin_actors_state",
  "frc46_token",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ testing-fake-proofs = []
 m2-native = []
 
 [workspace]
-members = ["actors/*", "state", "runtime", "test_vm"]
+members = ["actors/*", "state", "runtime", "test_vm", "actors/evm/shared"]
 
 [patch.crates-io]
 #fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -32,7 +32,6 @@ strum = "0.24"
 strum_macros = "0.24"
 multihash = { version = "0.16.1", default-features = false }
 derive_more = "0.99"
-uint = { version = "0.9.3", default-features = false }
 fixed-hash = { version = "0.7.0", default-features = false }
 impl-serde = { version = "0.3.2", default-features = false }
 arrayvec = { version = "0.7.2", features = ["serde"] }
@@ -43,6 +42,7 @@ near-blake2 = { version = "0.9.1", git = "https://github.com/filecoin-project/ne
 lazy_static = "1.4.0"
 once_cell = { version = "1.16.0", default-features = false}
 frc42_dispatch = "3.0.1-alpha.1"
+fil_actors_evm_shared = { version = "10.0.0-alpha.1", path = "shared" }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/evm/shared/Cargo.toml
+++ b/actors/evm/shared/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "fil_actors_evm_shared"
+description = "Shared libraries for the built-in EVM actor for Filecoin"
+version = "10.0.0-alpha.1"
+license = "MIT OR Apache-2.0"
+authors = ["Protocol Labs", "Filecoin Core Devs"]
+edition = "2021"
+repository = "https://github.com/filecoin-project/builtin-actors"
+keywords = ["filecoin", "web3", "wasm", "evm"]
+
+[dependencies]
+serde = { version = "1.0.136", features = ["derive"] }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../../runtime" }
+fvm_ipld_encoding = "0.3.3"
+uint = { version = "0.9.3", default-features = false }
+hex = "0.4.3"

--- a/actors/evm/shared/src/address.rs
+++ b/actors/evm/shared/src/address.rs
@@ -1,4 +1,4 @@
-use crate::U256;
+use crate::uints::U256;
 use fil_actors_runtime::EAM_ACTOR_ID;
 use fvm_ipld_encoding::{serde, strict_bytes};
 use fvm_shared::address::Address;
@@ -86,8 +86,8 @@ impl AsRef<[u8]> for EthAddress {
 
 #[cfg(test)]
 mod tests {
-    use crate::interpreter::address::EthAddress;
-    use crate::U256;
+    use super::EthAddress;
+    use crate::uints::U256;
 
     const TYPE_PADDING: &[u8] = &[0; 12]; // padding (12 bytes)
     const ID_ADDRESS_MARKER: &[u8] = &[0xff]; // ID address marker (1 byte)

--- a/actors/evm/shared/src/lib.rs
+++ b/actors/evm/shared/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod address;
+pub mod uints;

--- a/actors/evm/shared/src/uints.rs
+++ b/actors/evm/shared/src/uints.rs
@@ -1,12 +1,12 @@
-#![allow(dead_code)]
 // to silence construct_uint! clippy warnings
 // see https://github.com/paritytech/parity-common/issues/660
 #![allow(clippy::ptr_offset_with_cast, clippy::assign_op_pattern)]
 
-use serde::{Deserialize, Serialize};
-use substrate_bn::arith;
+#[doc(inline)]
+pub use uint::byteorder;
 
-use crate::BytecodeHash;
+use serde::{Deserialize, Serialize};
+//use substrate_bn::arith;
 
 use {
     fvm_shared::bigint::BigInt, fvm_shared::econ::TokenAmount, std::cmp::Ordering, std::fmt,
@@ -64,6 +64,84 @@ impl U256 {
         }
     }
 
+    #[inline(always)]
+    pub fn i256_cmp(&self, other: &U256) -> Ordering {
+        // true > false:
+        // - true < positive:
+        match other.i256_is_negative().cmp(&self.i256_is_negative()) {
+            Ordering::Equal => self.cmp(other),
+            sign_cmp => sign_cmp,
+        }
+    }
+
+    #[inline]
+    pub fn i256_div(&self, other: &U256) -> U256 {
+        if self.is_zero() || other.is_zero() {
+            // EVM defines X/0 to be 0.
+            return U256::ZERO;
+        }
+
+        // min-negative-value can't be represented as a positive value, but we don't need to.
+        // NOTE: we've already checked that 'second' isn't zero above.
+        if (self, other) == (&U256::I128_MIN, &U256::ONE) {
+            return U256::I128_MIN;
+        }
+
+        let mut first = *self;
+        let mut second = *other;
+
+        // Record and strip the signs. We add them back at the end.
+        let first_neg = first.i256_is_negative();
+        let second_neg = second.i256_is_negative();
+
+        if first_neg {
+            first = first.i256_neg()
+        }
+
+        if second_neg {
+            second = second.i256_neg()
+        }
+
+        let d = first / second;
+
+        // Flip the sign back if necessary.
+        if d.is_zero() || first_neg == second_neg {
+            d
+        } else {
+            d.i256_neg()
+        }
+    }
+
+    #[inline]
+    pub fn i256_mod(&self, other: &U256) -> U256 {
+        if self.is_zero() || other.is_zero() {
+            // X % 0  or 0 % X is always 0.
+            return U256::ZERO;
+        }
+
+        let mut first = *self;
+        let mut second = *other;
+
+        // Record and strip the sign.
+        let negative = first.i256_is_negative();
+        if negative {
+            first = first.i256_neg();
+        }
+
+        if second.i256_is_negative() {
+            second = second.i256_neg()
+        }
+
+        let r = first % second;
+
+        // Restore the sign.
+        if negative && !r.is_zero() {
+            r.i256_neg()
+        } else {
+            r
+        }
+    }
+
     pub fn to_bytes(&self) -> [u8; 32] {
         let mut buf = [0u8; 32];
         self.to_big_endian(&mut buf);
@@ -94,11 +172,13 @@ impl From<&TokenAmount> for U256 {
     }
 }
 
+/*
 impl From<U256> for arith::U256 {
     fn from(src: U256) -> arith::U256 {
         arith::U256::from(src.0)
     }
 }
+*/
 
 impl From<U256> for U512 {
     fn from(v: U256) -> Self {
@@ -112,13 +192,6 @@ impl From<&U256> for TokenAmount {
         let mut bits = [0u8; 32];
         ui.to_big_endian(&mut bits);
         TokenAmount::from_atto(BigInt::from_bytes_be(fvm_shared::bigint::Sign::Plus, &bits))
-    }
-}
-
-impl From<BytecodeHash> for U256 {
-    fn from(bytecode: BytecodeHash) -> Self {
-        let bytes: [u8; 32] = bytecode.into();
-        Self::from(bytes)
     }
 }
 
@@ -165,7 +238,9 @@ fn zeroless_view(v: &impl AsRef<[u8]>) -> &[u8] {
     &v[v.iter().take_while(|&&b| b == 0).count()..]
 }
 
+/*
 macro_rules! impl_rlp_codec_uint {
+serde = { version = "1.0.136", features = ["derive"] }
   ($type:ident, $bytes_len: expr) => {
     impl rlp::Encodable for $type {
       fn rlp_append(&self, s: &mut rlp::RlpStream) {
@@ -188,78 +263,7 @@ macro_rules! impl_rlp_codec_uint {
 // RLP Support
 impl_rlp_codec_uint!(U256, 32);
 impl_rlp_codec_uint!(U512, 64);
-
-#[inline(always)]
-pub fn i256_div(mut first: U256, mut second: U256) -> U256 {
-    if first.is_zero() || second.is_zero() {
-        // EVM defines X/0 to be 0.
-        return U256::ZERO;
-    }
-
-    // min-negative-value can't be represented as a positive value, but we don't need to.
-    // NOTE: we've already checked that 'second' isn't zero above.
-    if (first, second) == (U256::I128_MIN, U256::ONE) {
-        return U256::I128_MIN;
-    }
-
-    // Record and strip the signs. We add them back at the end.
-    let first_neg = first.i256_is_negative();
-    let second_neg = second.i256_is_negative();
-
-    if first_neg {
-        first = first.i256_neg()
-    }
-
-    if second_neg {
-        second = second.i256_neg()
-    }
-
-    let d = first / second;
-
-    // Flip the sign back if necessary.
-    if d.is_zero() || first_neg == second_neg {
-        d
-    } else {
-        d.i256_neg()
-    }
-}
-
-#[inline(always)]
-pub fn i256_mod(mut first: U256, mut second: U256) -> U256 {
-    if first.is_zero() || second.is_zero() {
-        // X % 0  or 0 % X is always 0.
-        return U256::ZERO;
-    }
-
-    // Record and strip the sign.
-    let negative = first.i256_is_negative();
-    if negative {
-        first = first.i256_neg();
-    }
-
-    if second.i256_is_negative() {
-        second = second.i256_neg()
-    }
-
-    let r = first % second;
-
-    // Restore the sign.
-    if negative && !r.is_zero() {
-        r.i256_neg()
-    } else {
-        r
-    }
-}
-
-#[inline(always)]
-pub fn i256_cmp(first: U256, second: U256) -> Ordering {
-    // true > false:
-    // - true < positive:
-    match second.i256_is_negative().cmp(&first.i256_is_negative()) {
-        Ordering::Equal => first.cmp(&second),
-        sign_cmp => sign_cmp,
-    }
-}
+*/
 
 #[cfg(test)]
 mod tests {
@@ -282,17 +286,17 @@ mod tests {
         let max_value = U256::from(2).pow(255.into()) - 1;
         let neg_max_value = U256::from(2).pow(255.into()) - 1;
 
-        assert_eq!(i256_div(U256::I128_MIN, minus_one), U256::I128_MIN);
-        assert_eq!(i256_div(U256::I128_MIN, one), U256::I128_MIN);
-        assert_eq!(i256_div(one, U256::I128_MIN), zero);
-        assert_eq!(i256_div(max_value, one), max_value);
-        assert_eq!(i256_div(max_value, minus_one), neg_max_value);
-        assert_eq!(i256_div(one_hundred, minus_one), neg_one_hundred);
-        assert_eq!(i256_div(one_hundred, two), fifty);
+        assert_eq!(U256::I128_MIN.i256_div(&minus_one), U256::I128_MIN);
+        assert_eq!(U256::I128_MIN.i256_div(&one), U256::I128_MIN);
+        assert_eq!(one.i256_div(&U256::I128_MIN), zero);
+        assert_eq!(max_value.i256_div(&one), max_value);
+        assert_eq!(max_value.i256_div(&minus_one), neg_max_value);
+        assert_eq!(one_hundred.i256_div(&minus_one), neg_one_hundred);
+        assert_eq!(one_hundred.i256_div(&two), fifty);
 
-        assert_eq!(i256_div(zero, zero), zero);
-        assert_eq!(i256_div(one, zero), zero);
-        assert_eq!(i256_div(zero, one), zero);
+        assert_eq!(zero.i256_div(&zero), zero);
+        assert_eq!(one.i256_div(&zero), zero);
+        assert_eq!(zero.i256_div(&one), zero);
     }
 
     #[test]
@@ -309,21 +313,21 @@ mod tests {
         let max_value = U256::from(2).pow(255.into()) - 1;
 
         // zero
-        assert_eq!(i256_mod(minus_one, U256::ZERO), U256::ZERO);
-        assert_eq!(i256_mod(max_value, U256::ZERO), U256::ZERO);
-        assert_eq!(i256_mod(U256::ZERO, U256::ZERO), U256::ZERO);
+        assert_eq!(minus_one.i256_mod(&U256::ZERO), U256::ZERO);
+        assert_eq!(max_value.i256_mod(&U256::ZERO), U256::ZERO);
+        assert_eq!(U256::ZERO.i256_mod(&U256::ZERO), U256::ZERO);
 
-        assert_eq!(i256_mod(minus_one, two), minus_one);
-        assert_eq!(i256_mod(U256::I128_MIN, one), 0);
-        assert_eq!(i256_mod(one, U256::I128_MIN), one);
-        assert_eq!(i256_mod(one, U256::from(i128::MAX)), one);
+        assert_eq!(minus_one.i256_mod(&two), minus_one);
+        assert_eq!(U256::I128_MIN.i256_mod(&one), 0);
+        assert_eq!(one.i256_mod(&U256::I128_MIN), one);
+        assert_eq!(one.i256_mod(&U256::from(i128::MAX)), one);
 
-        assert_eq!(i256_mod(max_value, minus_one), zero);
-        assert_eq!(i256_mod(neg_one_hundred, minus_one), zero);
-        assert_eq!(i256_mod(one_hundred, two), zero);
-        assert_eq!(i256_mod(one_hundred, neg_three), one);
+        assert_eq!(max_value.i256_mod(&minus_one), zero);
+        assert_eq!(neg_one_hundred.i256_mod(&minus_one), zero);
+        assert_eq!(one_hundred.i256_mod(&two), zero);
+        assert_eq!(one_hundred.i256_mod(&neg_three), one);
 
-        assert_eq!(i256_mod(neg_one_hundred, three), minus_one);
+        assert_eq!(neg_one_hundred.i256_mod(&three), minus_one);
 
         let a = U256::from(95).i256_neg();
         let b = U256::from(256);

--- a/actors/evm/shared/src/uints.rs
+++ b/actors/evm/shared/src/uints.rs
@@ -172,14 +172,6 @@ impl From<&TokenAmount> for U256 {
     }
 }
 
-/*
-impl From<U256> for arith::U256 {
-    fn from(src: U256) -> arith::U256 {
-        arith::U256::from(src.0)
-    }
-}
-*/
-
 impl From<U256> for U512 {
     fn from(v: U256) -> Self {
         let [a, b, c, d] = v.0;
@@ -237,33 +229,6 @@ fn zeroless_view(v: &impl AsRef<[u8]>) -> &[u8] {
     let v = v.as_ref();
     &v[v.iter().take_while(|&&b| b == 0).count()..]
 }
-
-/*
-macro_rules! impl_rlp_codec_uint {
-serde = { version = "1.0.136", features = ["derive"] }
-  ($type:ident, $bytes_len: expr) => {
-    impl rlp::Encodable for $type {
-      fn rlp_append(&self, s: &mut rlp::RlpStream) {
-        let mut bytes = [0u8; $bytes_len];
-        self.to_big_endian(&mut bytes);
-        let zbytes = zeroless_view(&bytes);
-        s.encoder().encode_value(&zbytes);
-      }
-    }
-    impl rlp::Decodable for $type {
-      fn decode(rlp: &rlp::Rlp) -> Result<Self, rlp::DecoderError> {
-        rlp
-          .decoder()
-          .decode_value(|bytes| Ok($type::from_big_endian(bytes)))
-      }
-    }
-  };
-}
-
-// RLP Support
-impl_rlp_codec_uint!(U256, 32);
-impl_rlp_codec_uint!(U512, 64);
-*/
 
 #[cfg(test)]
 mod tests {

--- a/actors/evm/src/ext.rs
+++ b/actors/evm/src/ext.rs
@@ -1,0 +1,30 @@
+pub mod eam {
+    use crate::interpreter::address::EthAddress;
+    use fvm_ipld_encoding::{strict_bytes, tuple::*};
+    use fvm_shared::address::Address;
+
+    pub const CREATE_METHOD_NUM: u64 = 2;
+    pub const CREATE2_METHOD_NUM: u64 = 3;
+
+    #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+    pub struct CreateParams {
+        #[serde(with = "strict_bytes")]
+        pub code: Vec<u8>,
+        pub nonce: u64,
+    }
+
+    #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+    pub struct Create2Params {
+        #[serde(with = "strict_bytes")]
+        pub code: Vec<u8>,
+        #[serde(with = "strict_bytes")]
+        pub salt: [u8; 32],
+    }
+
+    #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct CreateReturn {
+        pub actor_id: u64,
+        pub robust_address: Option<Address>,
+        pub eth_address: EthAddress,
+    }
+}

--- a/actors/evm/src/ext.rs
+++ b/actors/evm/src/ext.rs
@@ -1,5 +1,5 @@
 pub mod eam {
-    use crate::interpreter::address::EthAddress;
+    use fil_actors_evm_shared::address::EthAddress;
     use fvm_ipld_encoding::{strict_bytes, tuple::*};
     use fvm_shared::address::Address;
 

--- a/actors/evm/src/interpreter/bytecode.rs
+++ b/actors/evm/src/interpreter/bytecode.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::ops::Deref;
 
 use super::opcodes;

--- a/actors/evm/src/interpreter/bytecode.rs
+++ b/actors/evm/src/interpreter/bytecode.rs
@@ -2,7 +2,7 @@
 
 use std::ops::Deref;
 
-use super::execution::opcodes;
+use super::opcodes;
 
 #[derive(Clone, Debug)]
 pub struct Bytecode {

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -1,14 +1,12 @@
-#![allow(dead_code)]
-
+use fil_actors_evm_shared::address::EthAddress;
 use fil_actors_runtime::ActorError;
 use fvm_shared::econ::TokenAmount;
 
-use super::address::EthAddress;
 use {
     super::instructions,
-    crate::interpreter::memory::Memory,
-    crate::interpreter::stack::Stack,
-    crate::interpreter::{Bytecode, Output, System},
+    super::memory::Memory,
+    super::stack::Stack,
+    super::{Bytecode, Output, System},
     bytes::Bytes,
     fil_actors_runtime::runtime::Runtime,
 };

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -57,7 +57,7 @@ pub struct Machine<'r, 'a, RT: Runtime + 'a> {
 
 macro_rules! def_opcodes {
     ($($code:literal: $op:ident,)*) => {
-        pub const fn jumptable<'r, 'a, RT: Runtime>() -> [Instruction<'r, 'a, RT>; 256] {
+        pub(crate) const fn jumptable<'r, 'a, RT: Runtime>() -> [Instruction<'r, 'a, RT>; 256] {
             def_ins_raw! {
                 UNDEFINED(_m) {
                     Err(ActorError::unchecked(
@@ -98,7 +98,7 @@ pub mod opcodes {
     use fil_actors_runtime::runtime::Runtime;
     use fil_actors_runtime::ActorError;
 
-    pub type Instruction<'r, 'a, RT> =
+    pub(crate) type Instruction<'r, 'a, RT> =
         unsafe fn(*mut Machine<'r, 'a, RT>) -> Result<(), ActorError>;
 
     def_opcodes! {

--- a/actors/evm/src/interpreter/instructions/arithmetic.rs
+++ b/actors/evm/src/interpreter/instructions/arithmetic.rs
@@ -1,4 +1,4 @@
-use {crate::interpreter::uints::*, crate::interpreter::U256};
+use fil_actors_evm_shared::uints::{U256, U512};
 
 #[inline]
 pub fn add(a: U256, b: U256) -> U256 {
@@ -28,7 +28,7 @@ pub fn div(a: U256, b: U256) -> U256 {
 
 #[inline]
 pub fn sdiv(a: U256, b: U256) -> U256 {
-    i256_div(a, b)
+    a.i256_div(&b)
 }
 
 #[inline]
@@ -42,7 +42,7 @@ pub fn modulo(a: U256, b: U256) -> U256 {
 
 #[inline]
 pub fn smod(a: U256, b: U256) -> U256 {
-    i256_mod(a, b)
+    a.i256_mod(&b)
 }
 
 #[inline]
@@ -111,8 +111,8 @@ pub fn exp(mut base: U256, power: U256) -> U256 {
 #[cfg(test)]
 mod test {
     mod basic {
-        use crate::interpreter::instructions::arithmetic::*;
-        use crate::interpreter::U256;
+        use super::super::*;
+        use fil_actors_evm_shared::uints::U256;
 
         #[test]
         fn test_addmod() {

--- a/actors/evm/src/interpreter/instructions/bitwise.rs
+++ b/actors/evm/src/interpreter/instructions/bitwise.rs
@@ -1,4 +1,4 @@
-use crate::interpreter::U256;
+use fil_actors_evm_shared::uints::U256;
 
 #[inline]
 pub fn byte(i: U256, x: U256) -> U256 {

--- a/actors/evm/src/interpreter/instructions/boolean.rs
+++ b/actors/evm/src/interpreter/instructions/boolean.rs
@@ -1,4 +1,6 @@
-use {crate::interpreter::uints::*, crate::interpreter::U256, std::cmp::Ordering};
+use std::cmp::Ordering;
+
+use fil_actors_evm_shared::uints::U256;
 
 #[inline]
 pub fn lt(a: U256, b: U256) -> U256 {
@@ -12,12 +14,12 @@ pub fn gt(a: U256, b: U256) -> U256 {
 
 #[inline]
 pub(crate) fn slt(a: U256, b: U256) -> U256 {
-    U256::from_u64((i256_cmp(a, b) == Ordering::Less).into())
+    U256::from_u64((a.i256_cmp(&b) == Ordering::Less).into())
 }
 
 #[inline]
 pub(crate) fn sgt(a: U256, b: U256) -> U256 {
-    U256::from_u64((i256_cmp(a, b) == Ordering::Greater).into())
+    U256::from_u64((a.i256_cmp(&b) == Ordering::Greater).into())
 }
 
 #[inline]

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -4,7 +4,10 @@ use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::BytesDe;
 use fvm_shared::{address::Address, sys::SendFlags, MethodNum, IPLD_RAW};
 
-use crate::interpreter::precompiles::{is_reserved_precompile_address, PrecompileContext};
+use crate::interpreter::{
+    precompiles::{is_reserved_precompile_address, PrecompileContext},
+    CallKind,
+};
 
 use super::ext::{get_contract_type, get_evm_bytecode_cid, ContractType};
 
@@ -25,14 +28,6 @@ use {
 
 /// The gas granted on bare "transfers".
 const TRANSFER_GAS_LIMIT: U256 = U256::from_u64(10_000_000);
-
-/// The kind of call-like instruction.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum CallKind {
-    Call,
-    DelegateCall,
-    StaticCall,
-}
 
 pub fn calldataload(
     state: &mut ExecutionState,

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
+use fil_actors_evm_shared::{address::EthAddress, uints::U256};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::BytesDe;
 use fvm_shared::{address::Address, sys::SendFlags, MethodNum, IPLD_RAW};
@@ -13,12 +14,10 @@ use super::ext::{get_contract_type, get_evm_bytecode_cid, ContractType};
 
 use {
     super::memory::{copy_to_memory, get_memory_region},
-    crate::interpreter::address::EthAddress,
     crate::interpreter::instructions::memory::MemoryRegion,
     crate::interpreter::precompiles,
     crate::interpreter::ExecutionState,
     crate::interpreter::System,
-    crate::interpreter::U256,
     crate::{DelegateCallParams, Method},
     fil_actors_runtime::runtime::Runtime,
     fil_actors_runtime::ActorError,

--- a/actors/evm/src/interpreter/instructions/context.rs
+++ b/actors/evm/src/interpreter/instructions/context.rs
@@ -1,10 +1,11 @@
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::ActorError;
 use fvm_shared::clock::ChainEpoch;
 
 use crate::EVM_WORD_SIZE;
 
 use {
-    crate::interpreter::{ExecutionState, System, U256},
+    crate::interpreter::{ExecutionState, System},
     fil_actors_runtime::runtime::Runtime,
 };
 

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::{ActorError, AsActorError};
 
 use crate::{
@@ -10,7 +11,7 @@ use crate::{
 use {
     super::memory::get_memory_region,
     crate::interpreter::Bytecode,
-    crate::interpreter::{ExecutionState, System, U256},
+    crate::interpreter::{ExecutionState, System},
     fil_actors_runtime::runtime::Runtime,
 };
 
@@ -158,8 +159,9 @@ pub fn jumpi(bytecode: &Bytecode, pc: usize, dest: U256, test: U256) -> Result<u
 
 #[cfg(test)]
 mod tests {
+    use fil_actors_evm_shared::uints::U256;
+
     use crate::evm_unit_test;
-    use crate::interpreter::U256;
     use crate::EVM_CONTRACT_BAD_JUMPDEST;
 
     #[test]

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -1,7 +1,9 @@
 use crate::interpreter::instructions::memory::copy_to_memory;
-use crate::interpreter::{address::EthAddress, precompiles::Precompiles};
-use crate::{BytecodeHash, U256};
+use crate::interpreter::precompiles::Precompiles;
+use crate::BytecodeHash;
 use cid::Cid;
+use fil_actors_evm_shared::address::EthAddress;
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::ActorError;
 use fil_actors_runtime::{deserialize_block, AsActorError};

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -89,6 +89,7 @@ pub fn extcodecopy(
 }
 
 #[derive(Debug)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum ContractType {
     Precompile,
     /// EVM ID Address and the CID of the actor (not the bytecode)

--- a/actors/evm/src/interpreter/instructions/hash.rs
+++ b/actors/evm/src/interpreter/instructions/hash.rs
@@ -1,8 +1,9 @@
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::ActorError;
 
 use {
     super::memory::get_memory_region,
-    crate::interpreter::{ExecutionState, System, U256},
+    crate::interpreter::{ExecutionState, System},
     fil_actors_runtime::runtime::Runtime,
     fvm_shared::crypto::hash::SupportedHashes,
 };
@@ -29,9 +30,10 @@ pub fn keccak256(
 
 #[cfg(test)]
 mod test {
+    use fil_actors_evm_shared::uints::U256;
     use fil_actors_runtime::runtime::Primitives;
 
-    use crate::{evm_unit_test, interpreter::U256, BytecodeHash};
+    use crate::{evm_unit_test, BytecodeHash};
 
     #[test]
     fn keccak256_large() {

--- a/actors/evm/src/interpreter/instructions/lifecycle.rs
+++ b/actors/evm/src/interpreter/instructions/lifecycle.rs
@@ -4,13 +4,12 @@ use fil_actors_runtime::ActorError;
 use fil_actors_runtime::EAM_ACTOR_ADDR;
 use fil_actors_runtime::{deserialize_block, extract_send_result};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::{strict_bytes, tuple::*};
 use fvm_shared::sys::SendFlags;
 use fvm_shared::MethodNum;
 use fvm_shared::METHOD_SEND;
 use fvm_shared::{address::Address, econ::TokenAmount};
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
+use crate::ext::eam;
 use crate::interpreter::Output;
 use crate::interpreter::{address::EthAddress, U256};
 use crate::EVM_CONTRACT_SELFDESTRUCT_FAILED;
@@ -20,31 +19,6 @@ use {
     crate::interpreter::{ExecutionState, System},
     fil_actors_runtime::runtime::Runtime,
 };
-
-pub const CREATE_METHOD_NUM: u64 = 2;
-pub const CREATE2_METHOD_NUM: u64 = 3;
-
-#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
-pub struct CreateParams {
-    #[serde(with = "strict_bytes")]
-    pub code: Vec<u8>,
-    pub nonce: u64,
-}
-
-#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
-pub struct Create2Params {
-    #[serde(with = "strict_bytes")]
-    pub code: Vec<u8>,
-    #[serde(with = "strict_bytes")]
-    pub salt: [u8; 32],
-}
-
-#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Copy, PartialEq, Eq)]
-pub struct EamReturn {
-    pub actor_id: u64,
-    pub robust_address: Option<Address>,
-    pub eth_address: EthAddress,
-}
 
 #[inline]
 pub fn create(
@@ -73,8 +47,8 @@ pub fn create(
     };
 
     let nonce = system.increment_nonce();
-    let params = CreateParams { code: input_data.to_vec(), nonce };
-    create_init(system, IpldBlock::serialize_cbor(&params)?, CREATE_METHOD_NUM, value)
+    let params = eam::CreateParams { code: input_data.to_vec(), nonce };
+    create_init(system, IpldBlock::serialize_cbor(&params)?, eam::CREATE_METHOD_NUM, value)
 }
 
 pub fn create2(
@@ -107,10 +81,10 @@ pub fn create2(
     } else {
         &[]
     };
-    let params = Create2Params { code: input_data.to_vec(), salt };
+    let params = eam::Create2Params { code: input_data.to_vec(), salt };
 
     system.increment_nonce();
-    create_init(system, IpldBlock::serialize_cbor(&params)?, CREATE2_METHOD_NUM, endowment)
+    create_init(system, IpldBlock::serialize_cbor(&params)?, eam::CREATE2_METHOD_NUM, endowment)
 }
 
 /// call into Ethereum Address Manager to make the new account
@@ -145,7 +119,7 @@ fn create_init(
 
     Ok(match ret {
         Ok(eam_ret) => {
-            let ret: EamReturn = deserialize_block(eam_ret)?;
+            let ret: eam::CreateReturn = deserialize_block(eam_ret)?;
             ret.eth_address.as_evm_word()
         }
         Err(_) => U256::zero(),

--- a/actors/evm/src/interpreter/instructions/lifecycle.rs
+++ b/actors/evm/src/interpreter/instructions/lifecycle.rs
@@ -1,5 +1,7 @@
 use bytes::Bytes;
 
+use fil_actors_evm_shared::address::EthAddress;
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::ActorError;
 use fil_actors_runtime::EAM_ACTOR_ADDR;
 use fil_actors_runtime::{deserialize_block, extract_send_result};
@@ -11,7 +13,6 @@ use fvm_shared::{address::Address, econ::TokenAmount};
 
 use crate::ext::eam;
 use crate::interpreter::Output;
-use crate::interpreter::{address::EthAddress, U256};
 use crate::EVM_CONTRACT_SELFDESTRUCT_FAILED;
 
 use super::memory::{get_memory_region, MemoryRegion};

--- a/actors/evm/src/interpreter/instructions/log_event.rs
+++ b/actors/evm/src/interpreter/instructions/log_event.rs
@@ -1,9 +1,10 @@
 use crate::interpreter::instructions::memory::get_memory_region;
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::ActorError;
 use fvm_ipld_encoding::{to_vec, BytesSer, RawBytes};
 use fvm_shared::event::{Entry, Flags};
 use {
-    crate::interpreter::{ExecutionState, System, U256},
+    crate::interpreter::{ExecutionState, System},
     fil_actors_runtime::runtime::Runtime,
 };
 

--- a/actors/evm/src/interpreter/instructions/memory.rs
+++ b/actors/evm/src/interpreter/instructions/memory.rs
@@ -1,12 +1,13 @@
 #!allow[clippy::result-unit-err]
 
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::{ActorError, AsActorError};
 
 use crate::{EVM_CONTRACT_ILLEGAL_MEMORY_ACCESS, EVM_WORD_SIZE};
 
 use {
     crate::interpreter::memory::Memory,
-    crate::interpreter::{ExecutionState, System, U256},
+    crate::interpreter::{ExecutionState, System},
     fil_actors_runtime::runtime::Runtime,
     std::num::NonZeroUsize,
 };

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -1,19 +1,19 @@
 #![allow(clippy::unnecessary_mut_passed)]
 
-pub mod arithmetic;
-pub mod bitwise;
-pub mod boolean;
-pub mod call;
-pub mod context;
-pub mod control;
-pub mod ext;
-pub mod hash;
-pub mod lifecycle;
-pub mod log_event;
-pub mod memory;
-pub mod stack;
-pub mod state;
-pub mod storage;
+mod arithmetic;
+mod bitwise;
+mod boolean;
+mod call;
+mod context;
+mod control;
+mod ext;
+mod hash;
+mod lifecycle;
+mod log_event;
+mod memory;
+mod stack;
+mod state;
+mod storage;
 
 use crate::interpreter::execution::Machine;
 use crate::interpreter::U256;

--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -16,7 +16,7 @@ mod state;
 mod storage;
 
 use crate::interpreter::execution::Machine;
-use crate::interpreter::U256;
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::ActorError;
 

--- a/actors/evm/src/interpreter/instructions/stack.rs
+++ b/actors/evm/src/interpreter/instructions/stack.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::missing_safety_doc)]
 
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::ActorError;
 
 use crate::interpreter::stack::Stack;
-use crate::interpreter::U256;
 
 macro_rules! be_u64 {
     ($byte:expr) => {$byte as u64};

--- a/actors/evm/src/interpreter/instructions/state.rs
+++ b/actors/evm/src/interpreter/instructions/state.rs
@@ -1,9 +1,8 @@
+use fil_actors_evm_shared::{address::EthAddress, uints::U256};
 use fil_actors_runtime::ActorError;
 use fvm_shared::address::Address;
 
-use crate::U256;
 use {
-    crate::interpreter::address::EthAddress,
     crate::interpreter::{ExecutionState, System},
     fil_actors_runtime::runtime::Runtime,
 };
@@ -38,12 +37,10 @@ pub fn selfbalance(
 
 #[cfg(test)]
 mod test {
+    use fil_actors_evm_shared::{address::EthAddress, uints::U256};
     use fvm_shared::address::Address;
 
-    use crate::{
-        evm_unit_test,
-        interpreter::{address::EthAddress, U256},
-    };
+    use crate::evm_unit_test;
 
     #[test]
     fn balance_basic() {

--- a/actors/evm/src/interpreter/instructions/storage.rs
+++ b/actors/evm/src/interpreter/instructions/storage.rs
@@ -1,7 +1,8 @@
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::ActorError;
 
 use {
-    crate::interpreter::{ExecutionState, System, U256},
+    crate::interpreter::{ExecutionState, System},
     fil_actors_runtime::runtime::Runtime,
 };
 

--- a/actors/evm/src/interpreter/mod.rs
+++ b/actors/evm/src/interpreter/mod.rs
@@ -1,31 +1,29 @@
 pub mod address;
 pub mod bytecode;
-pub mod execution;
-pub mod instructions;
-pub mod memory;
-pub mod output;
-pub mod precompiles;
-pub mod stack;
-pub mod system;
-pub mod uints;
+mod execution;
+mod instructions;
+mod memory;
+mod output;
+mod precompiles;
+mod stack;
+mod system;
+mod uints;
 
 #[cfg(test)]
 pub mod test_util;
 
 pub use {
     bytecode::Bytecode,
-    execution::{execute, ExecutionState},
-    output::Output,
+    execution::{execute, opcodes, ExecutionState},
+    output::{Outcome, Output},
     system::System,
     uints::{U256, U512},
 };
 
-#[macro_export]
-macro_rules! abort {
-  ($code:ident, $msg:literal $(, $ex:expr)*) => {
-      fvm_sdk::vm::abort(
-          fvm_shared::error::ExitCode::$code.value(),
-          Some(format!($msg, $($ex,)*).as_str()),
-      )
-  };
+/// The kind of call-like instruction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CallKind {
+    Call,
+    DelegateCall,
+    StaticCall,
 }

--- a/actors/evm/src/interpreter/mod.rs
+++ b/actors/evm/src/interpreter/mod.rs
@@ -1,5 +1,4 @@
-pub mod address;
-pub mod bytecode;
+mod bytecode;
 mod execution;
 mod instructions;
 mod memory;
@@ -7,7 +6,6 @@ mod output;
 mod precompiles;
 mod stack;
 mod system;
-mod uints;
 
 #[cfg(test)]
 pub mod test_util;
@@ -17,7 +15,6 @@ pub use {
     execution::{execute, opcodes, ExecutionState},
     output::{Outcome, Output},
     system::System,
-    uints::{U256, U512},
 };
 
 /// The kind of call-like instruction.

--- a/actors/evm/src/interpreter/precompiles/evm.rs
+++ b/actors/evm/src/interpreter/precompiles/evm.rs
@@ -1,5 +1,9 @@
 use std::ops::Range;
 
+use fil_actors_evm_shared::uints::{
+    byteorder::{ByteOrder, LE},
+    U256,
+};
 use fil_actors_runtime::runtime::Runtime;
 use fvm_shared::crypto::{
     hash::SupportedHashes,
@@ -7,10 +11,9 @@ use fvm_shared::crypto::{
 };
 use num_traits::{One, Zero};
 use substrate_bn::{pairing_batch, AffineG1, AffineG2, Fq, Fq2, Fr, Group, Gt, G1, G2};
-use uint::byteorder::{ByteOrder, LE};
 
 use crate::{
-    interpreter::{precompiles::PrecompileError, System, U256},
+    interpreter::{precompiles::PrecompileError, System},
     EVM_WORD_SIZE,
 };
 

--- a/actors/evm/src/interpreter/precompiles/evm.rs
+++ b/actors/evm/src/interpreter/precompiles/evm.rs
@@ -300,7 +300,7 @@ pub(super) fn blake2f<RT: Runtime>(
 
 #[cfg(test)]
 mod tests {
-    use crate::interpreter::instructions::call::CallKind;
+    use crate::interpreter::CallKind;
 
     use super::*;
     use fil_actors_runtime::test_utils::MockRuntime;

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -3,7 +3,7 @@ use fil_actors_runtime::runtime::Runtime;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::{address::Address, econ::TokenAmount, sys::SendFlags, METHOD_SEND};
 
-use crate::interpreter::{instructions::call::CallKind, System, U256};
+use crate::interpreter::{CallKind, System, U256};
 
 use super::{PrecompileContext, PrecompileError, PrecompileResult};
 use crate::reader::ValueReader;

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -1,9 +1,10 @@
 use crate::{EVM_MAX_RESERVED_METHOD, EVM_WORD_SIZE};
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::runtime::Runtime;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::{address::Address, econ::TokenAmount, sys::SendFlags, METHOD_SEND};
 
-use crate::interpreter::{CallKind, System, U256};
+use crate::interpreter::{CallKind, System};
 
 use super::{PrecompileContext, PrecompileError, PrecompileResult};
 use crate::reader::ValueReader;

--- a/actors/evm/src/interpreter/precompiles/mod.rs
+++ b/actors/evm/src/interpreter/precompiles/mod.rs
@@ -6,7 +6,7 @@ use substrate_bn::{CurveError, FieldError, GroupError};
 
 use crate::reader::OverflowError;
 
-use super::{address::EthAddress, instructions::call::CallKind, System, U256};
+use super::{address::EthAddress, CallKind, System, U256};
 mod evm;
 mod fvm;
 
@@ -113,7 +113,6 @@ pub enum PrecompileError {
     // EVM precompile errors
     EcErr(CurveError),
     IncorrectInputSize,
-    OutOfGas,
     // FVM precompile errors
     InvalidInput,
     CallForbidden,
@@ -161,20 +160,6 @@ pub struct PrecompileContext {
     pub call_type: CallKind,
     pub gas_limit: u64,
     pub value: U256,
-}
-
-/// Native Type of a given contract
-#[repr(u32)]
-pub enum NativeType {
-    NonExistent = 0,
-    // user actors are flattened to "system"
-    /// System includes any singletons not otherwise defined.
-    System = 1,
-    Placeholder = 2,
-    Account = 3,
-    StorageProvider = 4,
-    EVMContract = 5,
-    OtherTypes = 6,
 }
 
 #[cfg(test)]

--- a/actors/evm/src/interpreter/precompiles/mod.rs
+++ b/actors/evm/src/interpreter/precompiles/mod.rs
@@ -1,12 +1,13 @@
 use std::{marker::PhantomData, num::TryFromIntError};
 
+use fil_actors_evm_shared::{address::EthAddress, uints::U256};
 use fil_actors_runtime::{runtime::Runtime, ActorError};
 use fvm_shared::{address::Address, econ::TokenAmount};
 use substrate_bn::{CurveError, FieldError, GroupError};
 
 use crate::reader::OverflowError;
 
-use super::{address::EthAddress, CallKind, System, U256};
+use super::{CallKind, System};
 mod evm;
 mod fvm;
 
@@ -164,9 +165,10 @@ pub struct PrecompileContext {
 
 #[cfg(test)]
 mod test {
+    use fil_actors_evm_shared::address::EthAddress;
     use fil_actors_runtime::test_utils::MockRuntime;
 
-    use crate::interpreter::{address::EthAddress, precompiles::is_reserved_precompile_address};
+    use crate::interpreter::precompiles::is_reserved_precompile_address;
 
     use super::Precompiles;
 

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code, clippy::missing_safety_doc)]
 
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::{ActorError, AsActorError};
 
-use crate::{interpreter::U256, EVM_CONTRACT_STACK_OVERFLOW, EVM_CONTRACT_STACK_UNDERFLOW};
+use crate::{EVM_CONTRACT_STACK_OVERFLOW, EVM_CONTRACT_STACK_UNDERFLOW};
 
 /// Ethereum Yellow Paper (9.1)
 pub const STACK_SIZE: usize = 1024;

--- a/actors/evm/src/interpreter/stack.rs
+++ b/actors/evm/src/interpreter/stack.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, clippy::missing_safety_doc)]
+#![allow(clippy::missing_safety_doc)]
 
 use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::{ActorError, AsActorError};

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::borrow::Cow;
 
 use fil_actors_evm_shared::{address::EthAddress, uints::U256};

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -23,7 +23,7 @@ use once_cell::unsync::OnceCell;
 use crate::state::{State, Tombstone};
 use crate::BytecodeHash;
 
-use super::{address::EthAddress, Bytecode};
+use super::address::EthAddress;
 
 use {
     crate::interpreter::U256,
@@ -459,17 +459,5 @@ impl<'r, RT: Runtime> System<'r, RT> {
     pub fn mark_selfdestructed(&mut self) {
         self.saved_state_root = None;
         self.tombstone = Some(crate::current_tombstone(self.rt));
-    }
-}
-
-pub fn load_bytecode<BS: Blockstore>(bs: &BS, cid: &Cid) -> Result<Option<Bytecode>, ActorError> {
-    let bytecode = bs
-        .get(cid)
-        .context_code(ExitCode::USR_NOT_FOUND, "failed to read bytecode")?
-        .expect("bytecode not in state tree");
-    if bytecode.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(Bytecode::new(bytecode)))
     }
 }

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use fil_actors_evm_shared::{address::EthAddress, uints::U256};
 use fil_actors_runtime::{
     actor_error, extract_send_result, runtime::EMPTY_ARR_CID, AsActorError, EAM_ACTOR_ID,
 };
@@ -23,10 +24,7 @@ use once_cell::unsync::OnceCell;
 use crate::state::{State, Tombstone};
 use crate::BytecodeHash;
 
-use super::address::EthAddress;
-
 use {
-    crate::interpreter::U256,
     cid::Cid,
     fil_actors_runtime::{runtime::Runtime, ActorError},
     fvm_ipld_blockstore::Blockstore,

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -1,3 +1,5 @@
+use fil_actors_evm_shared::address::EthAddress;
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::{actor_error, AsActorError, EAM_ACTOR_ADDR, INIT_ACTOR_ADDR};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
@@ -5,7 +7,6 @@ use fvm_ipld_encoding::{strict_bytes, BytesDe, BytesSer};
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use interpreter::address::EthAddress;
 
 use crate::interpreter::Outcome;
 use crate::reader::ValueReader;
@@ -17,7 +18,7 @@ pub(crate) mod reader;
 mod state;
 
 use {
-    crate::interpreter::{execute, Bytecode, ExecutionState, System, U256},
+    crate::interpreter::{execute, Bytecode, ExecutionState, System},
     bytes::Bytes,
     cid::Cid,
     fil_actors_runtime::{

--- a/actors/evm/src/reader.rs
+++ b/actors/evm/src/reader.rs
@@ -1,9 +1,8 @@
 use std::{borrow::Cow, fmt::Display};
 
+use fil_actors_evm_shared::uints::U256;
 use fvm_shared::{bigint::BigUint, error::ExitCode};
 use substrate_bn::{AffineG1, CurveError, FieldError, Fq, Fr, Group, G1};
-
-use crate::interpreter::U256;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct OverflowError;

--- a/actors/evm/src/state.rs
+++ b/actors/evm/src/state.rs
@@ -1,5 +1,6 @@
 use std::array::TryFromSliceError;
 
+use fil_actors_evm_shared::uints::U256;
 use fvm_shared::ActorID;
 
 use {
@@ -73,6 +74,13 @@ impl From<BytecodeHash> for [u8; 32] {
 impl From<BytecodeHash> for Vec<u8> {
     fn from(digest: BytecodeHash) -> Self {
         digest.0.into()
+    }
+}
+
+impl From<BytecodeHash> for U256 {
+    fn from(bytecode: BytecodeHash) -> Self {
+        let bytes: [u8; 32] = bytecode.into();
+        Self::from(bytes)
     }
 }
 

--- a/actors/evm/tests/asm.rs
+++ b/actors/evm/tests/asm.rs
@@ -1,5 +1,5 @@
 use etk_asm::ingest::Ingest;
-use evm::interpreter::execution::opcodes;
+use evm::interpreter::opcodes;
 use fil_actor_evm as evm;
 
 const PRELUDE: &str = r#"

--- a/actors/evm/tests/basic.rs
+++ b/actors/evm/tests/basic.rs
@@ -1,8 +1,8 @@
 mod asm;
 
 use cid::Cid;
-use fil_actors_evm_shared::uints::U256;
 use fil_actor_evm as evm;
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::test_utils::*;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::ipld_block::IpldBlock;

--- a/actors/evm/tests/basic.rs
+++ b/actors/evm/tests/basic.rs
@@ -1,7 +1,7 @@
 mod asm;
 
 use cid::Cid;
-use evm::interpreter::U256;
+use fil_actors_evm_shared::uints::U256;
 use fil_actor_evm as evm;
 use fil_actors_runtime::test_utils::*;
 use fvm_ipld_blockstore::Blockstore;

--- a/actors/evm/tests/calc.rs
+++ b/actors/evm/tests/calc.rs
@@ -1,7 +1,6 @@
 mod asm;
 
-use evm::interpreter::U256;
-use fil_actor_evm as evm;
+use fil_actors_evm_shared::uints::U256;
 
 mod util;
 

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -8,10 +8,10 @@ use ethers::prelude::builders::ContractCall;
 use ethers::prelude::*;
 use ethers::providers::{MockProvider, Provider};
 use ethers::types::Bytes;
-use evm::interpreter::address::EthAddress;
-use evm::interpreter::U256;
 use evm::{Method, EVM_CONTRACT_REVERTED};
 use fil_actor_evm as evm;
+use fil_actors_evm_shared::address::EthAddress;
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::{test_utils::*, EAM_ACTOR_ID, INIT_ACTOR_ADDR};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::{BytesDe, BytesSer, CBOR, IPLD_RAW};
@@ -301,7 +301,7 @@ pub fn test_call_output_region() {
 # this contract truncates return from send to output length
 
 # prepare the proxy call
-push1 0x00 
+push1 0x00
 calldataload # size from first word
 push1 0x00 # offset
 

--- a/actors/evm/tests/create.rs
+++ b/actors/evm/tests/create.rs
@@ -1,8 +1,8 @@
 mod asm;
 
 use evm::ext::eam;
-use fil_actors_evm_shared::address::EthAddress;
 use fil_actor_evm as evm;
+use fil_actors_evm_shared::address::EthAddress;
 use fil_actors_runtime::EAM_ACTOR_ADDR;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::econ::TokenAmount;

--- a/actors/evm/tests/create.rs
+++ b/actors/evm/tests/create.rs
@@ -1,9 +1,7 @@
 mod asm;
 
+use evm::ext::eam;
 use evm::interpreter::address::EthAddress;
-use evm::interpreter::instructions::lifecycle::{
-    Create2Params, CreateParams, EamReturn, CREATE2_METHOD_NUM, CREATE_METHOD_NUM,
-};
 use fil_actor_evm as evm;
 use fil_actors_runtime::EAM_ACTOR_ADDR;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
@@ -30,7 +28,7 @@ mstore # "bytecode"
 test_create:
     jumpdest
     push1 0x10   # in size (16 bytes)
-    push2 0x0110 # in offset 
+    push2 0x0110 # in offset
     push1 0x01   # value (attoFil)
     create
     %return_stack_word()
@@ -55,7 +53,7 @@ fn test_create() {
     let mut rt = util::construct_and_verify(contract);
 
     let fake_eth_addr = EthAddress(hex_literal::hex!("CAFEB0BA00000000000000000000000000000000"));
-    let fake_ret = EamReturn {
+    let fake_ret = eam::CreateReturn {
         actor_id: 12345,
         eth_address: fake_eth_addr,
         robust_address: Some((&fake_eth_addr).try_into().unwrap()),
@@ -64,12 +62,12 @@ fn test_create() {
     let salt =
         hex_literal::hex!("0000000000000000000000000000000000000000000000796573206D616E6921");
 
-    let create2_params = Create2Params {
+    let create2_params = eam::Create2Params {
         code: hex_literal::hex!("666F6F206261722062617A20626F7879").to_vec(),
         salt,
     };
 
-    let mut create_params = CreateParams {
+    let mut create_params = eam::CreateParams {
         code: hex_literal::hex!("666F6F206261722062617A20626F7879").to_vec(),
         nonce: 1,
     };
@@ -83,7 +81,7 @@ fn test_create() {
 
         rt.expect_send_simple(
             EAM_ACTOR_ADDR,
-            CREATE_METHOD_NUM,
+            eam::CREATE_METHOD_NUM,
             IpldBlock::serialize_cbor(&create_params).unwrap(),
             TokenAmount::from_atto(1),
             IpldBlock::serialize_cbor(&fake_ret).unwrap(),
@@ -105,7 +103,7 @@ fn test_create() {
 
         rt.expect_send_simple(
             EAM_ACTOR_ADDR,
-            CREATE_METHOD_NUM,
+            eam::CREATE_METHOD_NUM,
             IpldBlock::serialize_cbor(&create_params).unwrap(),
             TokenAmount::from_atto(1),
             IpldBlock::serialize_cbor(&fake_ret).unwrap(),
@@ -127,7 +125,7 @@ fn test_create() {
 
         rt.expect_send_simple(
             EAM_ACTOR_ADDR,
-            CREATE2_METHOD_NUM,
+            eam::CREATE2_METHOD_NUM,
             IpldBlock::serialize_cbor(&create2_params).unwrap(),
             TokenAmount::from_atto(1),
             IpldBlock::serialize_cbor(&fake_ret).unwrap(),

--- a/actors/evm/tests/create.rs
+++ b/actors/evm/tests/create.rs
@@ -1,7 +1,7 @@
 mod asm;
 
 use evm::ext::eam;
-use evm::interpreter::address::EthAddress;
+use fil_actors_evm_shared::address::EthAddress;
 use fil_actor_evm as evm;
 use fil_actors_runtime::EAM_ACTOR_ADDR;
 use fvm_ipld_encoding::ipld_block::IpldBlock;

--- a/actors/evm/tests/delegate_call.rs
+++ b/actors/evm/tests/delegate_call.rs
@@ -1,7 +1,5 @@
-use fil_actor_evm::{
-    interpreter::{address::EthAddress, U256},
-    DelegateCallParams, Method,
-};
+use fil_actor_evm::{DelegateCallParams, Method};
+use fil_actors_evm_shared::{address::EthAddress, uints::U256};
 use fil_actors_runtime::{runtime::EMPTY_ARR_CID, test_utils::EVM_ACTOR_CODE_ID};
 use fvm_ipld_encoding::{ipld_block::IpldBlock, BytesSer, RawBytes, DAG_CBOR};
 use fvm_shared::{

--- a/actors/evm/tests/env.rs
+++ b/actors/evm/tests/env.rs
@@ -3,8 +3,8 @@ use ethers::{
     prelude::{builders::ContractCall, decode_function_data},
     providers::{MockProvider, Provider},
 };
-use fil_actors_evm_shared::address::EthAddress;
 use fil_actor_evm as evm;
+use fil_actors_evm_shared::address::EthAddress;
 use fil_actors_runtime::{
     test_utils::{MockRuntime, EVM_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID},
     INIT_ACTOR_ADDR,

--- a/actors/evm/tests/env.rs
+++ b/actors/evm/tests/env.rs
@@ -3,7 +3,7 @@ use ethers::{
     prelude::{builders::ContractCall, decode_function_data},
     providers::{MockProvider, Provider},
 };
-use evm::interpreter::address::EthAddress;
+use fil_actors_evm_shared::address::EthAddress;
 use fil_actor_evm as evm;
 use fil_actors_runtime::{
     test_utils::{MockRuntime, EVM_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID},

--- a/actors/evm/tests/ext_opcodes.rs
+++ b/actors/evm/tests/ext_opcodes.rs
@@ -1,7 +1,7 @@
 mod asm;
 
 use cid::Cid;
-use evm::interpreter::U256;
+use fil_actors_evm_shared::uints::U256;
 use evm::BytecodeHash;
 use fil_actor_evm as evm;
 use fil_actors_runtime::runtime::{Primitives, Runtime, EMPTY_ARR_CID};

--- a/actors/evm/tests/ext_opcodes.rs
+++ b/actors/evm/tests/ext_opcodes.rs
@@ -1,9 +1,9 @@
 mod asm;
 
 use cid::Cid;
-use fil_actors_evm_shared::uints::U256;
 use evm::BytecodeHash;
 use fil_actor_evm as evm;
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::runtime::{Primitives, Runtime, EMPTY_ARR_CID};
 use fil_actors_runtime::test_utils::*;
 use fvm_ipld_blockstore::Blockstore;

--- a/actors/evm/tests/misc.rs
+++ b/actors/evm/tests/misc.rs
@@ -2,8 +2,8 @@ mod asm;
 mod util;
 
 use cid::Cid;
-use evm::interpreter::{address::EthAddress, U256};
-use fil_actor_evm as evm;
+use fil_actors_evm_shared::address::EthAddress;
+use fil_actors_evm_shared::uints::U256;
 use fvm_ipld_encoding::DAG_CBOR;
 use fvm_shared::chainid::ChainID;
 use fvm_shared::{address::Address, econ::TokenAmount};

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -1,7 +1,6 @@
 mod asm;
 
-use evm::interpreter::{address::EthAddress, U256};
-use fil_actor_evm as evm;
+use fil_actors_evm_shared::{address::EthAddress, uints::U256};
 use fil_actors_runtime::{
     test_utils::{new_bls_addr, MockRuntime},
     EAM_ACTOR_ID,

--- a/actors/evm/tests/selfdestruct.rs
+++ b/actors/evm/tests/selfdestruct.rs
@@ -1,7 +1,7 @@
 use fil_actor_evm::{
-    interpreter::{address::EthAddress, U256},
     EvmContractActor, Method, ResurrectParams, State, Tombstone, EVM_CONTRACT_SELFDESTRUCT_FAILED,
 };
+use fil_actors_evm_shared::{address::EthAddress, uints::U256};
 use fil_actors_runtime::{test_utils::*, EAM_ACTOR_ADDR, INIT_ACTOR_ADDR};
 use fvm_ipld_encoding::{ipld_block::IpldBlock, BytesSer, RawBytes};
 use fvm_shared::{

--- a/actors/evm/tests/storage_footprint.rs
+++ b/actors/evm/tests/storage_footprint.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use ethers::contract::Lazy;
 use ethers::prelude::abigen;
 use ethers::providers::{MockProvider, Provider};
-use fil_actor_evm::interpreter::address::EthAddress;
+use fil_actors_evm_shared::address::EthAddress;
 use fvm_ipld_blockstore::tracking::BSStats as BlockstoreStats;
 use fvm_shared::address::Address;
 use fvm_shared::ActorID;

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -1,8 +1,8 @@
 use cid::Cid;
-use fil_actors_evm_shared::address::EthAddress;
-use fil_actors_evm_shared::uints::U256;
 use fil_actor_evm as evm;
 use fil_actor_evm::State;
+use fil_actors_evm_shared::address::EthAddress;
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::{
     test_utils::{self, *},

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -1,6 +1,6 @@
 use cid::Cid;
-use evm::interpreter::address::EthAddress;
-use evm::interpreter::U256;
+use fil_actors_evm_shared::address::EthAddress;
+use fil_actors_evm_shared::uints::U256;
 use fil_actor_evm as evm;
 use fil_actor_evm::State;
 use fil_actors_runtime::runtime::Runtime;

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -52,6 +52,7 @@ regex = "1"
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 libsecp256k1 = { version = "0.7.1"}
+fil_actors_evm_shared = { version = "10.0.0-alpha.1", path = "../actors/evm/shared" }
 
 [dev-dependencies]
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }

--- a/test_vm/tests/evm_test.rs
+++ b/test_vm/tests/evm_test.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use ethers::prelude::abigen;
 use ethers::providers::Provider;
 use ethers::{core::types::Address as EthAddress, prelude::builders::ContractCall};
-use fil_actor_evm::interpreter::U256;
+use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::{
     test_utils::{ETHACCOUNT_ACTOR_CODE_ID, EVM_ACTOR_CODE_ID},
     EAM_ACTOR_ADDR, EAM_ACTOR_ID,


### PR DESCRIPTION
This change-set moves code around to:

1. Make things private where possible. We were defaulting to public, but I think we can now safely say what should be private/public.
2. Attaches some helper methods to the U256 type.
3. Factors EthAddress and U256 into a helper crate.
4. Follows the `ext.rs` convention for defining external APIs.

This patch _does not_ change the EAM (yet). It just moves code around (and deletes a bit of dead code).

part of https://github.com/filecoin-project/ref-fvm/issues/974