### PR TITLE
feat: update fvm and switch to the new event structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "num-derive",
  "num-traits",
  "serde",
@@ -1800,7 +1800,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "log",
  "num-derive",
  "num-traits",
@@ -1819,7 +1819,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "log",
  "num-derive",
@@ -1838,7 +1838,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "hex-literal",
  "log",
  "multihash",
@@ -1857,7 +1857,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "hex-literal",
  "num-derive",
  "num-traits",
@@ -1882,7 +1882,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_kamt",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "hex",
  "hex-literal",
  "impl-serde 0.3.2",
@@ -1914,7 +1914,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "log",
  "num-derive",
  "num-traits",
@@ -1938,7 +1938,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "integer-encoding",
  "itertools",
  "libipld-core 0.13.1",
@@ -1968,7 +1968,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "itertools",
  "lazy_static",
  "log",
@@ -1992,7 +1992,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -2013,7 +2013,7 @@ dependencies = [
  "fvm_ipld_amt",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "num-derive",
  "num-traits",
  "serde",
@@ -2035,7 +2035,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -2052,7 +2052,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "log",
  "num",
@@ -2070,7 +2070,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "num-derive",
  "num-traits",
  "serde",
@@ -2089,7 +2089,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "log",
  "num-derive",
@@ -2103,7 +2103,7 @@ version = "10.0.0-alpha.1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "hex",
  "serde",
  "uint",
@@ -2124,8 +2124,8 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.24",
+ "fvm_shared 3.0.0-alpha.20",
  "hex",
  "itertools",
  "lazy_static",
@@ -2195,7 +2195,7 @@ dependencies = [
  "frc46_token",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "num-derive",
  "num-traits",
  "serde",
@@ -2252,15 +2252,15 @@ dependencies = [
 
 [[package]]
 name = "frc42_dispatch"
-version = "3.0.1-alpha.1"
+version = "3.0.1-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4831f9a09043a3796e88dd6683f5c1ded58bfbb6dbde95708ee675cf3c6b157b"
+checksum = "b9d7a133ea05356dbb3115ddb6bb302a9cb82efcc7561602ed687c277d96e55b"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.24",
+ "fvm_shared 3.0.0-alpha.20",
  "thiserror",
 ]
 
@@ -2290,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "frc46_token"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361570ac004ff4c032db36985790b39a7c3e30c039dcc98661155227eba378f4"
+checksum = "d88d59160be82c91c9ba8dd4d670693ab826178a1d94ae792ded0d6b92a723cd"
 dependencies = [
  "anyhow",
  "cid",
@@ -2302,8 +2302,8 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.24",
+ "fvm_shared 3.0.0-alpha.20",
  "integer-encoding",
  "num-traits",
  "serde",
@@ -2440,17 +2440,17 @@ dependencies = [
 
 [[package]]
 name = "fvm_actor_utils"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a584440086c6900c43b131b326751aeb45e1ec547fbf62299db61d8eeb060f8"
+checksum = "f2d45c603677e42634b25f52aff45db3d57a7f46c524e6d528489e193564cc38"
 dependencies = [
  "anyhow",
  "cid",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_sdk 3.0.0-alpha.24",
+ "fvm_shared 3.0.0-alpha.20",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -2602,13 +2602,13 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.22"
+version = "3.0.0-alpha.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51908aab9e7564fbcb278d78e31c12402b68c70517661780feb29adbb234aaf"
+checksum = "ad163015237811580399ce929938f3bdca2d1a133672ff01693f555a632ec425"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "log",
  "num-traits",
@@ -2646,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0-alpha.17"
+version = "3.0.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779876441e390f414161474701404b5641e02a5b9acfece9b212f6d24e482e1"
+checksum = "b594b4d4c1393f03e3430f106c09874fcac565e68a560686de37ca2982a61d1a"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4577,7 +4577,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "hex",
  "hex-literal",
  "indexmap",

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.1-alpha.1"
-fvm_actor_utils = "4.0.0"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_actor_utils = "4.0.1-alpha.1"
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -18,12 +18,12 @@ fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime"}
 
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 frc42_dispatch = "3.0.1-alpha.1"
-frc46_token = "4.0.0"
-fvm_actor_utils = "4.0.0"
+frc46_token = "4.0.1-alpha.1"
+fvm_actor_utils = "4.0.1-alpha.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 lazy_static = "1.4.0"
 num-derive = "0.3.3"
 num-traits = "0.2.14"

--- a/actors/eam/Cargo.toml
+++ b/actors/eam/Cargo.toml
@@ -24,7 +24,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 multihash = { version = "0.16.1", default-features = false }
 cid = "0.8.6"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 hex-literal = "0.3.4"

--- a/actors/ethaccount/Cargo.toml
+++ b/actors/ethaccount/Cargo.toml
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.1-alpha.1"
-fvm_actor_utils = "4.0.0"
+fvm_actor_utils = "4.0.1-alpha.1"
 serde = { version = "1.0.136", features = ["derive"] }
 fvm_ipld_encoding = "0.3.3"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 hex-literal = "0.3.4"

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 fvm_ipld_kamt = { version = "0.2.0" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5"

--- a/actors/evm/shared/Cargo.toml
+++ b/actors/evm/shared/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["filecoin", "web3", "wasm", "evm"]
 
 [dependencies]
 serde = { version = "1.0.136", features = ["derive"] }
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../../runtime" }
 fvm_ipld_encoding = "0.3.3"
 uint = { version = "0.9.3", default-features = false }

--- a/actors/evm/src/interpreter/instructions/log_event.rs
+++ b/actors/evm/src/interpreter/instructions/log_event.rs
@@ -1,7 +1,7 @@
 use crate::interpreter::instructions::memory::get_memory_region;
 use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::ActorError;
-use fvm_ipld_encoding::{to_vec, BytesSer, RawBytes};
+use fvm_ipld_encoding::IPLD_RAW;
 use fvm_shared::event::{Entry, Flags};
 use {
     crate::interpreter::{ExecutionState, System},
@@ -42,7 +42,8 @@ pub fn log(
         let entry = Entry {
             flags: Flags::FLAG_INDEXED_ALL,
             key: (*key).to_owned(),
-            value: to_vec(&topic)?.into(), // U256 serializes as a byte string.
+            codec: IPLD_RAW,
+            value: topic.to_bytes().into(), // U256 serializes as a byte string.
         };
         entries.push(entry);
     }
@@ -53,7 +54,8 @@ pub fn log(
         let entry = Entry {
             flags: Flags::FLAG_INDEXED_ALL,
             key: EVENT_DATA_KEY.to_owned(),
-            value: RawBytes::serialize(BytesSer(&data))?,
+            codec: IPLD_RAW,
+            value: data,
         };
         entries.push(entry);
     }
@@ -66,7 +68,7 @@ pub fn log(
 #[cfg(test)]
 mod tests {
     use fil_actors_evm_shared::uints::U256;
-    use fvm_ipld_encoding::{to_vec, BytesSer, RawBytes};
+    use fvm_ipld_encoding::IPLD_RAW;
     use fvm_shared::event::{ActorEvent, Entry, Flags};
 
     use super::{EVENT_DATA_KEY, EVENT_TOPIC_KEYS};
@@ -85,7 +87,8 @@ mod tests {
                     ActorEvent::from(vec![Entry{
                         flags: Flags::FLAG_INDEXED_ALL,
                         key: EVENT_DATA_KEY.to_owned(),
-                        value: RawBytes::serialize(BytesSer(&data)).unwrap(),
+                        codec: IPLD_RAW,
+                        value: data.into(),
                     }])
                 );
             }
@@ -118,12 +121,14 @@ mod tests {
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key:  EVENT_TOPIC_KEYS[0].to_owned(),
-                            value: to_vec(&t1).unwrap().into(),
+                            codec: IPLD_RAW,
+                            value: t1.to_bytes().into(),
                         },
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key: EVENT_DATA_KEY.to_owned(),
-                            value: RawBytes::serialize(BytesSer(&data)).unwrap(),
+                            codec: IPLD_RAW,
+                            value: data.into(),
                         }
                     ])
                 );
@@ -159,17 +164,20 @@ mod tests {
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key:  EVENT_TOPIC_KEYS[0].to_owned(),
-                            value: to_vec(&t1).unwrap().into(),
+                            codec: IPLD_RAW,
+                            value: t1.to_bytes().into(),
                         },
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key:  EVENT_TOPIC_KEYS[1].to_owned(),
-                            value: to_vec(&t2).unwrap().into(),
+                            codec: IPLD_RAW,
+                            value: t2.to_bytes().into(),
                         },
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key: EVENT_DATA_KEY.to_owned(),
-                            value: RawBytes::serialize(BytesSer(&data)).unwrap(),
+                            codec: IPLD_RAW,
+                            value: data.into(),
                         }
                     ])
                 );
