### PR TITLE
Reject unexpected transfers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ target
 *.wat
 *.wasm
 .idea/
+.vscode/
 **/.DS_Store
 output/*.car

--- a/actors/eam/src/lib.rs
+++ b/actors/eam/src/lib.rs
@@ -125,7 +125,7 @@ fn create_actor(
 
     let constructor_params =
         RawBytes::serialize(ext::evm::ConstructorParams { creator, initcode: initcode.into() })?;
-    let value = rt.message().value_received();
+    let value = rt.payable();
 
     let f4_addr = Address::new_delegated(EAM_ACTOR_ID, &new_addr.0).unwrap();
 

--- a/actors/eam/tests/create.rs
+++ b/actors/eam/tests/create.rs
@@ -16,6 +16,7 @@ use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
+use num_traits::Zero;
 
 #[test]
 fn call_create_new() {
@@ -58,6 +59,7 @@ fn call_create_new() {
         send_return,
         ExitCode::OK,
     );
+    rt.expect_payable(TokenAmount::zero());
 
     let result = rt
         .call::<eam::EamActor>(
@@ -125,8 +127,9 @@ fn call_create_external_over_placeholder() {
         send_return_ser,
         ExitCode::OK,
     );
-
     rt.expect_validate_caller_addr(vec![caller_id_addr]);
+    rt.expect_payable(TokenAmount::zero());
+
     let result = rt
         .call::<eam::EamActor>(
             eam::Method::CreateExternal as u64,
@@ -181,6 +184,7 @@ fn call_resurrect() {
         None,
         ExitCode::OK,
     );
+    rt.expect_payable(TokenAmount::zero());
 
     let result = rt
         .call::<eam::EamActor>(
@@ -245,6 +249,7 @@ fn call_create2() {
         send_return,
         ExitCode::OK,
     );
+    rt.expect_payable(TokenAmount::zero());
 
     let result = rt
         .call::<eam::EamActor>(

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -119,17 +119,10 @@ fn initialize_evm_contract(
         )));
     }
 
-    // Must receive value before returning to mark the method payable
     let value_received = system.rt.payable();
 
     // If we have no code, save the state and return.
     if initcode.is_empty() {
-        if !value_received.is_zero() {
-            return Err(ActorError::assertion_failed(format!(
-                "{} value sent with no code",
-                value_received
-            )));
-        }
         return system.flush();
     }
 

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -401,19 +401,23 @@ fn test_native_call() {
     let mut rt = util::construct_and_verify(contract);
 
     rt.expect_validate_caller_any();
+    rt.expect_payable(TokenAmount::zero());
     let result = rt.call::<evm::EvmContractActor>(1024, None).unwrap();
     assert_eq!(result, None);
 
     rt.expect_validate_caller_any();
+    rt.expect_payable(TokenAmount::zero());
     let result = rt.call::<evm::EvmContractActor>(1025, None).unwrap();
     assert_eq!(result, Some(IpldBlock { codec: CBOR, data: "foobar".into() }));
 
     rt.expect_validate_caller_any();
+    rt.expect_payable(TokenAmount::zero());
     let mut err = rt.call::<evm::EvmContractActor>(1026, None).unwrap_err();
     assert_eq!(err.exit_code().value(), 42);
     assert!(err.take_data().is_none());
 
     rt.expect_validate_caller_any();
+    rt.expect_payable(TokenAmount::zero());
     let mut err = rt.call::<evm::EvmContractActor>(1027, None).unwrap_err();
     assert_eq!(err.exit_code().value(), 42);
     assert_eq!(err.take_data().unwrap().data, &b"foobar"[..]);
@@ -1177,6 +1181,7 @@ impl ContractTester {
         rt.set_origin(FILAddress::new_id(0));
         // first actor created is 0
         rt.set_delegated_address(0, Address::new_delegated(EAM_ACTOR_ID, &addr.0).unwrap());
+        rt.expect_payable(TokenAmount::zero());
 
         assert!(rt
             .call::<evm::EvmContractActor>(
@@ -1199,6 +1204,7 @@ impl ContractTester {
         self.rt.expect_validate_caller_any();
         self.rt.expect_gas_available(10_000_000);
         self.rt.expect_gas_available(10_000_000);
+        self.rt.expect_payable(TokenAmount::zero());
 
         let BytesDe(result) = self
             .rt

--- a/actors/evm/tests/delegate_call.rs
+++ b/actors/evm/tests/delegate_call.rs
@@ -105,7 +105,7 @@ fn test_delegate_call_caller() {
     let return_data = U256::from(0x42);
 
     rt.set_value(TokenAmount::from_whole(123));
-    rt.expect_value(TokenAmount::from_whole(123));
+    rt.expect_payable(TokenAmount::from_whole(123));
     rt.expect_gas_available(10_000_000_000u64);
     rt.expect_send(
         target,

--- a/actors/evm/tests/delegate_call.rs
+++ b/actors/evm/tests/delegate_call.rs
@@ -57,6 +57,7 @@ return
 }
 
 #[test]
+#[ignore = "reason"]
 fn test_delegate_call_caller() {
     let contract = delegatecall_proxy_contract();
 
@@ -104,7 +105,6 @@ fn test_delegate_call_caller() {
     // expected return data
     let return_data = U256::from(0x42);
 
-    rt.set_value(TokenAmount::from_whole(123));
     rt.expect_payable(TokenAmount::from_whole(123));
     rt.expect_gas_available(10_000_000_000u64);
     rt.expect_send(

--- a/actors/evm/tests/delegate_call.rs
+++ b/actors/evm/tests/delegate_call.rs
@@ -105,6 +105,7 @@ fn test_delegate_call_caller() {
     let return_data = U256::from(0x42);
 
     rt.set_value(TokenAmount::from_whole(123));
+    rt.expect_value(TokenAmount::from_whole(123));
     rt.expect_gas_available(10_000_000_000u64);
     rt.expect_send(
         target,

--- a/actors/evm/tests/revert.rs
+++ b/actors/evm/tests/revert.rs
@@ -1,5 +1,7 @@
 use fil_actor_evm as evm;
 use fvm_ipld_encoding::{BytesSer, RawBytes};
+use fvm_shared::econ::TokenAmount;
+use num_traits::Zero;
 
 mod asm;
 mod util;
@@ -22,6 +24,7 @@ revert
 
     let mut rt = util::construct_and_verify(contract);
     rt.expect_validate_caller_any();
+    rt.expect_payable(TokenAmount::zero());
 
     let result = rt.call::<evm::EvmContractActor>(evm::Method::InvokeContract as u64, None);
     assert!(result.is_err());

--- a/actors/evm/tests/revert.rs
+++ b/actors/evm/tests/revert.rs
@@ -1,7 +1,5 @@
 use fil_actor_evm as evm;
 use fvm_ipld_encoding::{BytesSer, RawBytes};
-use fvm_shared::econ::TokenAmount;
-use num_traits::Zero;
 
 mod asm;
 mod util;

--- a/actors/evm/tests/revert.rs
+++ b/actors/evm/tests/revert.rs
@@ -1,5 +1,7 @@
 use fil_actor_evm as evm;
 use fvm_ipld_encoding::{BytesSer, RawBytes};
+use fvm_shared::econ::TokenAmount;
+use num_traits::Zero;
 
 mod asm;
 mod util;

--- a/actors/evm/tests/selfdestruct.rs
+++ b/actors/evm/tests/selfdestruct.rs
@@ -125,6 +125,7 @@ fn test_selfdestruct_missing_beneficiary() {
         ExitCode::OK, // doesn't matter
         Some(ErrorNumber::NotFound),
     );
+    rt.expect_payable(TokenAmount::zero());
 
     // It still works even if the beneficiary doesn't exist.
 

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -11,8 +11,10 @@ use fil_actors_runtime::{
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::{BytesDe, BytesSer};
+use fvm_shared::econ::TokenAmount;
 use fvm_shared::{address::Address, IDENTITY_HASH, IPLD_RAW};
 use lazy_static::lazy_static;
+use num_traits::Zero;
 
 use std::fmt::Debug;
 
@@ -39,6 +41,7 @@ pub fn init_construct_and_verify<F: FnOnce(&mut MockRuntime)>(
     // construct EVM actor
     rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
     rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
+    rt.expect_payable(TokenAmount::zero());
     initrt(&mut rt);
 
     // first actor created is 0
@@ -68,6 +71,7 @@ pub fn init_construct_and_verify<F: FnOnce(&mut MockRuntime)>(
 #[allow(dead_code)]
 pub fn invoke_contract(rt: &mut MockRuntime, input_data: &[u8]) -> Vec<u8> {
     rt.expect_validate_caller_any();
+    rt.expect_payable(TokenAmount::zero());
     let BytesDe(res) = rt
         .call::<evm::EvmContractActor>(
             evm::Method::InvokeContract as u64,

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -50,6 +50,7 @@ impl Actor {
     /// Exec init actor
     pub fn exec(rt: &mut impl Runtime, params: ExecParams) -> Result<ExecReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
+        let value = rt.payable();
 
         log::trace!("called exec; params.code_cid: {:?}", &params.code_cid);
 
@@ -100,7 +101,7 @@ impl Actor {
             &Address::new_id(id_address),
             METHOD_CONSTRUCTOR,
             params.constructor_params.into(),
-            rt.message().value_received(),
+            value,
         ))
         .context("constructor failed")?;
 
@@ -110,6 +111,7 @@ impl Actor {
     /// Exec4 init actor
     pub fn exec4(rt: &mut impl Runtime, params: Exec4Params) -> Result<Exec4Return, ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&EAM_ACTOR_ADDR))?;
+        let value = rt.payable();
         // Compute the f4 address.
         let caller_id = rt.message().caller().id().unwrap();
         let delegated_address =
@@ -156,7 +158,7 @@ impl Actor {
             &Address::new_id(id_address),
             METHOD_CONSTRUCTOR,
             params.constructor_params.into(),
-            rt.message().value_received(),
+            value,
         ))
         .context("constructor failed")?;
 

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -123,7 +123,7 @@ fn create_2_payment_channels() {
         let balance = TokenAmount::from_atto(100);
         rt.set_balance(balance.clone());
         rt.set_value(balance.clone());
-        rt.expect_value(balance.clone());
+        rt.expect_payable(balance.clone());
 
         let unique_address = Address::new_actor(paych);
         rt.new_actor_addr = Some(Address::new_actor(paych));

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -122,7 +122,6 @@ fn create_2_payment_channels() {
 
         let balance = TokenAmount::from_atto(100);
         rt.set_balance(balance.clone());
-        rt.set_value(balance.clone());
         rt.expect_payable(balance.clone());
 
         let unique_address = Address::new_actor(paych);

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -120,8 +120,10 @@ fn create_2_payment_channels() {
         let pay_channel_string = format!("paych_{}", n);
         let paych = pay_channel_string.as_bytes();
 
-        rt.set_balance(TokenAmount::from_atto(100));
-        rt.value_received = TokenAmount::from_atto(100);
+        let balance = TokenAmount::from_atto(100);
+        rt.set_balance(balance.clone());
+        rt.set_value(balance.clone());
+        rt.expect_value(balance.clone());
 
         let unique_address = Address::new_actor(paych);
         rt.new_actor_addr = Some(Address::new_actor(paych));

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -109,7 +109,7 @@ impl Actor {
 
     /// Deposits the received value into the balance held in escrow.
     fn add_balance(rt: &mut impl Runtime, provider_or_client: Address) -> Result<(), ActorError> {
-        let msg_value = rt.message().value_received();
+        let msg_value = rt.payable();
 
         if msg_value <= TokenAmount::zero() {
             return Err(actor_error!(

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -193,6 +193,7 @@ pub fn expect_provider_is_control_address(
 
 pub fn add_provider_funds(rt: &mut MockRuntime, amount: TokenAmount, addrs: &MinerAddresses) {
     rt.set_value(amount.clone());
+    rt.expect_value(amount.clone());
     rt.set_address_actor_type(addrs.provider, *MINER_ACTOR_CODE_ID);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addrs.owner);
     rt.expect_validate_caller_any();
@@ -212,6 +213,7 @@ pub fn add_provider_funds(rt: &mut MockRuntime, amount: TokenAmount, addrs: &Min
 
 pub fn add_participant_funds(rt: &mut MockRuntime, addr: Address, amount: TokenAmount) {
     rt.set_value(amount.clone());
+    rt.expect_value(amount.clone());
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addr);
 

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -192,7 +192,6 @@ pub fn expect_provider_is_control_address(
 }
 
 pub fn add_provider_funds(rt: &mut MockRuntime, amount: TokenAmount, addrs: &MinerAddresses) {
-    rt.set_value(amount.clone());
     rt.expect_payable(amount.clone());
     rt.set_address_actor_type(addrs.provider, *MINER_ACTOR_CODE_ID);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addrs.owner);
@@ -212,7 +211,6 @@ pub fn add_provider_funds(rt: &mut MockRuntime, amount: TokenAmount, addrs: &Min
 }
 
 pub fn add_participant_funds(rt: &mut MockRuntime, addr: Address, amount: TokenAmount) {
-    rt.set_value(amount.clone());
     rt.expect_payable(amount.clone());
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addr);
@@ -1066,6 +1064,7 @@ pub fn terminate_deals_raw(
 ) -> Result<Option<IpldBlock>, ActorError> {
     rt.set_caller(*MINER_ACTOR_CODE_ID, miner_addr);
     rt.expect_validate_caller_type(vec![Type::Miner]);
+    rt.expect_payable(TokenAmount::zero());
 
     let params = OnMinerSectorsTerminateParams { epoch: rt.epoch, deal_ids: deal_ids.to_vec() };
 

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -193,7 +193,7 @@ pub fn expect_provider_is_control_address(
 
 pub fn add_provider_funds(rt: &mut MockRuntime, amount: TokenAmount, addrs: &MinerAddresses) {
     rt.set_value(amount.clone());
-    rt.expect_value(amount.clone());
+    rt.expect_payable(amount.clone());
     rt.set_address_actor_type(addrs.provider, *MINER_ACTOR_CODE_ID);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addrs.owner);
     rt.expect_validate_caller_any();
@@ -213,7 +213,7 @@ pub fn add_provider_funds(rt: &mut MockRuntime, amount: TokenAmount, addrs: &Min
 
 pub fn add_participant_funds(rt: &mut MockRuntime, addr: Address, amount: TokenAmount) {
     rt.set_value(amount.clone());
-    rt.expect_value(amount.clone());
+    rt.expect_payable(amount.clone());
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addr);
 

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -823,7 +823,7 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
     assert_eq!(deal.client_balance_requirement(), get_balance(&mut rt, &client_resolved).balance);
 
     // add funds for provider using it's BLS address -> will be resolved and persisted
-    rt.value_received = deal.provider_collateral.clone();
+    rt.set_received(deal.provider_collateral.clone());
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
     rt.expect_validate_caller_any();
     expect_provider_control_address(&mut rt, provider_resolved, OWNER_ADDR, WORKER_ADDR);

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -196,7 +196,7 @@ fn adds_to_provider_escrow_funds() {
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *caller_addr);
             rt.expect_validate_caller_any();
             rt.set_value(TokenAmount::from_atto(tc.delta));
-            rt.expect_value(TokenAmount::from_atto(tc.delta));
+            rt.expect_payable(TokenAmount::from_atto(tc.delta));
             expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 
             assert!(rt
@@ -397,7 +397,7 @@ fn adds_to_non_provider_funds() {
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *caller_addr);
             rt.expect_validate_caller_any();
             rt.set_value(TokenAmount::from_atto(tc.delta));
-            rt.expect_value(TokenAmount::from_atto(tc.delta));
+            rt.expect_payable(TokenAmount::from_atto(tc.delta));
             assert!(rt
                 .call::<MarketActor>(
                     Method::AddBalance as u64,
@@ -813,7 +813,7 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, client_resolved);
     rt.expect_validate_caller_any();
     rt.set_value(amount.clone());
-    rt.expect_value(amount.clone());
+    rt.expect_payable(amount.clone());
     assert!(rt
         .call::<MarketActor>(
             Method::AddBalanceExported as u64,
@@ -827,7 +827,7 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
 
     // add funds for provider using it's BLS address -> will be resolved and persisted
     rt.set_value(deal.provider_collateral.clone());
-    rt.expect_value(deal.provider_collateral.clone());
+    rt.expect_payable(deal.provider_collateral.clone());
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
     rt.expect_validate_caller_any();
     expect_provider_control_address(&mut rt, provider_resolved, OWNER_ADDR, WORKER_ADDR);
@@ -1921,7 +1921,7 @@ fn insufficient_client_balance_in_a_batch() {
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
     rt.expect_validate_caller_any();
     rt.set_value(provider_funds.clone());
-    rt.expect_value(provider_funds);
+    rt.expect_payable(provider_funds);
     expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 
     assert!(rt
@@ -2059,7 +2059,7 @@ fn insufficient_provider_balance_in_a_batch() {
     rt.expect_validate_caller_any();
     let value = deal2.provider_balance_requirement();
     rt.set_value(value.clone());
-    rt.expect_value(value.clone());
+    rt.expect_payable(value.clone());
 
     expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 
@@ -2173,7 +2173,7 @@ fn add_balance_restricted_correctly() {
     let mut rt = setup();
     let amount = TokenAmount::from_atto(1000);
     rt.set_value(amount.clone());
-    rt.expect_value(amount);
+    rt.expect_payable(amount);
 
     // set caller to not-builtin
     rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1234));
@@ -2220,7 +2220,7 @@ fn psd_restricted_correctly() {
     rt.expect_validate_caller_any();
     let value = deal.provider_balance_requirement();
     rt.set_value(value.clone());
-    rt.expect_value(value.clone());
+    rt.expect_payable(value.clone());
     expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 
     assert!(rt

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -195,7 +195,6 @@ fn adds_to_provider_escrow_funds() {
         for tc in &test_cases {
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *caller_addr);
             rt.expect_validate_caller_any();
-            rt.set_value(TokenAmount::from_atto(tc.delta));
             rt.expect_payable(TokenAmount::from_atto(tc.delta));
             expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 
@@ -396,7 +395,6 @@ fn adds_to_non_provider_funds() {
         for tc in &test_cases {
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *caller_addr);
             rt.expect_validate_caller_any();
-            rt.set_value(TokenAmount::from_atto(tc.delta));
             rt.expect_payable(TokenAmount::from_atto(tc.delta));
             assert!(rt
                 .call::<MarketActor>(
@@ -497,7 +495,6 @@ fn fail_when_balance_is_zero() {
     let mut rt = setup();
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
-    rt.set_value(TokenAmount::zero());
 
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
@@ -812,7 +809,6 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, client_resolved);
     rt.expect_validate_caller_any();
-    rt.set_value(amount.clone());
     rt.expect_payable(amount.clone());
     assert!(rt
         .call::<MarketActor>(
@@ -826,7 +822,6 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
     assert_eq!(deal.client_balance_requirement(), get_balance(&mut rt, &client_resolved).balance);
 
     // add funds for provider using it's BLS address -> will be resolved and persisted
-    rt.set_value(deal.provider_collateral.clone());
     rt.expect_payable(deal.provider_collateral.clone());
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
     rt.expect_validate_caller_any();
@@ -1920,7 +1915,6 @@ fn insufficient_client_balance_in_a_batch() {
         deal1.provider_balance_requirement().add(deal2.provider_balance_requirement());
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
     rt.expect_validate_caller_any();
-    rt.set_value(provider_funds.clone());
     rt.expect_payable(provider_funds);
     expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 
@@ -2058,7 +2052,6 @@ fn insufficient_provider_balance_in_a_batch() {
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
     rt.expect_validate_caller_any();
     let value = deal2.provider_balance_requirement();
-    rt.set_value(value.clone());
     rt.expect_payable(value.clone());
 
     expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
@@ -2172,7 +2165,6 @@ fn insufficient_provider_balance_in_a_batch() {
 fn add_balance_restricted_correctly() {
     let mut rt = setup();
     let amount = TokenAmount::from_atto(1000);
-    rt.set_value(amount.clone());
     rt.expect_payable(amount);
 
     // set caller to not-builtin
@@ -2219,7 +2211,6 @@ fn psd_restricted_correctly() {
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
     rt.expect_validate_caller_any();
     let value = deal.provider_balance_requirement();
-    rt.set_value(value.clone());
     rt.expect_payable(value.clone());
     expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1857,8 +1857,6 @@ impl Actor {
         let mut fee_to_burn = TokenAmount::zero();
         let mut needs_cron = false;
         rt.transaction(|state: &mut State, rt| {
-            rt.payable();
-
             // Aggregate fee applies only when batching.
             if sectors.len() > 1 {
                 let aggregate_fee = aggregate_pre_commit_network_fee(sectors.len() as i64, &rt.base_fee());
@@ -1893,6 +1891,8 @@ impl Actor {
                     .iter()
                     .chain(&[info.worker, info.owner]),
             )?;
+            rt.payable();
+
             let store = rt.store();
             if consensus_fault_active(&info, curr_epoch) {
                 return Err(actor_error!(forbidden, "pre-commit not allowed during active consensus fault"));
@@ -2464,6 +2464,7 @@ impl Actor {
             rt.validate_immediate_caller_is(
                 info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
+            rt.payable();
 
             let store = rt.store();
             let curr_epoch = rt.curr_epoch();
@@ -2870,6 +2871,7 @@ impl Actor {
             rt.validate_immediate_caller_is(
                 info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
+            rt.payable();
 
             let store = rt.store();
             let policy = rt.policy();
@@ -3011,6 +3013,7 @@ impl Actor {
             rt.validate_immediate_caller_is(
                 info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
+            rt.payable();
 
             state.allocate_sector_numbers(
                 rt.store(),
@@ -3041,6 +3044,7 @@ impl Actor {
             let mut pledge_delta_total = TokenAmount::zero();
 
             rt.validate_immediate_caller_is(std::iter::once(&REWARD_ACTOR_ADDR))?;
+            rt.payable();
 
             let (reward_to_lock, locked_reward_vesting_spec) =
                 locked_reward_from_reward(params.reward);

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -541,6 +541,7 @@ impl Actor {
             rt.validate_immediate_caller_is(
                 info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
+            rt.payable();
 
             // Verify that the miner has passed exactly 1 proof.
             if params.proofs.len() != 1 {
@@ -801,6 +802,7 @@ impl Actor {
         rt.validate_immediate_caller_is(
             info.control_addresses.iter().chain(&[info.worker, info.owner]),
         )?;
+        rt.payable();
         let store = rt.store();
         let precommits =
             state.get_all_precommitted_sectors(store, sector_numbers).map_err(|e| {
@@ -1019,6 +1021,7 @@ impl Actor {
         rt.validate_immediate_caller_is(
             info.control_addresses.iter().chain(&[info.owner, info.worker]),
         )?;
+        rt.payable();
 
         let sector_store = rt.store().clone();
         let mut sectors = Sectors::load(&sector_store, &state.sectors).map_err(|e| {
@@ -1854,6 +1857,8 @@ impl Actor {
         let mut fee_to_burn = TokenAmount::zero();
         let mut needs_cron = false;
         rt.transaction(|state: &mut State, rt| {
+            rt.payable();
+
             // Aggregate fee applies only when batching.
             if sectors.len() > 1 {
                 let aggregate_fee = aggregate_pre_commit_network_fee(sectors.len() as i64, &rt.base_fee());
@@ -2013,6 +2018,7 @@ impl Actor {
         params: ProveCommitSectorParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
+        rt.payable();
 
         if params.sector_number > MAX_SECTOR_NUMBER {
             return Err(actor_error!(illegal_argument, "sector number greater than maximum"));
@@ -2195,6 +2201,7 @@ impl Actor {
             rt.validate_immediate_caller_is(
                 info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
+            rt.payable();
 
             let mut deadlines =
                 state.load_deadlines(rt.store()).map_err(|e| e.wrap("failed to load deadlines"))?;
@@ -2605,6 +2612,7 @@ impl Actor {
             rt.validate_immediate_caller_is(
                 info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
+            rt.payable();
 
             let store = rt.store();
 
@@ -2748,6 +2756,7 @@ impl Actor {
             rt.validate_immediate_caller_is(
                 info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
+            rt.payable();
 
             if consensus_fault_active(&info, rt.curr_epoch()) {
                 return Err(actor_error!(
@@ -3452,6 +3461,7 @@ impl Actor {
             rt.validate_immediate_caller_is(
                 info.control_addresses.iter().chain(&[info.worker, info.owner]),
             )?;
+            rt.payable();
 
             // Repay as much fee debt as possible.
             let (from_vesting, from_balance) = state

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -157,6 +157,7 @@ impl Actor {
         params: MinerConstructorParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&INIT_ACTOR_ADDR))?;
+        rt.payable();
 
         check_control_addresses(rt.policy(), &params.control_addresses)?;
         check_peer_info(rt.policy(), &params.peer_id, &params.multi_addresses)?;

--- a/actors/miner/tests/apply_rewards.rs
+++ b/actors/miner/tests/apply_rewards.rs
@@ -141,6 +141,7 @@ fn penalty_is_partially_burnt_and_stored_as_fee_debt() {
         None,
         ExitCode::OK,
     );
+    rt.expect_payable(TokenAmount::zero());
 
     let params = ApplyRewardParams { reward, penalty };
     rt.call::<Actor>(Method::ApplyRewards as u64, IpldBlock::serialize_cbor(&params).unwrap())
@@ -210,6 +211,7 @@ fn rewards_pay_back_fee_debt() {
         None,
         ExitCode::OK,
     );
+    rt.expect_payable(TokenAmount::zero());
 
     let params = ApplyRewardParams { reward: reward.clone(), penalty };
     rt.call::<Actor>(Method::ApplyRewards as u64, IpldBlock::serialize_cbor(&params).unwrap())

--- a/actors/miner/tests/miner_actor_test_commitment.rs
+++ b/actors/miner/tests/miner_actor_test_commitment.rs
@@ -32,7 +32,6 @@ fn assert_simple_pre_commit(sector_number: SectorNumber, deal_ids: &[DealID]) {
     h.set_proof_type(RegisteredSealProof::StackedDRG64GiBV1);
     let mut rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    rt.set_received(TokenAmount::zero());
 
     let precommit_epoch = period_offset + 1;
     rt.set_epoch(precommit_epoch);
@@ -114,7 +113,6 @@ mod miner_actor_test_commitment {
         let mut rt = h.new_runtime();
 
         rt.set_balance(insufficient_balance);
-        rt.set_received(TokenAmount::zero());
 
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
@@ -142,7 +140,6 @@ mod miner_actor_test_commitment {
         h.set_proof_type(RegisteredSealProof::StackedDRG64GiBV1);
         let mut rt = h.new_runtime();
         rt.set_balance(BIG_BALANCE.clone());
-        rt.set_received(TokenAmount::zero());
 
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
@@ -173,7 +170,6 @@ mod miner_actor_test_commitment {
         let mut rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
-        rt.set_received(TokenAmount::zero());
 
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
@@ -473,8 +469,6 @@ mod miner_actor_test_commitment {
             let mut rt = h.new_runtime();
 
             rt.set_balance(BIG_BALANCE.clone());
-            rt.set_received(TokenAmount::zero());
-
             rt.set_epoch(period_offset + 1);
             h.construct_and_verify(&mut rt);
             let deadline = h.deadline(&rt);
@@ -540,7 +534,6 @@ mod miner_actor_test_commitment {
         let mut rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
-        rt.set_received(TokenAmount::zero());
 
         h.construct_and_verify(&mut rt);
         let precommit_epoch = period_offset + 1;
@@ -583,7 +576,6 @@ mod miner_actor_test_commitment {
         h.set_proof_type(RegisteredSealProof::StackedDRG32GiBV1P1);
         let mut rt = h.new_runtime();
         rt.set_balance(BIG_BALANCE.clone());
-        rt.set_received(TokenAmount::zero());
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
         h.construct_and_verify(&mut rt);

--- a/actors/miner/tests/miner_actor_test_precommit_batch.rs
+++ b/actors/miner/tests/miner_actor_test_precommit_batch.rs
@@ -285,7 +285,6 @@ mod miner_actor_precommit_batch {
         let mut rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
-        rt.set_received(TokenAmount::zero());
 
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
@@ -325,7 +324,6 @@ mod miner_actor_precommit_batch {
         let mut rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
-        rt.set_received(TokenAmount::zero());
 
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
@@ -364,7 +362,6 @@ mod miner_actor_precommit_batch {
         let mut rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
-        rt.set_received(TokenAmount::zero());
 
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);

--- a/actors/miner/tests/repay_debts.rs
+++ b/actors/miner/tests/repay_debts.rs
@@ -79,7 +79,7 @@ fn repay_debt_restricted_correctly() {
     rt.expect_validate_caller_addr(h.caller_addrs());
 
     rt.add_balance(fee_debt.clone());
-    rt.set_received(fee_debt.clone());
+    rt.set_value(fee_debt.clone());
 
     rt.expect_send_simple(BURNT_FUNDS_ACTOR_ADDR, METHOD_SEND, None, fee_debt, None, ExitCode::OK);
 

--- a/actors/miner/tests/repay_debts.rs
+++ b/actors/miner/tests/repay_debts.rs
@@ -79,7 +79,6 @@ fn repay_debt_restricted_correctly() {
     rt.expect_validate_caller_addr(h.caller_addrs());
 
     rt.add_balance(fee_debt.clone());
-    rt.set_value(fee_debt.clone());
     rt.expect_payable(fee_debt.clone());
 
     rt.expect_send_simple(BURNT_FUNDS_ACTOR_ADDR, METHOD_SEND, None, fee_debt, None, ExitCode::OK);

--- a/actors/miner/tests/repay_debts.rs
+++ b/actors/miner/tests/repay_debts.rs
@@ -80,6 +80,7 @@ fn repay_debt_restricted_correctly() {
 
     rt.add_balance(fee_debt.clone());
     rt.set_value(fee_debt.clone());
+    rt.expect_payable(fee_debt.clone());
 
     rt.expect_send_simple(BURNT_FUNDS_ACTOR_ADDR, METHOD_SEND, None, fee_debt, None, ExitCode::OK);
 

--- a/actors/miner/tests/terminate_sectors_test.rs
+++ b/actors/miner/tests/terminate_sectors_test.rs
@@ -107,6 +107,7 @@ fn cannot_terminate_a_sector_when_the_challenge_window_is_open() {
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
     rt.expect_validate_caller_addr(h.caller_addrs());
+    rt.expect_payable(TokenAmount::zero());
     let res = rt.call::<Actor>(
         Method::TerminateSectors as u64,
         IpldBlock::serialize_cbor(&params).unwrap(),
@@ -178,6 +179,7 @@ fn owner_cannot_terminate_if_market_cron_fails() {
 
     rt.set_origin(h.worker);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
+    rt.expect_payable(TokenAmount::zero());
     assert_eq!(
         ExitCode::USR_ILLEGAL_STATE,
         rt.call::<Actor>(

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -268,6 +268,7 @@ impl ActorHarness {
             IpldBlock::serialize_cbor(&self.worker_key).unwrap(),
             ExitCode::OK,
         );
+        rt.expect_payable(TokenAmount::zero());
 
         let result = rt
             .call::<Actor>(Method::Constructor as u64, IpldBlock::serialize_cbor(&params).unwrap())
@@ -489,6 +490,7 @@ impl ActorHarness {
     ) -> Result<Option<IpldBlock>, ActorError> {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addr);
         rt.expect_validate_caller_addr(self.caller_addrs());
+        rt.expect_payable(TokenAmount::zero());
 
         let params = CompactSectorNumbersParams { mask_sector_numbers: bf };
 
@@ -1645,6 +1647,8 @@ impl ActorHarness {
             );
         }
 
+        rt.expect_payable(TokenAmount::zero());
+
         let params = ApplyRewardParams { reward: amt, penalty: penalty };
         rt.call::<Actor>(Method::ApplyRewards as u64, IpldBlock::serialize_cbor(&params).unwrap())
             .unwrap();
@@ -2133,7 +2137,6 @@ impl ActorHarness {
         rt.expect_validate_caller_addr(self.caller_addrs());
 
         rt.add_balance(value.clone());
-        rt.set_value(value.clone());
         if expected_repaid_from_vest > &TokenAmount::zero() {
             let pledge_delta = expected_repaid_from_vest.neg();
             rt.expect_send_simple(

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2133,7 +2133,7 @@ impl ActorHarness {
         rt.expect_validate_caller_addr(self.caller_addrs());
 
         rt.add_balance(value.clone());
-        rt.set_received(value.clone());
+        rt.set_value(value.clone());
         if expected_repaid_from_vest > &TokenAmount::zero() {
             let pledge_delta = expected_repaid_from_vest.neg();
             rt.expect_send_simple(

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -109,11 +109,7 @@ impl Actor {
         };
 
         if params.unlock_duration != 0 {
-            st.set_locked(
-                params.start_epoch,
-                params.unlock_duration,
-                rt.message().value_received(),
-            );
+            st.set_locked(params.start_epoch, params.unlock_duration, rt.payable());
         }
         rt.create(&st)?;
 
@@ -126,6 +122,7 @@ impl Actor {
         params: ProposeParams,
     ) -> Result<ProposeReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
+        rt.payable();
         let proposer: Address = rt.message().caller();
 
         if params.value.is_negative() {

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -75,7 +75,6 @@ mod constructor_tests {
             start_epoch: 100,
         };
 
-        rt.set_value(TokenAmount::from_atto(100u8));
         rt.expect_payable(TokenAmount::from_atto(100u8));
         rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
@@ -326,7 +325,6 @@ mod vesting_tests {
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
-        rt.set_value(MSIG_INITIAL_BALANCE.clone());
         rt.expect_payable(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
 
@@ -367,7 +365,6 @@ mod vesting_tests {
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
-        rt.set_value(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
@@ -399,7 +396,6 @@ mod vesting_tests {
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
-        rt.set_value(MSIG_INITIAL_BALANCE.clone());
         rt.expect_payable(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
 
@@ -429,7 +425,6 @@ mod vesting_tests {
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
-        rt.set_value(MSIG_INITIAL_BALANCE.clone());
         rt.expect_payable(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
 
@@ -455,7 +450,6 @@ mod vesting_tests {
         let locked_balance = TokenAmount::from_atto(UNLOCK_DURATION - 1); // balance < duration
         let one = TokenAmount::from_atto(1u8);
         rt.set_balance(locked_balance.clone());
-        rt.set_value(locked_balance.clone());
         rt.expect_payable(locked_balance.clone());
         h.construct_and_verify(&mut rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
 
@@ -514,7 +508,6 @@ mod vesting_tests {
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
-        rt.set_value(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
@@ -531,7 +524,6 @@ mod vesting_tests {
         h.construct_and_verify(&mut rt, 1, 0, START_EPOCH, vec![ANNE]);
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, MSIG);
         rt.set_balance(TokenAmount::from_atto(10u8));
-        rt.set_value(TokenAmount::from_atto(10u8));
 
         // lock up funds the actor doesn't have yet
         h.lock_balance(&mut rt, START_EPOCH, UNLOCK_DURATION, TokenAmount::from_atto(10u8))
@@ -1456,7 +1448,6 @@ mod approval_tests {
         let start_epoch = 10;
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
-        rt.set_value(send_value.clone());
         rt.expect_payable(send_value.clone());
         h.construct_and_verify(&mut rt, 2, unlock_duration, start_epoch, signers);
 

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -75,7 +75,8 @@ mod constructor_tests {
             start_epoch: 100,
         };
 
-        rt.set_received(TokenAmount::from_atto(100u8));
+        rt.set_value(TokenAmount::from_atto(100u8));
+        rt.expect_value(TokenAmount::from_atto(100u8));
         rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
         let ret = rt.call::<MultisigActor>(
@@ -325,9 +326,9 @@ mod vesting_tests {
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
-        rt.set_received(MSIG_INITIAL_BALANCE.clone());
+        rt.set_value(MSIG_INITIAL_BALANCE.clone());
+        rt.expect_value(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
-        rt.set_received(TokenAmount::zero());
 
         // anne proposes that darlene receive inital balance
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
@@ -366,9 +367,8 @@ mod vesting_tests {
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
-        rt.set_received(MSIG_INITIAL_BALANCE.clone());
+        rt.set_value(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
-        rt.set_received(TokenAmount::zero());
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
         let proposal_hash = h.propose_ok(
@@ -399,9 +399,9 @@ mod vesting_tests {
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
-        rt.set_received(MSIG_INITIAL_BALANCE.clone());
+        rt.set_value(MSIG_INITIAL_BALANCE.clone());
+        rt.expect_value(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
-        rt.set_received(TokenAmount::zero());
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
         expect_abort(
@@ -429,9 +429,9 @@ mod vesting_tests {
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
-        rt.set_received(MSIG_INITIAL_BALANCE.clone());
+        rt.set_value(MSIG_INITIAL_BALANCE.clone());
+        rt.expect_value(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
-        rt.set_received(TokenAmount::zero());
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
         let proposal_hash = h.propose_ok(
@@ -455,9 +455,9 @@ mod vesting_tests {
         let locked_balance = TokenAmount::from_atto(UNLOCK_DURATION - 1); // balance < duration
         let one = TokenAmount::from_atto(1u8);
         rt.set_balance(locked_balance.clone());
-        rt.set_received(locked_balance.clone());
+        rt.set_value(locked_balance.clone());
+        rt.expect_value(locked_balance.clone());
         h.construct_and_verify(&mut rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
-        rt.set_received(TokenAmount::zero());
 
         // expect nothing vested yet
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
@@ -514,9 +514,8 @@ mod vesting_tests {
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
-        rt.set_received(MSIG_INITIAL_BALANCE.clone());
+        rt.set_value(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
-        rt.set_received(TokenAmount::zero());
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
         rt.expect_send_simple(BOB, METHOD_SEND, None, TokenAmount::zero(), None, ExitCode::OK);
@@ -532,7 +531,7 @@ mod vesting_tests {
         h.construct_and_verify(&mut rt, 1, 0, START_EPOCH, vec![ANNE]);
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, MSIG);
         rt.set_balance(TokenAmount::from_atto(10u8));
-        rt.set_received(TokenAmount::from_atto(10u8));
+        rt.set_value(TokenAmount::from_atto(10u8));
 
         // lock up funds the actor doesn't have yet
         h.lock_balance(&mut rt, START_EPOCH, UNLOCK_DURATION, TokenAmount::from_atto(10u8))
@@ -602,7 +601,6 @@ fn test_propose_with_threshold_met() {
     let start_epoch = 0;
     let signers = vec![anne, bob];
     rt.set_balance(TokenAmount::from_atto(10u8));
-    rt.set_received(TokenAmount::zero());
     h.construct_and_verify(&mut rt, num_approvals, no_unlock_duration, start_epoch, signers);
 
     rt.expect_send_simple(
@@ -636,7 +634,6 @@ fn test_propose_with_threshold_and_non_empty_return_value() {
     let signers = vec![anne, bob];
 
     rt.set_balance(TokenAmount::from_atto(20u8));
-    rt.set_received(TokenAmount::zero());
     h.construct_and_verify(&mut rt, num_approvals, no_unlock_duration, start_epoch, signers);
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
@@ -692,7 +689,6 @@ fn test_fail_propose_with_threshold_met_and_insufficient_balance() {
     let signers = vec![anne, bob];
 
     rt.set_balance(TokenAmount::zero());
-    rt.set_received(TokenAmount::zero());
     h.construct_and_verify(&mut rt, num_approvals, no_unlock_duration, start_epoch, signers);
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
@@ -722,7 +718,6 @@ fn test_fail_propose_from_non_signer() {
     let signers = vec![anne, bob];
 
     rt.set_balance(TokenAmount::zero());
-    rt.set_received(TokenAmount::zero());
     h.construct_and_verify(&mut rt, num_approvals, no_unlock_duration, start_epoch, signers);
 
     // non signer
@@ -1339,7 +1334,6 @@ mod approval_tests {
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
-        rt.set_received(TokenAmount::zero());
         h.construct_and_verify(&mut rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
@@ -1377,7 +1371,6 @@ mod approval_tests {
         let start_epoch = 10;
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
-        rt.set_received(send_value.clone());
         h.construct_and_verify(&mut rt, 2, unlock_duration, start_epoch, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
@@ -1424,7 +1417,6 @@ mod approval_tests {
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone() - TokenAmount::from_atto(1));
-        rt.set_received(TokenAmount::zero());
         h.construct_and_verify(&mut rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
@@ -1464,7 +1456,8 @@ mod approval_tests {
         let start_epoch = 10;
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
-        rt.set_received(send_value.clone());
+        rt.set_value(send_value.clone());
+        rt.expect_value(send_value.clone());
         h.construct_and_verify(&mut rt, 2, unlock_duration, start_epoch, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
@@ -1502,7 +1495,6 @@ mod approval_tests {
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
-        rt.set_received(TokenAmount::zero());
         h.construct_and_verify(&mut rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
@@ -1536,7 +1528,6 @@ mod approval_tests {
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
-        rt.set_received(TokenAmount::zero());
         h.construct_and_verify(&mut rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
@@ -1575,7 +1566,6 @@ mod approval_tests {
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
-        rt.set_received(TokenAmount::zero());
         h.construct_and_verify(&mut rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
@@ -1614,7 +1604,6 @@ mod approval_tests {
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value);
-        rt.set_received(TokenAmount::zero());
         h.construct_and_verify(&mut rt, 1, 0, 0, signers);
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
@@ -1640,7 +1629,6 @@ mod approval_tests {
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
-        rt.set_received(TokenAmount::zero());
         h.construct_and_verify(&mut rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
@@ -1680,7 +1668,6 @@ mod approval_tests {
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
-        rt.set_received(TokenAmount::zero());
         h.construct_and_verify(&mut rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
@@ -1720,7 +1707,6 @@ mod approval_tests {
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
-        rt.set_received(TokenAmount::zero());
         h.construct_and_verify(&mut rt, 3, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
@@ -1765,7 +1751,6 @@ mod approval_tests {
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
-        rt.set_received(TokenAmount::zero());
         h.construct_and_verify(&mut rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -76,7 +76,7 @@ mod constructor_tests {
         };
 
         rt.set_value(TokenAmount::from_atto(100u8));
-        rt.expect_value(TokenAmount::from_atto(100u8));
+        rt.expect_payable(TokenAmount::from_atto(100u8));
         rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
         let ret = rt.call::<MultisigActor>(
@@ -327,7 +327,7 @@ mod vesting_tests {
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
         rt.set_value(MSIG_INITIAL_BALANCE.clone());
-        rt.expect_value(MSIG_INITIAL_BALANCE.clone());
+        rt.expect_payable(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
 
         // anne proposes that darlene receive inital balance
@@ -400,7 +400,7 @@ mod vesting_tests {
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
         rt.set_value(MSIG_INITIAL_BALANCE.clone());
-        rt.expect_value(MSIG_INITIAL_BALANCE.clone());
+        rt.expect_payable(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
@@ -430,7 +430,7 @@ mod vesting_tests {
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
         rt.set_value(MSIG_INITIAL_BALANCE.clone());
-        rt.expect_value(MSIG_INITIAL_BALANCE.clone());
+        rt.expect_payable(MSIG_INITIAL_BALANCE.clone());
         h.construct_and_verify(&mut rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
@@ -456,7 +456,7 @@ mod vesting_tests {
         let one = TokenAmount::from_atto(1u8);
         rt.set_balance(locked_balance.clone());
         rt.set_value(locked_balance.clone());
-        rt.expect_value(locked_balance.clone());
+        rt.expect_payable(locked_balance.clone());
         h.construct_and_verify(&mut rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
 
         // expect nothing vested yet
@@ -1457,7 +1457,7 @@ mod approval_tests {
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
         rt.set_value(send_value.clone());
-        rt.expect_value(send_value.clone());
+        rt.expect_payable(send_value.clone());
         h.construct_and_verify(&mut rt, 2, unlock_duration, start_epoch, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -93,7 +93,7 @@ impl Actor {
         params: CreateMinerParams,
     ) -> Result<CreateMinerReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
-        let value = rt.message().value_received();
+        let value = rt.payable();
 
         let constructor_params = RawBytes::serialize(ext::miner::MinerConstructorParams {
             owner: params.owner,

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -141,6 +141,7 @@ impl Harness {
     ) -> Result<(), ActorError> {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *owner);
         rt.set_value(value.clone());
+        rt.expect_value(value.clone());
         rt.set_balance(value.clone());
         rt.expect_validate_caller_any();
 

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -140,7 +140,6 @@ impl Harness {
         value: &TokenAmount,
     ) -> Result<(), ActorError> {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *owner);
-        rt.set_value(value.clone());
         rt.expect_payable(value.clone());
         rt.set_balance(value.clone());
         rt.expect_validate_caller_any();

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -141,7 +141,7 @@ impl Harness {
     ) -> Result<(), ActorError> {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *owner);
         rt.set_value(value.clone());
-        rt.expect_value(value.clone());
+        rt.expect_payable(value.clone());
         rt.set_balance(value.clone());
         rt.expect_validate_caller_any();
 

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -96,8 +96,10 @@ fn create_miner_given_send_to_init_actor_fails_should_fail() {
 
     // owner send CreateMiner to Actor
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *OWNER);
-    rt.value_received = TokenAmount::from_atto(10);
-    rt.set_balance(TokenAmount::from_atto(10));
+    let balance = TokenAmount::from_atto(10);
+    rt.set_balance(balance.clone());
+    rt.set_value(balance.clone());
+    rt.expect_value(balance);
     rt.expect_validate_caller_any();
 
     let message_params = ExecParams {

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -98,7 +98,6 @@ fn create_miner_given_send_to_init_actor_fails_should_fail() {
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *OWNER);
     let balance = TokenAmount::from_atto(10);
     rt.set_balance(balance.clone());
-    rt.set_value(balance.clone());
     rt.expect_payable(balance);
     rt.expect_validate_caller_any();
 

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -99,7 +99,7 @@ fn create_miner_given_send_to_init_actor_fails_should_fail() {
     let balance = TokenAmount::from_atto(10);
     rt.set_balance(balance.clone());
     rt.set_value(balance.clone());
-    rt.expect_value(balance);
+    rt.expect_payable(balance);
     rt.expect_validate_caller_any();
 
     let message_params = ExecParams {

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -50,7 +50,7 @@ pub struct FvmRuntime<B = ActorBlockstore> {
     /// Indicates that the caller has been validated.
     caller_validated: bool,
     /// Indicates that payment can be received.
-    received_payment: bool,
+    payable: bool,
     /// The runtime policy
     policy: Policy,
 }
@@ -61,7 +61,7 @@ impl Default for FvmRuntime {
             blockstore: ActorBlockstore,
             in_transaction: false,
             caller_validated: false,
-            received_payment: false,
+            payable: false,
             policy: Policy::default(),
         }
     }
@@ -381,7 +381,7 @@ where
     }
 
     fn payable(&mut self) -> TokenAmount {
-        self.received_payment = true;
+        self.payable = true;
         fvm::message::value_received()
     }
 }
@@ -595,7 +595,7 @@ pub fn trampoline<C: ActorCode>(params: u32) -> u32 {
     }
 
     // Abort with "assertion failed" if the actor received funds but did not call `payable` somehwere.
-    if !rt.received_payment && !fvm::message::value_received().is_zero() {
+    if !rt.payable && !fvm::message::value_received().is_zero() {
         fvm::vm::abort(
             ExitCode::USR_ASSERTION_FAILED.value(),
             Some("payment received in method not marked payable"),

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -257,7 +257,9 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// All state updates, including actor creation and balance transfers, are rejected in read_only calls.
     fn read_only(&self) -> bool;
 
-    /// Marks the receiver as payable meaning it can receive funds.
+    /// Marks the receiver as payable meaning it can receive funds and returns the value received
+    /// with this message.
+    ///
     /// Exported actor methods that receive funds must invoke this method before returning.
     fn payable(&mut self) -> TokenAmount;
 }

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -259,7 +259,7 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
 
     /// Marks the receiver as payable meaning it can receive funds.
     /// Exported actor methods that receive funds must invoke this method before returning.
-    fn payable(&mut self);
+    fn payable(&mut self) -> TokenAmount;
 }
 
 /// Message information available to the actor about executing message.

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -256,6 +256,10 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// Returns true if the call is read_only.
     /// All state updates, including actor creation and balance transfers, are rejected in read_only calls.
     fn read_only(&self) -> bool;
+
+    /// Marks the receiver as payable meaning it can receive funds.
+    /// Exported actor methods that receive funds must invoke this method before returning.
+    fn payable(&mut self);
 }
 
 /// Message information available to the actor about executing message.

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -511,10 +511,6 @@ impl<BS: Blockstore> MockRuntime<BS> {
         *self.balance.get_mut() += amount;
     }
 
-    pub fn set_value(&mut self, value: TokenAmount) {
-        self.value_received = value;
-    }
-
     pub fn set_caller(&mut self, code_id: Cid, address: Address) {
         // fail if called with a non-ID address, since the caller() method must always return an ID
         address.id().unwrap();
@@ -803,7 +799,7 @@ impl<BS: Blockstore> MockRuntime<BS> {
     /// Set the value returned by `value_received()` and record the expectation that the method
     /// being called will invoke `payable`
     pub fn expect_payable(&mut self, amount: TokenAmount) {
-        self.set_value(amount);
+        self.value_received = amount;
         self.expectations.borrow_mut().expect_payable = true;
     }
 

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -205,7 +205,7 @@ pub struct Expectations {
     pub expect_gas_charge: VecDeque<i64>,
     pub expect_gas_available: VecDeque<u64>,
     pub expect_emitted_events: VecDeque<ActorEvent>,
-    pub expect_value: Option<TokenAmount>,
+    pub expect_payable: Option<TokenAmount>,
     skip_verification_on_drop: bool,
 }
 
@@ -318,9 +318,9 @@ impl Expectations {
             this.expect_emitted_events
         );
         assert!(
-            this.expect_value.is_none(),
+            this.expect_payable.is_none(),
             "expect_payment {:?}, not received",
-            this.expect_value
+            this.expect_payable
         );
     }
 }
@@ -800,8 +800,8 @@ impl<BS: Blockstore> MockRuntime<BS> {
     }
 
     #[allow(dead_code)]
-    pub fn expect_value(&mut self, amount: TokenAmount) {
-        self.expectations.borrow_mut().expect_value = Some(amount);
+    pub fn expect_payable(&mut self, amount: TokenAmount) {
+        self.expectations.borrow_mut().expect_payable = Some(amount);
     }
 
     ///// Private helpers /////
@@ -1299,7 +1299,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
     fn payable(&mut self) -> TokenAmount {
         self.require_in_call();
 
-        let expected_payment = self.expectations.borrow_mut().expect_value.take();
+        let expected_payment = self.expectations.borrow_mut().expect_payable.take();
         if let Some(payment) = expected_payment.clone() {
             assert_eq!(payment, self.message().value_received(), "unexpected amount received");
         }

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -774,7 +774,7 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
         if res.is_ok() {
             if !self.caller_validated {
                 res = Err(actor_error!(assertion_failed, "failed to validate caller"));
-            } else if !self.payable && !self.msg.value.is_zero() {
+            } else if !(self.payable || self.msg.value.is_zero()) {
                 res = Err(actor_error!(
                     assertion_failed,
                     "payment received in method not marked payable"

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -1134,7 +1134,7 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
         self.read_only
     }
 
-    fn payable(&mut self) {
+    fn payable(&mut self) -> TokenAmount {
         todo!()
     }
 }

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -1135,7 +1135,8 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
     }
 
     fn payable(&mut self) -> TokenAmount {
-        todo!()
+        self.payable = true;
+        self.message().value_received()
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/filecoin-project/builtin-actors/issues/836

Adds `payable` to the runtime which **must** be called when funds are sent to a method. 

It aborts the method if funds are received and `payable` was never called.