### PR TITLE
chore: update deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "arrayref"
@@ -177,9 +177,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -356,24 +356,24 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
+checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.1.5",
+ "constant_time_eq",
 ]
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
+checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.1.5",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -386,7 +386,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.2.4",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -590,18 +590,18 @@ dependencies = [
 
 [[package]]
 name = "cbor4ii"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebce4be718fce03915a0a6220eaca81becdab6485d6ad57d483ed6ff76def7b7"
+checksum = "b544cf8c89359205f4f990d0e6f3828db42df85b5dac95d09157a250eb0749c4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -762,12 +762,6 @@ name = "const-oid"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -1060,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
@@ -1757,7 +1751,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1789,7 +1783,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "log",
  "num-derive",
  "num-traits",
@@ -1808,7 +1802,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "lazy_static",
  "log",
  "num-derive",
@@ -1827,7 +1821,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "hex-literal",
  "log",
  "multihash",
@@ -1846,7 +1840,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "hex-literal",
  "num-derive",
  "num-traits",
@@ -1867,7 +1861,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_kamt",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "hex",
  "hex-literal",
  "lazy_static",
@@ -1894,7 +1888,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "log",
  "num-derive",
  "num-traits",
@@ -1918,7 +1912,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "integer-encoding",
  "itertools",
  "lazy_static",
@@ -1949,7 +1943,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "itertools",
  "lazy_static",
  "log",
@@ -1973,7 +1967,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -1994,7 +1988,7 @@ dependencies = [
  "fvm_ipld_amt",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "lazy_static",
  "num-derive",
  "num-traits",
@@ -2017,7 +2011,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -2034,7 +2028,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "lazy_static",
  "log",
  "num",
@@ -2052,7 +2046,7 @@ dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -2071,7 +2065,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "lazy_static",
  "log",
  "num-derive",
@@ -2085,7 +2079,7 @@ version = "10.0.0"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "hex",
  "serde",
  "uint",
@@ -2106,8 +2100,8 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_sdk 3.0.0-alpha.24",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_sdk 3.0.0",
+ "fvm_shared 3.0.0",
  "hex",
  "itertools",
  "lazy_static",
@@ -2178,7 +2172,7 @@ dependencies = [
  "frc46_token",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -2235,15 +2229,15 @@ dependencies = [
 
 [[package]]
 name = "frc42_dispatch"
-version = "3.0.1-alpha.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d7a133ea05356dbb3115ddb6bb302a9cb82efcc7561602ed687c277d96e55b"
+checksum = "d7d55d92f2660a840a438bbc2795a0cd2a6877f9d47638dea4a2af3c5286e5b6"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.24",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_sdk 3.0.0",
+ "fvm_shared 3.0.0",
  "thiserror",
 ]
 
@@ -2273,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "frc46_token"
-version = "4.0.1-alpha.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88d59160be82c91c9ba8dd4d670693ab826178a1d94ae792ded0d6b92a723cd"
+checksum = "d6851ff4de4e71e5abcb0041975c1f6e0f9554d07e7d334bab7ca0ac06b76c4a"
 dependencies = [
  "anyhow",
  "cid",
@@ -2285,8 +2279,8 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_sdk 3.0.0-alpha.24",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_sdk 3.0.0",
+ "fvm_shared 3.0.0",
  "integer-encoding",
  "num-traits",
  "serde",
@@ -2317,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2327,9 +2321,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
@@ -2344,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -2376,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2387,15 +2381,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-timer"
@@ -2405,9 +2399,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2423,17 +2417,17 @@ dependencies = [
 
 [[package]]
 name = "fvm_actor_utils"
-version = "4.0.1-alpha.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d45c603677e42634b25f52aff45db3d57a7f46c524e6d528489e193564cc38"
+checksum = "cfa2c762bf64bfe8e5af09c7694330ceda2bc1fe27e96b2f07ea335efb326eca"
 dependencies = [
  "anyhow",
  "cid",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0-alpha.24",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_sdk 3.0.0",
+ "fvm_shared 3.0.0",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -2585,13 +2579,13 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.24"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad163015237811580399ce929938f3bdca2d1a133672ff01693f555a632ec425"
+checksum = "2fef17308967cceb1d22f05003d60adb0d5b9ba53e34ace4ae04701eb7e6af02"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "lazy_static",
  "log",
  "num-traits",
@@ -2629,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0-alpha.20"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b594b4d4c1393f03e3430f106c09874fcac565e68a560686de37ca2982a61d1a"
+checksum = "c99c06aa865e34198d9ca0da54e53e2fca14ae9ce5402f51b7c8e78175205861"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -3371,9 +3365,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -3728,9 +3722,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -4200,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
@@ -4343,9 +4337,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -4459,9 +4453,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4550,7 +4544,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "hex",
  "hex-literal",
  "indexmap",

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -14,9 +14,9 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-frc42_dispatch = "3.0.1-alpha.2"
-fvm_actor_utils = "4.0.1-alpha.1"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+frc42_dispatch = "3.0.1"
+fvm_actor_utils = "4.0.1"
+fvm_shared = { version = "3.0.0", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -17,13 +17,13 @@ crate-type = ["cdylib", "lib"]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime"}
 
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.0.1-alpha.2"
-frc46_token = "4.0.1-alpha.1"
-fvm_actor_utils = "4.0.1-alpha.1"
+frc42_dispatch = "3.0.1"
+frc46_token = "4.0.1"
+fvm_actor_utils = "4.0.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 lazy_static = "1.4.0"
 num-derive = "0.3.3"
 num-traits = "0.2.14"

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -390,6 +390,9 @@ impl<RT> SyscallProvider<RT> {
     pub fn new(rt: &mut RT) -> &mut Self {
         // This is safe as `SyscallProvider` contains exactly one field of type `RT`, and is
         // transparent.
+        //
+        // We do this so we can construct an `ActorRuntime` from a reference to a builtin-actors
+        // `Runtime` without having to leave a temporary on the stack. See `as_actor_runtime` below.
         unsafe { &mut *(rt as *mut RT as *mut SyscallProvider<RT>) }
     }
 }

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -382,11 +382,14 @@ impl Actor {
 /// runtime library.
 #[repr(transparent)]
 struct SyscallProvider<RT> {
+    // Do not add fields.
     rt: RT,
 }
 
 impl<RT> SyscallProvider<RT> {
     pub fn new(rt: &mut RT) -> &mut Self {
+        // This is safe as `SyscallProvider` contains exactly one field of type `RT`, and is
+        // transparent.
         unsafe { &mut *(rt as *mut RT as *mut SyscallProvider<RT>) }
     }
 }
@@ -444,19 +447,19 @@ where
     RT: Runtime,
 {
     fn root(&self) -> Result<Cid, NoStateError> {
-        (&**self).root()
+        (**self).root()
     }
 
     fn set_root(&self, cid: &Cid) -> Result<(), NoStateError> {
-        (&**self).set_root(cid)
+        (**self).set_root(cid)
     }
 
     fn receiver(&self) -> ActorID {
-        (&**self).receiver()
+        (**self).receiver()
     }
 
     fn caller(&self) -> ActorID {
-        (&**self).caller()
+        (**self).caller()
     }
 
     // This never returns an Err.  However we could return an error if the
@@ -469,11 +472,11 @@ where
         params: Option<IpldBlock>,
         value: TokenAmount,
     ) -> Result<Response, ErrorNumber> {
-        (&**self).send(to, method, params, value)
+        (**self).send(to, method, params, value)
     }
 
     fn resolve_address(&self, addr: &Address) -> Option<ActorID> {
-        (&**self).resolve_address(addr)
+        (**self).resolve_address(addr)
     }
 }
 
@@ -489,9 +492,7 @@ where
 }
 
 // Returns an ActorRuntime wrapping the Runtime and Blockstore
-fn as_actor_runtime<'st, RT>(
-    rt: &'st mut RT,
-) -> ActorRuntime<&'st SyscallProvider<RT>, &'st RT::Blockstore>
+fn as_actor_runtime<RT>(rt: &mut RT) -> ActorRuntime<&SyscallProvider<RT>, &RT::Blockstore>
 where
     RT: Runtime,
 {

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -118,8 +118,8 @@ impl Actor {
     pub fn total_supply(rt: &mut impl Runtime) -> Result<TokenAmount, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let mut st: State = rt.state()?;
-        let msg = SyscallProvider { rt };
-        let token = as_token(&mut st, &msg);
+        let art = as_actor_runtime(rt);
+        let token = as_token(&mut st, &art);
         Ok(token.total_supply())
     }
 
@@ -127,8 +127,8 @@ impl Actor {
         // NOTE: mutability and method caller here are awkward for a read-only call
         rt.validate_immediate_caller_accept_any()?;
         let mut st: State = rt.state()?;
-        let msg = SyscallProvider { rt };
-        let token = as_token(&mut st, &msg);
+        let art = as_actor_runtime(rt);
+        let token = as_token(&mut st, &art);
         token.balance_of(&params).actor_result()
     }
 
@@ -138,8 +138,8 @@ impl Actor {
     ) -> Result<TokenAmount, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let mut st: State = rt.state()?;
-        let msg = SyscallProvider { rt };
-        let token = as_token(&mut st, &msg);
+        let art = as_actor_runtime(rt);
+        let token = as_token(&mut st, &art);
         token.allowance(&params.owner, &params.operator).actor_result()
     }
 
@@ -154,8 +154,8 @@ impl Actor {
                 rt.validate_immediate_caller_is(std::iter::once(&st.governor))?;
                 let operator = st.governor;
 
-                let msg = SyscallProvider { rt };
-                let mut token = as_token(st, &msg);
+                let art = as_actor_runtime(rt);
+                let mut token = as_token(st, &art);
                 // Mint tokens "from" the operator to the beneficiary.
                 let ret = token
                     .mint(
@@ -179,9 +179,9 @@ impl Actor {
             .context("state transaction failed")?;
 
         let mut st: State = rt.state()?;
-        let sys_provider = SyscallProvider { rt };
-        let intermediate = hook.call(&as_actor_runtime(&sys_provider)).actor_result()?;
-        as_token(&mut st, &sys_provider).mint_return(intermediate).actor_result()
+        let art = as_actor_runtime(rt);
+        let intermediate = hook.call(&art).actor_result()?;
+        as_token(&mut st, &art).mint_return(intermediate).actor_result()
     }
 
     /// Destroys data cap tokens for an address (a verified client).
@@ -193,8 +193,8 @@ impl Actor {
             // Only the governor can destroy datacap tokens on behalf of a holder.
             rt.validate_immediate_caller_is(std::iter::once(&st.governor))?;
 
-            let msg = SyscallProvider { rt };
-            let mut token = as_token(st, &msg);
+            let art = as_actor_runtime(rt);
+            let mut token = as_token(st, &art);
             // Burn tokens as if the holder had invoked burn() themselves.
             // The governor doesn't need an allowance.
             token.burn(&params.owner, &params.amount).actor_result()
@@ -231,8 +231,8 @@ impl Actor {
                     ));
                 }
 
-                let msg = SyscallProvider { rt };
-                let mut token = as_token(st, &msg);
+                let art = as_actor_runtime(rt);
+                let mut token = as_token(st, &art);
                 token
                     .transfer(
                         from,
@@ -246,9 +246,9 @@ impl Actor {
             .context("state transaction failed")?;
 
         let mut st: State = rt.state()?;
-        let sys_provider = SyscallProvider { rt };
-        let intermediate = hook.call(&as_actor_runtime(&sys_provider)).actor_result()?;
-        as_token(&mut st, &sys_provider).transfer_return(intermediate).actor_result()
+        let art = as_actor_runtime(rt);
+        let intermediate = hook.call(&art).actor_result()?;
+        as_token(&mut st, &art).transfer_return(intermediate).actor_result()
     }
 
     /// Transfers data cap tokens between addresses.
@@ -280,8 +280,8 @@ impl Actor {
                     ));
                 }
 
-                let msg = SyscallProvider { rt };
-                let mut token = as_token(st, &msg);
+                let art = as_actor_runtime(rt);
+                let mut token = as_token(st, &art);
                 token
                     .transfer_from(
                         &operator,
@@ -296,9 +296,9 @@ impl Actor {
             .context("state transaction failed")?;
 
         let mut st: State = rt.state()?;
-        let sys_provider = SyscallProvider { rt };
-        let intermediate = hook.call(&as_actor_runtime(&sys_provider)).actor_result()?;
-        as_token(&mut st, &sys_provider).transfer_from_return(intermediate).actor_result()
+        let art = as_actor_runtime(rt);
+        let intermediate = hook.call(&art).actor_result()?;
+        as_token(&mut st, &art).transfer_from_return(intermediate).actor_result()
     }
 
     pub fn increase_allowance(
@@ -310,8 +310,8 @@ impl Actor {
         let operator = params.operator;
 
         rt.transaction(|st: &mut State, rt| {
-            let msg = SyscallProvider { rt };
-            let mut token = as_token(st, &msg);
+            let art = as_actor_runtime(rt);
+            let mut token = as_token(st, &art);
             token.increase_allowance(&owner, &operator, &params.increase).actor_result()
         })
         .context("state transaction failed")
@@ -326,8 +326,8 @@ impl Actor {
         let operator = &params.operator;
 
         rt.transaction(|st: &mut State, rt| {
-            let msg = SyscallProvider { rt };
-            let mut token = as_token(st, &msg);
+            let art = as_actor_runtime(rt);
+            let mut token = as_token(st, &art);
             token.decrease_allowance(owner, operator, &params.decrease).actor_result()
         })
         .context("state transaction failed")
@@ -342,8 +342,8 @@ impl Actor {
         let operator = &params.operator;
 
         rt.transaction(|st: &mut State, rt| {
-            let msg = SyscallProvider { rt };
-            let mut token = as_token(st, &msg);
+            let art = as_actor_runtime(rt);
+            let mut token = as_token(st, &art);
             token.revoke_allowance(owner, operator).actor_result()
         })
         .context("state transaction failed")
@@ -354,8 +354,8 @@ impl Actor {
         let owner = &rt.message().caller();
 
         rt.transaction(|st: &mut State, rt| {
-            let msg = SyscallProvider { rt };
-            let mut token = as_token(st, &msg);
+            let art = as_actor_runtime(rt);
+            let mut token = as_token(st, &art);
             token.burn(owner, &params.amount).actor_result()
         })
         .context("state transaction failed")
@@ -370,8 +370,8 @@ impl Actor {
         let owner = &params.owner;
 
         rt.transaction(|st: &mut State, rt| {
-            let msg = SyscallProvider { rt };
-            let mut token = as_token(st, &msg);
+            let art = as_actor_runtime(rt);
+            let mut token = as_token(st, &art);
             token.burn_from(operator, owner, &params.amount).actor_result()
         })
         .context("state transaction failed")
@@ -380,11 +380,18 @@ impl Actor {
 
 /// Implementation of the token library's messenger trait in terms of the built-in actors'
 /// runtime library.
-struct SyscallProvider<'a, RT> {
-    rt: &'a mut RT,
+#[repr(transparent)]
+struct SyscallProvider<RT> {
+    rt: RT,
 }
 
-impl<'a, RT> Syscalls for &SyscallProvider<'a, RT>
+impl<RT> SyscallProvider<RT> {
+    pub fn new(rt: &mut RT) -> &mut Self {
+        unsafe { &mut *(rt as *mut RT as *mut SyscallProvider<RT>) }
+    }
+}
+
+impl<RT> Syscalls for SyscallProvider<RT>
 where
     RT: Runtime,
 {
@@ -392,8 +399,16 @@ where
         self.rt.get_state_root().map_err(|_| NoStateError)
     }
 
+    fn set_root(&self, cid: &Cid) -> Result<(), NoStateError> {
+        self.rt.set_state_root(cid).map_err(|_| NoStateError)
+    }
+
     fn receiver(&self) -> ActorID {
         self.rt.message().receiver().id().unwrap()
+    }
+
+    fn caller(&self) -> ActorID {
+        self.rt.message().caller().id().unwrap()
     }
 
     // This never returns an Err.  However we could return an error if the
@@ -424,25 +439,64 @@ where
     }
 }
 
-// Returns a token instance wrapping the token state.
-fn as_token<'st, RT>(
-    st: &'st mut State,
-    msg: &'st SyscallProvider<'st, RT>,
-) -> Token<'st, &'st SyscallProvider<'st, RT>, &'st RT::Blockstore>
+impl<RT> Syscalls for &SyscallProvider<RT>
 where
     RT: Runtime,
 {
-    Token::wrap(ActorRuntime::new(msg, msg.rt.store()), DATACAP_GRANULARITY, &mut st.token)
+    fn root(&self) -> Result<Cid, NoStateError> {
+        (&**self).root()
+    }
+
+    fn set_root(&self, cid: &Cid) -> Result<(), NoStateError> {
+        (&**self).set_root(cid)
+    }
+
+    fn receiver(&self) -> ActorID {
+        (&**self).receiver()
+    }
+
+    fn caller(&self) -> ActorID {
+        (&**self).caller()
+    }
+
+    // This never returns an Err.  However we could return an error if the
+    // Runtime send method passed through the underlying syscall error
+    // instead of hiding it behind a client-side chosen exit code.
+    fn send(
+        &self,
+        to: &Address,
+        method: MethodNum,
+        params: Option<IpldBlock>,
+        value: TokenAmount,
+    ) -> Result<Response, ErrorNumber> {
+        (&**self).send(to, method, params, value)
+    }
+
+    fn resolve_address(&self, addr: &Address) -> Option<ActorID> {
+        (&**self).resolve_address(addr)
+    }
+}
+
+// Returns a token instance wrapping the token state.
+fn as_token<'st, RT>(
+    st: &'st mut State,
+    rt: &'st ActorRuntime<&'st SyscallProvider<RT>, &'st RT::Blockstore>,
+) -> Token<'st, &'st SyscallProvider<RT>, &'st RT::Blockstore>
+where
+    RT: Runtime,
+{
+    Token::wrap(rt, DATACAP_GRANULARITY, &mut st.token)
 }
 
 // Returns an ActorRuntime wrapping the Runtime and Blockstore
 fn as_actor_runtime<'st, RT>(
-    sys_provider: &'st SyscallProvider<'st, RT>,
-) -> ActorRuntime<&'st SyscallProvider<'st, RT>, &'st RT::Blockstore>
+    rt: &'st mut RT,
+) -> ActorRuntime<&'st SyscallProvider<RT>, &'st RT::Blockstore>
 where
     RT: Runtime,
 {
-    ActorRuntime::new(sys_provider, sys_provider.rt.store())
+    let syscalls = SyscallProvider::new(rt);
+    ActorRuntime { blockstore: syscalls.rt.store(), syscalls }
 }
 
 trait AsActorResult<T> {

--- a/actors/eam/Cargo.toml
+++ b/actors/eam/Cargo.toml
@@ -24,7 +24,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 multihash = { version = "0.16.1", default-features = false }
 cid = "0.8.6"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 hex-literal = "0.3.4"

--- a/actors/ethaccount/Cargo.toml
+++ b/actors/ethaccount/Cargo.toml
@@ -15,11 +15,11 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-frc42_dispatch = "3.0.1-alpha.2"
-fvm_actor_utils = "4.0.1-alpha.1"
+frc42_dispatch = "3.0.1"
+fvm_actor_utils = "4.0.1"
 serde = { version = "1.0.136", features = ["derive"] }
 fvm_ipld_encoding = "0.3.3"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 hex-literal = "0.3.4"

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 fvm_ipld_kamt = { version = "0.2.0" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5"
@@ -31,7 +31,7 @@ multihash = { version = "0.16.1", default-features = false }
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.3.4"
 substrate-bn = { version = "0.6.0", default-features = false }
-frc42_dispatch = "3.0.1-alpha.2"
+frc42_dispatch = "3.0.1"
 fil_actors_evm_shared = { version = "10.0.0", path = "shared" }
 
 [dev-dependencies]

--- a/actors/evm/shared/Cargo.toml
+++ b/actors/evm/shared/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["filecoin", "web3", "wasm", "evm"]
 
 [dependencies]
 serde = { version = "1.0.136", features = ["derive"] }
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 fil_actors_runtime = { version = "10.0.0", path = "../../../runtime" }
 fvm_ipld_encoding = "0.3.3"
 uint = { version = "0.9.3", default-features = false }

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-frc42_dispatch = "3.0.1-alpha.2"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+frc42_dispatch = "3.0.1"
+fvm_shared = { version = "3.0.0", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -18,13 +18,13 @@ fil_actors_runtime = { version = "10.0.0", path = "../../runtime"}
 
 anyhow = "1.0.65"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.0.1-alpha.2"
-frc46_token = "4.0.1-alpha.1"
+frc42_dispatch = "3.0.1"
+frc46_token = "4.0.1"
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 integer-encoding = { version = "3.0.3", default-features = false }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 log = "0.4.14"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-frc42_dispatch = "3.0.1-alpha.2"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+frc42_dispatch = "3.0.1"
+fvm_shared = { version = "3.0.0", default-features = false }
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
 fvm_ipld_hamt = "0.6.1"

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -18,12 +18,12 @@ fil_actors_runtime = { version = "10.0.0", path = "../../runtime"}
 
 anyhow = "1.0.65"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.0.1-alpha.2"
-fvm_actor_utils = "4.0.1-alpha.1"
+frc42_dispatch = "3.0.1"
+fvm_actor_utils = "4.0.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 num-derive = "0.3.3"

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-frc42_dispatch = "3.0.1-alpha.2"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+frc42_dispatch = "3.0.1"
+fvm_shared = { version = "3.0.0", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-frc42_dispatch = "3.0.1-alpha.2"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+frc42_dispatch = "3.0.1"
+fvm_shared = { version = "3.0.0", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -18,13 +18,13 @@ fil_actors_runtime = { version = "10.0.0", path = "../../runtime"}
 
 anyhow = "1.0.65"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.0.1-alpha.2"
-frc46_token = "4.0.1-alpha.1"
-fvm_actor_utils = "4.0.1-alpha.1"
+frc42_dispatch = "3.0.1"
+frc46_token = "4.0.1"
+fvm_actor_utils = "4.0.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 lazy_static = "1.4.0"
 log = "0.4.14"
 num-derive = "0.3.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 [dependencies]
 fvm_ipld_hamt = "0.6.1"
 fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 num = { version = "0.4", features = ["serde"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -22,7 +22,7 @@ cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] 
 log = "0.4.14"
 thiserror = "1.0.30"
 anyhow = "1.0.65"
-fvm_sdk = { version = "3.0.0-alpha.24", optional = true }
+fvm_sdk = { version = "3.0.0", optional = true }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_bitfield = "0.5.4"

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -260,7 +260,7 @@ where
         Ok(fvm::sself::root()?)
     }
 
-    fn set_state_root(&mut self, root: &Cid) -> Result<(), ActorError> {
+    fn set_state_root(&self, root: &Cid) -> Result<(), ActorError> {
         Ok(fvm::sself::set_root(root)?)
     }
 

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -155,7 +155,7 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     fn get_state_root(&self) -> Result<Cid, ActorError>;
 
     /// Sets the state-root.
-    fn set_state_root(&mut self, root: &Cid) -> Result<(), ActorError>;
+    fn set_state_root(&self, root: &Cid) -> Result<(), ActorError>;
 
     /// Loads a mutable copy of the state of the receiver, passes it to `f`,
     /// and after `f` completes puts the state object back to the store and sets it as

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -27,8 +27,8 @@ fil_actor_reward = { version = "10.0.0", path = "../actors/reward"}
 fil_actor_system = { version = "10.0.0", path = "../actors/system"}
 fil_actor_init = { version = "10.0.0", path = "../actors/init"}
 fil_actors_runtime = { version = "10.0.0", path = "../runtime"}
-frc46_token = "4.0.1-alpha.1"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+frc46_token = "4.0.1"
+fvm_shared = { version = "3.0.0", default-features = false }
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -33,13 +33,13 @@ anyhow = "1.0.65"
 bimap = { version = "0.6.2" }
 blake2b_simd = "1.0"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc46_token = "4.0.1-alpha.1"
-fvm_actor_utils = "4.0.1-alpha.1"
+frc46_token = "4.0.1"
+fvm_actor_utils = "4.0.1"
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_blockstore = { version = "0.1.1", default-features = false }
 fvm_ipld_encoding = { version = "0.3.3", default-features = false }
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_shared = { version = "3.0.0", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 lazy_static = "1.4.0"

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -1025,7 +1025,7 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
         Ok(self.v.get_actor(self.to()).unwrap().head)
     }
 
-    fn set_state_root(&mut self, root: &Cid) -> Result<(), ActorError> {
+    fn set_state_root(&self, root: &Cid) -> Result<(), ActorError> {
         let maybe_act = self.v.get_actor(self.to());
         match maybe_act {
             None => Err(ActorError::unchecked(


### PR DESCRIPTION
Updates the FVM to the final 3.0 release and update helix libraries. I'd like to make this change against v10, but there are too many breaking changes in the helix library.