@@ -207,22 +215,26 @@ mod tests {
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key:  EVENT_TOPIC_KEYS[0].to_owned(),
-                            value: to_vec(&t1).unwrap().into(),
+                            codec: IPLD_RAW,
+                            value: t1.to_bytes().into(),
                         },
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key:  EVENT_TOPIC_KEYS[1].to_owned(),
-                            value: to_vec(&t2).unwrap().into(),
+                            codec: IPLD_RAW,
+                            value: t2.to_bytes().into(),
                         },
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key:  EVENT_TOPIC_KEYS[2].to_owned(),
-                            value: to_vec(&t3).unwrap().into(),
+                            codec: IPLD_RAW,
+                            value: t3.to_bytes().into(),
                         },
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key: EVENT_DATA_KEY.to_owned(),
-                            value: RawBytes::serialize(BytesSer(&data)).unwrap(),
+                            codec: IPLD_RAW,
+                            value: data.into(),
                         }
                     ])
                 );
@@ -262,27 +274,32 @@ mod tests {
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key:  EVENT_TOPIC_KEYS[0].to_owned(),
-                            value: to_vec(&t1).unwrap().into(),
+                            codec: IPLD_RAW,
+                            value: t1.to_bytes().into(),
                         },
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key:  EVENT_TOPIC_KEYS[1].to_owned(),
-                            value: to_vec(&t2).unwrap().into(),
+                            codec: IPLD_RAW,
+                            value: t2.to_bytes().into(),
                         },
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key:  EVENT_TOPIC_KEYS[2].to_owned(),
-                            value: to_vec(&t3).unwrap().into(),
+                            codec: IPLD_RAW,
+                            value: t3.to_bytes().into(),
                         },
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key:  EVENT_TOPIC_KEYS[3].to_owned(),
-                            value: to_vec(&t4).unwrap().into(),
+                            codec: IPLD_RAW,
+                            value: t4.to_bytes().into(),
                         },
                         Entry{
                             flags: Flags::FLAG_INDEXED_ALL,
                             key: EVENT_DATA_KEY.to_owned(),
-                            value: RawBytes::serialize(BytesSer(&data)).unwrap(),
+                            codec: IPLD_RAW,
+                            value: data.into(),
                         }
                     ])
                 );

