### PR TITLE
EVM: correctly handle nonce overflows

### DIFF
--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -191,11 +191,11 @@ impl<'r, RT: Runtime> System<'r, RT> {
         })
     }
 
-    pub fn increment_nonce(&mut self) -> u64 {
+    pub fn increment_nonce(&mut self) -> Option<u64> {
         self.saved_state_root = None;
         let nonce = self.nonce;
-        self.nonce = self.nonce.checked_add(1).unwrap();
-        nonce
+        self.nonce = self.nonce.checked_add(1)?;
+        Some(nonce)
     }
 
     /// Transfers funds to the receiver. This doesn't bother saving/reloading state.


### PR DESCRIPTION
We shouldn't abort the entire call, just return a failure. This should never happen, but it's technically incorrect.

fixes https://github.com/filecoin-project/ref-fvm/issues/1436

(and comments from auditors)