### PR TITLE
Remove HashSet from policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,7 +2448,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.5.1"
-source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e84f16d6927ce342ef86bd20fcc2d5bd498ed33ae6d7a22fea7a1b453488ec88"
 dependencies = [
  "anyhow",
  "cid",
@@ -2463,7 +2464,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
-source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
 dependencies = [
  "fvm_ipld_encoding",
  "serde",
@@ -2474,7 +2476,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
-source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688239a96199577f6705a3f9689abfd795f867f91f5847bc7e236017cc672df7"
 dependencies = [
  "anyhow",
  "cid",
@@ -2499,7 +2502,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.3.3"
-source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0816a2a6df4853de08a723d261110d56a121aa313bc570fe9d248f0a4bc5288"
 dependencies = [
  "anyhow",
  "cid",
@@ -2515,7 +2519,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.6.1"
-source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c942494dde990aeac314311bde34c787be99cab7d0836397a75556cbaa2c3e7"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2553,7 +2558,8 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.0.0"
-source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fef17308967cceb1d22f05003d60adb0d5b9ba53e34ace4ae04701eb7e6af02"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -2567,7 +2573,8 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.1.0"
-source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45742ae0f445a80121a97e9ee36fd0112f56e19daa5865fe458452ec6ff358f2"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,8 +2448,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84f16d6927ce342ef86bd20fcc2d5bd498ed33ae6d7a22fea7a1b453488ec88"
 dependencies = [
  "anyhow",
  "cid",
@@ -2464,8 +2462,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
 dependencies = [
  "fvm_ipld_encoding",
  "serde",
@@ -2476,8 +2472,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688239a96199577f6705a3f9689abfd795f867f91f5847bc7e236017cc672df7"
 dependencies = [
  "anyhow",
  "cid",
@@ -2502,8 +2496,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0816a2a6df4853de08a723d261110d56a121aa313bc570fe9d248f0a4bc5288"
 dependencies = [
  "anyhow",
  "cid",
@@ -2519,8 +2511,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c942494dde990aeac314311bde34c787be99cab7d0836397a75556cbaa2c3e7"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2558,8 +2548,6 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fef17308967cceb1d22f05003d60adb0d5b9ba53e34ace4ae04701eb7e6af02"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -2573,8 +2561,6 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45742ae0f445a80121a97e9ee36fd0112f56e19daa5865fe458452ec6ff358f2"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,6 +2448,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.5.1"
+source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
 dependencies = [
  "anyhow",
  "cid",
@@ -2462,6 +2463,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
+source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
 dependencies = [
  "fvm_ipld_encoding",
  "serde",
@@ -2472,6 +2474,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
+source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
 dependencies = [
  "anyhow",
  "cid",
@@ -2496,6 +2499,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.3.3"
+source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
 dependencies = [
  "anyhow",
  "cid",
@@ -2511,6 +2515,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.6.1"
+source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2548,6 +2553,7 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.0.0"
+source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -2561,6 +2567,7 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.1.0"
+source = "git+https://github.com/helix-onchain/ref-fvm?branch=alex/remove-hashset-from-builtin-actors#9d1922038bc6b5d6cd03fcf928f023282ba8365e"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,29 +57,29 @@ members = [
      "test_vm",
 ]
 
-# [patch.crates-io]
-# fvm_shared = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-# fvm_sdk = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-# fvm_ipld_hamt = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-# fvm_ipld_amt = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-# fvm_ipld_bitfield = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-# fvm_ipld_encoding = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-# fvm_ipld_blockstore = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-# fvm_actor_utils = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
-# frc42_dispatch = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
-# frc46_token = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
+[patch.crates-io]
+#fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+#fvm_actor_utils = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
+#frc42_dispatch = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
+#frc46_token = { git = "https://github.com/helix-onchain/filecoin", branch = "main" }
 
 ## Uncomment when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
 ## (Valid while FVM modules aren't published to crates.io)
-# [patch."https://github.com/helix-onchain/ref-fvm"]
-# fvm_shared = { path = "../ref-fvm/shared" }
-# fvm_sdk = { path = "../ref-fvm/sdk" }
-# fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
-# fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
-# fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
-# fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
-# fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
+#[patch."https://github.com/filecoin-project/ref-fvm"]
+#fvm_shared = { path = "../ref-fvm/shared" }
+#fvm_sdk = { path = "../ref-fvm/sdk" }
+#fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
+#fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
+#fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
+#fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
+#fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
 
 ## Uncomment entries below when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
@@ -92,9 +92,9 @@ members = [
 # fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
 # fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
 # fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
-# fvm_actor_utils = { path = "../../filecoin/fvm_actor_utils"}
-# frc42_dispatch = { path = "../../filecoin/frc42_dispatch"}
-# frc46_token = { path = "../../filecoin/frc46_token"}
+#fvm_actor_utils = { path = "../../filecoin/fvm_actor_utils"}
+#frc42_dispatch = { path = "../../filecoin/frc42_dispatch"}
+#frc46_token = { path = "../../filecoin/frc46_token"}
 
 [profile.wasm]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,14 +57,14 @@ members = [
      "test_vm",
 ]
 
-# [patch.crates-io]
-# fvm_shared = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
-# fvm_sdk = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
-# fvm_ipld_hamt = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
-# fvm_ipld_amt = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
-# fvm_ipld_bitfield = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
-# fvm_ipld_encoding = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
-# fvm_ipld_blockstore = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
+[patch.crates-io]
+fvm_shared = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+fvm_sdk = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+fvm_ipld_hamt = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+fvm_ipld_amt = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+fvm_ipld_bitfield = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+fvm_ipld_encoding = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+fvm_ipld_blockstore = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
 # fvm_actor_utils = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
 # frc42_dispatch = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
 # frc46_token = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
@@ -84,14 +84,14 @@ members = [
 ## Uncomment entries below when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
 ## (Valid once FVM modules are published to crates.io)
-[patch.crates-io]
-fvm_shared = { path = "../ref-fvm/shared" }
-fvm_sdk = { path = "../ref-fvm/sdk" }
-fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
-fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
-fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
-fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
-fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
+# [patch.crates-io]
+# fvm_shared = { path = "../ref-fvm/shared" }
+# fvm_sdk = { path = "../ref-fvm/sdk" }
+# fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
+# fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
+# fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
+# fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
+# fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
 # fvm_actor_utils = { path = "../../filecoin/fvm_actor_utils"}
 # frc42_dispatch = { path = "../../filecoin/frc42_dispatch"}
 # frc46_token = { path = "../../filecoin/frc46_token"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,14 +57,14 @@ members = [
      "test_vm",
 ]
 
-[patch.crates-io]
-fvm_shared = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-fvm_sdk = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-fvm_ipld_hamt = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-fvm_ipld_amt = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-fvm_ipld_bitfield = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-fvm_ipld_encoding = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
-fvm_ipld_blockstore = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+# [patch.crates-io]
+# fvm_shared = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+# fvm_sdk = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+# fvm_ipld_hamt = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+# fvm_ipld_amt = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+# fvm_ipld_bitfield = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+# fvm_ipld_encoding = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
+# fvm_ipld_blockstore = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/remove-hashset-from-builtin-actors" }
 # fvm_actor_utils = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
 # frc42_dispatch = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
 # frc46_token = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,34 +57,22 @@ members = [
      "test_vm",
 ]
 
-[patch.crates-io]
-#fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_actor_utils = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
-#frc42_dispatch = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
-#frc46_token = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
+# [patch.crates-io]
+# fvm_shared = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
+# fvm_sdk = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
+# fvm_ipld_hamt = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
+# fvm_ipld_amt = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
+# fvm_ipld_bitfield = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
+# fvm_ipld_encoding = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
+# fvm_ipld_blockstore = { git = "https://github.com/helix-onchain/ref-fvm", branch = "alex/update-helix-deps" }
+# fvm_actor_utils = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
+# frc42_dispatch = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
+# frc46_token = { git = "https://github.com/helix-onchain/filecoin", branch = "release/fvm-v3.1" }
 
 ## Uncomment when working locally on ref-fvm and this repo simultaneously.
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
 ## (Valid while FVM modules aren't published to crates.io)
-#[patch."https://github.com/filecoin-project/ref-fvm"]
-#fvm_shared = { path = "../ref-fvm/shared" }
-#fvm_sdk = { path = "../ref-fvm/sdk" }
-#fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
-#fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
-#fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
-#fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
-#fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
-
-## Uncomment entries below when working locally on ref-fvm and this repo simultaneously.
-## Assumes the ref-fvm checkout is in a sibling directory with the same name.
-## (Valid once FVM modules are published to crates.io)
-# [patch.crates-io]
+# [patch."https://github.com/helix-onchain/ref-fvm"]
 # fvm_shared = { path = "../ref-fvm/shared" }
 # fvm_sdk = { path = "../ref-fvm/sdk" }
 # fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
@@ -92,9 +80,21 @@ members = [
 # fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
 # fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
 # fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
-#fvm_actor_utils = { path = "../../filecoin/fvm_actor_utils"}
-#frc42_dispatch = { path = "../../filecoin/frc42_dispatch"}
-#frc46_token = { path = "../../filecoin/frc46_token"}
+
+## Uncomment entries below when working locally on ref-fvm and this repo simultaneously.
+## Assumes the ref-fvm checkout is in a sibling directory with the same name.
+## (Valid once FVM modules are published to crates.io)
+[patch.crates-io]
+fvm_shared = { path = "../ref-fvm/shared" }
+fvm_sdk = { path = "../ref-fvm/sdk" }
+fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
+fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
+fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
+fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
+fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
+# fvm_actor_utils = { path = "../../filecoin/fvm_actor_utils"}
+# frc42_dispatch = { path = "../../filecoin/frc42_dispatch"}
+# frc46_token = { path = "../../filecoin/frc46_token"}
 
 [profile.wasm]
 inherits = "release"

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -4654,7 +4654,7 @@ fn check_valid_post_proof_type(
     policy: &Policy,
     proof_type: RegisteredPoStProof,
 ) -> Result<(), ActorError> {
-    if policy.valid_post_proof_type.contains(&proof_type) {
+    if policy.valid_post_proof_type.contains(proof_type) {
         Ok(())
     } else {
         Err(actor_error!(

--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -50,7 +50,7 @@ pub fn is_sealed_sector(c: &Cid) -> bool {
 
 /// List of proof types which can be used when creating new miner actors
 pub fn can_pre_commit_seal_proof(policy: &Policy, proof: RegisteredSealProof) -> bool {
-    policy.valid_pre_commit_proof_type.contains(&proof)
+    policy.valid_pre_commit_proof_type.contains(proof)
 }
 
 /// Checks whether a seal proof type is supported for new miners and sectors.

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof, StoragePower};
@@ -129,10 +129,10 @@ pub struct Policy {
     pub chain_finality: ChainEpoch,
 
     /// Allowed post proof types for new miners
-    pub valid_post_proof_type: HashSet<RegisteredPoStProof>,
+    pub valid_post_proof_type: BTreeSet<RegisteredPoStProof>,
 
     /// Allowed pre commit proof types for new miners
-    pub valid_pre_commit_proof_type: HashSet<RegisteredSealProof>,
+    pub valid_pre_commit_proof_type: BTreeSet<RegisteredSealProof>,
 
     // --- verifreg policy
     /// Minimum verified deal size
@@ -206,7 +206,7 @@ impl Default for Policy {
             new_sectors_per_period_max: policy_constants::NEW_SECTORS_PER_PERIOD_MAX,
             chain_finality: policy_constants::CHAIN_FINALITY,
 
-            valid_post_proof_type: HashSet::<RegisteredPoStProof>::from([
+            valid_post_proof_type: BTreeSet::<RegisteredPoStProof>::from([
                 #[cfg(feature = "sector-2k")]
                 RegisteredPoStProof::StackedDRGWindow2KiBV1,
                 #[cfg(feature = "sector-8m")]
@@ -218,7 +218,7 @@ impl Default for Policy {
                 #[cfg(feature = "sector-64g")]
                 RegisteredPoStProof::StackedDRGWindow64GiBV1,
             ]),
-            valid_pre_commit_proof_type: HashSet::<RegisteredSealProof>::from([
+            valid_pre_commit_proof_type: BTreeSet::<RegisteredSealProof>::from([
                 #[cfg(feature = "sector-2k")]
                 RegisteredSealProof::StackedDRG2KiBV1P1,
                 #[cfg(feature = "sector-8m")]

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof, StoragePower};
 use num_traits::FromPrimitive;
@@ -129,10 +127,10 @@ pub struct Policy {
     pub chain_finality: ChainEpoch,
 
     /// Allowed post proof types for new miners
-    pub valid_post_proof_type: BTreeSet<RegisteredPoStProof>,
+    pub valid_post_proof_type: ProofSet,
 
     /// Allowed pre commit proof types for new miners
-    pub valid_pre_commit_proof_type: BTreeSet<RegisteredSealProof>,
+    pub valid_pre_commit_proof_type: ProofSet,
 
     // --- verifreg policy
     /// Minimum verified deal size
@@ -206,31 +204,8 @@ impl Default for Policy {
             new_sectors_per_period_max: policy_constants::NEW_SECTORS_PER_PERIOD_MAX,
             chain_finality: policy_constants::CHAIN_FINALITY,
 
-            valid_post_proof_type: BTreeSet::<RegisteredPoStProof>::from([
-                #[cfg(feature = "sector-2k")]
-                RegisteredPoStProof::StackedDRGWindow2KiBV1,
-                #[cfg(feature = "sector-8m")]
-                RegisteredPoStProof::StackedDRGWindow8MiBV1,
-                #[cfg(feature = "sector-512m")]
-                RegisteredPoStProof::StackedDRGWindow512MiBV1,
-                #[cfg(feature = "sector-32g")]
-                RegisteredPoStProof::StackedDRGWindow32GiBV1,
-                #[cfg(feature = "sector-64g")]
-                RegisteredPoStProof::StackedDRGWindow64GiBV1,
-            ]),
-            valid_pre_commit_proof_type: BTreeSet::<RegisteredSealProof>::from([
-                #[cfg(feature = "sector-2k")]
-                RegisteredSealProof::StackedDRG2KiBV1P1,
-                #[cfg(feature = "sector-8m")]
-                RegisteredSealProof::StackedDRG8MiBV1P1,
-                #[cfg(feature = "sector-512m")]
-                RegisteredSealProof::StackedDRG512MiBV1P1,
-                #[cfg(feature = "sector-32g")]
-                RegisteredSealProof::StackedDRG32GiBV1P1,
-                #[cfg(feature = "sector-64g")]
-                RegisteredSealProof::StackedDRG64GiBV1P1,
-            ]),
-
+            valid_post_proof_type: ProofSet::default_post_proofs(),
+            valid_pre_commit_proof_type: ProofSet::default_seal_proofs(),
             minimum_verified_allocation_size: StoragePower::from_i32(
                 policy_constants::MINIMUM_VERIFIED_ALLOCATION_SIZE,
             )
@@ -379,6 +354,12 @@ pub mod policy_constants {
     /// This is a conservative value that is chosen via simulations of all known attacks.
     pub const CHAIN_FINALITY: ChainEpoch = 900;
 
+    /// The number of total possible types (enum variants) of RegisteredPoStProof
+    pub const REGISTERED_POST_PROOF_VARIANTS: usize = 10;
+
+    /// The number of total possible types (enum variants) of RegisteredSealProof
+    pub const REGISTERED_SEAL_PROOF_VARIANTS: usize = 10;
+
     #[cfg(not(feature = "small-deals"))]
     pub const MINIMUM_VERIFIED_ALLOCATION_SIZE: i32 = 1 << 20;
     #[cfg(feature = "small-deals")]
@@ -416,4 +397,76 @@ pub mod policy_constants {
         feature = "min-power-32g"
     )))]
     pub const MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;
+}
+
+/// A set indicating which proofs are considered valid, optimised for lookup of a small number of
+/// sequential enum variants. Backed by an array of booleans where each index indicates if that
+/// proof type is valid
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct ProofSet(Vec<bool>);
+
+impl ProofSet {
+    /// Create a `ProofSet` for enabled `RegisteredPoStProof`s
+    pub fn default_post_proofs() -> Self {
+        let mut proofs = vec![false; policy_constants::REGISTERED_POST_PROOF_VARIANTS];
+        #[cfg(feature = "sector-2k")]
+        {
+            proofs[i64::from(RegisteredPoStProof::StackedDRGWindow2KiBV1) as usize] = true;
+        }
+        #[cfg(feature = "sector-8m")]
+        {
+            proofs[i64::from(RegisteredPoStProof::StackedDRGWindow8MiBV1) as usize] = true;
+        }
+        #[cfg(feature = "sector-512m")]
+        {
+            proofs[i64::from(RegisteredPoStProof::StackedDRGWindow512MiBV1) as usize] = true;
+        }
+        #[cfg(feature = "sector-32g")]
+        {
+            proofs[i64::from(RegisteredPoStProof::StackedDRGWindow32GiBV1) as usize] = true;
+        }
+        #[cfg(feature = "sector-64g")]
+        {
+            proofs[i64::from(RegisteredPoStProof::StackedDRGWindow64GiBV1) as usize] = true;
+        }
+        ProofSet(proofs)
+    }
+
+    /// Create a `ProofSet` for enabled `RegisteredSealProof`s
+    pub fn default_seal_proofs() -> Self {
+        let mut proofs = vec![false; policy_constants::REGISTERED_SEAL_PROOF_VARIANTS];
+        #[cfg(feature = "sector-2k")]
+        {
+            proofs[i64::from(RegisteredSealProof::StackedDRG2KiBV1P1) as usize] = true;
+        }
+        #[cfg(feature = "sector-8m")]
+        {
+            proofs[i64::from(RegisteredSealProof::StackedDRG8MiBV1P1) as usize] = true;
+        }
+        #[cfg(feature = "sector-512m")]
+        {
+            proofs[i64::from(RegisteredSealProof::StackedDRG512MiBV1P1) as usize] = true;
+        }
+        #[cfg(feature = "sector-32g")]
+        {
+            proofs[i64::from(RegisteredSealProof::StackedDRG32GiBV1P1) as usize] = true;
+        }
+        #[cfg(feature = "sector-64g")]
+        {
+            proofs[i64::from(RegisteredSealProof::StackedDRG64GiBV1P1) as usize] = true;
+        }
+        ProofSet(proofs)
+    }
+
+    /// Checks if the requested proof type exists in the set
+    pub fn contains<P: Into<i64>>(&self, proof: P) -> bool {
+        let index: i64 = proof.into();
+        *self.0.get(index as usize).unwrap_or(&false)
+    }
+
+    /// Adds the requested proof type to the set of valid proofs
+    pub fn insert<P: Into<i64>>(&mut self, proof: P) {
+        let index: i64 = proof.into();
+        self.0[index as usize] = true;
+    }
 }


### PR DESCRIPTION
Relies on https://github.com/filecoin-project/ref-fvm/pull/1713 to impl Ord so that the registered proofs can be stored in a BTreeSet

Requires https://github.com/filecoin-project/builtin-actors/pull/1244 so that the Helix library deps pull the same version of fvm_shared etc.

Closes https://github.com/filecoin-project/builtin-actors/issues/97