### PR TITLE
Increase market deal update processing interval to 30 days (FIP-0060)

### DIFF
--- a/actors/market/src/deal.rs
+++ b/actors/market/src/deal.rs
@@ -98,7 +98,6 @@ pub struct DealProposal {
     pub provider: Address,
 
     /// Arbitrary client chosen label to apply to the deal
-    // ! This is the field that requires unsafe unchecked utf8 deserialization
     pub label: Label,
 
     // Nominal start epoch. Deal payment is linear between StartEpoch and EndEpoch,

--- a/actors/market/tests/cron_tick_deal_expiry.rs
+++ b/actors/market/tests/cron_tick_deal_expiry.rs
@@ -53,8 +53,6 @@ fn deal_is_correctly_processed_if_first_cron_after_expiry() {
 
 #[test]
 fn regular_payments_till_deal_expires_and_then_locked_funds_are_unlocked() {
-    // The logic of this test relies on deal ID == 0 so that it's scheduled for
-    // updated in the 0th epoch of every interval, and the start epoch being the same.
     let start_epoch = Policy::default().deal_updates_interval;
     let end_epoch = start_epoch + DURATION_EPOCHS;
     let rt = setup();
@@ -67,6 +65,9 @@ fn regular_payments_till_deal_expires_and_then_locked_funds_are_unlocked() {
         0,
         end_epoch,
     );
+    // The logic of this test relies on deal ID == 0 so that it's scheduled for
+    // updated in the 0th epoch of every interval, and the start epoch being the same.
+    assert_eq!(0, deal_id);
     let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     // move the current epoch to startEpoch + 5 so payment is made

--- a/actors/market/tests/cron_tick_deal_slashing.rs
+++ b/actors/market/tests/cron_tick_deal_slashing.rs
@@ -110,7 +110,7 @@ fn deal_is_slashed() {
 
 const START_EPOCH: ChainEpoch = 50;
 const DEAL_DURATION_EPOCHS: ChainEpoch = 200 * EPOCHS_IN_DAY;
-const END_EPOCH: ChainEpoch = 50 + DEAL_DURATION_EPOCHS;
+const END_EPOCH: ChainEpoch = START_EPOCH + DEAL_DURATION_EPOCHS;
 
 #[test]
 fn deal_is_slashed_at_the_end_epoch_should_not_be_slashed_and_should_be_considered_expired() {

--- a/actors/market/tests/cron_tick_deal_slashing.rs
+++ b/actors/market/tests/cron_tick_deal_slashing.rs
@@ -15,8 +15,6 @@ mod harness;
 
 use harness::*;
 
-const SECTOR_EXPIRY: ChainEpoch = 400 + 200 * EPOCHS_IN_DAY;
-
 #[test]
 fn deal_is_slashed() {
     struct Case {
@@ -83,7 +81,7 @@ fn deal_is_slashed() {
             tc.deal_start,
             tc.deal_end,
             tc.activation_epoch,
-            SECTOR_EXPIRY,
+            tc.deal_end,
         );
         let deal_proposal = get_deal_proposal(&rt, deal_id);
 
@@ -111,7 +109,8 @@ fn deal_is_slashed() {
 }
 
 const START_EPOCH: ChainEpoch = 50;
-const END_EPOCH: ChainEpoch = 50 + 200 * EPOCHS_IN_DAY;
+const DEAL_DURATION_EPOCHS: ChainEpoch = 200 * EPOCHS_IN_DAY;
+const END_EPOCH: ChainEpoch = 50 + DEAL_DURATION_EPOCHS;
 
 #[test]
 fn deal_is_slashed_at_the_end_epoch_should_not_be_slashed_and_should_be_considered_expired() {
@@ -123,7 +122,7 @@ fn deal_is_slashed_at_the_end_epoch_should_not_be_slashed_and_should_be_consider
         START_EPOCH,
         END_EPOCH,
         0,
-        SECTOR_EXPIRY,
+        END_EPOCH,
     );
     let deal_proposal = get_deal_proposal(&rt, deal_id);
 
@@ -152,15 +151,16 @@ fn deal_is_slashed_at_the_end_epoch_should_not_be_slashed_and_should_be_consider
 fn deal_payment_and_slashing_correctly_processed_in_same_crontick() {
     // start epoch should equal first processing epoch for logic to work
     let start_epoch: ChainEpoch = Policy::default().deal_updates_interval;
+    let end_epoch = start_epoch + DEAL_DURATION_EPOCHS;
     let rt = setup();
     let deal_id = publish_and_activate_deal(
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
-        END_EPOCH,
+        end_epoch,
         0,
-        SECTOR_EXPIRY,
+        end_epoch,
     );
     let deal_proposal = get_deal_proposal(&rt, deal_id);
 
@@ -202,7 +202,7 @@ fn slash_multiple_deals_in_the_same_epoch() {
         START_EPOCH,
         END_EPOCH,
         0,
-        SECTOR_EXPIRY,
+        END_EPOCH,
     );
     let deal_proposal1 = get_deal_proposal(&rt, deal_id1);
 
@@ -213,7 +213,7 @@ fn slash_multiple_deals_in_the_same_epoch() {
         START_EPOCH,
         END_EPOCH + 1,
         0,
-        SECTOR_EXPIRY,
+        END_EPOCH + 1,
     );
     let deal_proposal2 = get_deal_proposal(&rt, deal_id2);
 
@@ -224,7 +224,7 @@ fn slash_multiple_deals_in_the_same_epoch() {
         START_EPOCH,
         END_EPOCH + 2,
         0,
-        SECTOR_EXPIRY,
+        END_EPOCH + 2,
     );
     let deal_proposal3 = get_deal_proposal(&rt, deal_id3);
 
@@ -263,14 +263,13 @@ fn regular_payments_till_deal_is_slashed_and_then_slashing_is_processed() {
         START_EPOCH,
         END_EPOCH,
         0,
-        SECTOR_EXPIRY,
+        END_EPOCH,
     );
     let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     // move the current epoch to the process epoch + 5 so payment is made
     let process_start = process_epoch(START_EPOCH, deal_id);
-    let current = process_start + 5;
-    rt.set_epoch(current);
+    let current = rt.set_epoch(process_start + 5);
 
     // assert payment
     let (pay, slashed) =
@@ -280,17 +279,15 @@ fn regular_payments_till_deal_is_slashed_and_then_slashing_is_processed() {
 
     // Setting the current epoch to before the next schedule will NOT make any changes as the deal
     // is still not scheduled
-    let current = current + Policy::default().deal_updates_interval - 1;
-    rt.set_epoch(current);
+    rt.set_epoch(process_start + Policy::default().deal_updates_interval - 1);
     cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     // a second cron tick for the same epoch should not change anything
     cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     // make another payment
-    let current = current + 1;
-    rt.set_epoch(current);
-    let duration = Policy::default().deal_updates_interval;
+    let current = rt.set_epoch(process_start + Policy::default().deal_updates_interval);
+    let duration = Policy::default().deal_updates_interval - 5;
     let (pay, slashed) =
         cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(pay, duration * &deal_proposal.storage_price_per_epoch);
@@ -299,23 +296,19 @@ fn regular_payments_till_deal_is_slashed_and_then_slashing_is_processed() {
     // a second cron tick for the same epoch should not change anything
     cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
-    // now terminate the deal
-    let slash_epoch = current + 1;
-    rt.set_epoch(slash_epoch);
-    let duration = slash_epoch - current;
+    // now terminate the deal 1 epoch later
+    rt.set_epoch(process_start + Policy::default().deal_updates_interval + 1);
     terminate_deals(&rt, PROVIDER_ADDR, &[deal_id]);
 
     // Setting the epoch to anything less than next schedule will not make any change even though the deal is slashed
-    let current = current + Policy::default().deal_updates_interval - 1;
-    rt.set_epoch(current);
+    rt.set_epoch(process_start + 2 * Policy::default().deal_updates_interval - 1);
     cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     // next epoch for cron schedule  -> payment will be made and deal will be slashed
-    let current = current + 1;
-    rt.set_epoch(current);
+    let current = rt.set_epoch(process_start + 2 * Policy::default().deal_updates_interval);
     let (pay, slashed) =
         cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
-    assert_eq!(pay, duration * &deal_proposal.storage_price_per_epoch);
+    assert_eq!(pay, 1 * &deal_proposal.storage_price_per_epoch);
     assert_eq!(slashed, deal_proposal.provider_collateral);
 
     // deal should be deleted as it should have expired
@@ -333,7 +326,7 @@ fn regular_payments_till_deal_expires_and_then_we_attempt_to_slash_it_but_it_wil
         START_EPOCH,
         END_EPOCH,
         0,
-        SECTOR_EXPIRY,
+        END_EPOCH,
     );
     let deal_proposal = get_deal_proposal(&rt, deal_id);
 

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -11,7 +11,7 @@ use std::{cell::RefCell, collections::HashMap};
 use fil_actor_market::ext::account::{AuthenticateMessageParams, AUTHENTICATE_MESSAGE_METHOD};
 use fil_actor_market::ext::verifreg::{AllocationID, AllocationRequest, AllocationsResponse};
 use fil_actor_market::{
-    deal_id_key, ext, ext::miner::GetControlAddressesReturnParams, gen_rand_next_epoch,
+    deal_id_key, ext, ext::miner::GetControlAddressesReturnParams, next_update_epoch,
     testing::check_state_invariants, ActivateDealsParams, ActivateDealsResult,
     Actor as MarketActor, ClientDealProposal, DealArray, DealMetaArray, DealProposal, DealState,
     GetBalanceReturn, Label, MarketNotifyDealParams, Method, OnMinerSectorsTerminateParams,
@@ -376,8 +376,6 @@ pub fn delete_deal_proposal(rt: &MockRuntime, deal_id: DealID) {
     rt.replace_state(&st)
 }
 
-// if this is the first crontick for the deal, it's next tick will be scheduled at `desiredNextEpoch`
-// if this is not the first crontick, the `desiredNextEpoch` param is ignored.
 pub fn cron_tick_and_assert_balances(
     rt: &MockRuntime,
     client_addr: Address,
@@ -890,8 +888,7 @@ where
 }
 
 pub fn process_epoch(start_epoch: ChainEpoch, deal_id: DealID) -> ChainEpoch {
-    let policy = Policy::default();
-    gen_rand_next_epoch(&policy, start_epoch, deal_id)
+    next_update_epoch(deal_id, Policy::default().deal_updates_interval, start_epoch)
 }
 
 pub fn publish_and_activate_deal(

--- a/actors/market/tests/on_miner_sectors_terminate.rs
+++ b/actors/market/tests/on_miner_sectors_terminate.rs
@@ -6,7 +6,6 @@ use std::convert::TryInto;
 use fil_actor_market::{Actor as MarketActor, Method, OnMinerSectorsTerminateParams};
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::builtins::Type;
-use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::test_utils::*;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
@@ -19,7 +18,6 @@ mod harness;
 
 use harness::*;
 
-// Converted from https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1274
 #[test]
 fn terminate_multiple_deals_from_multiple_providers() {
     let start_epoch = 10;
@@ -142,14 +140,12 @@ fn terminate_valid_deals_along_with_just_expired_deal() {
 // Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1346
 #[test]
 fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
-    let deal_updates_interval = Policy::default().deal_updates_interval;
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
-    let current_epoch = 5;
 
     let rt = setup();
-    rt.set_epoch(current_epoch);
+    let current_epoch = rt.set_epoch(5);
 
     let deal1 = generate_deal_and_add_funds(
         &rt,
@@ -163,7 +159,7 @@ fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
-        end_epoch - deal_updates_interval,
+        end_epoch - 10, // Expires earlier
     );
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -369,8 +369,8 @@ pub mod policy_constants {
     pub const MAXIMUM_VERIFIED_ALLOCATION_EXPIRATION: i64 = 60 * EPOCHS_IN_DAY;
     pub const END_OF_LIFE_CLAIM_DROP_PERIOD: ChainEpoch = 30 * EPOCHS_IN_DAY;
 
-    /// DealUpdatesInterval is the number of blocks between payouts for deals
-    pub const DEAL_UPDATES_INTERVAL: i64 = EPOCHS_IN_DAY;
+    /// DealUpdatesInterval is the number of epochs between payouts for deals
+    pub const DEAL_UPDATES_INTERVAL: i64 = 30 * EPOCHS_IN_DAY;
 
     /// Numerator of the percentage of normalized cirulating
     /// supply that must be covered by provider collateral

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -725,8 +725,9 @@ impl<BS: Blockstore> MockRuntime<BS> {
     }
 
     #[allow(dead_code)]
-    pub fn set_epoch(&self, epoch: ChainEpoch) {
+    pub fn set_epoch(&self, epoch: ChainEpoch) -> ChainEpoch {
         self.epoch.replace(epoch);
+        epoch
     }
 
     pub fn expect_get_randomness_from_tickets(


### PR DESCRIPTION
Increases the deal update interval to 30 days and reworks the scheduling to be independent of either the current epoch or old schedule. This means that new code can be deployed into mainnet that will re-distribute the updates across a 30-day period, effectively an on-the-fly migration. Plus it's a more robust construction anyway.

See https://github.com/filecoin-project/FIPs/discussions/638

This came out nicely - most of the work was updating tests with fragile assumptions.

- [x] A test that it does redistribute deals that are scheduled in the "wrong" epoch (e.g. by previous code)
- [ ] Wait for a FIP before merging

Closes #1238.