### PR TITLE
Fail PSD if Market Deal Notify fails

### DIFF
--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -446,7 +446,7 @@ impl Actor {
 
         // notify clients ignoring any errors
         for (i, valid_deal) in valid_deals.iter().enumerate() {
-            _ = extract_send_result(rt.send_simple(
+            extract_send_result(rt.send_simple(
                 &valid_deal.proposal.client,
                 MARKET_NOTIFY_DEAL_METHOD,
                 IpldBlock::serialize_cbor(&MarketNotifyDealParams {
@@ -454,7 +454,7 @@ impl Actor {
                     deal_id: new_deal_ids[i],
                 })?,
                 TokenAmount::zero(),
-            ));
+            ))?;
         }
 
         Ok(PublishStorageDealsReturn { ids: new_deal_ids, valid_deals: valid_input_bf })


### PR DESCRIPTION
If Market deal notify fails, then its possible that datacap for a user actor has been spent without the actor being aware and performing any related actions.
Fail PSD to roll back any other transactions including datacap if market notify deal fails
