### PR TITLE
EVM: more unit tests

### DIFF
--- a/actors/evm/src/interpreter/instructions/log_event.rs
+++ b/actors/evm/src/interpreter/instructions/log_event.rs
@@ -65,10 +65,11 @@ pub fn log(
 
 #[cfg(test)]
 mod tests {
-    use fvm_ipld_encoding::{BytesSer, RawBytes};
+    use fil_actors_evm_shared::uints::U256;
+    use fvm_ipld_encoding::{to_vec, BytesSer, RawBytes};
     use fvm_shared::event::{ActorEvent, Entry, Flags};
 
-    use super::EVENT_DATA_KEY;
+    use super::{EVENT_DATA_KEY, EVENT_TOPIC_KEYS};
     use crate::evm_unit_test;
 
     #[test]
@@ -95,6 +96,46 @@ mod tests {
                 PUSH1; 0x20;
                 PUSH0;
                 LOG0;
+            }
+
+            let result = m.execute();
+            assert!(result.is_ok(), "execution step failed");
+        };
+    }
+
+    #[test]
+    fn test_log1() {
+        evm_unit_test! {
+            (rt) {
+                let t1 = U256::from(0x01);
+                let mut data = [0u8; 32];
+                data[28] = 0xCA;
+                data[29] = 0xFE;
+                data[30] = 0xBA;
+                data[31] = 0xBE;
+                rt.expect_emitted_event(
+                    ActorEvent::from(vec![
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key:  EVENT_TOPIC_KEYS[0].to_owned(),
+                            value: to_vec(&t1).unwrap().into(),
+                        },
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key: EVENT_DATA_KEY.to_owned(),
+                            value: RawBytes::serialize(BytesSer(&data)).unwrap(),
+                        }
+                    ])
+                );
+            }
+            (m) {
+                PUSH4; 0xCA; 0xFE; 0xBA; 0xBE;
+                PUSH0;
+                MSTORE;
+                PUSH1; 0x01;
+                PUSH1; 0x20;
+                PUSH0;
+                LOG1;
             }
 
             let result = m.execute();

--- a/actors/evm/src/interpreter/instructions/log_event.rs
+++ b/actors/evm/src/interpreter/instructions/log_event.rs
@@ -142,4 +142,167 @@ mod tests {
             assert!(result.is_ok(), "execution step failed");
         };
     }
+
+    #[test]
+    fn test_log2() {
+        evm_unit_test! {
+            (rt) {
+                let t1 = U256::from(0x01);
+                let t2 = U256::from(0x02);
+                let mut data = [0u8; 32];
+                data[28] = 0xCA;
+                data[29] = 0xFE;
+                data[30] = 0xBA;
+                data[31] = 0xBE;
+                rt.expect_emitted_event(
+                    ActorEvent::from(vec![
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key:  EVENT_TOPIC_KEYS[0].to_owned(),
+                            value: to_vec(&t1).unwrap().into(),
+                        },
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key:  EVENT_TOPIC_KEYS[1].to_owned(),
+                            value: to_vec(&t2).unwrap().into(),
+                        },
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key: EVENT_DATA_KEY.to_owned(),
+                            value: RawBytes::serialize(BytesSer(&data)).unwrap(),
+                        }
+                    ])
+                );
+            }
+            (m) {
+                PUSH4; 0xCA; 0xFE; 0xBA; 0xBE;
+                PUSH0;
+                MSTORE;
+                PUSH1; 0x02;
+                PUSH1; 0x01;
+                PUSH1; 0x20;
+                PUSH0;
+                LOG2;
+            }
+
+            let result = m.execute();
+            assert!(result.is_ok(), "execution step failed");
+        };
+    }
+
+    #[test]
+    fn test_log3() {
+        evm_unit_test! {
+            (rt) {
+                let t1 = U256::from(0x01);
+                let t2 = U256::from(0x02);
+                let t3 = U256::from(0x03);
+                let mut data = [0u8; 32];
+                data[28] = 0xCA;
+                data[29] = 0xFE;
+                data[30] = 0xBA;
+                data[31] = 0xBE;
+                rt.expect_emitted_event(
+                    ActorEvent::from(vec![
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key:  EVENT_TOPIC_KEYS[0].to_owned(),
+                            value: to_vec(&t1).unwrap().into(),
+                        },
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key:  EVENT_TOPIC_KEYS[1].to_owned(),
+                            value: to_vec(&t2).unwrap().into(),
+                        },
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key:  EVENT_TOPIC_KEYS[2].to_owned(),
+                            value: to_vec(&t3).unwrap().into(),
+                        },
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key: EVENT_DATA_KEY.to_owned(),
+                            value: RawBytes::serialize(BytesSer(&data)).unwrap(),
+                        }
+                    ])
+                );
+            }
+            (m) {
+                PUSH4; 0xCA; 0xFE; 0xBA; 0xBE;
+                PUSH0;
+                MSTORE;
+                PUSH1; 0x03;
+                PUSH1; 0x02;
+                PUSH1; 0x01;
+                PUSH1; 0x20;
+                PUSH0;
+                LOG3;
+            }
+
+            let result = m.execute();
+            assert!(result.is_ok(), "execution step failed");
+        };
+    }
+
+    #[test]
+    fn test_log4() {
+        evm_unit_test! {
+            (rt) {
+                let t1 = U256::from(0x01);
+                let t2 = U256::from(0x02);
+                let t3 = U256::from(0x03);
+                let t4 = U256::from(0x04);
+                let mut data = [0u8; 32];
+                data[28] = 0xCA;
+                data[29] = 0xFE;
+                data[30] = 0xBA;
+                data[31] = 0xBE;
+                rt.expect_emitted_event(
+                    ActorEvent::from(vec![
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key:  EVENT_TOPIC_KEYS[0].to_owned(),
+                            value: to_vec(&t1).unwrap().into(),
+                        },
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key:  EVENT_TOPIC_KEYS[1].to_owned(),
+                            value: to_vec(&t2).unwrap().into(),
+                        },
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key:  EVENT_TOPIC_KEYS[2].to_owned(),
+                            value: to_vec(&t3).unwrap().into(),
+                        },
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key:  EVENT_TOPIC_KEYS[3].to_owned(),
+                            value: to_vec(&t4).unwrap().into(),
+                        },
+                        Entry{
+                            flags: Flags::FLAG_INDEXED_ALL,
+                            key: EVENT_DATA_KEY.to_owned(),
+                            value: RawBytes::serialize(BytesSer(&data)).unwrap(),
+                        }
+                    ])
+                );
+            }
+
+            (m) {
+                PUSH4; 0xCA; 0xFE; 0xBA; 0xBE;
+                PUSH0;
+                MSTORE;
+                PUSH1; 0x04;
+                PUSH1; 0x03;
+                PUSH1; 0x02;
+                PUSH1; 0x01;
+                PUSH1; 0x20;
+                PUSH0;
+                LOG4;
+            }
+
+            let result = m.execute();
+            assert!(result.is_ok(), "execution step failed");
+        };
+    }
 }