--- a/actors/evm/tests/events.rs
+++ b/actors/evm/tests/events.rs
@@ -1,6 +1,7 @@
 mod asm;
 
-use fvm_ipld_encoding::{to_vec, RawBytes};
+use fil_actors_evm_shared::uints::U256;
+use fvm_ipld_encoding::IPLD_RAW;
 use fvm_shared::event::{ActorEvent, Entry, Flags};
 
 mod util;
@@ -78,11 +79,8 @@ fn test_events() {
         entries: vec![Entry {
             flags: Flags::FLAG_INDEXED_ALL,
             key: "d".to_string(),
-            value: to_vec(&RawBytes::from(
-                [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88].to_vec(),
-            ))
-            .unwrap()
-            .into(),
+            codec: IPLD_RAW,
+            value: vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         }],
     });
     util::invoke_contract(&mut rt, &contract_params);
@@ -99,31 +97,32 @@ fn test_events() {
             Entry {
                 flags: Flags::FLAG_INDEXED_ALL,
                 key: "t1".to_string(),
-                value: to_vec(&RawBytes::from([0x11, 0x11].to_vec())).unwrap().into(),
+                codec: IPLD_RAW,
+                value: U256::from(0x1111).to_bytes().into(),
             },
             Entry {
                 flags: Flags::FLAG_INDEXED_ALL,
                 key: "t2".to_string(),
-                value: to_vec(&RawBytes::from([0x22, 0x22].to_vec())).unwrap().into(),
+                codec: IPLD_RAW,
+                value: U256::from(0x2222).to_bytes().into(),
             },
             Entry {
                 flags: Flags::FLAG_INDEXED_ALL,
                 key: "t3".to_string(),
-                value: to_vec(&RawBytes::from([0x33, 0x33].to_vec())).unwrap().into(),
+                codec: IPLD_RAW,
+                value: U256::from(0x3333).to_bytes().into(),
             },
             Entry {
                 flags: Flags::FLAG_INDEXED_ALL,
                 key: "t4".to_string(),
-                value: to_vec(&RawBytes::from([0x44, 0x44].to_vec())).unwrap().into(),
+                codec: IPLD_RAW,
+                value: U256::from(0x4444).to_bytes().into(),
             },
             Entry {
                 flags: Flags::FLAG_INDEXED_ALL,
                 key: "d".to_string(),
-                value: to_vec(&RawBytes::from(
-                    [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88].to_vec(),
-                ))
-                .unwrap()
-                .into(),
+                codec: IPLD_RAW,
+                value: vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
             },
         ],
     });

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.1-alpha.1"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -19,12 +19,12 @@ fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime"}
 anyhow = "1.0.65"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 frc42_dispatch = "3.0.1-alpha.1"
