### PR TITLE
Runtime: Add several new methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,15 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
@@ -391,6 +400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,11 +528,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.3",
  "crypto-common",
 ]
 
@@ -829,6 +853,7 @@ dependencies = [
  "integer-encoding",
  "itertools",
  "lazy_static",
+ "libsecp256k1",
  "log",
  "multihash",
  "num",
@@ -839,7 +864,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_repr",
- "sha2",
+ "sha2 0.10.6",
  "thiserror",
  "unsigned-varint",
 ]
@@ -1202,7 +1227,7 @@ dependencies = [
  "multihash",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.6",
  "thiserror",
 ]
 
@@ -1477,6 +1502,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsecp256k1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
+dependencies = [
+ "arrayref",
+ "base64",
+ "digest 0.9.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand",
+ "serde",
+ "sha2 0.9.9",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,12 +1584,12 @@ dependencies = [
  "blake2s_simd",
  "blake3",
  "core2",
- "digest",
+ "digest 0.10.6",
  "multihash-derive",
  "ripemd",
  "serde",
  "serde-big-array",
- "sha2",
+ "sha2 0.10.6",
  "sha3",
  "unsigned-varint",
 ]
@@ -1632,6 +1703,12 @@ name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "os_str_bytes"
@@ -1788,7 +1865,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1904,13 +1981,26 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1919,7 +2009,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest",
+ "digest 0.10.6",
  "keccak",
 ]
 
@@ -1947,6 +2037,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/actors/miner/tests/miner_actor_test_construction.rs
+++ b/actors/miner/tests/miner_actor_test_construction.rs
@@ -47,7 +47,7 @@ fn prepare_env() -> TestEnv {
     env.rt.actor_code_cids.insert(env.worker, *ACCOUNT_ACTOR_CODE_ID);
     env.rt.actor_code_cids.insert(env.control_addrs[0], *ACCOUNT_ACTOR_CODE_ID);
     env.rt.actor_code_cids.insert(env.control_addrs[1], *ACCOUNT_ACTOR_CODE_ID);
-    env.rt.hash_func = Box::new(blake2b_256);
+    env.rt.hash_func = Box::new(hash);
     env.rt.caller = INIT_ACTOR_ADDR;
     env.rt.caller_type = *INIT_ACTOR_CODE_ID;
     env

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -88,6 +88,7 @@ use fil_actor_miner::testing::{
 };
 use fil_actors_runtime::cbor::serialize;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fvm_shared::crypto::hash::SupportedHashes;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::TryInto;
 use std::iter;
@@ -2931,14 +2932,14 @@ where
 }
 
 // Returns a fake hashing function that always arranges the first 8 bytes of the digest to be the binary
