### PR TITLE
FIP-0055: Introduce the EthAccount actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actor_ethaccount"
+version = "10.0.0-alpha.1"
+dependencies = [
+ "fil_actors_runtime",
+ "frc42_dispatch",
+ "fvm_actor_utils",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0-alpha.17",
+ "hex-literal",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "fil_actor_init"
 version = "10.0.0-alpha.1"
 dependencies = [
@@ -879,6 +894,7 @@ dependencies = [
  "fil_actor_bundler",
  "fil_actor_cron",
  "fil_actor_datacap",
+ "fil_actor_ethaccount",
  "fil_actor_init",
  "fil_actor_market",
  "fil_actor_miner",
@@ -1380,6 +1396,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "ident_case"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 fil_actor_account = { version = "10.0.0-alpha.1", path = "./actors/account", features = ["fil-actor"] }
 fil_actor_cron = { version = "10.0.0-alpha.1", path = "./actors/cron", features = ["fil-actor"] }
 fil_actor_datacap = { version = "10.0.0-alpha.1", path = "./actors/datacap", features = ["fil-actor"] }
+fil_actor_ethaccount = { version = "10.0.0-alpha.1", path = "actors/ethaccount", features = ["fil-actor"] }
 fil_actor_init = { version = "10.0.0-alpha.1", path = "./actors/init", features = ["fil-actor"] }
 fil_actor_market = { version = "10.0.0-alpha.1", path = "./actors/market", features = ["fil-actor"] }
 fil_actor_miner = { version = "10.0.0-alpha.1", path = "./actors/miner", features = ["fil-actor"] }

--- a/actors/ethaccount/Cargo.toml
+++ b/actors/ethaccount/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "fil_actor_ethaccount"
+description = "Builtin Ethereum Externally Owned Address actor for Filecoin"
+version = "10.0.0-alpha.1"
+license = "MIT OR Apache-2.0"
+authors = ["Protocol Labs", "Filecoin Core Devs"]
+edition = "2021"
+repository = "https://github.com/filecoin-project/builtin-actors"
+keywords = ["filecoin", "web3", "wasm", "evm"]
+
+[lib]
+## lib is necessary for integration tests
+## cdylib is necessary for Wasm build
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
+frc42_dispatch = "3.0.1-alpha.1"
+fvm_actor_utils = "4.0.0"
+serde = { version = "1.0.136", features = ["derive"] }
+fvm_ipld_encoding = "0.3.3"
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+num-traits = "0.2.15"
+num-derive = "0.3.3"
+hex-literal = "0.3.4"
+
+[dev-dependencies]
+fil_actors_runtime = { path = "../../runtime", features = ["test_utils"] }
+
+[features]
+fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/ethaccount/src/lib.rs
+++ b/actors/ethaccount/src/lib.rs
@@ -1,0 +1,150 @@
+pub mod types;
+
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fvm_shared::address::{Payload, Protocol};
+use fvm_shared::crypto::hash::SupportedHashes::Keccak256;
+use fvm_shared::error::ExitCode;
+use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
+use num_derive::FromPrimitive;
+
+use crate::types::AuthenticateMessageParams;
+use fil_actors_runtime::runtime::{ActorCode, Runtime};
+use fil_actors_runtime::{
+    actor_dispatch, actor_error, ActorDowncast, ActorError, AsActorError, EAM_ACTOR_ID,
+    FIRST_EXPORTED_METHOD_NUMBER, SYSTEM_ACTOR_ADDR,
+};
+
+#[cfg(feature = "fil-actor")]
+fil_actors_runtime::wasm_trampoline!(EthAccountActor);
+
+/// Ethereum Account actor methods.
+#[derive(FromPrimitive)]
+#[repr(u64)]
+pub enum Method {
+    Constructor = METHOD_CONSTRUCTOR,
+    AuthenticateMessageExported = frc42_dispatch::method_hash!("AuthenticateMessage"),
+}
+
+/// Ethereum Account actor.
+pub struct EthAccountActor;
+
+impl EthAccountActor {
+    /// Ethereum Account actor constructor.
+    /// NOTE: This method is NOT currently called from anywhere, instead the FVM just deploys EthAccounts.
+    pub fn constructor(rt: &mut impl Runtime) -> Result<(), ActorError> {
+        rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
+
+        match rt
+            .lookup_delegated_address(rt.message().receiver().id().unwrap())
+            .map(|a| *a.payload())
+        {
+            Some(Payload::Delegated(da)) if da.namespace() == EAM_ACTOR_ID => {}
+            Some(_) => {
+                return Err(ActorError::illegal_argument(
+                    "invalid target for EthAccount creation".to_string(),
+                ));
+            }
+            None => {
+                return Err(ActorError::illegal_argument(
+                    "receiver must have a predictable address".to_string(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Authenticates whether the provided signature is valid for the provided message.
+    /// Should be called with the raw bytes of a signature, NOT a serialized Signature object that includes a SignatureType.
+    /// Errors with USR_ILLEGAL_ARGUMENT if the authentication is invalid.
+    pub fn authenticate_message(
+        rt: &mut impl Runtime,
+        params: AuthenticateMessageParams,
+    ) -> Result<(), ActorError> {
+        rt.validate_immediate_caller_accept_any()?;
+        let msg_hash = rt.hash_blake2b(&params.message);
+
+        let signer_pk = rt
+            .recover_secp_public_key(
+                &msg_hash,
+                params
+                    .signature
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| actor_error!(illegal_argument; "invalid signature length"))?,
+            )
+            .map_err(|e| {
+                e.downcast_default(
+                    ExitCode::USR_ILLEGAL_ARGUMENT,
+                    "failed to recover signer public key",
+                )
+            })?;
+
+        // 0x04 to indicate uncompressed point
+        if signer_pk[0] != 0x04 {
+            return Err(actor_error!(assertion_failed; "pubkey should start with 0x04, not {}",
+                signer_pk[0]));
+        }
+
+        // The subaddress is the last 20 bytes of the keccak hash of the public key
+        let signer_pk_hash = rt.hash(Keccak256, &signer_pk[1..]);
+        if signer_pk_hash.len() < 20 {
+            return Err(
+                actor_error!(assertion_failed; "invalid keccak hash length {}", signer_pk_hash.len()),
+            );
+        }
+
+        let signer_subaddress_bytes = &signer_pk_hash[signer_pk_hash.len() - 20..];
+
+        let self_address = rt
+            .lookup_delegated_address(
+                rt.message().receiver().id().expect("receiver must be ID address"),
+            )
+            .context_code(
+                ExitCode::USR_ILLEGAL_STATE,
+                "ethaccount should always have delegated address",
+            )?;
+
+        let self_address_bytes = self_address.to_bytes();
+        if self_address_bytes[0] != Protocol::Delegated as u8
+            || self_address_bytes[1] != EAM_ACTOR_ID as u8
+        {
+            return Err(actor_error!(illegal_state;
+                    "first 2 bytes of f4 address payload weren't Delegated protocol {} and EAM address {}",
+                    self_address_bytes[0],
+                    self_address_bytes[1]));
+        }
+
+        // drop the first 2 bytes (protocol and EAM namespace)
+        let self_subaddress_bytes = &self_address_bytes[2..];
+
+        if self_subaddress_bytes != signer_subaddress_bytes {
+            return Err(actor_error!(illegal_argument; "invalid signature for {}", self_address));
+        }
+
+        Ok(())
+    }
+
+    // Always succeeds, accepting any transfers.
+    pub fn fallback(
+        rt: &mut impl Runtime,
+        method: MethodNum,
+        _: Option<IpldBlock>,
+    ) -> Result<Option<IpldBlock>, ActorError> {
+        rt.validate_immediate_caller_accept_any()?;
+        if method >= FIRST_EXPORTED_METHOD_NUMBER {
+            Ok(None)
+        } else {
+            Err(actor_error!(unhandled_message; "invalid method: {}", method))
+        }
+    }
+}
+
+impl ActorCode for EthAccountActor {
+    type Methods = Method;
+    actor_dispatch! {
+        Constructor => constructor,
+        AuthenticateMessageExported => authenticate_message,
+        _ => fallback [raw],
+    }
+}

--- a/actors/ethaccount/src/lib.rs
+++ b/actors/ethaccount/src/lib.rs
@@ -10,7 +10,7 @@ use num_derive::FromPrimitive;
 use crate::types::AuthenticateMessageParams;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
-    actor_dispatch, actor_error, ActorDowncast, ActorError, AsActorError, EAM_ACTOR_ID,
+    actor_dispatch, actor_error, ActorError, AsActorError, EAM_ACTOR_ID,
     FIRST_EXPORTED_METHOD_NUMBER, SYSTEM_ACTOR_ADDR,
 };
 
@@ -73,11 +73,8 @@ impl EthAccountActor {
                     .try_into()
                     .map_err(|_| actor_error!(illegal_argument; "invalid signature length"))?,
             )
-            .map_err(|e| {
-                e.downcast_default(
-                    ExitCode::USR_ILLEGAL_ARGUMENT,
-                    "failed to recover signer public key",
-                )
+            .with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
+                "failed to recover signer public key"
             })?;
 
         // 0x04 to indicate uncompressed point

--- a/actors/ethaccount/src/types.rs
+++ b/actors/ethaccount/src/types.rs
@@ -1,0 +1,10 @@
+use fvm_ipld_encoding::serde_bytes;
+use fvm_ipld_encoding::tuple::*;
+
+#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct AuthenticateMessageParams {
+    #[serde(with = "serde_bytes")]
+    pub signature: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub message: Vec<u8>,
+}

--- a/actors/ethaccount/src/types.rs
+++ b/actors/ethaccount/src/types.rs
@@ -1,10 +1,10 @@
-use fvm_ipld_encoding::serde_bytes;
+use fvm_ipld_encoding::strict_bytes;
 use fvm_ipld_encoding::tuple::*;
 
 #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct AuthenticateMessageParams {
-    #[serde(with = "serde_bytes")]
+    #[serde(with = "strict_bytes")]
     pub signature: Vec<u8>,
-    #[serde(with = "serde_bytes")]
+    #[serde(with = "strict_bytes")]
     pub message: Vec<u8>,
 }

--- a/actors/ethaccount/tests/authenticate_message.rs
+++ b/actors/ethaccount/tests/authenticate_message.rs
@@ -1,0 +1,39 @@
+mod util;
+
+use crate::util::*;
+use fil_actor_ethaccount::types::AuthenticateMessageParams;
+use fil_actor_ethaccount::{EthAccountActor, Method};
+use fil_actors_runtime::test_utils::expect_abort_contains_message;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fvm_shared::error::ExitCode;
+use fvm_shared::MethodNum;
+
+#[test]
+fn must_have_params() {
+    let mut rt = setup();
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        "method expects arguments",
+        rt.call::<EthAccountActor>(Method::AuthenticateMessageExported as MethodNum, None),
+    );
+    rt.verify();
+}
+
+#[test]
+fn signature_bad_length_fails() {
+    let mut rt = setup();
+    rt.expect_validate_caller_any();
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        "invalid signature length",
+        rt.call::<EthAccountActor>(
+            Method::AuthenticateMessageExported as MethodNum,
+            IpldBlock::serialize_cbor(&AuthenticateMessageParams {
+                signature: vec![0xde, 0xad, 0xbe, 0xef],
+                message: vec![0xfa, 0xce],
+            })
+            .unwrap(),
+        ),
+    );
+    rt.verify();
+}

--- a/actors/ethaccount/tests/ethaccount_test.rs
+++ b/actors/ethaccount/tests/ethaccount_test.rs
@@ -1,0 +1,48 @@
+mod util;
+
+use crate::util::*;
+use fvm_actor_utils::receiver::UniversalReceiverParams;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::Address;
+
+use fil_actor_ethaccount::{EthAccountActor, Method};
+use fvm_shared::error::ExitCode;
+use fvm_shared::MethodNum;
+
+use fil_actors_runtime::test_utils::{
+    expect_abort_contains_message, ACCOUNT_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID,
+};
+use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
+
+#[test]
+fn no_delegated_cant_deploy() {
+    let mut rt = new_runtime();
+    rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
+    rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        "receiver must have a predictable address",
+        rt.call::<EthAccountActor>(Method::Constructor as MethodNum, None),
+    );
+    rt.verify();
+}
+
+#[test]
+fn token_receiver() {
+    let mut rt = setup();
+
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(1234));
+    rt.expect_validate_caller_any();
+    let ret = rt
+        .call::<EthAccountActor>(
+            frc42_dispatch::method_hash!("Receive"),
+            IpldBlock::serialize_cbor(&UniversalReceiverParams {
+                type_: 0,
+                payload: RawBytes::new(vec![1, 2, 3]),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+    assert!(ret.is_none());
+}

--- a/actors/ethaccount/tests/util.rs
+++ b/actors/ethaccount/tests/util.rs
@@ -1,0 +1,35 @@
+use fil_actor_ethaccount::{EthAccountActor, Method};
+use fil_actors_runtime::test_utils::{MockRuntime, SYSTEM_ACTOR_CODE_ID};
+use fil_actors_runtime::EAM_ACTOR_ID;
+use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
+use fvm_shared::address::Address;
+use fvm_shared::MethodNum;
+
+pub const EOA: Address = Address::new_id(1000);
+
+pub fn new_runtime() -> MockRuntime {
+    MockRuntime {
+        receiver: EOA,
+        caller: SYSTEM_ACTOR_ADDR,
+        caller_type: *SYSTEM_ACTOR_CODE_ID,
+        ..Default::default()
+    }
+}
+
+#[allow(dead_code)]
+pub fn setup() -> MockRuntime {
+    let mut rt = new_runtime();
+    rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
+    rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
+    rt.set_delegated_address(
+        EOA.id().unwrap(),
+        Address::new_delegated(
+            EAM_ACTOR_ID,
+            &hex_literal::hex!("FEEDFACECAFEBEEF000000000000000000000000"),
+        )
+        .unwrap(),
+    );
+    rt.call::<EthAccountActor>(Method::Constructor as MethodNum, None).unwrap();
+    rt.verify();
+    rt
+}

--- a/runtime/src/builtin/singletons.rs
+++ b/runtime/src/builtin/singletons.rs
@@ -25,6 +25,7 @@ define_singletons! {
     STORAGE_MARKET_ACTOR = 5,
     VERIFIED_REGISTRY_ACTOR = 6,
     DATACAP_TOKEN_ACTOR = 7,
+    EAM_ACTOR = 10,
     BURNT_FUNDS_ACTOR = 99,
 }
 


### PR DESCRIPTION
Extracted from `next`.

Implements the EthAccount actor, as defined in [FIP-0055](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0055.md). This PR does NOT introduce the Ethereum Address Manager actor described in FIP-0055, but makes reference to the ID address it will receive (10).