### PR TITLE
fix: remove hyperspace-specific hacks

### DIFF
--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -169,8 +169,6 @@ pub(super) fn call_actor_shared<RT: Runtime>(
         // TODO only CBOR or "nothing" for now. We should support RAW and DAG_CBOR in the future.
         let params = match codec {
             fvm_ipld_encoding::CBOR => Some(IpldBlock { codec, data: params.into() }),
-            #[cfg(feature = "hyperspace")]
-            fvm_ipld_encoding::DAG_CBOR => Some(IpldBlock { codec, data: params.into() }),
             0 if params.is_empty() => None,
             _ => return Err(PrecompileError::InvalidInput),
         };

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -361,8 +361,6 @@ fn handle_filecoin_method_output(output: &[u8]) -> Result<Option<IpldBlock>, Act
         }
         // Supported codecs.
         fvm_ipld_encoding::CBOR => Some(IpldBlock { codec, data: return_data.into() }),
-        #[cfg(feature = "hyperspace")]
-        fvm_ipld_encoding::DAG_CBOR => Some(IpldBlock { codec, data: return_data.into() }),
         // Everything else.
         _ => return Err(ActorError::serialization(format!("unsupported codec: {codec}"))),
     };


### PR DESCRIPTION
We've decided that it's more important that hyperspace match mainnet.