-// encoding of a target uint64.
-fn fixed_hasher(offset: ChainEpoch) -> Box<dyn Fn(&[u8]) -> [u8; 32]> {
-    let hash = move |_: &[u8]| -> [u8; 32] {
-        let mut result = [0u8; 32];
+// encoding of a target uint64 and ignores the hash function.
+fn fixed_hasher(offset: ChainEpoch) -> Box<dyn Fn(SupportedHashes, &[u8]) -> ([u8; 64], usize)> {
+    let hash = move |_: SupportedHashes, _: &[u8]| -> ([u8; 64], usize) {
+        let mut result = [0u8; 64];
         for (i, item) in result.iter_mut().enumerate().take(8) {
             *item = ((offset >> (8 * (7 - i))) & 0xff) as u8;
         }
-        result
+        (result, 32)
     };
     Box::new(hash)
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -44,6 +44,12 @@ castaway = "0.2.2"
 [dependencies.sha2]
 version = "0.10"
 
+[dependencies.libsecp256k1]
+version = "0.7.1"
+default-features = false
+features = ["static-context", "std"]
+optional = true
+
 [dev-dependencies]
 derive_builder = "0.10.2"
 hex = "0.4.3"
@@ -81,4 +87,4 @@ no-provider-deal-collateral = []
 # fake proofs (for testing)
 fake-proofs = []
 
-test_utils = ["hex", "multihash/sha2", "lazy_static"]
+test_utils = ["hex", "multihash/sha2", "libsecp256k1", "lazy_static"]

--- a/runtime/src/actor_error.rs
+++ b/runtime/src/actor_error.rs
@@ -74,6 +74,10 @@ impl ActorError {
         Self { exit_code: ExitCode::USR_ASSERTION_FAILED, msg, data: None }
     }
 
+    pub fn read_only(msg: String) -> Self {
+        Self { exit_code: ExitCode::USR_READ_ONLY, msg, data: None }
+    }
+
     /// Returns the exit code of the error.
     pub fn exit_code(&self) -> ExitCode {
         self.exit_code

--- a/runtime/src/runtime/builtins.rs
+++ b/runtime/src/runtime/builtins.rs
@@ -20,6 +20,7 @@ pub enum Type {
     Reward = 10,
     VerifiedRegistry = 11,
     DataCap = 12,
+    Placeholder = 13,
 }
 
 impl Type {
@@ -37,6 +38,7 @@ impl Type {
             Type::Reward => "reward",
             Type::VerifiedRegistry => "verifiedregistry",
             Type::DataCap => "datacap",
+            Type::Placeholder => "placeholder",
         }
     }
 }

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -336,8 +336,9 @@ where
         fvm::network::tipset_timestamp()
     }
 
-    fn tipset_cid(&self, epoch: i64) -> Option<Cid> {
-        fvm::network::tipset_cid(epoch).ok()
+    fn tipset_cid(&self, epoch: i64) -> Result<Cid, ActorError> {
+        fvm::network::tipset_cid(epoch)
+            .map_err(|_| actor_error!(illegal_argument; "invalid epoch to query tipset_cid"))
     }
 
     fn read_only(&self) -> bool {

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -10,7 +10,10 @@ use fvm_sdk as fvm;
 use fvm_sdk::NO_DATA_BLOCK_ID;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
-use fvm_shared::crypto::signature::Signature;
+use fvm_shared::crypto::hash::SupportedHashes;
+use fvm_shared::crypto::signature::{
+    Signature, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
+};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::piece::PieceInfo;
@@ -84,12 +87,24 @@ impl MessageInfo for FvmMessage {
         Address::new_id(fvm::message::caller())
     }
 
+    fn origin(&self) -> Address {
+        Address::new_id(fvm::message::origin())
+    }
+
     fn receiver(&self) -> Address {
         Address::new_id(fvm::message::receiver())
     }
 
     fn value_received(&self) -> TokenAmount {
         fvm::message::value_received()
+    }
+
+    fn gas_premium(&self) -> TokenAmount {
+        fvm::message::gas_premium()
+    }
+
+    fn nonce(&self) -> u64 {
+        fvm::message::nonce()
     }
 }
 
@@ -158,6 +173,10 @@ where
         fvm::sself::current_balance()
     }
 
+    fn actor_balance(&self, id: ActorID) -> Option<TokenAmount> {
+        fvm::actor::balance_of(id)
+    }
+
     fn resolve_address(&self, address: &Address) -> Option<ActorID> {
         fvm::actor::resolve_address(address)
     }
@@ -184,30 +203,14 @@ where
         rand_epoch: ChainEpoch,
         entropy: &[u8],
     ) -> Result<[u8; RANDOMNESS_LENGTH], ActorError> {
-        // Note: For Go actors, Lotus treated all failures to get randomness as "fatal" errors,
-        // which it then translated into exit code SysErrReserved1 (= 4, and now known as
-        // SYS_ILLEGAL_INSTRUCTION), rather than just aborting with an appropriate exit code.
-        //
-        // We can replicate that here prior to network v16, but from nv16 onwards the FVM will
-        // override the attempt to use a system exit code, and produce
-        // SYS_ILLEGAL_EXIT_CODE (9) instead.
-        //
-        // Since that behaviour changes, we may as well abort with a more appropriate exit code
-        // explicitly.
-        fvm::rand::get_chain_randomness(personalization as i64, rand_epoch, entropy)
-            .map_err(|e| {
-                if self.network_version() < NetworkVersion::V16 {
-                    ActorError::unchecked(ExitCode::SYS_ILLEGAL_INSTRUCTION,
-                                          "failed to get chain randomness".into())
-                } else {
-                    match e {
-                        ErrorNumber::LimitExceeded => {
-                            actor_error!(illegal_argument; "randomness lookback exceeded: {}", e)
-                        }
-                        e => actor_error!(assertion_failed; "get chain randomness failed with an unexpected error: {}", e),
-                    }
+        fvm::rand::get_chain_randomness(personalization as i64, rand_epoch, entropy).map_err(|e| {
+            match e {
+                ErrorNumber::LimitExceeded => {
+                    actor_error!(illegal_argument; "randomness lookback exceeded: {}", e)
                 }
-            })
+                e => actor_error!(assertion_failed; "get chain randomness failed with an unexpected error: {}", e),
+            }
+        })
     }
 
     fn get_randomness_from_beacon(
@@ -216,21 +219,14 @@ where
         rand_epoch: ChainEpoch,
         entropy: &[u8],
     ) -> Result<[u8; RANDOMNESS_LENGTH], ActorError> {
-        // See note on exit codes in get_randomness_from_tickets.
-        fvm::rand::get_beacon_randomness(personalization as i64, rand_epoch, entropy)
-            .map_err(|e| {
-                if self.network_version() < NetworkVersion::V16 {
-                    ActorError::unchecked(ExitCode::SYS_ILLEGAL_INSTRUCTION,
-                                          "failed to get chain randomness".into())
-                } else {
-                    match e {
-                        ErrorNumber::LimitExceeded => {
-                            actor_error!(illegal_argument; "randomness lookback exceeded: {}", e)
-                        }
-                        e => actor_error!(assertion_failed; "get chain randomness failed with an unexpected error: {}", e),
-                    }
+        fvm::rand::get_beacon_randomness(personalization as i64, rand_epoch, entropy).map_err(|e| {
+            match e {
+                ErrorNumber::LimitExceeded => {
+                    actor_error!(illegal_argument; "randomness lookback exceeded: {}", e)
                 }
-            })
+                e => actor_error!(assertion_failed; "get beacon randomness failed with an unexpected error: {}", e),
+            }
+        })
     }
 
     fn get_state_root(&self) -> Result<Cid, ActorError> {
@@ -306,6 +302,7 @@ where
             ErrorNumber::IllegalArgument => {
                 ActorError::illegal_argument("failed to create actor".into())
             }
+            ErrorNumber::Forbidden => ActorError::forbidden("actor already exists".into()),
             _ => actor_error!(assertion_failed; "create failed with unknown error: {}", e),
         })
     }
@@ -329,6 +326,18 @@ where
 
     fn base_fee(&self) -> TokenAmount {
         fvm::network::base_fee()
+    }
+
+    fn gas_available(&self) -> u64 {
+        fvm::gas::available()
+    }
+
+    fn tipset_timestamp(&self) -> u64 {
+        fvm::network::tipset_timestamp()
+    }
+
+    fn tipset_cid(&self, epoch: i64) -> Option<Cid> {
+        fvm::network::tipset_cid(epoch).ok()
     }
 
     fn read_only(&self) -> bool {
@@ -365,6 +374,25 @@ where
         // exit code ErrIllegalArgument. We should probably move that here, or to the syscall itself.
         fvm::crypto::compute_unsealed_sector_cid(proof_type, pieces)
             .map_err(|e| anyhow!("failed to compute unsealed sector CID; exit code: {}", e))
+    }
+
+    fn hash(&self, hasher: SupportedHashes, data: &[u8]) -> Vec<u8> {
+        fvm::crypto::hash_owned(hasher, data)
+    }
+
+    fn hash_64(&self, hasher: SupportedHashes, data: &[u8]) -> ([u8; 64], usize) {
+        let mut buf = [0u8; 64];
+        let len = fvm::crypto::hash_into(hasher, data, &mut buf);
+        (buf, len)
+    }
+
+    fn recover_secp_public_key(
+        &self,
+        hash: &[u8; SECP_SIG_MESSAGE_HASH_SIZE],
+        signature: &[u8; SECP_SIG_LEN],
+    ) -> Result<[u8; SECP_PUB_LEN], anyhow::Error> {
+        fvm::crypto::recover_secp_public_key(hash, signature)
+            .map_err(|e| anyhow!("failed to recover pubkey; exit code: {}", e))
     }
 }
 

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -59,7 +59,8 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// Information related to the current message being executed.
     fn message(&self) -> &dyn MessageInfo;
 
