### PR TITLE
Fix macro DSL

### DIFF
--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -165,13 +165,13 @@ mod tests {
     #[test]
     fn test_jump() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 JUMP;
                 JUMPDEST;
                 JUMPDEST;
                 JUMPDEST;
                 JUMPDEST;
-            ]
+            }
             m.state.stack.push(U256::from(2)).unwrap();
             let result = m.step();
             assert!(result.is_ok(), "execution step failed");
@@ -183,14 +183,14 @@ mod tests {
     #[test]
     fn test_jump_err() {
         evm_unit_test!(
-            (m) [
+            (m) {
                 JUMP; // JUMP
                 PUSH4; // PUSH4 -- garbage
                 0x01; // garbage
                 0x02; // garbage
                 0x03; // garbage
                 0x04; // garbage
-            ]
+            }
             m.state.stack.push(U256::from(2)).unwrap();
             let result = m.step();
             assert_eq!(m.state.stack.len(), 0);
@@ -202,14 +202,14 @@ mod tests {
     #[test]
     fn test_jump_err2() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 JUMP;  // JUMP
                 PUSH4; // PUSH4 -- garbage
                 0x01;  // garbage
                 0x02;  // garbage
                 0x03;  // garbage
                 0x04;  // garbage
-            ]
+            }
 
             m.state.stack.push(U256::from(123)).unwrap();
             let result = m.step();
@@ -222,14 +222,14 @@ mod tests {
     #[test]
     fn test_jump_err3() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 JUMP;
                 PUSH4;
                 JUMPDEST;
                 JUMPDEST;
                 JUMPDEST;
                 JUMPDEST;
-            ]
+            }
             m.state.stack.push(U256::from(2)).unwrap();
             let result = m.step();
             assert_eq!(m.state.stack.len(), 0);
@@ -241,13 +241,13 @@ mod tests {
     #[test]
     fn test_jumpi_t() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 JUMPI;
                 JUMPDEST;
                 JUMPDEST;
                 JUMPDEST;
                 JUMPDEST;
-            ]
+            }
             m.state.stack.push(U256::from(1)).unwrap();
             m.state.stack.push(U256::from(2)).unwrap();
             let result = m.step();
@@ -260,13 +260,13 @@ mod tests {
     #[test]
     fn test_jumpi_f() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 JUMPI;
                 JUMPDEST;
                 JUMPDEST;
                 JUMPDEST;
                 JUMPDEST;
-            ]
+            }
             m.state.stack.push(U256::from(0)).unwrap();
             m.state.stack.push(U256::from(2)).unwrap();
             let result = m.step();
@@ -279,13 +279,13 @@ mod tests {
     #[test]
     fn test_jumpi_err() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 JUMPI;
                 JUMPDEST;
                 JUMPDEST;
                 JUMPDEST;
                 JUMPDEST;
-            ]
+            }
             m.state.stack.push(U256::from(1)).unwrap();
             m.state.stack.push(U256::from(123)).unwrap();
             let result = m.step();
@@ -298,10 +298,10 @@ mod tests {
     #[test]
     fn test_pc() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 PC;
                 JUMPDEST;
-            ]
+            }
             let result = m.step();
             assert!(result.is_ok(), "execution step failed");
             assert_eq!(m.state.stack.len(), 1);

