### PR TITLE
EVM: Context tests

### DIFF
--- a/actors/evm/src/interpreter/instructions/context.rs
+++ b/actors/evm/src/interpreter/instructions/context.rs
@@ -330,4 +330,18 @@ mod tests {
             };
         }
     }
+
+    #[test]
+    fn test_address() {
+        let addr = EthAddress::from_id(1001);
+        evm_unit_test! {
+            (m) {
+                ADDRESS;
+            }
+            m.state.receiver = addr;
+            m.step().expect("execution step failed");
+            assert_eq!(m.state.stack.len(), 1);
+            assert_eq!(m.state.stack.pop().unwrap(), addr.as_evm_word());
+        };
+    }
 }

--- a/actors/evm/src/interpreter/instructions/context.rs
+++ b/actors/evm/src/interpreter/instructions/context.rs
@@ -397,4 +397,22 @@ mod tests {
             assert_eq!(m.state.stack.pop().unwrap(), addr.as_evm_word());
         };
     }
+
+    #[test]
+    fn test_gas() {
+        evm_unit_test! {
+            (rt) {
+                rt.expect_gas_available(1234000);
+            }
+            (m) {
+                GAS;
+            }
+            let addr = EthAddress::from_id(1001);
+            m.state.caller = addr;
+            m.step().expect("execution step failed");
+            assert_eq!(m.state.stack.len(), 1);
+            assert_eq!(m.state.stack.pop().unwrap(), U256::from(1234000));
+        };
+    }
+
 }

--- a/actors/evm/src/interpreter/instructions/context.rs
+++ b/actors/evm/src/interpreter/instructions/context.rs
@@ -384,4 +384,17 @@ mod tests {
         };
     }
 
+    #[test]
+    fn test_caller() {
+        evm_unit_test! {
+            (m) {
+                CALLER;
+            }
+            let addr = EthAddress::from_id(1001);
+            m.state.caller = addr;
+            m.step().expect("execution step failed");
+            assert_eq!(m.state.stack.len(), 1);
+            assert_eq!(m.state.stack.pop().unwrap(), addr.as_evm_word());
+        };
+    }
 }

--- a/actors/evm/src/interpreter/instructions/context.rs
+++ b/actors/evm/src/interpreter/instructions/context.rs
@@ -152,9 +152,9 @@ mod tests {
     use crate::evm_unit_test;
     use cid::Cid;
     use fil_actors_evm_shared::uints::U256;
+    use fil_actors_runtime::EAM_ACTOR_ID;
     use fvm_ipld_encoding::{DAG_CBOR, IPLD_RAW};
     use fvm_shared::address::Address as FilAddress;
-    use fil_actors_runtime::EAM_ACTOR_ID;
 
     #[test]
     fn test_blockhash() {
@@ -433,5 +433,4 @@ mod tests {
             assert_eq!(m.state.stack.pop().unwrap(), U256::from(1234000));
         };
     }
-
 }

--- a/actors/evm/src/interpreter/instructions/context.rs
+++ b/actors/evm/src/interpreter/instructions/context.rs
@@ -399,6 +399,25 @@ mod tests {
     }
 
     #[test]
+    fn test_gasprice() {
+        // Note: This is currently buggy, as the price needs to be capped by the MaxFeeCap.
+        evm_unit_test! {
+            (rt) {
+                rt.base_fee = TokenAmount::from_atto(1000);
+                rt.gas_premium = TokenAmount::from_atto(1234);
+            }
+            (m) {
+                GASPRICE;
+            }
+            let addr = EthAddress::from_id(1001);
+            m.state.caller = addr;
+            m.step().expect("execution step failed");
+            assert_eq!(m.state.stack.len(), 1);
+            assert_eq!(m.state.stack.pop().unwrap(), U256::from(2234));
+        };
+    }
+
+    #[test]
     fn test_gas() {
         evm_unit_test! {
             (rt) {


### PR DESCRIPTION
On top of https://github.com/filecoin-project/builtin-actors/pull/1181
Closes https://github.com/filecoin-project/ref-fvm/issues/1555
  - [x] `ADDRESS`
  - [x] `ORIGIN`
  - [x] `CALLER`
  - [x] `GASPRICE`
  - [x] `GAS`
