### PR TITLE
EVM: remove a few more deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,6 @@ name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "async-channel"
@@ -780,12 +777,6 @@ checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
@@ -1009,10 +1000,8 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version",
  "syn",
 ]
 
@@ -1869,14 +1858,11 @@ name = "fil_actor_evm"
 version = "10.0.0-alpha.1"
 dependencies = [
  "anyhow",
- "arrayvec",
  "cid",
- "derive_more",
  "ethers 1.0.2",
  "etk-asm",
  "fil_actors_evm_shared",
  "fil_actors_runtime",
- "fixed-hash 0.7.0",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
@@ -1884,7 +1870,6 @@ dependencies = [
  "fvm_shared 3.0.0-alpha.20",
  "hex",
  "hex-literal",
- "impl-serde 0.3.2",
  "lazy_static",
  "log",
  "multihash",
@@ -1893,12 +1878,9 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rand",
- "rlp",
  "serde",
  "serde_json",
  "serde_tuple",
- "strum",
- "strum_macros",
  "substrate-bn",
 ]
 

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -27,29 +27,22 @@ anyhow = "1.0.65"
 log = "0.4.14"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
-rlp = { version = "0.5.1", default-features = false }
-strum = "0.24"
-strum_macros = "0.24"
 multihash = { version = "0.16.1", default-features = false }
-derive_more = "0.99"
-fixed-hash = { version = "0.7.0", default-features = false }
-impl-serde = { version = "0.3.2", default-features = false }
-arrayvec = { version = "0.7.2", features = ["serde"] }
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.3.4"
 substrate-bn = { version = "0.6.0", default-features = false }
 near-blake2 = { version = "0.9.1", git = "https://github.com/filecoin-project/near-blake2.git" }
-lazy_static = "1.4.0"
-once_cell = { version = "1.16.0", default-features = false}
 frc42_dispatch = "3.0.1-alpha.2"
 fil_actors_evm_shared = { version = "10.0.0-alpha.1", path = "shared" }
 
 [dev-dependencies]
+lazy_static = "1.4.0"
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
 etk-asm = "^0.2.1"
 ethers = { version = "1.0.2", features = ["abigen"] }
 serde_json = "1.0"
 rand = "0.8.5"
+once_cell = "1.17.0"
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/evm/src/interpreter/memory.rs
+++ b/actors/evm/src/interpreter/memory.rs
@@ -1,11 +1,24 @@
-use derive_more::{Deref, DerefMut};
-
 use crate::EVM_WORD_SIZE;
+use std::ops::{Deref, DerefMut};
 
 const PAGE_SIZE: usize = 4 * 1024;
 
-#[derive(Clone, Debug, Deref, DerefMut)]
+#[derive(Clone, Debug)]
 pub struct Memory(Vec<u8>);
+
+impl Deref for Memory {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+impl DerefMut for Memory {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.0
+    }
+}
 
 impl Default for Memory {
     fn default() -> Self {
@@ -59,6 +72,6 @@ mod tests {
         let mut mem = Memory::default();
         mem.grow(PAGE_SIZE * 2 + 1);
         assert_eq!(mem.len(), PAGE_SIZE * 2 + EVM_WORD_SIZE);
-        assert_eq!(mem.capacity(), PAGE_SIZE * 3);
+        assert_eq!(mem.0.capacity(), PAGE_SIZE * 3);
     }
 }

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -17,7 +17,6 @@ use fvm_shared::{
     MethodNum, Response, IPLD_RAW, METHOD_SEND,
 };
 use multihash::Code;
-use once_cell::unsync::OnceCell;
 
 use crate::state::{State, Tombstone};
 use crate::BytecodeHash;
@@ -29,33 +28,27 @@ use {
     fvm_ipld_kamt::{AsHashedKey, Config as KamtConfig, Kamt},
 };
 
-lazy_static::lazy_static! {
-    // The Solidity compiler creates contiguous array item keys.
-    // To prevent the tree from going very deep we use extensions,
-    // which the Kamt supports and does in all cases.
-    //
-    // There are maximum 32 levels in the tree with the default bit width of 8.
-    // The top few levels will have a higher level of overlap in their hashes.
-    // Intuitively these levels should be used for routing, not storing data.
-    //
-    // The only exception to this is the top level variables in the contract
-    // which solidity puts in the first few slots. There having to do extra
-    // lookups is burdensome, and they will always be accessed even for arrays
-    // because that's where the array length is stored.
-    //
-    // However, for Solidity, the size of the KV pairs is 2x256, which is
-    // comparable to a size of a CID pointer plus extension metadata.
-    // We can keep the root small either by force-pushing data down,
-    // or by not allowing many KV pairs in a slot.
-    //
-    // The following values have been set by looking at how the charts evolved
-    // with the test contract. They might not be the best for other contracts.
-    static ref KAMT_CONFIG: KamtConfig = KamtConfig {
-        min_data_depth: 0,
-        bit_width: 5,
-        max_array_width: 1
-    };
-}
+// The Solidity compiler creates contiguous array item keys.
+// To prevent the tree from going very deep we use extensions,
+// which the Kamt supports and does in all cases.
+//
+// There are maximum 32 levels in the tree with the default bit width of 8.
+// The top few levels will have a higher level of overlap in their hashes.
+// Intuitively these levels should be used for routing, not storing data.
+//
+// The only exception to this is the top level variables in the contract
+// which solidity puts in the first few slots. There having to do extra
+// lookups is burdensome, and they will always be accessed even for arrays
+// because that's where the array length is stored.
+//
+// However, for Solidity, the size of the KV pairs is 2x256, which is
+// comparable to a size of a CID pointer plus extension metadata.
+// We can keep the root small either by force-pushing data down,
+// or by not allowing many KV pairs in a slot.
+//
+// The following values have been set by looking at how the charts evolved
+// with the test contract. They might not be the best for other contracts.
+const KAMT_CONFIG: KamtConfig = KamtConfig { min_data_depth: 0, bit_width: 5, max_array_width: 1 };
 
 pub struct StateHashAlgorithm;
 
@@ -109,7 +102,7 @@ pub struct System<'r, RT: Runtime> {
     /// Read Only context (staticcall)
     pub readonly: bool,
     /// Randomness taken from the current epoch of chain randomness
-    randomness: OnceCell<[u8; 32]>,
+    randomness: Option<[u8; 32]>,
 
     /// This is "some" if the actor is currently a "zombie". I.e., it has selfdestructed, but the
     /// current message is still executing. `System` cannot load a contracts state with a
@@ -129,7 +122,7 @@ impl<'r, RT: Runtime> System<'r, RT> {
             saved_state_root: None,
             bytecode: None,
             readonly,
-            randomness: OnceCell::new(),
+            randomness: None,
             tombstone: None,
         }
     }
@@ -197,7 +190,7 @@ impl<'r, RT: Runtime> System<'r, RT> {
             saved_state_root: Some(state_root),
             bytecode: Some(EvmBytecode::new(state.bytecode, state.bytecode_hash)),
             readonly: read_only,
-            randomness: OnceCell::new(),
+            randomness: None,
             tombstone: state.tombstone,
         })
     }
@@ -441,14 +434,15 @@ impl<'r, RT: Runtime> System<'r, RT> {
     /// Gets the cached EVM randomness seed of the current epoch
     pub fn get_randomness(&mut self) -> Result<&[u8; 32], ActorError> {
         const ENTROPY: &[u8] = b"prevrandao";
-        self.randomness.get_or_try_init(|| {
+        match &mut self.randomness {
+            Some(rand) => Ok(&*rand),
             // get randomness from current beacon epoch with entropy of "prevrandao"
-            self.rt.get_randomness_from_beacon(
+            cache => Ok(cache.insert(self.rt.get_randomness_from_beacon(
                 fil_actors_runtime::runtime::DomainSeparationTag::EvmPrevRandao,
                 self.rt.curr_epoch(),
                 ENTROPY,
-            )
-        })
+            )?)),
+        }
     }
 
     /// Mark ourselves as "selfdestructed".


### PR DESCRIPTION
- Remove OnceCell and replace it with an Option.
- Move lazy_static to the dev dependencies.
- Manually implement deref instead of importing a crate just for that.
- Remove a bunch of unused dependencies.