-    /// The current chain epoch number. The genesis block has epoch zero.
+    /// The current chain epoch number, corresponding to the epoch in which the message is executed.
+    /// The genesis block has epoch zero.
     fn curr_epoch(&self) -> ChainEpoch;
 
     /// Validates the caller against some predicate.
@@ -227,10 +228,11 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// The gas still available for computation
     fn gas_available(&self) -> u64;
 
-    /// The current tipset's timestamp, as UNIX seconds
+    /// The timestamp of the tipset at the current epoch (see curr_epoch), as UNIX seconds.
     fn tipset_timestamp(&self) -> u64;
 
-    /// The hash of on of the last 256 blocks
+    /// The CID of the tipset at the specified epoch.
+    /// The epoch must satisfy: (curr_epoch - FINALITY) < epoch <= curr_epoch
     fn tipset_cid(&self, epoch: i64) -> Option<Cid>;
 
     /// Returns true if the call is read_only.

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -7,7 +7,10 @@ use fvm_ipld_encoding::CborStore;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;
-use fvm_shared::crypto::signature::Signature;
+use fvm_shared::crypto::hash::SupportedHashes;
+use fvm_shared::crypto::signature::{
+    Signature, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
+};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::RANDOMNESS_LENGTH;
@@ -71,6 +74,9 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
 
     /// The balance of the receiver.
     fn current_balance(&self) -> TokenAmount;