--- a/actors/evm/src/interpreter/instructions/hash.rs
+++ b/actors/evm/src/interpreter/instructions/hash.rs
@@ -41,13 +41,13 @@ mod test {
             let v = vec![0xff; len];
             let [a, b] = u16::try_from(len).unwrap().to_be_bytes();
             evm_unit_test! {
-                (m) [
+                (m) {
                     PUSH2;
                     {a};
                     {b};
                     PUSH0;
                     KECCAK256;
-                ]
+                }
 
                 let expect = &m.system.rt.hash_64(fvm_shared::crypto::hash::SupportedHashes::Keccak256, &v).0[..32];
 
@@ -68,12 +68,12 @@ mod test {
             [([0xfe].as_slice(), BytecodeHash::NATIVE_ACTOR), (&[], BytecodeHash::EMPTY)]
         {
             evm_unit_test! {
-                (m) [
+                (m) {
                     PUSH1;
                     {input.len() as u8};
                     PUSH0;
                     KECCAK256;
-                ]
+                }
                 m.state.memory.grow(input.len());
                 m.state.memory[..input.len()].copy_from_slice(input);
                 m.step().expect("execution step failed");

--- a/actors/evm/src/interpreter/instructions/memory.rs
+++ b/actors/evm/src/interpreter/instructions/memory.rs
@@ -202,10 +202,10 @@ mod tests {
     #[test]
     fn test_mload_nothing() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 PUSH0;
                 MLOAD;
-            ]
+            }
 
             m.step().expect("execution step failed");
             m.step().expect("execution step failed");
@@ -218,14 +218,14 @@ mod tests {
     #[test]
     fn test_mload_large_offset() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 PUSH4; // garbage offset
                 0x01;
                 0x02;
                 0x03;
                 0x04;
                 MLOAD;
-            ]
+            }
 
             m.step().expect("execution step failed");
             m.step().expect("execution step failed");
@@ -239,11 +239,11 @@ mod tests {
     fn test_mload_word() {
         for sh in 0..32 {
             evm_unit_test! {
-                (m) [
+                (m) {
                     PUSH1;
                     {sh};
                     MLOAD;
-                ]
+                }
 
                 m.state.memory.grow(32);
                 m.state.memory[..32].copy_from_slice(&U256::MAX.to_bytes());
@@ -261,12 +261,12 @@ mod tests {
     fn test_mstore8_basic() {
         for i in 0..=u8::MAX {
             evm_unit_test! {
-                (m) [
+                (m) {
                     PUSH1;
                     {i};
                     PUSH0;
                     MSTORE8;
-                ]
+                }
                 m.step().expect("execution step failed");
                 m.step().expect("execution step failed");
                 m.step().expect("execution step failed");
@@ -280,13 +280,13 @@ mod tests {
     #[test]
     fn test_mstore8_overwrite() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 PUSH1;
                 0x01;
                 PUSH1;
                 0x01;
                 MSTORE8;
-            ]
+            }
             // index has garbage
             m.state.memory.grow(32);
             m.state.memory[0] = 0xab;
@@ -313,14 +313,14 @@ mod tests {
             let i = 1u16 << sh;
             let [a, b] = i.to_be_bytes();
             evm_unit_test! {
-                (m) [
+                (m) {
                     PUSH1;
                     0xff;
                     PUSH2;
                     {a};
                     {b};
                     MSTORE8;
-                ]
+                }
                 m.step().expect("execution step failed");
                 m.step().expect("execution step failed");
                 m.step().expect("execution step failed");
@@ -336,7 +336,7 @@ mod tests {
     #[test]
     fn test_mstore8_garbage() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 PUSH32;
                 0xff;
                 0xff;
@@ -372,7 +372,7 @@ mod tests {
                 0x01;
                 PUSH0;
                 MSTORE8;
-            ]
+            }
             m.step().expect("execution step failed");
             m.step().expect("execution step failed");
             m.step().expect("execution step failed");
@@ -387,13 +387,13 @@ mod tests {
     #[test]
     fn test_mstore_basic() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 PUSH2;
                 0xff;
                 0xfe;
                 PUSH0;
                 MSTORE;
-            ]
+            }
             m.step().expect("execution step failed");
             m.step().expect("execution step failed");
             m.step().expect("execution step failed");
@@ -408,13 +408,13 @@ mod tests {
     #[test]
     fn test_mstore_overwrite() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 PUSH2;
                 0xff;
                 0xfe;
                 PUSH0;
                 MSTORE;
-            ]
+            }
             m.state.memory.grow(64);
             m.state.memory[..EVM_WORD_SIZE].copy_from_slice(&[0xff; EVM_WORD_SIZE]);
             // single byte outside expected overwritten area
@@ -436,14 +436,14 @@ mod tests {
     #[test]
     fn test_msize_multiple_mstore8() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 PUSH1;
                 0xff;
                 PUSH1;
                 {42}; // offset of 42
                 MSTORE8;
                 MSIZE;
-            ]
+            }
 
             m.step().expect("execution step failed");
             m.step().expect("execution step failed");
@@ -459,14 +459,14 @@ mod tests {
     #[test]
     fn test_msize_multiple_mstore() {
         evm_unit_test! {
-            (m) [
+            (m) {
                 PUSH1;
                 0xff;
                 PUSH1;
                 {12}; // offset of 12
                 MSTORE;
                 MSIZE;
-            ]
+            }
 
             m.step().expect("execution step failed");
             m.step().expect("execution step failed");
@@ -483,9 +483,9 @@ mod tests {
         // Demonstrate that MSIZE depends on memory.len()
         // Normally this should never happen and we wont panic from it.
         evm_unit_test! {
-            (m) [
+            (m) {
                 MSIZE;
-            ]
+            }
 
             m.state.memory.grow(12);
             m.step().expect("execution step failed");

--- a/actors/evm/src/interpreter/instructions/state.rs
+++ b/actors/evm/src/interpreter/instructions/state.rs
@@ -57,7 +57,7 @@ mod test {
                 (false, U256::MAX),
             ] {
                 evm_unit_test! {
-                    (rt:
+                    (rt) {
                         rt.in_call = true;
 
                         let id_address = 1111;
@@ -66,12 +66,12 @@ mod test {
                             rt.add_id_address(addr.into(), Address::new_id(id_address))
                         }
                         rt.actor_balances.insert(id_address, TokenAmount::from_atto(balance));
-                    )
-                    (m) [
+                    }
+                    (m) {
                         PUSH0;
                         MLOAD;
                         BALANCE;
-                    ]
+                    }
 
                     m.state.memory.grow(32);
                     m.state.memory[..32].copy_from_slice(&addr.to_bytes());
@@ -102,17 +102,17 @@ mod test {
         let addr = U256::from(buf);
 
         evm_unit_test! {
-            (rt:
+            (rt) {
                 rt.in_call = true;
 
                 // 0xff id address gets balance
                 rt.actor_balances.insert(id as u64, TokenAmount::from_atto(balance));
-            )
-            (m) [
+            }
+            (m) {
                 PUSH0;
                 MLOAD;
                 BALANCE;
-            ]
+            }
 
             m.state.memory.grow(32);
             m.state.memory[..32].copy_from_slice(&addr.to_bytes());
@@ -132,13 +132,13 @@ mod test {
         for i in 0..256 {
             let balance = U256::ONE << i;
             evm_unit_test! {
-                (rt:
+                (rt) {
                     rt.in_call = true;
                     rt.add_balance(TokenAmount::from(&balance));
-                )
-                (m) [
+                }
+                (m) {
                     SELFBALANCE;
-                ]
+                }
 
                 m.step().expect("execution step failed");
 

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -13,7 +13,38 @@ macro_rules! evm_instruction {
 
 #[macro_export]
 macro_rules! evm_unit_test {
-    (($machine:ident) [ $($inst:tt;)* ] $($body:tt)*) => {
+    (($rt:ident) $init:block ($machine:ident) { $($inst:tt;)* } $($body:tt)*) => {
+        use ::fil_actors_runtime::test_utils::MockRuntime;
+        use ::fvm_shared::econ::TokenAmount;
+        use $crate::interpreter::{execution::Machine, system::System, Output};
+        use $crate::{Bytecode, Bytes, EthAddress, ExecutionState};
+
+        let mut $rt = MockRuntime::default();
+        $init
+
+        let mut state = ExecutionState::new(
+            EthAddress::from_id(1000),
+            EthAddress::from_id(1000),
+            TokenAmount::from_atto(0),
+            Bytes::default(),
+        );
+
+        let code = vec![$($crate::evm_instruction!($inst)),*];
+
+        let mut system = System::new(&mut $rt, false);
+        let bytecode = Bytecode::new(code);
+        let mut $machine = Machine {
+            system: &mut system,
+            state: &mut state,
+            bytecode: &bytecode,
+            pc: 0,
+            output: Output::default(),
+        };
+
+        $($body)*
+    };
+
+    (($machine:ident) { $($inst:tt;)* } $($body:tt)*) => {
         use ::fil_actors_runtime::test_utils::MockRuntime;
         use ::fvm_shared::econ::TokenAmount;
         use $crate::interpreter::{execution::Machine, system::System, Output};
@@ -30,36 +61,6 @@ macro_rules! evm_unit_test {
         let code = vec![$($crate::evm_instruction!($inst)),*];
 
         let mut system = System::new(&mut rt, false);
-        let bytecode = Bytecode::new(code);
-        let mut $machine = Machine {
-            system: &mut system,
-            state: &mut state,
-            bytecode: &bytecode,
-            pc: 0,
-            output: Output::default(),
-        };
-
-        $($body)*
-    };
-    (($rt:ident: $($init:tt)*) ($machine:ident) [ $($inst:tt;)* ] $($body:tt)*) => {
-        use ::fil_actors_runtime::test_utils::MockRuntime;
-        use ::fvm_shared::econ::TokenAmount;
-        use $crate::interpreter::{execution::Machine, system::System, Output};
-        use $crate::{Bytecode, Bytes, EthAddress, ExecutionState};
-
-        let mut $rt = MockRuntime::default();
-        $($init)*
-
-        let mut state = ExecutionState::new(
-            EthAddress::from_id(1000),
-            EthAddress::from_id(1000),
-            TokenAmount::from_atto(0),
-            Bytes::default(),
-        );
-
-        let code = vec![$($crate::evm_instruction!($inst)),*];
-
-        let mut system = System::new(&mut $rt, false);
         let bytecode = Bytecode::new(code);
         let mut $machine = Machine {
             system: &mut system,


### PR DESCRIPTION
For https://github.com/filecoin-project/builtin-actors/pull/1144#pullrequestreview-1279767582 which makes two aesthetic crimes when it comes to DSLology: the embeded code for both constructs is interpretable garbage.

So:
`(rt: blah ...}` is `(rt) {blah ...}` which is optional and has nice block semantics.
and
`(m) [ blah...]` is `(m) {blah....}` again, since it doesn't have array semantcs.

I haz strong opinions when it comes to macro DSLs :)