### PR TITLE
feat: Runtime: Add an exit method

### DIFF
--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -341,6 +341,10 @@ where
             .map_err(|_| actor_error!(illegal_argument; "invalid epoch to query tipset_cid"))
     }
 
+    fn exit(&self, code: u32, data: Option<IpldBlock>, msg: Option<&str>) -> ! {
+        fvm::vm::exit(code, data, msg)
+    }
+
     fn read_only(&self) -> bool {
         fvm::vm::read_only()
     }

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -235,6 +235,10 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// The epoch must satisfy: (curr_epoch - FINALITY) < epoch <= curr_epoch
     fn tipset_cid(&self, epoch: i64) -> Result<Cid, ActorError>;
 
+    /// Exit the current computation with an error code and optionally data and a debugging
+    /// message.
+    fn exit(&self, code: u32, data: Option<IpldBlock>, msg: Option<&str>) -> !;
+
     /// Returns true if the call is read_only.
     /// All state updates, including actor creation and balance transfers, are rejected in read_only calls.
     fn read_only(&self) -> bool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@
 /// - "reward"
 /// - "system"
 /// - "verifreg"
+/// - "datacap"
+/// - "placeholder"
 ///
 /// The Filecoin client must import the contents of CAR into the blockstore, but
 /// may opt to exclude the index data structure.


### PR DESCRIPTION
Extracted from `next`.

Allows actors to exit the current message execution with an exit code and optional exit data of the actor's choice. This allows for actors that need to be able to exit with a non-zero exit code AND with some exit data.

Note that the test_vm implementation is a bit different from what's in `next`, I think this is neater.