+
+    /// The balance of an actor.
+    fn actor_balance(&self, id: ActorID) -> Option<TokenAmount>;
 
     /// Resolves an address of any protocol to an ID address (via the Init actor's table).
     /// This allows resolution of externally-provided SECP, BLS, or actor addresses to the canonical form.
@@ -218,6 +224,15 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// Returns the gas base fee (cost per unit) for the current epoch.
     fn base_fee(&self) -> TokenAmount;
 
+    /// The gas still available for computation
+    fn gas_available(&self) -> u64;
+
+    /// The current tipset's timestamp, as UNIX seconds
+    fn tipset_timestamp(&self) -> u64;
+
+    /// The hash of on of the last 256 blocks
+    fn tipset_cid(&self, epoch: i64) -> Option<Cid>;
+
     /// Returns true if the call is read_only.
     /// All state updates, including actor creation and balance transfers, are rejected in read_only calls.
     fn read_only(&self) -> bool;
@@ -225,8 +240,14 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
 
 /// Message information available to the actor about executing message.
 pub trait MessageInfo {
+    /// The nonce of the currently executing message.
+    fn nonce(&self) -> u64;
+
     /// The address of the immediate calling actor. Always an ID-address.
     fn caller(&self) -> Address;
+
+    /// The address of the origin of the current invocation. Always an ID-address
+    fn origin(&self) -> Address;
 
     /// The address of the actor receiving the message. Always an ID-address.
     fn receiver(&self) -> Address;
@@ -234,12 +255,21 @@ pub trait MessageInfo {
     /// The value attached to the message being processed, implicitly
     /// added to current_balance() before method invocation.
     fn value_received(&self) -> TokenAmount;
+
+    /// The message gas premium
+    fn gas_premium(&self) -> TokenAmount;
 }
 
 /// Pure functions implemented as primitives by the runtime.
 pub trait Primitives {
     /// Hashes input data using blake2b with 256 bit output.
     fn hash_blake2b(&self, data: &[u8]) -> [u8; 32];
+
+    /// Hashes input data using a supported hash function.
+    fn hash(&self, hasher: SupportedHashes, data: &[u8]) -> Vec<u8>;
+
+    /// Hashes input into a 64 byte buffer
+    fn hash_64(&self, hasher: SupportedHashes, data: &[u8]) -> ([u8; 64], usize);
 
     /// Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.
     fn compute_unsealed_sector_cid(
@@ -255,6 +285,12 @@ pub trait Primitives {
         signer: &Address,
         plaintext: &[u8],
     ) -> Result<(), anyhow::Error>;
+
+    fn recover_secp_public_key(
+        &self,
+        hash: &[u8; SECP_SIG_MESSAGE_HASH_SIZE],
+        signature: &[u8; SECP_SIG_LEN],
+    ) -> Result<[u8; SECP_PUB_LEN], anyhow::Error>;
 }
 
 /// filcrypto verification primitives provided by the runtime

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -233,7 +233,7 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
 
     /// The CID of the tipset at the specified epoch.
     /// The epoch must satisfy: (curr_epoch - FINALITY) < epoch <= curr_epoch
-    fn tipset_cid(&self, epoch: i64) -> Option<Cid>;
+    fn tipset_cid(&self, epoch: i64) -> Result<Cid, ActorError>;
 
     /// Returns true if the call is read_only.
     /// All state updates, including actor creation and balance transfers, are rejected in read_only calls.

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -17,7 +17,10 @@ use fvm_shared::address::{Address, Protocol};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::commcid::{FIL_COMMITMENT_SEALED, FIL_COMMITMENT_UNSEALED};
 use fvm_shared::consensus::ConsensusFault;
-use fvm_shared::crypto::signature::Signature;
+use fvm_shared::crypto::hash::SupportedHashes;
+use fvm_shared::crypto::signature::{
+    Signature, SECP_PUB_LEN, SECP_SIG_LEN, SECP_SIG_MESSAGE_HASH_SIZE,
+};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::piece::PieceInfo;
@@ -41,6 +44,7 @@ use crate::runtime::{
     Verifier, EMPTY_ARR_CID,
 };
 use crate::{actor_error, ActorError, SendError};
+use libsecp256k1::{recover, Message, RecoveryId, Signature as EcsdaSignature};
 
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::sys::SendFlags;
@@ -73,6 +77,7 @@ lazy_static::lazy_static! {
         map.insert(*REWARD_ACTOR_CODE_ID, Type::Reward);
         map.insert(*VERIFREG_ACTOR_CODE_ID, Type::VerifiedRegistry);
         map.insert(*DATACAP_TOKEN_ACTOR_CODE_ID, Type::DataCap);
+        map.insert(*PLACEHOLDER_ACTOR_CODE_ID, Type::Placeholder);
         map
     };
     pub static ref ACTOR_CODES: BTreeMap<Type, Cid> = [
@@ -88,6 +93,7 @@ lazy_static::lazy_static! {
         (Type::Reward, *REWARD_ACTOR_CODE_ID),
         (Type::VerifiedRegistry, *VERIFREG_ACTOR_CODE_ID),
         (Type::DataCap, *DATACAP_TOKEN_ACTOR_CODE_ID),
+        (Type::Placeholder, *PLACEHOLDER_ACTOR_CODE_ID),
     ]
     .into_iter()
     .collect();
@@ -97,6 +103,7 @@ lazy_static::lazy_static! {
         map.insert(*PAYCH_ACTOR_CODE_ID, ());
         map.insert(*MULTISIG_ACTOR_CODE_ID, ());
         map.insert(*MINER_ACTOR_CODE_ID, ());
+        map.insert(*PLACEHOLDER_ACTOR_CODE_ID, ());
         map
     };
 }
@@ -119,9 +126,17 @@ pub struct MockRuntime<BS = MemoryBlockstore> {
     pub receiver: Address,
     pub caller: Address,
     pub caller_type: Cid,
+    pub origin: Address,
     pub value_received: TokenAmount,
     #[allow(clippy::type_complexity)]
-    pub hash_func: Box<dyn Fn(&[u8]) -> [u8; 32]>,
+    pub hash_func: Box<dyn Fn(SupportedHashes, &[u8]) -> ([u8; 64], usize)>,
+    #[allow(clippy::type_complexity)]
+    pub recover_secp_pubkey_fn: Box<
+        dyn Fn(
+            &[u8; SECP_SIG_MESSAGE_HASH_SIZE],
+            &[u8; SECP_SIG_LEN],
+        ) -> Result<[u8; SECP_PUB_LEN], ()>,
+    >,
     pub network_version: NetworkVersion,
 
     // Actor State
@@ -140,6 +155,12 @@ pub struct MockRuntime<BS = MemoryBlockstore> {
     pub policy: Policy,
 
     pub circulating_supply: TokenAmount,
+
+    pub gas_limit: u64,
+    pub gas_premium: TokenAmount,
+    pub actor_balances: HashMap<ActorID, TokenAmount>,
+    pub tipset_timestamp: u64,
+    pub tipset_cids: Vec<Cid>,
 }
 
 #[derive(Default)]
@@ -161,6 +182,7 @@ pub struct Expectations {
     pub expect_aggregate_verify_seals: Option<ExpectAggregateVerifySeals>,
     pub expect_replica_verify: Option<ExpectReplicaVerify>,
     pub expect_gas_charge: VecDeque<i64>,
+    pub expect_gas_available: VecDeque<u64>,
     skip_verification_on_drop: bool,
 }
 
@@ -257,6 +279,11 @@ impl Expectations {
             "expect_gas_charge {:?}, not received",
             this.expect_gas_charge
         );
+        assert!(
+            this.expect_gas_available.is_empty(),
+            "expect_gas_available {:?}, not received",
+            this.expect_gas_available
+        );
     }
 }
 
@@ -279,8 +306,10 @@ impl<BS> MockRuntime<BS> {
             receiver: Address::new_id(0),
             caller: Address::new_id(0),
             caller_type: Default::default(),
+            origin: Address::new_id(0),
             value_received: Default::default(),
-            hash_func: Box::new(blake2b_256),
+            hash_func: Box::new(hash),
+            recover_secp_pubkey_fn: Box::new(recover_secp_public_key),
             network_version: NetworkVersion::V0,
             state: Default::default(),
             balance: Default::default(),
@@ -290,6 +319,11 @@ impl<BS> MockRuntime<BS> {
             expectations: Default::default(),
             policy: Default::default(),
             circulating_supply: Default::default(),
+            gas_limit: 10_000_000_000u64,
+            gas_premium: Default::default(),
+            actor_balances: Default::default(),
+            tipset_timestamp: Default::default(),
+            tipset_cids: Default::default(),
         }
     }
 }
