### PR TITLE
chore: EVM tests: add callvariants build rule to Makefile

### DIFF
--- a/actors/evm/Makefile
+++ b/actors/evm/Makefile
@@ -24,6 +24,8 @@ $(TEST_CONTRACTS_DIR)/%.hex: $(TEST_CONTRACTS_DIR)/%.sol | solc
 	solc --bin $< | sed '4q;d' | tr -d '\n' > $@
 	solc --bin --abi --storage-layout --hashes --overwrite $< -o $(TEST_CONTRACTS_DIR)
 
+$(TEST_CONTRACTS_DIR)/callvariants.hex: $(TEST_CONTRACTS_DIR)/callvariants.eas $(TEST_CONTRACTS_DIR)/callvariants_body.eas
+	eas $(TEST_CONTRACTS_DIR)/callvariants.eas | tr -d '\n' > $(TEST_CONTRACTS_DIR)/callvariants.hex
 
 # Run storage footprint tests.
 .PHONY: measure-storage-footprint


### PR DESCRIPTION
see https://github.com/filecoin-project/ref-fvm/issues/1252

```
vyzo@carbon6 evm $ make tests/contracts/callvariants.hex
make: 'tests/contracts/callvariants.hex' is up to date.
vyzo@carbon6 evm $ touch tests/contracts/callvariants.eas 
vyzo@carbon6 evm $ make tests/contracts/callvariants.hex
eas tests/contracts/callvariants.eas | tr -d '\n' > tests/contracts/callvariants.hex
vyzo@carbon6 evm $ touch tests/contracts/callvariants_body.eas 
vyzo@carbon6 evm $ make tests/contracts/callvariants.hex
eas tests/contracts/callvariants.eas | tr -d '\n' > tests/contracts/callvariants.hex
vyzo@carbon6 evm $ make tests/contracts/callvariants.hex
make: 'tests/contracts/callvariants.hex' is up to date.
```