### PR TITLE
fix: sector activation epoch

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3884,11 +3884,14 @@ fn extend_simple_qap_sector(
             &qa_pow,
             fil_actors_runtime::network::EPOCHS_IN_DAY,
         );
-        new_sector.expected_storage_pledge = expected_reward_for_power(
-            &reward_stats.this_epoch_reward_smoothed,
-            &power_stats.quality_adj_power_smoothed,
-            &qa_pow,
-            INITIAL_PLEDGE_PROJECTION_PERIOD,
+        new_sector.expected_storage_pledge = max(
+            sector.expected_storage_pledge.clone(),
+            expected_reward_for_power(
+                &reward_stats.this_epoch_reward_smoothed,
+                &power_stats.quality_adj_power_smoothed,
+                &qa_pow,
+                INITIAL_PLEDGE_PROJECTION_PERIOD,
+            ),
         );
         new_sector.replaced_day_reward =
             max(sector.expected_day_reward.clone(), sector.replaced_day_reward.clone());

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1336,9 +1336,10 @@ impl Actor {
                     );
 
                     new_sector_info.replaced_day_reward = max(
-                        with_details.sector_info.expected_day_reward.clone(),
-                        with_details.sector_info.replaced_day_reward.clone(),
-                    );
+                        &with_details.sector_info.expected_day_reward,
+                        &with_details.sector_info.replaced_day_reward,
+                    )
+                    .clone();
                     new_sector_info.expected_day_reward = expected_reward_for_power(
                         &rew.this_epoch_reward_smoothed,
                         &pow.quality_adj_power_smoothed,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1315,10 +1315,7 @@ impl Actor {
                     // Skip checking if CID is defined because it cannot be so in Rust
 
                     new_sector_info.deal_ids = with_details.update.deals.clone();
-
-                    if !with_details.deal_spaces.verified_deal_space.is_zero() {
-                        new_sector_info.power_base_epoch = rt.curr_epoch();
-                    }
+                    new_sector_info.power_base_epoch = rt.curr_epoch();
 
                     let duration = new_sector_info.expiration - new_sector_info.power_base_epoch;
 
@@ -3871,7 +3868,8 @@ fn extend_simple_qap_sector(
 
         new_sector.verified_deal_weight = BigInt::from(*new_verified_deal_space) * new_duration;
 
-        // We only bother updating the pledge for verified deals as it can increase power.
+        // We only bother updating the expected_day_reward, expected_storage_pledge, and replaced_day_reward
+        //  for verified deals, as it can increase power.
         let qa_pow = qa_power_for_weight(
             sector_size,
             new_duration,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3830,7 +3830,10 @@ fn extend_simple_qap_sector(
     // Update the non-verified deal weights. This won't change power, it'll just keep it the same
     // relative to the updated power base epoch.
     if sector.deal_weight.is_positive() {
-        new_sector.deal_weight = (&sector.deal_weight * new_duration) / old_duration;
+        // (old_deal_weight) / old_duration -> old_space
+        // old_space * (old_expiration - curr_epoch) -> remaining spacetime in the deals.
+        new_sector.deal_weight =
+            &sector.deal_weight * (sector.expiration - curr_epoch) / old_duration;
     }
 
     // Update the verified deal weights, and pledge if necessary.

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1343,11 +1343,14 @@ impl Actor {
                         &qa_pow,
                         fil_actors_runtime::network::EPOCHS_IN_DAY,
                     );
-                    new_sector_info.expected_storage_pledge = expected_reward_for_power(
-                        &rew.this_epoch_reward_smoothed,
-                        &pow.quality_adj_power_smoothed,
-                        &qa_pow,
-                        INITIAL_PLEDGE_PROJECTION_PERIOD,
+                    new_sector_info.expected_storage_pledge = max(
+                        new_sector_info.expected_storage_pledge,
+                        expected_reward_for_power(
+                            &rew.this_epoch_reward_smoothed,
+                            &pow.quality_adj_power_smoothed,
+                            &qa_pow,
+                            INITIAL_PLEDGE_PROJECTION_PERIOD,
+                        ),
                     );
 
                     new_sector_info.initial_pledge = max(

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1315,9 +1315,12 @@ impl Actor {
                     // Skip checking if CID is defined because it cannot be so in Rust
 
                     new_sector_info.deal_ids = with_details.update.deals.clone();
-                    new_sector_info.activation = rt.curr_epoch();
 
-                    let duration = new_sector_info.expiration - new_sector_info.activation;
+                    if !with_details.deal_spaces.verified_deal_space.is_zero() {
+                        new_sector_info.power_base_epoch = rt.curr_epoch();
+                    }
+
+                    let duration = new_sector_info.expiration - new_sector_info.power_base_epoch;
 
                     new_sector_info.deal_weight =
                         with_details.deal_spaces.deal_space.clone() * duration;
@@ -1346,8 +1349,6 @@ impl Actor {
                         &qa_pow,
                         INITIAL_PLEDGE_PROJECTION_PERIOD,
                     );
-                    new_sector_info.replaced_sector_age =
-                        ChainEpoch::max(0, rt.curr_epoch() - with_details.sector_info.activation);
 
                     new_sector_info.initial_pledge = max(
                         new_sector_info.initial_pledge,
@@ -3795,8 +3796,12 @@ fn extend_simple_qap_sector(
     claim_space_by_sector: &BTreeMap<SectorNumber, (u64, u64)>,
 ) -> Result<SectorOnChainInfo, ActorError> {
     let mut new_sector = sector.clone();
+    // Update the power_base_epoch, assuming the sector is actually being extended
+    if sector.expiration != new_expiration {
+        new_sector.power_base_epoch = curr_epoch
+    }
     if sector.verified_deal_weight > BigInt::zero() {
-        let old_duration = sector.expiration - sector.activation;
+        let old_duration = sector.expiration - sector.power_base_epoch;
         let deal_space = &sector.deal_weight / old_duration;
         let old_verified_deal_space = &sector.verified_deal_weight / old_duration;
         let (expected_verified_deal_space, new_verified_deal_space) = match claim_space_by_sector
@@ -3831,12 +3836,13 @@ fn extend_simple_qap_sector(
 
         new_sector.expiration = new_expiration;
         // update deal weights to account for new duration
-        new_sector.deal_weight = deal_space * (new_sector.expiration - new_sector.activation);
+        new_sector.deal_weight = deal_space * (new_sector.expiration - new_sector.power_base_epoch);
         new_sector.verified_deal_weight = BigInt::from(*new_verified_deal_space)
-            * (new_sector.expiration - new_sector.activation);
+            * (new_sector.expiration - new_sector.power_base_epoch);
     } else {
         new_sector.expiration = new_expiration
     }
+
     Ok(new_sector)
 }
 
@@ -3848,15 +3854,16 @@ fn extend_non_simple_qap_sector(
     let mut new_sector = sector.clone();
     // Remove "spent" deal weights for non simple_qa_power sectors with deal weight > 0
     let new_deal_weight = (&sector.deal_weight * (sector.expiration - curr_epoch))
-        .div_floor(&BigInt::from(sector.expiration - sector.activation));
+        .div_floor(&BigInt::from(sector.expiration - sector.power_base_epoch));
 
     let new_verified_deal_weight = (&sector.verified_deal_weight
         * (sector.expiration - curr_epoch))
-        .div_floor(&BigInt::from(sector.expiration - sector.activation));
+        .div_floor(&BigInt::from(sector.expiration - sector.power_base_epoch));
 
     new_sector.expiration = new_expiration;
     new_sector.deal_weight = new_deal_weight;
     new_sector.verified_deal_weight = new_verified_deal_weight;
+
     Ok(new_sector)
 }
 
@@ -4588,13 +4595,13 @@ fn termination_penalty(
         let sector_power = qa_power_for_sector(sector_size, sector);
         let fee = pledge_penalty_for_termination(
             &sector.expected_day_reward,
-            current_epoch - sector.activation,
+            current_epoch - sector.power_base_epoch,
             &sector.expected_storage_pledge,
             network_qa_power_estimate,
             &sector_power,
             reward_estimate,
             &sector.replaced_day_reward,
-            sector.replaced_sector_age,
+            sector.power_base_epoch - sector.activation,
         );
         total_fee += fee;
     }
@@ -4843,7 +4850,7 @@ fn confirm_sector_proofs_valid_internal(
                 initial_pledge,
                 expected_day_reward: day_reward,
                 expected_storage_pledge: storage_pledge,
-                replaced_sector_age: ChainEpoch::zero(),
+                power_base_epoch: activation,
                 replaced_day_reward: TokenAmount::zero(),
                 sector_key_cid: None,
                 simple_qa_power: true,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -28,7 +28,7 @@ use itertools::Itertools;
 use log::{error, info, warn};
 use multihash::Code::Blake2b256;
 use num_derive::FromPrimitive;
-use num_traits::Zero;
+use num_traits::{Signed, Zero};
 
 pub use beneficiary::*;
 pub use bitfield_queue::*;
@@ -3825,7 +3825,7 @@ fn extend_simple_qap_sector(
     new_sector.expiration = new_expiration;
     new_sector.power_base_epoch = curr_epoch;
     let old_duration = sector.expiration - sector.power_base_epoch;
-    let new_duration = new_sector.expiration - sector.power_base_epoch;
+    let new_duration = new_sector.expiration - new_sector.power_base_epoch;
 
     // Update the non-verified deal weights. This won't change power, it'll just keep it the same
     // relative to the updated power base epoch.
@@ -3911,6 +3911,7 @@ fn extend_non_simple_qap_sector(
     new_sector.expiration = new_expiration;
     new_sector.deal_weight = new_deal_weight;
     new_sector.verified_deal_weight = new_verified_deal_weight;
+    new_sector.power_base_epoch = curr_epoch;
 
     Ok(new_sector)
 }

--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -174,7 +174,7 @@ pub fn qa_power_for_weight(
 
 /// Returns the quality-adjusted power for a sector.
 pub fn qa_power_for_sector(size: SectorSize, sector: &SectorOnChainInfo) -> StoragePower {
-    let duration = sector.expiration - sector.activation;
+    let duration = sector.expiration - sector.power_base_epoch;
     qa_power_for_weight(size, duration, &sector.deal_weight, &sector.verified_deal_weight)
 }
 

--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -83,6 +83,14 @@ pub fn check_state_invariants<BS: Blockstore>(
                 if !sector.deal_ids.is_empty() {
                     miner_summary.sectors_with_deals.insert(sector_number);
                 }
+                acc.require(
+                    sector.activation <= sector.power_base_epoch,
+                    format!("invalid power base for {sector_number}"),
+                );
+                acc.require(
+                    sector.power_base_epoch < sector.expiration,
+                    format!("power base epoch is not before the sector expiration {sector_number}"),
+                );
                 Ok(())
             });
 

--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -76,13 +76,9 @@ pub fn check_state_invariants<BS: Blockstore>(
                     ),
                 );
                 sector.deal_ids.iter().for_each(|&deal| {
-                    miner_summary.deals.insert(
-                        deal,
-                        DealSummary {
-                            sector_start: sector.activation,
-                            sector_expiration: sector.expiration,
-                        },
-                    );
+                    miner_summary
+                        .deals
+                        .insert(deal, DealSummary { sector_expiration: sector.expiration });
                 });
                 if !sector.deal_ids.is_empty() {
                     miner_summary.sectors_with_deals.insert(sector_number);
@@ -135,7 +131,6 @@ pub fn check_state_invariants<BS: Blockstore>(
 }
 
 pub struct DealSummary {
-    pub sector_start: ChainEpoch,
     pub sector_expiration: ChainEpoch,
 }
 

--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -76,9 +76,13 @@ pub fn check_state_invariants<BS: Blockstore>(
                     ),
                 );
                 sector.deal_ids.iter().for_each(|&deal| {
-                    miner_summary
-                        .deals
-                        .insert(deal, DealSummary { sector_expiration: sector.expiration });
+                    miner_summary.deals.insert(
+                        deal,
+                        DealSummary {
+                            sector_start: sector.activation,
+                            sector_expiration: sector.expiration,
+                        },
+                    );
                 });
                 if !sector.deal_ids.is_empty() {
                     miner_summary.sectors_with_deals.insert(sector_number);
@@ -139,6 +143,7 @@ pub fn check_state_invariants<BS: Blockstore>(
 }
 
 pub struct DealSummary {
+    pub sector_start: ChainEpoch,
     pub sector_expiration: ChainEpoch,
 }
 

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -347,13 +347,13 @@ pub struct SectorOnChainInfo {
     pub verified_deal_weight: DealWeight,
     /// Pledge collected to commit this sector
     pub initial_pledge: TokenAmount,
-    /// Expected one day projection of reward for sector computed at activation time
+    /// Expected one day projection of reward for sector computed at activation / update / extension time
     pub expected_day_reward: TokenAmount,
-    /// Expected twenty day projection of reward for sector computed at activation time
+    /// Expected twenty day projection of reward for sector computed at activation / update / extension time
     pub expected_storage_pledge: TokenAmount,
     /// Epoch at which this sector's power was most recently updated
     pub power_base_epoch: ChainEpoch,
-    /// Day reward of this sector before its power was most recently updated
+    /// Maximum day reward this sector has had in previous iterations (zero for brand new sectors)
     pub replaced_day_reward: TokenAmount,
     /// The original SealedSectorCID, only gets set on the first ReplicaUpdate
     pub sector_key_cid: Option<Cid>,

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -351,9 +351,9 @@ pub struct SectorOnChainInfo {
     pub expected_day_reward: TokenAmount,
     /// Expected twenty day projection of reward for sector computed at activation time
     pub expected_storage_pledge: TokenAmount,
-    /// Age of sector this sector replaced or zero
-    pub replaced_sector_age: ChainEpoch,
-    /// Day reward of sector this sector replace or zero
+    /// Epoch at which this sector's power was most recently updated
+    pub power_base_epoch: ChainEpoch,
+    /// Day reward of this sector before its power was most recently updated
     pub replaced_day_reward: TokenAmount,
     /// The original SealedSectorCID, only gets set on the first ReplicaUpdate
     pub sector_key_cid: Option<Cid>,

--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -23,6 +23,7 @@ use fvm_shared::{
 use std::collections::HashMap;
 
 mod util;
+
 use fil_actors_runtime::runtime::Policy;
 use itertools::Itertools;
 use test_case::test_case;
@@ -946,7 +947,7 @@ fn assert_sector_verified_space(
     let new_sector = h.get_sector(rt, sector_number);
     assert_eq!(
         DealWeight::from(v_deal_space),
-        new_sector.verified_deal_weight / (new_sector.expiration - new_sector.activation)
+        new_sector.verified_deal_weight / (new_sector.expiration - new_sector.power_base_epoch)
     );
 }
 

--- a/actors/miner/tests/sector_assignment.rs
+++ b/actors/miner/tests/sector_assignment.rs
@@ -30,6 +30,7 @@ fn new_sector_on_chain_info(
         sealed_cid,
         activation,
         expiration: 1,
+        power_base_epoch: activation,
         deal_weight: weight.clone(),
         verified_deal_weight: weight,
         ..SectorOnChainInfo::default()

--- a/actors/miner/tests/sectors_stores_test.rs
+++ b/actors/miner/tests/sectors_stores_test.rs
@@ -109,6 +109,7 @@ fn new_sector_on_chain_info(
         sealed_cid,
         deal_ids: vec![],
         activation,
+        power_base_epoch: activation,
         expiration: ChainEpoch::from(1),
         deal_weight: weight.clone(),
         verified_deal_weight: weight,

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2385,6 +2385,7 @@ impl ActorHarness {
     ) -> Result<Option<IpldBlock>, ActorError> {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
         rt.expect_validate_caller_addr(self.caller_addrs());
+        self.expect_query_network_info(rt);
 
         let mut qa_delta = BigInt::zero();
         for extension in params.extensions.iter_mut() {
@@ -2469,6 +2470,7 @@ impl ActorHarness {
             }
         }
 
+        self.expect_query_network_info(rt);
         // Handle QA power updates
         for extension in params.extensions.iter_mut() {
             for sector_nr in extension.sectors.validate().unwrap().iter() {

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2475,6 +2475,7 @@ impl ActorHarness {
                 let sector = self.get_sector(&rt, sector_nr);
                 let mut new_sector = sector.clone();
                 new_sector.expiration = extension.new_expiration;
+                new_sector.power_base_epoch = *rt.epoch.borrow();
                 qa_delta += qa_power_for_sector(self.sector_size, &new_sector)
                     - qa_power_for_sector(self.sector_size, &sector);
             }
@@ -2487,13 +2488,14 @@ impl ActorHarness {
                     }
                 }
                 let sector = self.get_sector(&rt, sector_claim.sector_number);
-                let old_duration = sector.expiration - sector.activation;
+                let old_duration = sector.expiration - sector.power_base_epoch;
                 let old_verified_deal_space = &sector.verified_deal_weight / old_duration;
                 let new_verified_deal_space = old_verified_deal_space - dropped_space;
                 let mut new_sector = sector.clone();
                 new_sector.expiration = extension.new_expiration;
+                new_sector.power_base_epoch = *rt.epoch.borrow();
                 new_sector.verified_deal_weight = BigInt::from(new_verified_deal_space)
-                    * (new_sector.expiration - new_sector.activation);
+                    * (new_sector.expiration - new_sector.power_base_epoch);
                 qa_delta += qa_power_for_sector(self.sector_size, &new_sector)
                     - qa_power_for_sector(self.sector_size, &sector);
             }

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -364,6 +364,14 @@ fn check_deal_states_against_sectors(
         };
 
         acc.require(
+            deal.sector_start_epoch >= sector_deal.sector_start,
+            format!(
+                "deal state start {} does not match sector start {} for miner {}",
+                deal.sector_start_epoch, sector_deal.sector_start, deal.provider
+            ),
+        );
+
+        acc.require(
             deal.sector_start_epoch <= sector_deal.sector_expiration,
             format!(
                 "deal state start {} activated after sector expiration {} for miner {}",

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -364,14 +364,6 @@ fn check_deal_states_against_sectors(
         };
 
         acc.require(
-            deal.sector_start_epoch == sector_deal.sector_start,
-            format!(
-                "deal state start {} does not match sector start {} for miner {}",
-                deal.sector_start_epoch, sector_deal.sector_start, deal.provider
-            ),
-        );
-
-        acc.require(
             deal.sector_start_epoch <= sector_deal.sector_expiration,
             format!(
                 "deal state start {} activated after sector expiration {} for miner {}",

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -545,6 +545,16 @@ pub fn miner_extend_sector_expiration2<BS: Blockstore>(
             ..Default::default()
         })
     }
+    subinvocs.push(ExpectInvocation {
+        to: REWARD_ACTOR_ADDR,
+        method: RewardMethod::ThisEpochReward as u64,
+        ..Default::default()
+    });
+    subinvocs.push(ExpectInvocation {
+        to: STORAGE_POWER_ACTOR_ADDR,
+        method: PowerMethod::CurrentTotalPower as u64,
+        ..Default::default()
+    });
     if !power_delta.is_zero() {
         subinvocs.push(ExpectInvocation {
             to: STORAGE_POWER_ACTOR_ADDR,

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -1,11 +1,19 @@
+use fil_actor_market::State as MarketState;
+use fil_actor_market::{DealMetaArray, Method as MarketMethod};
 use fil_actor_miner::{
-    max_prove_commit_duration, ExpirationExtension, ExpirationExtension2,
+    max_prove_commit_duration, power_for_sector, ExpirationExtension, ExpirationExtension2,
     ExtendSectorExpiration2Params, ExtendSectorExpirationParams, Method as MinerMethod, PowerPair,
-    Sectors, State as MinerState,
+    ProveReplicaUpdatesParams2, ReplicaUpdate2, SectorClaim, Sectors, State as MinerState,
 };
 use fil_actor_power::{Method as PowerMethod, UpdateClaimedPowerParams};
+use fil_actor_reward::Method as RewardMethod;
+use fil_actor_verifreg::Method as VerifregMethod;
 use fil_actors_runtime::runtime::Policy;
-use fil_actors_runtime::{DealWeight, EPOCHS_IN_DAY, STORAGE_POWER_ACTOR_ADDR};
+use fil_actors_runtime::test_utils::{make_piece_cid, make_sealed_cid};
+use fil_actors_runtime::{
+    DealWeight, EPOCHS_IN_DAY, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
+    STORAGE_POWER_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
@@ -17,10 +25,10 @@ use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
 use test_vm::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
-    advance_by_deadline_to_index, advance_to_proving_deadline, apply_ok, create_accounts,
+    advance_by_deadline_to_index, advance_to_proving_deadline, apply_ok, bf_all, create_accounts,
     create_miner, cron_tick, invariant_failure_patterns, market_add_balance, market_publish_deal,
-    miner_precommit_sector, miner_prove_sector, submit_windowed_post, verifreg_add_client,
-    verifreg_add_verifier,
+    miner_precommit_sector, miner_prove_sector, sector_deadline, submit_windowed_post,
+    verifreg_add_client, verifreg_add_verifier,
 };
 use test_vm::{ExpectInvocation, TestVM, VM};
 
@@ -299,4 +307,229 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     v.expect_state_invariants(
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
     );
+}
+
+#[test]
+fn extend_updated_sector_with_claim() {
+    let store = MemoryBlockstore::new();
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let addrs = create_accounts(&v, 3, &TokenAmount::from_whole(10_000));
+    let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
+    let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);
+    let sector_number: SectorNumber = 100;
+    let policy = Policy::default();
+
+    // create miner
+    let miner_id = create_miner(
+        &mut v,
+        &owner,
+        &worker,
+        seal_proof.registered_window_post_proof().unwrap(),
+        &TokenAmount::from_whole(1_000),
+    )
+    .0;
+    let mut v = v.with_epoch(200);
+
+    //
+    // Precommit, prove and PoSt empty sector (more fully tested in TestCommitPoStFlow)
+    //
+
+    let expiration = v.get_epoch() + 360 * EPOCHS_IN_DAY;
+
+    miner_precommit_sector(&v, &worker, &miner_id, seal_proof, sector_number, vec![], expiration);
+
+    // advance time by a day and prove the sector
+    let prove_epoch = v.get_epoch() + EPOCHS_IN_DAY;
+    v = advance_by_deadline_to_epoch(v, miner_id, prove_epoch).0;
+    miner_prove_sector(&v, &worker, &miner_id, sector_number);
+    // trigger cron to validate the prove commit
+    cron_tick(&v);
+
+    // advance to proving period and submit post
+
+    let (deadline_info, partition_index, mut v) =
+        advance_to_proving_deadline(v, miner_id, sector_number);
+
+    let expected_power_delta =
+        PowerPair { raw: StoragePower::from(32u64 << 30), qa: StoragePower::from(32u64 << 30) };
+
+    submit_windowed_post(
+        &v,
+        &worker,
+        &miner_id,
+        deadline_info,
+        partition_index,
+        Some(expected_power_delta),
+    );
+
+    // move forward one deadline so sector is mutable
+    v = advance_by_deadline_to_index(
+        v,
+        miner_id,
+        deadline_info.index + 1 % policy.wpost_period_deadlines,
+    )
+    .0;
+
+    // Inspect basic sector info
+
+    let miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    let initial_sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    assert_eq!(expiration, initial_sector_info.expiration);
+    assert_eq!(StoragePower::zero(), initial_sector_info.deal_weight); // 0 space time
+    assert_eq!(StoragePower::zero(), initial_sector_info.verified_deal_weight); // 0 space time
+
+    // publish verified deals
+
+    // register verifier then verified client
+    let datacap = StoragePower::from(32_u128 << 40);
+    verifreg_add_verifier(&v, &verifier, datacap.clone());
+    verifreg_add_client(&v, &verifier, &verified_client, datacap);
+
+    // add market collateral for clients and miner
+    market_add_balance(&v, &verified_client, &verified_client, &TokenAmount::from_whole(3));
+    market_add_balance(&v, &worker, &miner_id, &TokenAmount::from_whole(64));
+
+    // create 1 verified deal for total sector capacity
+    let deal_start = v.get_epoch() + EPOCHS_IN_DAY;
+    let deal_ids = market_publish_deal(
+        &v,
+        &worker,
+        &verified_client,
+        &miner_id,
+        "deal1".to_string(),
+        PaddedPieceSize(32u64 << 30),
+        true,
+        deal_start,
+        340 * EPOCHS_IN_DAY,
+    )
+    .ids;
+
+    // replica update
+    let new_cid = make_sealed_cid(b"replica1");
+    let (d_idx, p_idx) = sector_deadline(&v, &miner_id, sector_number);
+    let replica_update = ReplicaUpdate2 {
+        sector_number,
+        deadline: d_idx,
+        partition: p_idx,
+        new_sealed_cid: new_cid,
+        deals: deal_ids.clone(),
+        update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
+        replica_proof: vec![],
+        new_unsealed_cid: make_piece_cid(b"unsealed from itest vm"),
+    };
+    let updated_sectors: BitField = apply_ok(
+        &v,
+        &worker,
+        &miner_id,
+        &TokenAmount::zero(),
+        MinerMethod::ProveReplicaUpdates2 as u64,
+        Some(ProveReplicaUpdatesParams2 { updates: vec![replica_update] }),
+    )
+    .deserialize()
+    .unwrap();
+    assert_eq!(vec![sector_number], bf_all(updated_sectors));
+
+    let old_power = power_for_sector(seal_proof.sector_size().unwrap(), &initial_sector_info);
+    let expected_update_claimed_power_params = UpdateClaimedPowerParams {
+        raw_byte_delta: StoragePower::zero(),
+        quality_adjusted_delta: 9 * old_power.qa, // sector now fully qap, 10x - x = 9x
+    };
+
+    // check for the expected subcalls
+    ExpectInvocation {
+        to: miner_id,
+        method: MinerMethod::ProveReplicaUpdates2 as u64,
+        subinvocs: Some(vec![
+            ExpectInvocation {
+                to: STORAGE_MARKET_ACTOR_ADDR,
+                method: MarketMethod::ActivateDeals as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: VERIFIED_REGISTRY_ACTOR_ADDR,
+                method: VerifregMethod::ClaimAllocations as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: STORAGE_MARKET_ACTOR_ADDR,
+                method: MarketMethod::VerifyDealsForActivation as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: REWARD_ACTOR_ADDR,
+                method: RewardMethod::ThisEpochReward as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::CurrentTotalPower as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::UpdatePledgeTotal as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::UpdateClaimedPower as u64,
+                params: Some(
+                    IpldBlock::serialize_cbor(&expected_update_claimed_power_params).unwrap(),
+                ),
+                ..Default::default()
+            },
+        ]),
+        ..Default::default()
+    }
+    .matches(v.take_invocations().last().unwrap());
+
+    // inspect sector info
+
+    let miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    let sector_info_after_update = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    assert_eq!(StoragePower::zero(), sector_info_after_update.deal_weight); // 0 space time
+
+    assert_eq!(
+        DealWeight::from((sector_info_after_update.expiration - v.get_epoch()) * (32i64 << 30)),
+        sector_info_after_update.verified_deal_weight
+    ); // 32 GiB * the remaining life of the sector
+
+    // extend the updated sector
+
+    let market_state: MarketState = v.get_state(&STORAGE_MARKET_ACTOR_ADDR).unwrap();
+    let deal_states = DealMetaArray::load(&market_state.states, v.store).unwrap();
+    let deal_state = deal_states.get(deal_ids[0]).unwrap().unwrap();
+    let claim_id = deal_state.verified_claim;
+
+    let extension_params = ExtendSectorExpiration2Params {
+        extensions: vec![ExpirationExtension2 {
+            deadline: d_idx,
+            partition: partition_index,
+            sectors: BitField::new(),
+            new_expiration: sector_info_after_update.expiration + 60 * EPOCHS_IN_DAY,
+            sectors_with_claims: vec![SectorClaim {
+                sector_number,
+                maintain_claims: vec![claim_id],
+                drop_claims: vec![],
+            }],
+        }],
+    };
+    apply_ok(
+        &v,
+        &worker,
+        &miner_id,
+        &TokenAmount::zero(),
+        MinerMethod::ExtendSectorExpiration2 as u64,
+        Some(extension_params),
+    );
+
+    let miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    let sector_info_after_extension =
+        miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    assert_eq!(StoragePower::zero(), sector_info_after_extension.deal_weight); // 0 space time
+
+    assert_eq!(
+        DealWeight::from((sector_info_after_extension.expiration - v.get_epoch()) * (32i64 << 30)),
+        sector_info_after_extension.verified_deal_weight
+    ); // 32 GiB * the remaining life of the sector
 }

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -102,12 +102,24 @@ fn extend<BS: Blockstore>(
     ExpectInvocation {
         to: maddr,
         method: extension_method,
-        subinvocs: Some(vec![ExpectInvocation {
-            to: STORAGE_POWER_ACTOR_ADDR,
-            method: PowerMethod::UpdateClaimedPower as u64,
-            params: Some(Some(power_update_params)),
-            ..Default::default()
-        }]),
+        subinvocs: Some(vec![
+            ExpectInvocation {
+                to: REWARD_ACTOR_ADDR,
+                method: RewardMethod::ThisEpochReward as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::CurrentTotalPower as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::UpdateClaimedPower as u64,
+                params: Some(Some(power_update_params)),
+                ..Default::default()
+            },
+        ]),
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -681,7 +681,7 @@ fn terminate_after_upgrade() {
     v.assert_state_invariants();
 }
 
-// Tests that an active CC sector can be correctly upgraded, and then the sector can be terminated
+// Tests that an active CC sector can be correctly upgraded, and then the sector can be extended
 #[test]
 fn extend_after_upgrade() {
     let store = &MemoryBlockstore::new();
@@ -699,12 +699,13 @@ fn extend_after_upgrade() {
         st.sectors = sectors.amt.flush().unwrap();
     });
 
+    let extension_epoch = v.epoch();
     let extension_params = ExtendSectorExpirationParams {
         extensions: vec![ExpirationExtension {
             deadline: deadline_index,
             partition: partition_index,
             sectors: make_bitfield(&[sector_number]),
-            new_expiration: v.epoch() + policy.max_sector_expiration_extension - 1,
+            new_expiration: extension_epoch + policy.max_sector_expiration_extension - 1,
         }],
     };
 
@@ -721,7 +722,7 @@ fn extend_after_upgrade() {
     let final_sector_info = miner_state.get_sector(store, sector_number).unwrap().unwrap();
     assert_eq!(
         policy.max_sector_expiration_extension - 1,
-        final_sector_info.expiration - final_sector_info.activation
+        final_sector_info.expiration - extension_epoch,
     );
     v.assert_state_invariants();
 }


### PR DESCRIPTION
Approach 2 from #914.

Additionally, given:

    | A | B | C |
    |   |   |   + new expiration
    |   |   + old expiration
    |   + new power base (current epoch)
    +- old power base (usually the activation epoch)

Previously, we'd take the remaining weight from B and then normalize it over A + B + C (new_expiration - activation).

This isn't quite correct, but it was as correct as we could get without recording the power base epoch. However, now that we have the power base epoch, we should normalize it (spread it out over) B + C, not A.

In practice, this just means:

1. Updating the power base when extending a non-simple QaP sector.
2. Adjusting the tests to account for these changes.