@@ -448,6 +482,10 @@ impl<BS: Blockstore> MockRuntime<BS> {
         self.caller = address;
         self.caller_type = code_id;
         self.actor_code_cids.insert(address, code_id);
+    }
+
+    pub fn set_origin(&mut self, address: Address) {
+        self.origin = address;
     }
 
     pub fn set_address_actor_type(&mut self, address: Address, actor_type: Cid) {
@@ -711,6 +749,11 @@ impl<BS: Blockstore> MockRuntime<BS> {
         self.expectations.borrow_mut().expect_gas_charge.push_back(value);
     }
 
+    #[allow(dead_code)]
+    pub fn expect_gas_available(&mut self, value: u64) {
+        self.expectations.borrow_mut().expect_gas_available.push_back(value);
+    }
+
     ///// Private helpers /////
 
     fn require_in_call(&self) {
@@ -727,14 +770,24 @@ impl<BS: Blockstore> MockRuntime<BS> {
 }
 
 impl<BS> MessageInfo for MockRuntime<BS> {
+    fn nonce(&self) -> u64 {
+        0
+    }
+
     fn caller(&self) -> Address {
         self.caller
+    }
+    fn origin(&self) -> Address {
+        self.origin
     }
     fn receiver(&self) -> Address {
         self.receiver
     }
     fn value_received(&self) -> TokenAmount {
         self.value_received.clone()
+    }
+    fn gas_premium(&self) -> TokenAmount {
+        self.gas_premium.clone()
     }
 }
 
@@ -834,6 +887,11 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
     fn current_balance(&self) -> TokenAmount {
         self.require_in_call();
         self.balance.borrow().clone()
+    }
+
+    fn actor_balance(&self, id: ActorID) -> Option<TokenAmount> {
+        self.require_in_call();
+        self.actor_balances.get(&id).cloned()
     }
 
     fn resolve_address(&self, address: &Address) -> Option<ActorID> {
@@ -1096,6 +1154,23 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         self.base_fee.clone()
     }
 
+    fn gas_available(&self) -> u64 {
+        let mut exs = self.expectations.borrow_mut();
+        assert!(!exs.expect_gas_available.is_empty(), "unexpected gas available call");
+        exs.expect_gas_available.pop_front().unwrap()
+    }
+
+    fn tipset_timestamp(&self) -> u64 {
+        self.tipset_timestamp
+    }
+
+    fn tipset_cid(&self, epoch: i64) -> Option<Cid> {
+        if epoch > self.epoch || epoch < 0 {
+            return None;
+        }
+        self.tipset_cids.get((self.epoch - epoch) as usize).copied()
+    }
+
     fn read_only(&self) -> bool {
         // Unsupported for unit tests
         unimplemented!()
@@ -1145,8 +1220,17 @@ impl<BS> Primitives for MockRuntime<BS> {
     }
 
     fn hash_blake2b(&self, data: &[u8]) -> [u8; 32] {
-        (*self.hash_func)(data)
+        let (digest, _) = (*self.hash_func)(SupportedHashes::Blake2b256, data);
+        let mut ret = [0u8; 32];
+        ret.copy_from_slice(&digest[..32]);
+        ret
     }
+
+    fn hash(&self, hasher: SupportedHashes, data: &[u8]) -> Vec<u8> {
+        let (digest, len) = (*self.hash_func)(hasher, data);
+        Vec::from(&digest[..len])
+    }
+
     fn compute_unsealed_sector_cid(
         &self,
         reg: RegisteredSealProof,
@@ -1174,6 +1258,19 @@ impl<BS> Primitives for MockRuntime<BS> {
             )));
         }
         Ok(exp.cid)
+    }
+
+    fn recover_secp_public_key(
+        &self,
+        hash: &[u8; SECP_SIG_MESSAGE_HASH_SIZE],
+        signature: &[u8; SECP_SIG_LEN],
+    ) -> Result<[u8; SECP_PUB_LEN], anyhow::Error> {
+        (*self.recover_secp_pubkey_fn)(hash, signature)
+            .map_err(|_| anyhow!("failed to recover pubkey."))
+    }
+
+    fn hash_64(&self, hasher: SupportedHashes, data: &[u8]) -> ([u8; 64], usize) {
+        (*self.hash_func)(hasher, data)
     }
 }
 
