### PR TITLE
make stop behaviour consistent with ethereum

### DIFF
--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -188,7 +188,6 @@ macro_rules! def_exit {
         def_op!{ $op (m) => {
             let &rev![$($arg),*] = m.state.stack.pop_many()?;
             m.output = $impl(&mut m.state, &mut m.system, $($arg),*)?;
-            m.pc = m.bytecode.len(); // stop execution
             Ok(())
         }}
     }

--- a/actors/evm/src/interpreter/output.rs
+++ b/actors/evm/src/interpreter/output.rs
@@ -2,9 +2,10 @@ use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum Outcome {
-    #[default]
     Return,
     Revert,
+    #[default]
+    Unset,
 }
 
 /// Output of EVM execution.

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -144,6 +144,7 @@ fn initialize_evm_contract(
             "constructor reverted".to_string(),
             IpldBlock::serialize_cbor(&BytesSer(&output.return_data)).unwrap(),
         )),
+        Outcome::Unset => Err(ActorError::unspecified(format!("execution ended without outcome"))),
     }
 }
 
@@ -183,6 +184,7 @@ where
             "contract reverted".to_string(),
             IpldBlock::serialize_cbor(&BytesSer(&output.return_data)).unwrap(),
         )),
+        Outcome::Unset => Err(ActorError::unspecified(format!("execution ended without outcome"))),
     }
 }
 


### PR DESCRIPTION
EVM has an interesting behavior: it will [pad the bytecode with STOP](https://github.com/ethereum/go-ethereum/blob/master/core/vm/contract.go#L145) when there is no explicit terminator .

And there's code from zkevm that's [depending](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/bus-mapping/src/circuit_input_builder/transaction.rs#L50) on this behaviour.

This PR tries to make this behaviour consistent.