### PR TITLE
feat: init actor: Add Exec4 method

### DIFF
--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -6,9 +6,11 @@ use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 
 use fil_actors_runtime::{
-    actor_dispatch, actor_error, extract_send_result, ActorContext, ActorError, SYSTEM_ACTOR_ADDR,
+    actor_dispatch, actor_error, extract_send_result, ActorContext, ActorError, AsActorError,
+    SYSTEM_ACTOR_ADDR,
 };
 use fvm_shared::address::Address;
+use fvm_shared::error::ExitCode;
 use fvm_shared::{ActorID, METHOD_CONSTRUCTOR};
 use num_derive::FromPrimitive;
 
@@ -28,6 +30,7 @@ fil_actors_runtime::wasm_trampoline!(Actor);
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
     Exec = 2,
+    Exec4 = 3,
     // Method numbers derived from FRC-0042 standards
     ExecExported = frc42_dispatch::method_hash!("Exec"),
 }
@@ -105,6 +108,62 @@ impl Actor {
 
         Ok(ExecReturn { id_address: Address::new_id(id_address), robust_address })
     }
+
+    /// Exec4 init actor
+    pub fn exec4(rt: &mut impl Runtime, params: Exec4Params) -> Result<Exec4Return, ActorError> {
+        rt.validate_immediate_caller_accept_any()?;
+        // Compute the f4 address.
+        let caller_id = rt.message().caller().id().unwrap();
+        let delegated_address =
+            Address::new_delegated(caller_id, &params.subaddress).map_err(|e| {
+                ActorError::illegal_argument(format!("invalid delegated address: {}", e))
+            })?;
+
+        log::trace!("delegated address: {:?}", &delegated_address);
+
+        // Compute a re-org-stable address.
+        // This address exists for use by messages coming from outside the system, in order to
+        // stably address the newly created actor even if a chain re-org causes it to end up with
+        // a different ID.
+        let robust_address = rt.new_actor_address()?;
+
+        log::trace!("robust address: {:?}", &robust_address);
+
+        // Allocate an ID for this actor.
+        // Store mapping of actor addresses to the actor ID.
+        let (id_address, existing): (ActorID, bool) = rt.transaction(|s: &mut State, rt| {
+            s.map_addresses_to_id(rt.store(), &robust_address, Some(&delegated_address))
+                .context("failed to map addresses to ID")
+        })?;
+
+        // If the f4 address was already assigned, make sure we're deploying over a placeholder and not
+        // some other existing actor (and make sure the target actor wasn't deleted either).
+        if existing {
+            let code_cid = rt
+                .get_actor_code_cid(&id_address)
+                .context_code(ExitCode::USR_FORBIDDEN, "cannot redeploy a deleted actor")?;
+            let placeholder_cid = rt.get_code_cid_for_type(Type::Placeholder);
+            if code_cid != placeholder_cid {
+                return Err(ActorError::forbidden(format!(
+                    "cannot replace an existing non-placeholder actor with code: {code_cid}"
+                )));
+            }
+        }
+
+        // Create an empty actor
+        rt.create_actor(params.code_cid, id_address, Some(delegated_address))?;
+
+        // Invoke constructor
+        extract_send_result(rt.send_simple(
+            &Address::new_id(id_address),
+            METHOD_CONSTRUCTOR,
+            params.constructor_params.into(),
+            rt.message().value_received(),
+        ))
+        .context("constructor failed")?;
+
+        Ok(Exec4Return { id_address: Address::new_id(id_address), robust_address })
+    }
 }
 
 impl ActorCode for Actor {
@@ -112,6 +171,7 @@ impl ActorCode for Actor {
     actor_dispatch! {
         Constructor => constructor,
         Exec => exec,
+        Exec4 => exec4,
         ExecExported => exec,
     }
 }

--- a/actors/init/src/types.rs
+++ b/actors/init/src/types.rs
@@ -20,10 +20,21 @@ pub struct ExecParams {
 }
 
 /// Init actor Exec Return value
-#[derive(Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct ExecReturn {
     /// ID based address for created actor
     pub id_address: Address,
     /// Reorg safe address for actor
     pub robust_address: Address,
 }
+
+/// Init actor Exec4 Params
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct Exec4Params {
+    pub code_cid: Cid,
+    pub constructor_params: RawBytes,
+    pub subaddress: RawBytes,
+}
+
+/// Init actor Exec4 Return value
+pub type Exec4Return = ExecReturn;


### PR DESCRIPTION
Extracted from `next`.

This PR adds the `Exec4` method described in FIP-0048, along with unit tests.

A later PR must restrict this new method to only being called by the future EAM Actor.