@@ -1330,6 +1427,30 @@ pub fn blake2b_256(data: &[u8]) -> [u8; 32] {
         .as_bytes()
         .try_into()
         .unwrap()
+}
+
+pub fn hash(hasher: SupportedHashes, data: &[u8]) -> ([u8; 64], usize) {
+    let hasher = Code::try_from(hasher as u64).unwrap();
+    let (_, digest, written) = hasher.digest(data).into_inner();
+    (digest, written as usize)
+}
+
+#[allow(clippy::result_unit_err)]
+pub fn recover_secp_public_key(
+    hash: &[u8; SECP_SIG_MESSAGE_HASH_SIZE],
+    signature: &[u8; SECP_SIG_LEN],
+) -> Result<[u8; SECP_PUB_LEN], ()> {
+    // generate types to recover key from
+    let rec_id = RecoveryId::parse(signature[64]).map_err(|_| ())?;
+    let message = Message::parse(hash);
+
+    // Signature value without recovery byte
+    let mut s = [0u8; 64];
+    s.copy_from_slice(signature[..64].as_ref());
+
+    // generate Signature
+    let sig = EcsdaSignature::parse_standard(&s).map_err(|_| ())?;
+    Ok(recover(&message, &sig, &rec_id).map_err(|_| ())?.serialize())
 }
 
 // multihash library doesn't support poseidon hashing, so we fake it

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -1164,11 +1164,13 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         self.tipset_timestamp
     }
 