--- a/actors/evm/src/interpreter/instructions/storage.rs
+++ b/actors/evm/src/interpreter/instructions/storage.rs
@@ -66,4 +66,20 @@ mod tests {
             assert_eq!(m.state.stack.pop().unwrap(), U256::from(0));
         };
     }
+
+    #[test]
+    fn test_sstore() {
+        evm_unit_test! {
+            (m) {
+                SSTORE;
+            }
+
+            m.state.stack.push(U256::from(0x42)).unwrap();
+            m.state.stack.push(U256::from(0)).unwrap();
+            let result = m.step();
+            assert!(result.is_ok(), "execution step failed");
+            assert_eq!(m.state.stack.len(), 0);
+            assert_eq!(m.system.get_storage(U256::from(0)).unwrap(), U256::from(0x42));
+        };
+    }
 }

--- a/actors/evm/src/interpreter/instructions/storage.rs
+++ b/actors/evm/src/interpreter/instructions/storage.rs
@@ -29,3 +29,41 @@ pub fn sstore(
 
     system.set_storage(key, value)
 }
+
+#[cfg(test)]
+mod tests {
+    use fil_actors_evm_shared::uints::U256;
+
+    use crate::evm_unit_test;
+
+    #[test]
+    fn test_sload() {
+        // happy path
+        evm_unit_test! {
+            (m) {
+                SLOAD;
+            }
+            m.system.set_storage(U256::from(0), U256::from(0x42)).unwrap();
+            m.state.stack.push(U256::from(0)).unwrap();
+            let result = m.step();
+            assert!(result.is_ok(), "execution step failed");
+            assert_eq!(m.state.stack.len(), 1);
+            assert_eq!(m.state.stack.pop().unwrap(), U256::from(0x42));
+        };
+    }
+
+    #[test]
+    fn test_sload_oob() {
+        // oob access -- it is a zero
+        evm_unit_test! {
+            (m) {
+                SLOAD;
+            }
+            m.state.stack.push(U256::from(1234)).unwrap();
+            let result = m.step();
+            assert!(result.is_ok(), "execution step failed");
+            assert_eq!(m.state.stack.len(), 1);
+            assert_eq!(m.state.stack.pop().unwrap(), U256::from(0));
+        };
+    }
+}

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -34,6 +34,7 @@ macro_rules! evm_unit_test {
 
         let mut system = System::new(&mut $rt, false);
         let bytecode = Bytecode::new(code);
+        #[allow(unused_mut)]
         let mut $machine = Machine {
             system: &mut system,
             state: &mut state,
@@ -63,6 +64,7 @@ macro_rules! evm_unit_test {
 
         let mut system = System::new(&mut rt, false);
         let bytecode = Bytecode::new(code);
+        #[allow(unused_mut)]
         let mut $machine = Machine {
             system: &mut system,
             state: &mut state,


### PR DESCRIPTION
- Closes https://github.com/filecoin-project/ref-fvm/issues/1548
  - [x] `LOG0`
  - [x] `LOG1`
  - [x] `LOG2`
  - [x] `LOG3`
  - [x] `LOG4`
- Closes https://github.com/filecoin-project/ref-fvm/issues/1551
  - [x] `SLOAD`
  - [x] `SSTORE`
