### PR TITLE
EVM: remove Bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,7 +1870,6 @@ version = "10.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "arrayvec",
- "bytes",
  "cid",
  "derive_more",
  "ethers 1.0.2",

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -28,7 +28,6 @@ log = "0.4.14"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 rlp = { version = "0.5.1", default-features = false }
-bytes = { version = "1.1.0", features = ["serde"], default-features = false }
 strum = "0.24"
 strum_macros = "0.24"
 multihash = { version = "0.16.1", default-features = false }

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -7,7 +7,6 @@ use {
     super::memory::Memory,
     super::stack::Stack,
     super::{Bytecode, Output, System},
-    bytes::Bytes,
     fil_actors_runtime::runtime::Runtime,
 };
 
@@ -16,8 +15,8 @@ use {
 pub struct ExecutionState {
     pub stack: Stack,
     pub memory: Memory,
-    pub input_data: Bytes,
-    pub return_data: Bytes,
+    pub input_data: Vec<u8>,
+    pub return_data: Vec<u8>,
     /// The EVM address of the caller.
     pub caller: EthAddress,
     /// The EVM address of the receiver.
@@ -31,7 +30,7 @@ impl ExecutionState {
         caller: EthAddress,
         receiver: EthAddress,
         value_received: TokenAmount,
-        input_data: Bytes,
+        input_data: Vec<u8>,
     ) -> Self {
         Self {
             stack: Stack::new(),

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -324,7 +324,7 @@ pub fn call_generic<RT: Runtime>(
         }
     };
 
-    state.return_data = return_data.into();
+    state.return_data = return_data;
 
     // copy return data to output region if it is non-zero
     copy_to_memory(memory, output_offset, output_size, U256::zero(), &state.return_data, false)?;
@@ -350,7 +350,7 @@ mod tests {
             (m) {
                 CALLDATALOAD;
             }
-            m.state.input_data = vec![0x00, 0x01, 0x02].into();
+            m.state.input_data = vec![0x00, 0x01, 0x02];
             m.state.stack.push(U256::from(1)).unwrap();
             let result = m.step();
             assert!(result.is_ok(), "execution step failed");
@@ -366,7 +366,7 @@ mod tests {
             (m) {
                 CALLDATALOAD;
             }
-            m.state.input_data = vec![0x00, 0x01, 0x02].into();
+            m.state.input_data = vec![0x00, 0x01, 0x02];
             m.state.stack.push(U256::from(10)).unwrap();
             let result = m.step();
             assert!(result.is_ok(), "execution step failed");
@@ -384,7 +384,7 @@ mod tests {
             }
             let mut input_data = [0u8;64];
             input_data[0] = 0x42;
-            m.state.input_data = Vec::from(input_data).into();
+            m.state.input_data = Vec::from(input_data);
             m.state.stack.push(U256::from(0)).unwrap();
             let result = m.step();
             assert!(result.is_ok(), "execution step failed");
@@ -399,7 +399,7 @@ mod tests {
             (m) {
                 CALLDATASIZE;
             }
-            m.state.input_data = vec![0x00, 0x01, 0x02].into();
+            m.state.input_data = vec![0x00, 0x01, 0x02];
             let result = m.step();
             assert!(result.is_ok(), "execution step failed");
             assert_eq!(m.state.stack.len(), 1);
@@ -414,7 +414,7 @@ mod tests {
             (m) {
                 CALLDATACOPY;
             }
-            m.state.input_data = vec![0x00, 0x01, 0x02].into();
+            m.state.input_data = vec![0x00, 0x01, 0x02];
             m.state.stack.push(U256::from(2)).unwrap();  // length
             m.state.stack.push(U256::from(1)).unwrap();  // offset
             m.state.stack.push(U256::from(0)).unwrap();  // dest-offset
@@ -424,7 +424,7 @@ mod tests {
             let mut expected = [0u8; 32];
             expected[0] = 0x01;
             expected[1] = 0x02;
-            assert_eq!(m.state.memory.as_ref(), &expected);
+            assert_eq!(&*m.state.memory, &expected);
         };
     }
 
@@ -435,7 +435,7 @@ mod tests {
             (m) {
                 CALLDATACOPY;
             }
-            m.state.input_data = vec![0x00, 0x01, 0x02].into();
+            m.state.input_data = vec![0x00, 0x01, 0x02];
             m.state.stack.push(U256::from(64)).unwrap(); // length -- too big
             m.state.stack.push(U256::from(1)).unwrap();  // offset
             m.state.stack.push(U256::from(0)).unwrap();  // dest-offset
@@ -445,7 +445,7 @@ mod tests {
             let mut expected = [0u8; 64];
             expected[0] = 0x01;
             expected[1] = 0x02;
-            assert_eq!(m.state.memory.as_ref(), &expected);
+            assert_eq!(&*m.state.memory, &expected);
         };
     }
 
@@ -456,7 +456,7 @@ mod tests {
             (m) {
                 CALLDATACOPY;
             }
-            m.state.input_data = vec![0x00, 0x01, 0x02].into();
+            m.state.input_data = vec![0x00, 0x01, 0x02];
             m.state.stack.push(U256::from(2)).unwrap();   // length
             m.state.stack.push(U256::from(10)).unwrap();  // offset -- out of bounds
             m.state.stack.push(U256::from(0)).unwrap();   // dest-offset
@@ -464,7 +464,7 @@ mod tests {
             assert!(result.is_ok(), "execution step failed");
             assert_eq!(m.state.stack.len(), 0);
             let expected = [0u8; 32];
-            assert_eq!(m.state.memory.as_ref(), &expected);
+            assert_eq!(&*m.state.memory, &expected);
         };
     }
 }

--- a/actors/evm/src/interpreter/instructions/control.rs
+++ b/actors/evm/src/interpreter/instructions/control.rs
@@ -1,4 +1,3 @@
-use bytes::Bytes;
 use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::{ActorError, AsActorError};
 
@@ -53,7 +52,7 @@ pub fn stop(
     _state: &mut ExecutionState,
     _system: &System<impl Runtime>,
 ) -> Result<Output, ActorError> {
-    Ok(Output { return_data: Bytes::new(), outcome: Outcome::Return })
+    Ok(Output { return_data: Vec::new(), outcome: Outcome::Return })
 }
 
 #[inline]
@@ -66,7 +65,7 @@ fn exit(
     Ok(Output {
         outcome: status,
         return_data: super::memory::get_memory_region(memory, offset, size)?
-            .map(|region| memory[region.offset..region.offset + region.size.get()].to_vec().into())
+            .map(|region| memory[region.offset..region.offset + region.size.get()].to_vec())
             .unwrap_or_default(),
     })
 }
@@ -318,7 +317,7 @@ mod tests {
             (m) {
                 RETURNDATASIZE;
             }
-            m.state.return_data = vec![0x00, 0x01, 0x02].into();
+            m.state.return_data = vec![0x00, 0x01, 0x02];
             let result = m.step();
             assert!(result.is_ok(), "execution step failed");
             assert_eq!(m.state.stack.len(), 1);
@@ -333,7 +332,7 @@ mod tests {
             (m) {
                 RETURNDATACOPY;
             }
-            m.state.return_data = vec![0x00, 0x01, 0x02].into();
+            m.state.return_data = vec![0x00, 0x01, 0x02];
             m.state.stack.push(U256::from(2)).unwrap();  // length
             m.state.stack.push(U256::from(1)).unwrap();  // offset
             m.state.stack.push(U256::from(0)).unwrap();  // dest-offset
@@ -343,7 +342,7 @@ mod tests {
             let mut expected = [0u8; 32];
             expected[0] = 0x01;
             expected[1] = 0x02;
-            assert_eq!(m.state.memory.as_ref(), &expected);
+            assert_eq!(&*m.state.memory, &expected);
         };
     }
 
@@ -354,7 +353,7 @@ mod tests {
             (m) {
                 RETURNDATACOPY;
             }
-            m.state.return_data = vec![0x00, 0x01, 0x02].into();
+            m.state.return_data = vec![0x00, 0x01, 0x02];
             m.state.stack.push(U256::from(10)).unwrap();  // length
             m.state.stack.push(U256::from(1)).unwrap();   // offset
             m.state.stack.push(U256::from(0)).unwrap();   // dest-offset
@@ -371,7 +370,7 @@ mod tests {
             (m) {
                 RETURNDATACOPY;
             }
-            m.state.return_data = vec![0x00, 0x01, 0x02].into();
+            m.state.return_data = vec![0x00, 0x01, 0x02];
             m.state.stack.push(U256::from(2)).unwrap();   // length
             m.state.stack.push(U256::from(10)).unwrap();  // offset
             m.state.stack.push(U256::from(0)).unwrap();   // dest-offset
@@ -388,7 +387,7 @@ mod tests {
             (m) {
                 RETURNDATACOPY;
             }
-            m.state.return_data = vec![0x00, 0x01, 0x02].into();
+            m.state.return_data = vec![0x00, 0x01, 0x02];
             m.state.stack.push(U256::from(2)).unwrap();   // length
             m.state.stack.push(U256::from(2)).unwrap();  // offset
             m.state.stack.push(U256::from(0)).unwrap();  // dest-offset

--- a/actors/evm/src/interpreter/instructions/lifecycle.rs
+++ b/actors/evm/src/interpreter/instructions/lifecycle.rs
@@ -1,5 +1,3 @@
-use bytes::Bytes;
-
 use fil_actors_evm_shared::address::EthAddress;
 use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::ActorError;
@@ -170,5 +168,5 @@ pub fn selfdestruct(
     //
     // 1. In the constructor, this will set our code to "empty". This is correct.
     // 2. Otherwise, we'll successfully return nothing to the caller.
-    Ok(Output { outcome: Outcome::Return, return_data: Bytes::new() })
+    Ok(Output { outcome: Outcome::Return, return_data: Vec::new() })
 }

--- a/actors/evm/src/interpreter/memory.rs
+++ b/actors/evm/src/interpreter/memory.rs
@@ -1,18 +1,15 @@
-use {
-    bytes::BytesMut,
-    derive_more::{Deref, DerefMut},
-};
+use derive_more::{Deref, DerefMut};
 
 use crate::EVM_WORD_SIZE;
 
 const PAGE_SIZE: usize = 4 * 1024;
 
 #[derive(Clone, Debug, Deref, DerefMut)]
-pub struct Memory(BytesMut);
+pub struct Memory(Vec<u8>);
 
 impl Default for Memory {
     fn default() -> Self {
-        Self(BytesMut::with_capacity(PAGE_SIZE))
+        Self(Vec::with_capacity(PAGE_SIZE))
     }
 }
 

--- a/actors/evm/src/interpreter/output.rs
+++ b/actors/evm/src/interpreter/output.rs
@@ -1,7 +1,5 @@
 use std::fmt::Debug;
 
-use bytes::Bytes;
-
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum Outcome {
     #[default]
@@ -15,5 +13,5 @@ pub struct Output {
     /// Indicates the "outcome" of the execution.
     pub outcome: Outcome,
     /// The return data.
-    pub return_data: Bytes,
+    pub return_data: Vec<u8>,
 }

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -17,7 +17,7 @@ macro_rules! evm_unit_test {
         use ::fil_actors_runtime::test_utils::MockRuntime;
         use ::fvm_shared::econ::TokenAmount;
         use $crate::interpreter::{execution::Machine, system::System, Output};
-        use $crate::{Bytecode, Bytes, EthAddress, ExecutionState};
+        use $crate::{Bytecode, EthAddress, ExecutionState};
 
         let mut $rt = MockRuntime::default();
         $rt.in_call = true;
@@ -27,7 +27,7 @@ macro_rules! evm_unit_test {
             EthAddress::from_id(1000),
             EthAddress::from_id(1000),
             TokenAmount::from_atto(0),
-            Bytes::default(),
+            Vec::new(),
         );
 
         let code = vec![$($crate::evm_instruction!($inst)),*];
@@ -50,14 +50,14 @@ macro_rules! evm_unit_test {
         use ::fil_actors_runtime::test_utils::MockRuntime;
         use ::fvm_shared::econ::TokenAmount;
         use $crate::interpreter::{execution::Machine, system::System, Output};
-        use $crate::{Bytecode, Bytes, EthAddress, ExecutionState};
+        use $crate::{Bytecode, EthAddress, ExecutionState};
 
         let mut rt = MockRuntime::default();
         let mut state = ExecutionState::new(
             EthAddress::from_id(1000),
             EthAddress::from_id(1000),
             TokenAmount::from_atto(0),
-            Bytes::default(),
+            Vec::new(),
         );
 
         let code = vec![$($crate::evm_instruction!($inst)),*];


### PR DESCRIPTION
This was probably intended to reduce copying between EVM contracts, but it makes no difference for us beyond introducing strange types.