-    fn tipset_cid(&self, epoch: i64) -> Option<Cid> {
+    fn tipset_cid(&self, epoch: i64) -> Result<Cid, ActorError> {
         if epoch > self.epoch || epoch < 0 {
-            return None;
+            return Err(
+                actor_error!(illegal_argument; "invalid epoch to fetch tipset_cid {}", epoch),
+            );
         }
-        self.tipset_cids.get((self.epoch - epoch) as usize).copied()
+        Ok(*self.tipset_cids.get((self.epoch - epoch) as usize).unwrap())
     }
 
     fn read_only(&self) -> bool {

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -220,6 +220,7 @@ pub fn check_state_invariants<'a, BS: Blockstore + Debug>(
                 acc.with_prefix("datacap: ").add_all(&msgs);
                 datacap_summary = Some(summary);
             }
+            Some(Type::Placeholder) => {}
             None => {
                 bail!("unexpected actor code CID {} for address {}", actor.code, key);
             }

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -1048,8 +1048,8 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
         0
     }
 
-    fn tipset_cid(&self, _epoch: i64) -> Option<Cid> {
-        Some(Cid::new_v1(IPLD_RAW, Multihash::wrap(0, b"faketipset").unwrap()))
+    fn tipset_cid(&self, _epoch: i64) -> Result<Cid, ActorError> {
+        Ok(Cid::new_v1(IPLD_RAW, Multihash::wrap(0, b"faketipset").unwrap()))
     }
 
     fn read_only(&self) -> bool {


### PR DESCRIPTION
Extracted from `next`.

This PR adds the following methods to the Runtime interface:
- `actor_balance`
- `gas_available`
- `tipset_timestamp`
- `tipset_cid`
- `hash`
- `hash_64`
- `recover_secp_public_key`

Note: This isn't the most cohesive PR, sorry :')