-frc46_token = "4.0.0"
+frc46_token = "4.0.1-alpha.1"
 fvm_ipld_bitfield = "0.5.2"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 integer-encoding = { version = "3.0.3", default-features = false }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 log = "0.4.14"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.1-alpha.1"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
 fvm_ipld_hamt = "0.6.1"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -19,11 +19,11 @@ fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime"}
 anyhow = "1.0.65"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 frc42_dispatch = "3.0.1-alpha.1"
-fvm_actor_utils = "4.0.0"
+fvm_actor_utils = "4.0.1-alpha.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 num-derive = "0.3.3"

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.1-alpha.1"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 frc42_dispatch = "3.0.1-alpha.1"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -19,12 +19,12 @@ fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../../runtime" }
 anyhow = "1.0.65"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 frc42_dispatch = "3.0.1-alpha.1"
-frc46_token = "4.0.0"
-fvm_actor_utils = "4.0.0"
+frc46_token = "4.0.1-alpha.1"
+fvm_actor_utils = "4.0.1-alpha.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 lazy_static = "1.4.0"
 log = "0.4.14"
 num-derive = "0.3.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 [dependencies]
 fvm_ipld_hamt = "0.6.1"
 fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 num = { version = "0.4", features = ["serde"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -37,7 +37,7 @@ castaway = "0.2.2"
 sha2 = "0.10"
 
 # fil-actor
-fvm_sdk = { version = "3.0.0-alpha.22", optional = true }
+fvm_sdk = { version = "3.0.0-alpha.24", optional = true }
 
 # test_util
 rand = { version = "0.8.5", default-features = false, optional = true }

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -27,8 +27,8 @@ fil_actor_reward = { version = "10.0.0-alpha.1", path = "../actors/reward"}
 fil_actor_system = { version = "10.0.0-alpha.1", path = "../actors/system"}
 fil_actor_init = { version = "10.0.0-alpha.1", path = "../actors/init"}
 fil_actors_runtime = { version = "10.0.0-alpha.1", path = "../runtime"}
-frc46_token = "4.0.0"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+frc46_token = "4.0.1-alpha.1"
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -33,13 +33,13 @@ anyhow = "1.0.65"
 bimap = { version = "0.6.2" }
 blake2b_simd = "1.0"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc46_token = "4.0.0"
-fvm_actor_utils = "4.0.0"
+frc46_token = "4.0.1-alpha.1"
+fvm_actor_utils = "4.0.1-alpha.1"
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_blockstore = { version = "0.1.1", default-features = false }
 fvm_ipld_encoding = { version = "0.3.3", default-features = false }
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 lazy_static = "1.4.0"


### PR DESCRIPTION
Unlike the previous version, this one _does not_ strip leading zeros from keys. We could, but:

1. It's easier not to.
2. It shouldn't make a difference in practice as keys are _usually_ hashes (i.e., random).