### PR TITLE
Refactor Runtime impls to use interior mutability

### DIFF
--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -42,7 +42,7 @@ pub struct Actor;
 
 impl Actor {
     /// Constructor for Account actor
-    pub fn constructor(rt: &mut impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
+    pub fn constructor(rt: &impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
         let address = params.address;
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
         match address.protocol() {
@@ -57,7 +57,7 @@ impl Actor {
     }
 
     /// Fetches the pubkey-type address from this actor.
-    pub fn pubkey_address(rt: &mut impl Runtime) -> Result<PubkeyAddressReturn, ActorError> {
+    pub fn pubkey_address(rt: &impl Runtime) -> Result<PubkeyAddressReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let st: State = rt.state()?;
         Ok(PubkeyAddressReturn { address: st.address })
@@ -67,7 +67,7 @@ impl Actor {
     /// Should be called with the raw bytes of a signature, NOT a serialized Signature object that includes a SignatureType.
     /// Errors with USR_ILLEGAL_ARGUMENT if the authentication is invalid.
     pub fn authenticate_message(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: AuthenticateMessageParams,
     ) -> Result<AuthenticateMessageReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -94,7 +94,7 @@ impl Actor {
 
     /// Fallback method for unimplemented method numbers.
     pub fn fallback(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         method: MethodNum,
         _: Option<IpldBlock>,
     ) -> Result<Option<IpldBlock>, ActorError> {

--- a/actors/account/tests/account_actor_test.rs
+++ b/actors/account/tests/account_actor_test.rs
@@ -18,7 +18,7 @@ use fil_actors_runtime::test_utils::*;
 #[test]
 fn construction() {
     fn construct(addr: Address, exit_code: ExitCode) {
-        let mut rt = MockRuntime { receiver: Address::new_id(100), ..Default::default() };
+        let rt = MockRuntime { receiver: Address::new_id(100), ..Default::default() };
         rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
 
@@ -61,7 +61,7 @@ fn construction() {
 
 #[test]
 fn token_receiver() {
-    let mut rt = MockRuntime { receiver: Address::new_id(100), ..Default::default() };
+    let rt = MockRuntime { receiver: Address::new_id(100), ..Default::default() };
     rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
 
@@ -89,7 +89,7 @@ fn token_receiver() {
 
 #[test]
 fn authenticate_message() {
-    let mut rt = MockRuntime { receiver: Address::new_id(100), ..Default::default() };
+    let rt = MockRuntime { receiver: Address::new_id(100), ..Default::default() };
     rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
 
     let addr = Address::new_secp256k1(&[2; fvm_shared::address::SECP_PUB_LEN]).unwrap();

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -44,7 +44,7 @@ pub struct Actor;
 
 impl Actor {
     /// Constructor for Cron actor
-    fn constructor(rt: &mut impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
+    fn constructor(rt: &impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
         rt.create(&State { entries: params.entries })?;
         Ok(())
@@ -52,7 +52,7 @@ impl Actor {
     /// Executes built-in periodic actions, run at every Epoch.
     /// epoch_tick(r) is called after all other messages in the epoch have been applied.
     /// This can be seen as an implicit last message.
-    fn epoch_tick(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    fn epoch_tick(rt: &impl Runtime) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
         let st: State = rt.state()?;

--- a/actors/cron/tests/cron_actor_test.rs
+++ b/actors/cron/tests/cron_actor_test.rs
@@ -1,6 +1,8 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::cell::RefCell;
+
 use fil_actor_cron::testing::check_state_invariants;
 use fil_actor_cron::{Actor as CronActor, ConstructorParams, Entry, State};
 use fil_actors_runtime::test_utils::*;
@@ -19,8 +21,8 @@ fn check_state(rt: &MockRuntime) {
 fn construct_runtime() -> MockRuntime {
     MockRuntime {
         receiver: Address::new_id(100),
-        caller: SYSTEM_ACTOR_ADDR,
-        caller_type: *SYSTEM_ACTOR_CODE_ID,
+        caller: RefCell::new(SYSTEM_ACTOR_ADDR),
+        caller_type: RefCell::new(*SYSTEM_ACTOR_CODE_ID),
         ..Default::default()
     }
 }

--- a/actors/cron/tests/cron_actor_test.rs
+++ b/actors/cron/tests/cron_actor_test.rs
@@ -29,9 +29,9 @@ fn construct_runtime() -> MockRuntime {
 
 #[test]
 fn construct_with_empty_entries() {
-    let mut rt = construct_runtime();
+    let rt = construct_runtime();
 
-    construct_and_verify(&mut rt, &ConstructorParams { entries: vec![] });
+    construct_and_verify(&rt, &ConstructorParams { entries: vec![] });
     let state: State = rt.get_state();
 
     assert_eq!(state.entries, vec![]);
@@ -40,7 +40,7 @@ fn construct_with_empty_entries() {
 
 #[test]
 fn construct_with_entries() {
-    let mut rt = construct_runtime();
+    let rt = construct_runtime();
 
     let entry1 = Entry { receiver: Address::new_id(1001), method_num: 1001 };
     let entry2 = Entry { receiver: Address::new_id(1002), method_num: 1002 };
@@ -49,7 +49,7 @@ fn construct_with_entries() {
 
     let params = ConstructorParams { entries: vec![entry1, entry2, entry3, entry4] };
 
-    construct_and_verify(&mut rt, &params);
+    construct_and_verify(&rt, &params);
 
     let state: State = rt.get_state();
 
@@ -59,15 +59,15 @@ fn construct_with_entries() {
 
 #[test]
 fn epoch_tick_with_empty_entries() {
-    let mut rt = construct_runtime();
+    let rt = construct_runtime();
 
-    construct_and_verify(&mut rt, &ConstructorParams { entries: vec![] });
-    epoch_tick_and_verify(&mut rt);
+    construct_and_verify(&rt, &ConstructorParams { entries: vec![] });
+    epoch_tick_and_verify(&rt);
 }
 
 #[test]
 fn epoch_tick_with_entries() {
-    let mut rt = construct_runtime();
+    let rt = construct_runtime();
 
     let entry1 = Entry { receiver: Address::new_id(1001), method_num: 1001 };
     let entry2 = Entry { receiver: Address::new_id(1002), method_num: 1002 };
@@ -78,7 +78,7 @@ fn epoch_tick_with_entries() {
         entries: vec![entry1.clone(), entry2.clone(), entry3.clone(), entry4.clone()],
     };
 
-    construct_and_verify(&mut rt, &params);
+    construct_and_verify(&rt, &params);
 
     // ExitCodes dont matter here
     rt.expect_send_simple(
@@ -114,10 +114,10 @@ fn epoch_tick_with_entries() {
         ExitCode::OK,
     );
 
-    epoch_tick_and_verify(&mut rt);
+    epoch_tick_and_verify(&rt);
 }
 
-fn construct_and_verify(rt: &mut MockRuntime, params: &ConstructorParams) {
+fn construct_and_verify(rt: &MockRuntime, params: &ConstructorParams) {
     rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
     let ret = rt.call::<CronActor>(1, IpldBlock::serialize_cbor(&params).unwrap()).unwrap();
@@ -125,7 +125,7 @@ fn construct_and_verify(rt: &mut MockRuntime, params: &ConstructorParams) {
     rt.verify();
 }
 
-fn epoch_tick_and_verify(rt: &mut MockRuntime) {
+fn epoch_tick_and_verify(rt: &MockRuntime) {
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
     let ret = rt.call::<CronActor>(2, None).unwrap();
     assert!(ret.is_none());

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -88,7 +88,7 @@ pub struct Actor;
 
 impl Actor {
     /// Constructor for DataCap Actor
-    pub fn constructor(rt: &mut impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
+    pub fn constructor(rt: &impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
         let governor = params.governor;
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
@@ -101,22 +101,22 @@ impl Actor {
         Ok(())
     }
 
-    pub fn name(rt: &mut impl Runtime) -> Result<NameReturn, ActorError> {
+    pub fn name(rt: &impl Runtime) -> Result<NameReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         Ok(NameReturn { name: "DataCap".to_string() })
     }
 
-    pub fn symbol(rt: &mut impl Runtime) -> Result<SymbolReturn, ActorError> {
+    pub fn symbol(rt: &impl Runtime) -> Result<SymbolReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         Ok(SymbolReturn { symbol: "DCAP".to_string() })
     }
 
-    pub fn granularity(rt: &mut impl Runtime) -> Result<GranularityReturn, ActorError> {
+    pub fn granularity(rt: &impl Runtime) -> Result<GranularityReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         Ok(GranularityReturn { granularity: DATACAP_GRANULARITY })
     }
 
-    pub fn total_supply(rt: &mut impl Runtime) -> Result<TotalSupplyReturn, ActorError> {
+    pub fn total_supply(rt: &impl Runtime) -> Result<TotalSupplyReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let mut st: State = rt.state()?;
         let msg = SyscallProvider { rt };
@@ -124,10 +124,7 @@ impl Actor {
         Ok(TotalSupplyReturn { supply: token.total_supply() })
     }
 
-    pub fn balance(
-        rt: &mut impl Runtime,
-        params: BalanceParams,
-    ) -> Result<BalanceReturn, ActorError> {
+    pub fn balance(rt: &impl Runtime, params: BalanceParams) -> Result<BalanceReturn, ActorError> {
         // NOTE: mutability and method caller here are awkward for a read-only call
         rt.validate_immediate_caller_accept_any()?;
         let mut st: State = rt.state()?;
@@ -137,7 +134,7 @@ impl Actor {
     }
 
     pub fn allowance(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: GetAllowanceParams,
     ) -> Result<GetAllowanceReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -154,7 +151,7 @@ impl Actor {
     /// Simultaneously sets the allowance for any specified operators to effectively infinite.
     /// Only the governor can call this method.
     /// This method is not part of the fungible token standard.
-    pub fn mint(rt: &mut impl Runtime, params: MintParams) -> Result<MintReturn, ActorError> {
+    pub fn mint(rt: &impl Runtime, params: MintParams) -> Result<MintReturn, ActorError> {
         let mut hook = rt
             .transaction(|st: &mut State, rt| {
                 // Only the governor can mint datacap tokens.
@@ -195,7 +192,7 @@ impl Actor {
     /// Only the governor can call this method.
     /// This method is not part of the fungible token standard, and is named distinctly from
     /// "burn" to reflect that distinction.
-    pub fn destroy(rt: &mut impl Runtime, params: DestroyParams) -> Result<BurnReturn, ActorError> {
+    pub fn destroy(rt: &impl Runtime, params: DestroyParams) -> Result<BurnReturn, ActorError> {
         rt.transaction(|st: &mut State, rt| {
             // Only the governor can destroy datacap tokens on behalf of a holder.
             rt.validate_immediate_caller_is(std::iter::once(&st.governor))?;
@@ -213,7 +210,7 @@ impl Actor {
     /// Data cap tokens are not generally transferable.
     /// Succeeds if the to or from address is the governor, otherwise always fails.
     pub fn transfer(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: TransferParams,
     ) -> Result<TransferReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -262,7 +259,7 @@ impl Actor {
     /// Data cap tokens are not generally transferable between addresses.
     /// Succeeds if the to address is the governor, otherwise always fails.
     pub fn transfer_from(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: TransferFromParams,
     ) -> Result<TransferFromReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -309,7 +306,7 @@ impl Actor {
     }
 
     pub fn increase_allowance(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: IncreaseAllowanceParams,
     ) -> Result<IncreaseAllowanceReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -328,7 +325,7 @@ impl Actor {
     }
 
     pub fn decrease_allowance(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: DecreaseAllowanceParams,
     ) -> Result<DecreaseAllowanceReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -347,7 +344,7 @@ impl Actor {
     }
 
     pub fn revoke_allowance(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: RevokeAllowanceParams,
     ) -> Result<RevokeAllowanceReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -365,7 +362,7 @@ impl Actor {
         .context("state transaction failed")
     }
 
-    pub fn burn(rt: &mut impl Runtime, params: BurnParams) -> Result<BurnReturn, ActorError> {
+    pub fn burn(rt: &impl Runtime, params: BurnParams) -> Result<BurnReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let owner = &rt.message().caller();
 
@@ -378,7 +375,7 @@ impl Actor {
     }
 
     pub fn burn_from(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: BurnFromParams,
     ) -> Result<BurnFromReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -397,7 +394,7 @@ impl Actor {
 /// Implementation of the token library's messenger trait in terms of the built-in actors'
 /// runtime library.
 struct SyscallProvider<'a, RT> {
-    rt: &'a mut RT,
+    rt: &'a RT,
 }
 
 impl<'a, RT> Syscalls for &SyscallProvider<'a, RT>

--- a/actors/datacap/tests/datacap_actor_test.rs
+++ b/actors/datacap/tests/datacap_actor_test.rs
@@ -22,9 +22,9 @@ mod construction {
 
     #[test]
     fn construct_with_verified() {
-        let mut rt = new_runtime();
+        let rt = new_runtime();
         let h = Harness { governor: VERIFIED_REGISTRY_ACTOR_ADDR };
-        h.construct_and_verify(&mut rt, &h.governor);
+        h.construct_and_verify(&rt, &h.governor);
         h.check_state(&rt);
 
         rt.expect_validate_caller_any();
@@ -76,20 +76,20 @@ mod mint {
     #[test]
     fn mint_balances() {
         // The token library has far more extensive tests, this is just a sanity check.
-        let (mut rt, h) = make_harness();
+        let (rt, h) = make_harness();
 
         let amt = TokenAmount::from_whole(1);
-        let ret = h.mint(&mut rt, &ALICE, &amt, vec![]).unwrap();
+        let ret = h.mint(&rt, &ALICE, &amt, vec![]).unwrap();
         assert_eq!(amt, ret.supply);
         assert_eq!(amt, ret.balance);
         assert_eq!(amt, h.get_supply(&rt));
-        assert_eq!(amt, h.get_balance(&mut rt, &*ALICE));
+        assert_eq!(amt, h.get_balance(&rt, &*ALICE));
 
-        let ret = h.mint(&mut rt, &BOB, &amt, vec![]).unwrap();
+        let ret = h.mint(&rt, &BOB, &amt, vec![]).unwrap();
         assert_eq!(&amt * 2, ret.supply);
         assert_eq!(amt, ret.balance);
         assert_eq!(&amt * 2, h.get_supply(&rt));
-        assert_eq!(amt, h.get_balance(&mut rt, &*BOB));
+        assert_eq!(amt, h.get_balance(&rt, &*BOB));
 
         h.check_state(&rt);
     }
@@ -115,12 +115,12 @@ mod mint {
 
     #[test]
     fn requires_whole_tokens() {
-        let (mut rt, h) = make_harness();
+        let (rt, h) = make_harness();
         let amt = TokenAmount::from_atto(100);
         expect_abort_contains_message(
             ExitCode::USR_ILLEGAL_ARGUMENT,
             "must be a multiple of 1000000000000000000",
-            h.mint(&mut rt, &ALICE, &amt, vec![]),
+            h.mint(&rt, &ALICE, &amt, vec![]),
         );
         rt.reset();
         h.check_state(&rt);
@@ -128,26 +128,25 @@ mod mint {
 
     #[test]
     fn auto_allowance_on_mint() {
-        let (mut rt, h) = make_harness();
+        let (rt, h) = make_harness();
         let amt = TokenAmount::from_whole(42);
-        h.mint(&mut rt, &ALICE, &amt, vec![*BOB]).unwrap();
+        h.mint(&rt, &ALICE, &amt, vec![*BOB]).unwrap();
         let allowance = h.get_allowance_between(&rt, &ALICE, &BOB);
         assert!(allowance.eq(&INFINITE_ALLOWANCE));
 
         // mint again
-        h.mint(&mut rt, &ALICE, &amt, vec![*BOB]).unwrap();
+        h.mint(&rt, &ALICE, &amt, vec![*BOB]).unwrap();
         let allowance2 = h.get_allowance_between(&rt, &ALICE, &BOB);
         assert!(allowance2.eq(&INFINITE_ALLOWANCE));
 
         // transfer of an allowance *does* deduct allowance even though it is too small to matter in practice
         let operator_data = RawBytes::new(vec![1, 2, 3, 4]);
-        h.transfer_from(&mut rt, &BOB, &ALICE, &h.governor, &(2 * amt.clone()), operator_data)
-            .unwrap();
+        h.transfer_from(&rt, &BOB, &ALICE, &h.governor, &(2 * amt.clone()), operator_data).unwrap();
         let allowance3 = h.get_allowance_between(&rt, &ALICE, &BOB);
-        assert!(allowance3.eq(&INFINITE_ALLOWANCE.clone().sub(2 * amt.clone())));
+        assert!(allowance3.eq(&INFINITE_ALLOWANCE.clone().sub(2 * amt)));
 
         // minting any amount to this address at the same operator resets at infinite
-        h.mint(&mut rt, &ALICE, &TokenAmount::from_whole(1), vec![*BOB]).unwrap();
+        h.mint(&rt, &ALICE, &TokenAmount::from_whole(1), vec![*BOB]).unwrap();
         let allowance = h.get_allowance_between(&rt, &ALICE, &BOB);
         assert!(allowance.eq(&INFINITE_ALLOWANCE));
 
@@ -166,39 +165,39 @@ mod transfer {
 
     #[test]
     fn only_governor_allowed() {
-        let (mut rt, h) = make_harness();
+        let (rt, h) = make_harness();
         let operator_data = RawBytes::new(vec![1, 2, 3, 4]);
 
         let amt = TokenAmount::from_whole(1);
-        h.mint(&mut rt, &ALICE, &amt, vec![]).unwrap();
+        h.mint(&rt, &ALICE, &amt, vec![]).unwrap();
 
         expect_abort_contains_message(
             ExitCode::USR_FORBIDDEN,
             "transfer not allowed",
-            h.transfer(&mut rt, &ALICE, &BOB, &amt, operator_data.clone()),
+            h.transfer(&rt, &ALICE, &BOB, &amt, operator_data.clone()),
         );
         rt.reset();
 
         // Transfer to governor is allowed.
-        h.transfer(&mut rt, &ALICE, &h.governor, &amt, operator_data.clone()).unwrap();
+        h.transfer(&rt, &ALICE, &h.governor, &amt, operator_data.clone()).unwrap();
 
         // The governor can transfer out.
-        h.transfer(&mut rt, &h.governor, &BOB, &amt, operator_data).unwrap();
+        h.transfer(&rt, &h.governor, &BOB, &amt, operator_data).unwrap();
     }
 
     #[test]
     fn transfer_from_restricted() {
-        let (mut rt, h) = make_harness();
+        let (rt, h) = make_harness();
         let operator_data = RawBytes::new(vec![1, 2, 3, 4]);
 
         let amt = TokenAmount::from_whole(1);
-        h.mint(&mut rt, &ALICE, &amt, vec![*BOB]).unwrap();
+        h.mint(&rt, &ALICE, &amt, vec![*BOB]).unwrap();
 
         // operator can't transfer out to third address
         expect_abort_contains_message(
             ExitCode::USR_FORBIDDEN,
             "transfer not allowed",
-            h.transfer_from(&mut rt, &BOB, &ALICE, &CARLA, &amt, operator_data.clone()),
+            h.transfer_from(&rt, &BOB, &ALICE, &CARLA, &amt, operator_data.clone()),
         );
         rt.reset();
 
@@ -206,16 +205,16 @@ mod transfer {
         expect_abort_contains_message(
             ExitCode::USR_FORBIDDEN,
             "transfer not allowed",
-            h.transfer_from(&mut rt, &BOB, &ALICE, &BOB, &amt, operator_data.clone()),
+            h.transfer_from(&rt, &BOB, &ALICE, &BOB, &amt, operator_data.clone()),
         );
         rt.reset();
         // even if governor has a delegate operator and enough tokens, delegated transfer
         // cannot send to non governor
-        h.mint(&mut rt, &h.governor, &amt, vec![*BOB]).unwrap();
+        h.mint(&rt, &h.governor, &amt, vec![*BOB]).unwrap();
         expect_abort_contains_message(
             ExitCode::USR_FORBIDDEN,
             "transfer not allowed",
-            h.transfer_from(&mut rt, &BOB, &h.governor, &ALICE, &amt, operator_data),
+            h.transfer_from(&rt, &BOB, &h.governor, &ALICE, &amt, operator_data),
         );
         rt.reset();
     }
@@ -235,10 +234,10 @@ mod destroy {
 
     #[test]
     fn only_governor_allowed() {
-        let (mut rt, h) = make_harness();
+        let (rt, h) = make_harness();
 
         let amt = TokenAmount::from_whole(1);
-        h.mint(&mut rt, &ALICE, &(2 * amt.clone()), vec![*BOB]).unwrap();
+        h.mint(&rt, &ALICE, &(2 * amt.clone()), vec![*BOB]).unwrap();
 
         // destroying from operator does not work
         let params = DestroyParams { owner: *ALICE, amount: amt.clone() };
@@ -256,15 +255,15 @@ mod destroy {
 
         // Destroying from 0 allowance having governor works
         assert!(h.get_allowance_between(&rt, &ALICE, &h.governor).is_zero());
-        let ret = h.destroy(&mut rt, &ALICE, &amt).unwrap();
+        let ret = h.destroy(&rt, &ALICE, &amt).unwrap();
         assert_eq!(ret.balance, amt); // burned 2 amt - amt = amt
         h.check_state(&rt)
     }
 }
 
 fn make_harness() -> (MockRuntime, Harness) {
-    let mut rt = new_runtime();
+    let rt = new_runtime();
     let h = Harness { governor: VERIFIED_REGISTRY_ACTOR_ADDR };
-    h.construct_and_verify(&mut rt, &h.governor);
+    h.construct_and_verify(&rt, &h.governor);
     (rt, h)
 }

--- a/actors/datacap/tests/datacap_actor_test.rs
+++ b/actors/datacap/tests/datacap_actor_test.rs
@@ -96,7 +96,7 @@ mod mint {
 
     #[test]
     fn requires_verifreg_caller() {
-        let (mut rt, h) = make_harness();
+        let (rt, h) = make_harness();
         let amt = TokenAmount::from_whole(1);
         let params = MintParams { to: *ALICE, amount: amt, operators: vec![] };
 

--- a/actors/datacap/tests/harness/mod.rs
+++ b/actors/datacap/tests/harness/mod.rs
@@ -33,9 +33,9 @@ pub fn new_runtime() -> MockRuntime {
 
 #[allow(dead_code)]
 pub fn new_harness() -> (Harness, MockRuntime) {
-    let mut rt = new_runtime();
+    let rt = new_runtime();
     let h = Harness { governor: VERIFIED_REGISTRY_ACTOR_ADDR };
-    h.construct_and_verify(&mut rt, &h.governor);
+    h.construct_and_verify(&rt, &h.governor);
     (h, rt)
 }
 
@@ -44,7 +44,7 @@ pub struct Harness {
 }
 
 impl Harness {
-    pub fn construct_and_verify(&self, rt: &mut MockRuntime, registry: &Address) {
+    pub fn construct_and_verify(&self, rt: &MockRuntime, registry: &Address) {
         rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
         let ret = rt
@@ -63,7 +63,7 @@ impl Harness {
 
     pub fn mint(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         to: &Address,
         amount: &TokenAmount,
         operators: Vec<Address>,
@@ -108,7 +108,7 @@ impl Harness {
 
     pub fn destroy(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         owner: &Address,
         amount: &TokenAmount,
     ) -> Result<BurnReturn, ActorError> {
@@ -128,7 +128,7 @@ impl Harness {
 
     pub fn transfer(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         from: &Address,
         to: &Address,
         amount: &TokenAmount,
@@ -174,7 +174,7 @@ impl Harness {
 
     pub fn transfer_from(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         operator: &Address,
         from: &Address,
         to: &Address,
@@ -226,7 +226,7 @@ impl Harness {
     }
 
     // Reads a balance from state directly.
-    pub fn get_balance(&self, rt: &mut MockRuntime, address: &Address) -> TokenAmount {
+    pub fn get_balance(&self, rt: &MockRuntime, address: &Address) -> TokenAmount {
         rt.expect_validate_caller_any();
         let ret = rt
             .call::<DataCapActor>(

--- a/actors/datacap/tests/harness/mod.rs
+++ b/actors/datacap/tests/harness/mod.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use frc46_token::receiver::{FRC46TokenReceived, FRC46_TOKEN_TYPE};
 use frc46_token::token::types::{
     BurnReturn, MintReturn, TransferFromParams, TransferFromReturn, TransferParams, TransferReturn,
@@ -23,8 +25,8 @@ use fvm_ipld_encoding::ipld_block::IpldBlock;
 pub fn new_runtime() -> MockRuntime {
     MockRuntime {
         receiver: DATACAP_TOKEN_ACTOR_ADDR,
-        caller: SYSTEM_ACTOR_ADDR,
-        caller_type: *SYSTEM_ACTOR_CODE_ID,
+        caller: RefCell::new(SYSTEM_ACTOR_ADDR),
+        caller_type: RefCell::new(*SYSTEM_ACTOR_CODE_ID),
         ..Default::default()
     }
 }

--- a/actors/eam/src/lib.rs
+++ b/actors/eam/src/lib.rs
@@ -111,7 +111,7 @@ fn can_assign_address(addr: &EthAddress) -> bool {
 }
 
 fn create_actor(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     creator: EthAddress,
     new_addr: EthAddress,
     initcode: Vec<u8>,
@@ -172,7 +172,7 @@ fn create_actor(
     Ok(Return::from_exec4(ret, new_addr))
 }
 
-fn resolve_eth_address(rt: &mut impl Runtime, actor_id: ActorID) -> Result<EthAddress, ActorError> {
+fn resolve_eth_address(rt: &impl Runtime, actor_id: ActorID) -> Result<EthAddress, ActorError> {
     match rt.lookup_delegated_address(actor_id).map(|a| *a.payload()) {
         Some(Payload::Delegated(addr)) if addr.namespace() == EAM_ACTOR_ID => Ok(EthAddress(
             addr.subaddress()
@@ -183,7 +183,7 @@ fn resolve_eth_address(rt: &mut impl Runtime, actor_id: ActorID) -> Result<EthAd
     }
 }
 
-fn resolve_caller_external(rt: &mut impl Runtime) -> Result<(EthAddress, EthAddress), ActorError> {
+fn resolve_caller_external(rt: &impl Runtime) -> Result<(EthAddress, EthAddress), ActorError> {
     let caller = rt.message().caller();
     let caller_id = caller.id().unwrap();
     let caller_code_cid = rt.get_actor_code_cid(&caller_id).expect("failed to lookup caller code");
@@ -227,7 +227,7 @@ fn resolve_caller_external(rt: &mut impl Runtime) -> Result<(EthAddress, EthAddr
 pub struct EamActor;
 
 impl EamActor {
-    pub fn constructor(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    pub fn constructor(rt: &impl Runtime) -> Result<(), ActorError> {
         let actor_id = rt.resolve_address(&rt.message().receiver()).unwrap();
         if actor_id != EAM_ACTOR_ID {
             return Err(ActorError::forbidden(format!(
@@ -240,7 +240,7 @@ impl EamActor {
     /// Create a new contract per the EVM's CREATE rules.
     ///
     /// Permissions: May be called by the EVM.
-    pub fn create(rt: &mut impl Runtime, params: CreateParams) -> Result<CreateReturn, ActorError> {
+    pub fn create(rt: &impl Runtime, params: CreateParams) -> Result<CreateReturn, ActorError> {
         // We only allow EVM actors to call this.
         rt.validate_immediate_caller_type(&[Type::EVM])?;
         let caller_addr = resolve_eth_address(rt, rt.message().caller().id().unwrap())?;
@@ -255,10 +255,7 @@ impl EamActor {
     /// Create a new contract per the EVM's CREATE2 rules.
     ///
     /// Permissions: May be called by the EVM.
-    pub fn create2(
-        rt: &mut impl Runtime,
-        params: Create2Params,
-    ) -> Result<Create2Return, ActorError> {
+    pub fn create2(rt: &impl Runtime, params: Create2Params) -> Result<Create2Return, ActorError> {
         // We only allow EVM actors to call this.
         rt.validate_immediate_caller_type(&[Type::EVM])?;
         let caller_addr = resolve_eth_address(rt, rt.message().caller().id().unwrap())?;
@@ -278,7 +275,7 @@ impl EamActor {
     ///
     /// Permissions: May be called by builtin or eth accounts.
     pub fn create_external(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: CreateExternalParams,
     ) -> Result<CreateExternalReturn, ActorError> {
         // We only accept calls by top-level accounts.
@@ -312,14 +309,14 @@ mod test {
 
     #[test]
     fn test_create_actor_rejects() {
-        let mut rt = MockRuntime::default();
+        let rt = MockRuntime::default();
         let creator = EthAddress::from_id(1);
 
         // Reject ID.
         let new_addr = EthAddress::from_id(8224);
         assert_eq!(
             ExitCode::USR_FORBIDDEN,
-            create_actor(&mut rt, creator, new_addr, Vec::new()).unwrap_err().exit_code()
+            create_actor(&rt, creator, new_addr, Vec::new()).unwrap_err().exit_code()
         );
 
         // Reject EVM Precompile.
@@ -327,21 +324,21 @@ mod test {
         new_addr.0[19] = 0x20;
         assert_eq!(
             ExitCode::USR_FORBIDDEN,
-            create_actor(&mut rt, creator, new_addr, Vec::new()).unwrap_err().exit_code()
+            create_actor(&rt, creator, new_addr, Vec::new()).unwrap_err().exit_code()
         );
 
         // Reject Native Precompile.
         new_addr.0[0] = 0xfe;
         assert_eq!(
             ExitCode::USR_FORBIDDEN,
-            create_actor(&mut rt, creator, new_addr, Vec::new()).unwrap_err().exit_code()
+            create_actor(&rt, creator, new_addr, Vec::new()).unwrap_err().exit_code()
         );
 
         // Reject Null.
         let new_addr = EthAddress::null();
         assert_eq!(
             ExitCode::USR_FORBIDDEN,
-            create_actor(&mut rt, creator, new_addr, Vec::new()).unwrap_err().exit_code()
+            create_actor(&rt, creator, new_addr, Vec::new()).unwrap_err().exit_code()
         );
     }
 

--- a/actors/eam/tests/create.rs
+++ b/actors/eam/tests/create.rs
@@ -19,7 +19,7 @@ use fvm_shared::error::ExitCode;
 
 #[test]
 fn call_create_new() {
-    let mut rt = construct_and_verify();
+    let rt = construct_and_verify();
 
     let id_addr = Address::new_id(110);
     let eth_addr = EthAddress(hex_literal::hex!("CAFEB0BA00000000000000000000000000000000"));
@@ -81,7 +81,7 @@ fn call_create_new() {
 
 #[test]
 fn call_create_external_over_placeholder() {
-    let mut rt = construct_and_verify();
+    let rt = construct_and_verify();
 
     let caller_id_addr = Address::new_id(110);
     let caller_eth_addr = EthAddress(hex_literal::hex!("CAFEB0BA00000000000000000000000000000000"));
@@ -149,7 +149,7 @@ fn call_create_external_over_placeholder() {
 
 #[test]
 fn call_resurrect() {
-    let mut rt = construct_and_verify();
+    let rt = construct_and_verify();
 
     let caller_id_addr = Address::new_id(110);
     let caller_eth_addr = EthAddress(hex_literal::hex!("CAFEB0BA00000000000000000000000000000000"));
@@ -201,7 +201,7 @@ fn call_resurrect() {
 
 #[test]
 fn call_create2() {
-    let mut rt = construct_and_verify();
+    let rt = construct_and_verify();
 
     let id_addr = Address::new_id(110);
     let eth_addr = EthAddress(hex_literal::hex!("CAFEB0BA00000000000000000000000000000000"));
@@ -267,7 +267,7 @@ fn call_create2() {
 }
 
 pub fn construct_and_verify() -> MockRuntime {
-    let mut rt = MockRuntime { receiver: Address::new_id(10), ..Default::default() };
+    let rt = MockRuntime { receiver: Address::new_id(10), ..Default::default() };
 
     // construct EAM singleton actor
     rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);

--- a/actors/ethaccount/src/lib.rs
+++ b/actors/ethaccount/src/lib.rs
@@ -27,7 +27,7 @@ pub struct EthAccountActor;
 impl EthAccountActor {
     /// Ethereum Account actor constructor.
     /// NOTE: This method is NOT currently called from anywhere, instead the FVM just deploys EthAccounts.
-    pub fn constructor(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    pub fn constructor(rt: &impl Runtime) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
         match rt
@@ -52,7 +52,7 @@ impl EthAccountActor {
 
     // Always succeeds, accepting any transfers.
     pub fn fallback(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         method: MethodNum,
         _: Option<IpldBlock>,
     ) -> Result<Option<IpldBlock>, ActorError> {

--- a/actors/ethaccount/tests/ethaccount_test.rs
+++ b/actors/ethaccount/tests/ethaccount_test.rs
@@ -17,7 +17,7 @@ use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
 
 #[test]
 fn no_delegated_cant_deploy() {
-    let mut rt = new_runtime();
+    let rt = new_runtime();
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
     rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
     expect_abort_contains_message(
@@ -30,7 +30,7 @@ fn no_delegated_cant_deploy() {
 
 #[test]
 fn token_receiver() {
-    let mut rt = setup();
+    let rt = setup();
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(1234));
     rt.expect_validate_caller_any();

--- a/actors/ethaccount/tests/util.rs
+++ b/actors/ethaccount/tests/util.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use fil_actor_ethaccount::{EthAccountActor, Method};
 use fil_actors_runtime::test_utils::{MockRuntime, SYSTEM_ACTOR_CODE_ID};
 use fil_actors_runtime::EAM_ACTOR_ID;
@@ -10,15 +12,15 @@ pub const EOA: Address = Address::new_id(1000);
 pub fn new_runtime() -> MockRuntime {
     MockRuntime {
         receiver: EOA,
-        caller: SYSTEM_ACTOR_ADDR,
-        caller_type: *SYSTEM_ACTOR_CODE_ID,
+        caller: RefCell::new(SYSTEM_ACTOR_ADDR),
+        caller_type: RefCell::new(*SYSTEM_ACTOR_CODE_ID),
         ..Default::default()
     }
 }
 
 #[allow(dead_code)]
 pub fn setup() -> MockRuntime {
-    let mut rt = new_runtime();
+    let rt = new_runtime();
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
     rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
     rt.set_delegated_address(

--- a/actors/evm/src/interpreter/instructions/call.rs
+++ b/actors/evm/src/interpreter/instructions/call.rs
@@ -558,7 +558,7 @@ mod tests {
         let output_data = vec![0xCA, 0xFE, 0xBA, 0xBE];
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
                 rt.expect_send(
                     fil_dest,
                     crate::Method::InvokeContract as u64,
@@ -605,7 +605,7 @@ mod tests {
         let output_data = vec![0xCA, 0xFE, 0xBA, 0xBE];
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
                 rt.expect_send(
                     fil_dest,
                     crate::Method::InvokeContract as u64,
@@ -651,7 +651,7 @@ mod tests {
         let input_data = vec![0x01, 0x02, 0x03, 0x04];
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
                 rt.expect_send(
                     fil_dest,
                     crate::Method::InvokeContract as u64,
@@ -701,7 +701,7 @@ mod tests {
         output_data[31] = 0x04;
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
                 rt.expect_gas_available(10_000_000_000);
             }
             (m) {
@@ -739,7 +739,7 @@ mod tests {
         let output_data = vec![0xCA, 0xFE, 0xBA, 0xBE];
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
                 rt.receiver = receiver;
                 rt.set_address_actor_type(fil_dest, *EVM_ACTOR_CODE_ID);
 
@@ -812,7 +812,7 @@ mod tests {
         let output_data = vec![0xCA, 0xFE, 0xBA, 0xBE];
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
                 rt.expect_send(
                     fil_dest,
                     crate::Method::InvokeContract as u64,

--- a/actors/evm/src/interpreter/instructions/context.rs
+++ b/actors/evm/src/interpreter/instructions/context.rs
@@ -185,7 +185,7 @@ mod tests {
             let [a, b] = getting.to_be_bytes();
             evm_unit_test! {
                 (rt) {
-                    rt.in_call = true;
+                    rt.in_call.replace(true);
                     rt.set_epoch(current);
                     rt.tipset_cids.resize(current as usize, Cid::default());
                     if let Some(cid) = insert {
@@ -259,7 +259,7 @@ mod tests {
         for basefee in [12345, u128::MAX, 0, 1].map(U256::from) {
             evm_unit_test! {
                 (rt) {
-                    rt.base_fee = TokenAmount::from(&basefee);
+                    rt.base_fee.replace(TokenAmount::from(&basefee));
                 }
                 (m) {
                     BASEFEE;
@@ -353,7 +353,7 @@ mod tests {
         let fil_addr = FilAddress::new_id(1000);
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
                 rt.set_origin(fil_addr);
             }
             (m) {
@@ -372,7 +372,7 @@ mod tests {
         let fil_addr = FilAddress::new_delegated(EAM_ACTOR_ID, &addr_bytes).unwrap();
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
                 rt.set_origin(fil_addr);
             }
             (m) {
@@ -403,7 +403,7 @@ mod tests {
         // Note: This is currently buggy, as the price needs to be capped by the MaxFeeCap.
         evm_unit_test! {
             (rt) {
-                rt.base_fee = TokenAmount::from_atto(1000);
+                rt.base_fee.replace(TokenAmount::from_atto(1000));
                 rt.gas_premium = TokenAmount::from_atto(1234);
             }
             (m) {

--- a/actors/evm/src/interpreter/instructions/ext.rs
+++ b/actors/evm/src/interpreter/instructions/ext.rs
@@ -171,7 +171,7 @@ mod tests {
     fn test_extcodesize() {
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
 
                 let addr = FilAddress::new_id(1001);
                 rt.set_address_actor_type(addr, *EVM_ACTOR_CODE_ID);
@@ -207,7 +207,7 @@ mod tests {
     fn test_extcodesize_nonexist() {
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
             }
             (m) {
                 EXTCODESIZE;
@@ -226,7 +226,7 @@ mod tests {
 
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
 
                 let addr = FilAddress::new_id(1001);
                 rt.set_address_actor_type(addr, *EVM_ACTOR_CODE_ID);
@@ -265,7 +265,7 @@ mod tests {
 
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
 
                 let addr = FilAddress::new_id(1001);
                 rt.set_address_actor_type(addr, *EVM_ACTOR_CODE_ID);
@@ -304,7 +304,7 @@ mod tests {
 
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
 
                 let addr = FilAddress::new_id(1001);
                 rt.set_address_actor_type(addr, *EVM_ACTOR_CODE_ID);
@@ -344,7 +344,7 @@ mod tests {
 
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
 
                 let addr = FilAddress::new_id(1001);
                 rt.set_address_actor_type(addr, *EVM_ACTOR_CODE_ID);
@@ -379,7 +379,7 @@ mod tests {
     fn test_extcodehash_nonexist() {
         evm_unit_test! {
             (rt) {
-                rt.in_call = true;
+                rt.in_call.replace(true);
             }
             (m) {
                 EXTCODEHASH;

--- a/actors/evm/src/interpreter/precompiles/evm.rs
+++ b/actors/evm/src/interpreter/precompiles/evm.rs
@@ -313,8 +313,8 @@ mod tests {
 
     #[test]
     fn bn_recover() {
-        let mut rt = MockRuntime::default();
-        let mut system = System::create(&mut rt).unwrap();
+        let rt = MockRuntime::default();
+        let mut system = System::create(&rt).unwrap();
 
         let input = &hex!(
             "456e9aea5e197a1f1af7a3e85a3212fa4049a3ba34c2289b4c860fc0b0c64ef3" // h(ash)
@@ -356,8 +356,8 @@ mod tests {
         use super::sha256 as hash;
         let input = "foo bar baz boxy".as_bytes();
 
-        let mut rt = MockRuntime::default();
-        let mut system = System::create(&mut rt).unwrap();
+        let rt = MockRuntime::default();
+        let mut system = System::create(&rt).unwrap();
 
         let expected = hex!("ace8597929092c14bd028ede7b07727875788c7e130278b5afed41940d965aba");
         let res = hash(&mut system, input, PrecompileContext::default()).unwrap();
@@ -369,8 +369,8 @@ mod tests {
         use super::ripemd160 as hash;
         let input = "foo bar baz boxy".as_bytes();
 
-        let mut rt = MockRuntime::default();
-        let mut system = System::create(&mut rt).unwrap();
+        let rt = MockRuntime::default();
+        let mut system = System::create(&rt).unwrap();
 
         let expected = hex!("0000000000000000000000004cd7a0452bd3d682e4cbd5fa90f446d7285b156a");
         let res = hash(&mut system, input, PrecompileContext::default()).unwrap();
@@ -388,8 +388,8 @@ mod tests {
             "0A" // mod
         );
 
-        let mut rt = MockRuntime::default();
-        let mut system = System::create(&mut rt).unwrap();
+        let rt = MockRuntime::default();
+        let mut system = System::create(&rt).unwrap();
 
         let expected = hex!("08");
         let res = modexp(&mut system, input, PrecompileContext::default()).unwrap();
@@ -449,8 +449,8 @@ mod tests {
 
         #[test]
         fn bn_add() {
-            let mut rt = MockRuntime::default();
-            let mut system = System::create(&mut rt).unwrap();
+            let rt = MockRuntime::default();
+            let mut system = System::create(&rt).unwrap();
 
             let input = hex::decode(
                 "\
@@ -518,8 +518,8 @@ mod tests {
                 (modexp, "modexp_eip2565"),
             ];
 
-            let mut rt = MockRuntime::default();
-            let mut system = System::create(&mut rt).unwrap();
+            let rt = MockRuntime::default();
+            let mut system = System::create(&rt).unwrap();
 
             for (f, name) in tests {
                 let td = std::fs::read_to_string(format!("{TESTDATA_PATH}/{name}.json")).unwrap();
@@ -545,8 +545,8 @@ mod tests {
             let failures: &[(PrecompileFn<MockRuntime>, &'static str)] =
                 &[(blake2f, "fail-blake2f")];
 
-            let mut rt = MockRuntime::default();
-            let mut system = System::create(&mut rt).unwrap();
+            let rt = MockRuntime::default();
+            let mut system = System::create(&rt).unwrap();
 
             for (f, name) in failures {
                 let td = std::fs::read_to_string(format!("{TESTDATA_PATH}/{name}.json")).unwrap();
@@ -560,8 +560,8 @@ mod tests {
 
         #[test]
         fn bn_mul() {
-            let mut rt = MockRuntime::default();
-            let mut system = System::create(&mut rt).unwrap();
+            let rt = MockRuntime::default();
+            let mut system = System::create(&rt).unwrap();
 
             let input = hex::decode(
                 "\
@@ -613,8 +613,8 @@ mod tests {
 
         #[test]
         fn bn_pair() {
-            let mut rt = MockRuntime::default();
-            let mut system = System::create(&mut rt).unwrap();
+            let rt = MockRuntime::default();
+            let mut system = System::create(&rt).unwrap();
 
             let input = hex::decode(
                 "\
@@ -700,8 +700,8 @@ mod tests {
     #[test]
     fn blake2() {
         use super::blake2f;
-        let mut rt = MockRuntime::default();
-        let mut system = System::create(&mut rt).unwrap();
+        let rt = MockRuntime::default();
+        let mut system = System::create(&rt).unwrap();
 
         // // helper to turn EIP test cases into something readable
         // fn test_case_formatter(mut remaining: impl ToString) {

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -84,7 +84,7 @@ impl EvmBytecode {
 /// Platform Abstraction Layer
 /// that bridges the FVM world to EVM world
 pub struct System<'r, RT: Runtime> {
-    pub rt: &'r mut RT,
+    pub rt: &'r RT,
 
     /// The current bytecode. This is usually only "none" when the actor is first constructed.
     /// (blake2b256(ipld_raw(bytecode)), keccak256(bytecode))
@@ -106,7 +106,7 @@ pub struct System<'r, RT: Runtime> {
 }
 
 impl<'r, RT: Runtime> System<'r, RT> {
-    pub(crate) fn new(rt: &'r mut RT, readonly: bool) -> Self
+    pub(crate) fn new(rt: &'r RT, readonly: bool) -> Self
     where
         RT::Blockstore: Clone,
     {
@@ -125,7 +125,7 @@ impl<'r, RT: Runtime> System<'r, RT> {
 
     /// Resurrect the contract. This will return a new empty contract if, and only if, the contract
     /// is "dead".
-    pub fn resurrect(rt: &'r mut RT) -> Result<Self, ActorError>
+    pub fn resurrect(rt: &'r RT) -> Result<Self, ActorError>
     where
         RT::Blockstore: Clone,
     {
@@ -146,7 +146,7 @@ impl<'r, RT: Runtime> System<'r, RT> {
 
     /// Create the contract. This will return a new empty contract if, and only if, the contract
     /// doesn't have any state.
-    pub fn create(rt: &'r mut RT) -> Result<Self, ActorError>
+    pub fn create(rt: &'r RT) -> Result<Self, ActorError>
     where
         RT::Blockstore: Clone,
     {
@@ -159,7 +159,7 @@ impl<'r, RT: Runtime> System<'r, RT> {
     }
 
     /// Load the actor from state.
-    pub fn load(rt: &'r mut RT) -> Result<Self, ActorError>
+    pub fn load(rt: &'r RT) -> Result<Self, ActorError>
     where
         RT::Blockstore: Clone,
     {

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -1,5 +1,3 @@
-#![allow(unused_mut)]
-
 #[macro_export]
 macro_rules! evm_instruction {
     ($i:ident) => {

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -1,3 +1,5 @@
+#![allow(unused_mut)]
+
 #[macro_export]
 macro_rules! evm_instruction {
     ($i:ident) => {
@@ -20,7 +22,7 @@ macro_rules! evm_unit_test {
         use $crate::{Bytecode, EthAddress, ExecutionState};
 
         let mut $rt = MockRuntime::default();
-        $rt.in_call = true;
+        $rt.in_call.replace(true);
         $init
 
         let mut state = ExecutionState::new(
@@ -32,7 +34,7 @@ macro_rules! evm_unit_test {
 
         let code = vec![$($crate::evm_instruction!($inst)),*];
 
-        let mut system = System::new(&mut $rt, false);
+        let mut system = System::new(&$rt, false);
         let bytecode = Bytecode::new(code);
         #[allow(unused_mut)]
         let mut $machine = Machine {
@@ -53,7 +55,7 @@ macro_rules! evm_unit_test {
         use $crate::{Bytecode, EthAddress, ExecutionState};
 
         let mut rt = MockRuntime::default();
-        rt.in_call = true;
+        rt.in_call.replace(true);
         let mut state = ExecutionState::new(
             EthAddress::from_id(1000),
             EthAddress::from_id(1000),
@@ -63,7 +65,7 @@ macro_rules! evm_unit_test {
 
         let code = vec![$($crate::evm_instruction!($inst)),*];
 
-        let mut system = System::new(&mut rt, false);
+        let mut system = System::new(&rt, false);
         let bytecode = Bytecode::new(code);
         #[allow(unused_mut)]
         let mut $machine = Machine {

--- a/actors/evm/src/interpreter/test_util.rs
+++ b/actors/evm/src/interpreter/test_util.rs
@@ -21,6 +21,7 @@ macro_rules! evm_unit_test {
         use $crate::interpreter::{execution::Machine, system::System, Output};
         use $crate::{Bytecode, EthAddress, ExecutionState};
 
+        #[allow(unused_mut)]
         let mut $rt = MockRuntime::default();
         $rt.in_call.replace(true);
         $init
@@ -54,7 +55,7 @@ macro_rules! evm_unit_test {
         use $crate::interpreter::{execution::Machine, system::System, Output};
         use $crate::{Bytecode, EthAddress, ExecutionState};
 
-        let mut rt = MockRuntime::default();
+        let rt = MockRuntime::default();
         rt.in_call.replace(true);
         let mut state = ExecutionState::new(
             EthAddress::from_id(1000),

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -188,7 +188,7 @@ where
 }
 
 impl EvmContractActor {
-    pub fn constructor<RT>(rt: &mut RT, params: ConstructorParams) -> Result<(), ActorError>
+    pub fn constructor<RT>(rt: &RT, params: ConstructorParams) -> Result<(), ActorError>
     where
         RT: Runtime,
         RT::Blockstore: Clone,
@@ -197,7 +197,7 @@ impl EvmContractActor {
         initialize_evm_contract(&mut System::create(rt)?, params.creator, params.initcode.into())
     }
 
-    pub fn resurrect<RT>(rt: &mut RT, params: ResurrectParams) -> Result<(), ActorError>
+    pub fn resurrect<RT>(rt: &RT, params: ResurrectParams) -> Result<(), ActorError>
     where
         RT: Runtime,
         RT::Blockstore: Clone,
@@ -207,7 +207,7 @@ impl EvmContractActor {
     }
 
     pub fn invoke_contract_delegate<RT>(
-        rt: &mut RT,
+        rt: &RT,
         params: DelegateCallParams,
     ) -> Result<DelegateCallReturn, ActorError>
     where
@@ -230,7 +230,7 @@ impl EvmContractActor {
     }
 
     pub fn invoke_contract<RT>(
-        rt: &mut RT,
+        rt: &RT,
         params: InvokeContractParams,
     ) -> Result<InvokeContractReturn, ActorError>
     where
@@ -262,7 +262,7 @@ impl EvmContractActor {
     }
 
     pub fn handle_filecoin_method<RT>(
-        rt: &mut RT,
+        rt: &RT,
         method: u64,
         args: Option<IpldBlock>,
     ) -> Result<Option<IpldBlock>, ActorError>
@@ -281,7 +281,7 @@ impl EvmContractActor {
 
     /// Returns the contract's EVM bytecode, or `None` if the contract has been deleted (has called
     /// SELFDESTRUCT).
-    pub fn bytecode(rt: &mut impl Runtime) -> Result<BytecodeReturn, ActorError> {
+    pub fn bytecode(rt: &impl Runtime) -> Result<BytecodeReturn, ActorError> {
         // Any caller can fetch the bytecode of a contract; this is now EXT* opcodes work.
         rt.validate_immediate_caller_accept_any()?;
 
@@ -293,7 +293,7 @@ impl EvmContractActor {
         }
     }
 
-    pub fn bytecode_hash(rt: &mut impl Runtime) -> Result<BytecodeHash, ActorError> {
+    pub fn bytecode_hash(rt: &impl Runtime) -> Result<BytecodeHash, ActorError> {
         // Any caller can fetch the bytecode hash of a contract; this is where EXTCODEHASH gets it's value for EVM contracts.
         rt.validate_immediate_caller_accept_any()?;
 
@@ -307,7 +307,7 @@ impl EvmContractActor {
     }
 
     pub fn storage_at<RT>(
-        rt: &mut RT,
+        rt: &RT,
         params: GetStorageAtParams,
     ) -> Result<GetStorageAtReturn, ActorError>
     where

--- a/actors/evm/tests/basic.rs
+++ b/actors/evm/tests/basic.rs
@@ -27,7 +27,7 @@ fn simplecoin_test(bytecode: Vec<u8>) {
     let contract = Address::new_id(100);
 
     let mut rt = util::init_construct_and_verify(bytecode, |rt| {
-        rt.actor_code_cids.insert(contract, *EVM_ACTOR_CODE_ID);
+        rt.actor_code_cids.borrow_mut().insert(contract, *EVM_ACTOR_CODE_ID);
         rt.set_origin(contract);
     });
 
@@ -84,7 +84,7 @@ return
         (asm::new_contract("get_bytecode", init, body).unwrap(), body_bytecode)
     };
 
-    let mut rt = util::construct_and_verify(init_code);
+    let rt = util::construct_and_verify(init_code);
 
     rt.reset();
     rt.expect_validate_caller_any();
@@ -114,14 +114,14 @@ sstore";
         asm::new_contract("get_storage_at", init, body).unwrap()
     };
 
-    let mut rt = util::construct_and_verify(init_code);
+    let rt = util::construct_and_verify(init_code);
 
     rt.reset();
     let params = evm::GetStorageAtParams { storage_key: 0x8965.into() };
 
     let sender = Address::new_id(0); // zero address because this method is not invokable on-chain
     rt.expect_validate_caller_addr(vec![sender]);
-    rt.caller = sender;
+    rt.caller.replace(sender);
 
     //
     // Get the storage key that was initialized in the init code.

--- a/actors/evm/tests/basic.rs
+++ b/actors/evm/tests/basic.rs
@@ -26,7 +26,7 @@ fn basic_contract_construction_and_invocation() {
 fn simplecoin_test(bytecode: Vec<u8>) {
     let contract = Address::new_id(100);
 
-    let mut rt = util::init_construct_and_verify(bytecode, |rt| {
+    let rt = util::init_construct_and_verify(bytecode, |rt| {
         rt.actor_code_cids.borrow_mut().insert(contract, *EVM_ACTOR_CODE_ID);
         rt.set_origin(contract);
     });
@@ -41,7 +41,7 @@ fn simplecoin_test(bytecode: Vec<u8>) {
     let mut arg0 = vec![0u8; 32];
     solidity_params.append(&mut arg0);
 
-    let result = util::invoke_contract(&mut rt, &solidity_params);
+    let result = util::invoke_contract(&rt, &solidity_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(0));
 
     // invoke contract -- getBalance
@@ -54,7 +54,7 @@ fn simplecoin_test(bytecode: Vec<u8>) {
     arg0[31] = 100; // the owner address
     solidity_params.append(&mut arg0);
 
-    let result = util::invoke_contract(&mut rt, &solidity_params);
+    let result = util::invoke_contract(&rt, &solidity_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(10000));
 }
 
@@ -198,7 +198,7 @@ fn test_push_last_byte() {
     // bytecode where push32 opcode is the last/only byte
     let init_code = hex::decode("600180600b6000396000f37f").unwrap();
 
-    let mut rt = util::construct_and_verify(init_code);
+    let rt = util::construct_and_verify(init_code);
 
-    util::invoke_contract(&mut rt, &[]);
+    util::invoke_contract(&rt, &[]);
 }

--- a/actors/evm/tests/calc.rs
+++ b/actors/evm/tests/calc.rs
@@ -69,12 +69,12 @@ return
 fn test_magic_calc() {
     let contract = magic_calc_contract();
 
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
 
     // invoke contract -- get_magic
     let contract_params = vec![0u8; 32];
 
-    let result = util::invoke_contract(&mut rt, &contract_params);
+    let result = util::invoke_contract(&rt, &contract_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(0x42));
 
     // invoke contract -- add_magic
@@ -82,7 +82,7 @@ fn test_magic_calc() {
     contract_params[3] = 0x01;
     contract_params[35] = 0x01;
 
-    let result = util::invoke_contract(&mut rt, &contract_params);
+    let result = util::invoke_contract(&rt, &contract_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(0x43));
 
     // invoke contract -- mul_magic
@@ -90,6 +90,6 @@ fn test_magic_calc() {
     contract_params[3] = 0x02;
     contract_params[35] = 0x02;
 
-    let result = util::invoke_contract(&mut rt, &contract_params);
+    let result = util::invoke_contract(&rt, &contract_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(0x84));
 }

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -176,7 +176,7 @@ fn test_call() {
     let target = FILAddress::new_id(target_id);
     let evm_target = EthAddress(hex_literal::hex!("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"));
     let f4_target: FILAddress = evm_target.try_into().unwrap();
-    rt.actor_code_cids.insert(target, *EVM_ACTOR_CODE_ID);
+    rt.actor_code_cids.borrow_mut().insert(target, *EVM_ACTOR_CODE_ID);
     rt.set_delegated_address(target.id().unwrap(), f4_target);
 
     let evm_target_word = evm_target.as_evm_word();
@@ -223,7 +223,7 @@ fn test_transfer_nogas() {
     // create a mock actor and proxy a call through the proxy
     let target_id = 0x100;
     let target = FILAddress::new_id(target_id);
-    rt.actor_code_cids.insert(target, *EVM_ACTOR_CODE_ID);
+    rt.actor_code_cids.borrow_mut().insert(target, *EVM_ACTOR_CODE_ID);
 
     let evm_target_word = EthAddress::from_id(target_id).as_evm_word();
 
@@ -264,7 +264,7 @@ fn test_transfer_2300() {
     // create a mock actor and proxy a call through the proxy
     let target_id = 0x100;
     let target = FILAddress::new_id(target_id);
-    rt.actor_code_cids.insert(target, *EVM_ACTOR_CODE_ID);
+    rt.actor_code_cids.borrow_mut().insert(target, *EVM_ACTOR_CODE_ID);
 
     let evm_target_word = EthAddress::from_id(target_id).as_evm_word();
 
@@ -389,7 +389,7 @@ pub fn filecoin_call_actor_contract() -> Vec<u8> {
 #[test]
 fn test_reserved_method() {
     let contract = filecoin_fallback_contract();
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
 
     let code = rt.call::<evm::EvmContractActor>(0x42, None).unwrap_err().exit_code();
     assert_eq!(ExitCode::USR_UNHANDLED_MESSAGE, code);
@@ -398,7 +398,7 @@ fn test_reserved_method() {
 #[test]
 fn test_native_call() {
     let contract = filecoin_fallback_contract();
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
 
     rt.expect_validate_caller_any();
     let result = rt.call::<evm::EvmContractActor>(1024, None).unwrap();
@@ -468,7 +468,7 @@ fn test_callactor_inner(method_num: MethodNum, exit_code: ExitCode, valid_call_i
     // create a mock target and proxy a call through the proxy
     let target_id = 0x100;
     let target = FILAddress::new_id(target_id);
-    rt.actor_code_cids.insert(target, *EVM_ACTOR_CODE_ID);
+    rt.actor_code_cids.borrow_mut().insert(target, *EVM_ACTOR_CODE_ID);
 
     // dest + method with no data
     let mut contract_params = Vec::new();
@@ -1163,7 +1163,7 @@ impl ContractTester {
     fn new(addr: EthAddress, id: u64, contract_hex: &str) -> Self {
         init_logging().ok();
 
-        let mut rt = MockRuntime::default();
+        let rt = MockRuntime::default();
         let params = evm::ConstructorParams {
             creator: EthAddress::from_id(EAM_ACTOR_ID),
             initcode: hex::decode(contract_hex).unwrap().into(),

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -169,7 +169,7 @@ fn test_call() {
     let contract = call_proxy_contract();
 
     // construct the proxy
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
 
     // create a mock target and proxy a call through the proxy
     let target_id = 0x100;
@@ -206,7 +206,7 @@ fn test_call() {
         None,
     );
 
-    let result = util::invoke_contract(&mut rt, &contract_params);
+    let result = util::invoke_contract(&rt, &contract_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(0x42));
 }
 
@@ -218,7 +218,7 @@ fn test_transfer_nogas() {
     let contract = call_proxy_transfer_contract();
 
     // construct the proxy
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
 
     // create a mock actor and proxy a call through the proxy
     let target_id = 0x100;
@@ -248,7 +248,7 @@ fn test_transfer_nogas() {
         None,
     );
 
-    let result = util::invoke_contract(&mut rt, &contract_params);
+    let result = util::invoke_contract(&rt, &contract_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(0));
     rt.verify();
 }
@@ -259,7 +259,7 @@ fn test_transfer_2300() {
     let contract = call_proxy_gas2300_contract();
 
     // construct the proxy
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
 
     // create a mock actor and proxy a call through the proxy
     let target_id = 0x100;
@@ -289,7 +289,7 @@ fn test_transfer_2300() {
         None,
     );
 
-    let result = util::invoke_contract(&mut rt, &contract_params);
+    let result = util::invoke_contract(&rt, &contract_params);
     assert_eq!(U256::from_big_endian(&result), U256::from(0));
     rt.verify();
 }
@@ -329,7 +329,7 @@ return
 "#;
 
     let contract = asm::new_contract("call-output-region", init, body).unwrap();
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
 
     let address = EthAddress(util::CONTRACT_ADDRESS);
 
@@ -353,7 +353,7 @@ return
         rt.expect_gas_available(10_000_000_000);
 
         let out = util::invoke_contract(
-            &mut rt,
+            &rt,
             &[
                 U256::from(output_size).to_bytes().to_vec(),
                 address.as_evm_word().to_bytes().to_vec(),
@@ -463,7 +463,7 @@ fn test_callactor_inner(method_num: MethodNum, exit_code: ExitCode, valid_call_i
     const CALLACTOR_NUM_PARAMS: usize = 8;
 
     // construct the proxy
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
 
     // create a mock target and proxy a call through the proxy
     let target_id = 0x100;
@@ -577,7 +577,7 @@ fn test_callactor_inner(method_num: MethodNum, exit_code: ExitCode, valid_call_i
     };
 
     // invoke
-    test.run_test(&mut rt);
+    test.run_test(&rt);
 }
 
 #[test]
@@ -586,7 +586,7 @@ fn call_actor_weird_offset() {
         let (init, body) = util::PrecompileTest::test_runner_assembly();
         asm::new_contract("call_actor-precompile-test", &init, &body).unwrap()
     };
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
 
     let addr = Address::new_delegated(1234, b"foobarboxy").unwrap();
     let addr_bytes = addr.to_bytes();
@@ -629,7 +629,7 @@ fn call_actor_weird_offset() {
 
     let precompile_return = CallActorReturn::default();
 
-    test.run_test_expecting(&mut rt, precompile_return, util::PrecompileExit::Success);
+    test.run_test_expecting(&rt, precompile_return, util::PrecompileExit::Success);
 }
 
 #[test]
@@ -638,7 +638,7 @@ fn call_actor_overlapping() {
         let (init, body) = util::PrecompileTest::test_runner_assembly();
         asm::new_contract("call_actor-precompile-test", &init, &body).unwrap()
     };
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
     let addr = Address::new_delegated(1234, b"foobarboxy").unwrap();
 
     let mut call_params = CallActorParams::default();
@@ -679,7 +679,7 @@ fn call_actor_overlapping() {
     );
 
     test.input = call_params.into();
-    test.run_test_expecting(&mut rt, CallActorReturn::default(), util::PrecompileExit::Success);
+    test.run_test_expecting(&rt, CallActorReturn::default(), util::PrecompileExit::Success);
 }
 
 #[test]
@@ -688,7 +688,7 @@ fn call_actor_id_with_full_address() {
         let (init, body) = util::PrecompileTest::test_runner_assembly();
         asm::new_contract("call_actor-precompile-test", &init, &body).unwrap()
     };
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
     let addr = Address::new_delegated(1234, b"foobarboxy").unwrap();
     let actual_id_addr = 1234;
 
@@ -722,7 +722,7 @@ fn call_actor_id_with_full_address() {
     );
 
     test.input = call_params.into();
-    test.run_test_expecting(&mut rt, CallActorReturn::default(), util::PrecompileExit::Success);
+    test.run_test_expecting(&rt, CallActorReturn::default(), util::PrecompileExit::Success);
 }
 
 #[test]
@@ -731,7 +731,7 @@ fn call_actor_syscall_error() {
         let (init, body) = util::PrecompileTest::test_runner_assembly();
         asm::new_contract("call_actor-precompile-test", &init, &body).unwrap()
     };
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
     let addr = Address::new_delegated(1234, b"foobarboxy").unwrap();
 
     let mut call_params = CallActorParams::default();
@@ -768,7 +768,7 @@ fn call_actor_syscall_error() {
     );
 
     test.input = call_params.into();
-    test.run_test_expecting(&mut rt, expect, util::PrecompileExit::Success);
+    test.run_test_expecting(&rt, expect, util::PrecompileExit::Success);
 }
 
 #[cfg(test)]
@@ -780,7 +780,7 @@ mod call_actor_invalid {
             let (init, body) = util::PrecompileTest::test_runner_assembly();
             asm::new_contract("call_actor-precompile-test", &init, &body).unwrap()
         };
-        let mut rt = util::construct_and_verify(contract);
+        let rt = util::construct_and_verify(contract);
 
         let mut test = util::PrecompileTest {
             precompile_address: util::NativePrecompile::CallActor.eth_address(),
@@ -798,7 +798,7 @@ mod call_actor_invalid {
         }
 
         test.input = call_params.into();
-        test.run_test_expecting(&mut rt, vec![], util::PrecompileExit::Reverted);
+        test.run_test_expecting(&rt, vec![], util::PrecompileExit::Reverted);
     }
 
     #[test]

--- a/actors/evm/tests/context_opcodes.rs
+++ b/actors/evm/tests/context_opcodes.rs
@@ -42,7 +42,7 @@ cache:
 
 #[test]
 fn test_prevrandao() {
-    let mut rt = util::construct_and_verify(prevrandao_contract());
+    let rt = util::construct_and_verify(prevrandao_contract());
     rt.epoch.replace(101);
 
     // simple test
@@ -54,7 +54,7 @@ fn test_prevrandao() {
             [0u8; 32],
         );
 
-        let result = util::invoke_contract(&mut rt, &dispatch_num_word(0));
+        let result = util::invoke_contract(&rt, &dispatch_num_word(0));
         rt.verify();
         assert_eq!(result, [0u8; 32], "expected empty randomness");
         rt.reset();
@@ -72,7 +72,7 @@ fn test_prevrandao() {
             expected,
         );
 
-        let result = util::invoke_contract(&mut rt, &dispatch_num_word(0));
+        let result = util::invoke_contract(&rt, &dispatch_num_word(0));
         rt.verify();
         assert_eq!(result, expected, "expected random value {expected:?}");
         rt.reset();
@@ -89,7 +89,7 @@ fn test_prevrandao() {
         );
         let expected = [expected, expected].concat();
 
-        let result = util::invoke_contract(&mut rt, &dispatch_num_word(1));
+        let result = util::invoke_contract(&rt, &dispatch_num_word(1));
         rt.verify();
         assert_eq!(result, expected, "expected 2 of the same random value {expected:?}");
         rt.reset();

--- a/actors/evm/tests/context_opcodes.rs
+++ b/actors/evm/tests/context_opcodes.rs
@@ -43,7 +43,7 @@ cache:
 #[test]
 fn test_prevrandao() {
     let mut rt = util::construct_and_verify(prevrandao_contract());
-    rt.epoch = 101;
+    rt.epoch.replace(101);
 
     // simple test
     {

--- a/actors/evm/tests/create.rs
+++ b/actors/evm/tests/create.rs
@@ -54,7 +54,7 @@ fn test_create() {
     const GAS_SUBCALL: u64 = 63_000_000;
 
     let contract = magic_precompile_contract();
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
 
     let fake_eth_addr = EthAddress(hex_literal::hex!("CAFEB0BA00000000000000000000000000000000"));
     let fake_ret = eam::CreateReturn {
@@ -96,7 +96,7 @@ fn test_create() {
             None,
         );
 
-        let result = util::invoke_contract(&mut rt, &contract_params);
+        let result = util::invoke_contract(&rt, &contract_params);
         let result: [u8; 20] = result[12..].try_into().unwrap();
         let result = EthAddress(result);
         // make sure we arent doing weird things to EAM's return value
@@ -122,7 +122,7 @@ fn test_create() {
             None,
         );
 
-        let result = util::invoke_contract(&mut rt, &contract_params);
+        let result = util::invoke_contract(&rt, &contract_params);
         let result: [u8; 20] = result[12..].try_into().unwrap();
         let result = EthAddress(result);
         // make sure we arent doing weird things to EAM's return value
@@ -148,7 +148,7 @@ fn test_create() {
             None,
         );
 
-        let result = util::invoke_contract(&mut rt, &contract_params);
+        let result = util::invoke_contract(&rt, &contract_params);
         let result: [u8; 20] = result[12..].try_into().unwrap();
         let result = EthAddress(result);
         // make sure we arent doing weird things to EAM's return value
@@ -157,7 +157,7 @@ fn test_create() {
 
     // not enough funds -- create2
     {
-        let result = util::invoke_contract(&mut rt, &contract_params);
+        let result = util::invoke_contract(&rt, &contract_params);
         assert_eq!(&result[..], &[0; 32]);
     }
 
@@ -167,7 +167,7 @@ fn test_create() {
     {
         create_params.nonce += 3;
 
-        let result = util::invoke_contract(&mut rt, &contract_params);
+        let result = util::invoke_contract(&rt, &contract_params);
         assert_eq!(&result[..], &[0; 32]);
     }
 }

--- a/actors/evm/tests/delegate_call.rs
+++ b/actors/evm/tests/delegate_call.rs
@@ -131,6 +131,6 @@ fn test_delegate_call_caller() {
         None,
     );
 
-    let result = util::invoke_contract(&mut rt, &contract_params);
+    let result = util::invoke_contract(&rt, &contract_params);
     assert_eq!(U256::from_big_endian(&result), return_data);
 }

--- a/actors/evm/tests/delegate_call.rs
+++ b/actors/evm/tests/delegate_call.rs
@@ -68,7 +68,7 @@ fn test_delegate_call_caller() {
     let target = FILAddress::new_id(target_id);
     let evm_target = EthAddress(hex_literal::hex!("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"));
     let f4_target: FILAddress = evm_target.try_into().unwrap();
-    rt.actor_code_cids.insert(target, *EVM_ACTOR_CODE_ID);
+    rt.actor_code_cids.borrow_mut().insert(target, *EVM_ACTOR_CODE_ID);
     rt.set_delegated_address(target.id().unwrap(), f4_target);
     rt.receiver = target;
 
@@ -77,7 +77,7 @@ fn test_delegate_call_caller() {
     let evm_caller = EthAddress(util::CONTRACT_ADDRESS);
     let f4_caller = evm_caller.try_into().unwrap();
     rt.set_delegated_address(caller.id().unwrap(), f4_caller);
-    rt.caller = caller;
+    rt.caller.replace(caller);
 
     let evm_target_word = evm_target.as_evm_word();
 
@@ -104,7 +104,7 @@ fn test_delegate_call_caller() {
     // expected return data
     let return_data = U256::from(0x42);
 
-    rt.set_value(TokenAmount::from_whole(123));
+    rt.set_received(TokenAmount::from_whole(123));
     rt.expect_gas_available(10_000_000_000u64);
     rt.expect_send(
         target,

--- a/actors/evm/tests/env.rs
+++ b/actors/evm/tests/env.rs
@@ -35,9 +35,9 @@ impl TestEnv {
     /// Create a new test environment where the EVM actor code is already
     /// loaded under an actor address.
     pub fn new(evm_address: Address) -> Self {
-        let mut runtime = MockRuntime::new(TrackingBlockstore::new(MemoryBlockstore::new()));
+        let runtime = MockRuntime::new(TrackingBlockstore::new(MemoryBlockstore::new()));
 
-        runtime.actor_code_cids.insert(evm_address, *EVM_ACTOR_CODE_ID);
+        runtime.actor_code_cids.borrow_mut().insert(evm_address, *EVM_ACTOR_CODE_ID);
 
         Self { evm_address, runtime }
     }

--- a/actors/evm/tests/events.rs
+++ b/actors/evm/tests/events.rs
@@ -71,7 +71,7 @@ return
 fn test_events() {
     let contract = events_contract();
 
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
 
     // log zero with data
     let mut contract_params = vec![0u8; 32];
@@ -83,12 +83,12 @@ fn test_events() {
             value: vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         }],
     });
-    util::invoke_contract(&mut rt, &contract_params);
+    util::invoke_contract(&rt, &contract_params);
 
     // log zero without data
     contract_params[3] = 0x01;
     rt.expect_emitted_event(ActorEvent { entries: vec![] });
-    util::invoke_contract(&mut rt, &contract_params);
+    util::invoke_contract(&rt, &contract_params);
 
     // log four with data
     contract_params[3] = 0x02;
@@ -126,7 +126,7 @@ fn test_events() {
             },
         ],
     });
-    util::invoke_contract(&mut rt, &contract_params);
+    util::invoke_contract(&rt, &contract_params);
 
     rt.verify();
 }

--- a/actors/evm/tests/ext_opcodes.rs
+++ b/actors/evm/tests/ext_opcodes.rs
@@ -81,7 +81,7 @@ non_existent:
         asm::new_contract("extcodesize", init, body).unwrap()
     };
 
-    let mut rt = util::construct_and_verify(bytecode);
+    let rt = util::construct_and_verify(bytecode);
 
     // a fake CID
     let bytecode_cid = Cid::try_from("baeaikaia").unwrap();
@@ -125,7 +125,7 @@ non_existent:
             None,
         );
 
-        let result = util::invoke_contract(&mut rt, &method);
+        let result = util::invoke_contract(&rt, &method);
         rt.verify();
         assert_eq!(U256::from_big_endian(&result), expected);
         rt.reset();
@@ -135,7 +135,7 @@ non_existent:
     let method = util::dispatch_num_word(1);
     let expected = U256::from(0x01);
     {
-        let result = util::invoke_contract(&mut rt, &method);
+        let result = util::invoke_contract(&rt, &method);
         rt.verify();
         assert_eq!(U256::from_big_endian(&result), expected);
         rt.reset();
@@ -145,7 +145,7 @@ non_existent:
     let method = util::dispatch_num_word(2);
     let expected = U256::from(0x00);
     {
-        let result = util::invoke_contract(&mut rt, &method);
+        let result = util::invoke_contract(&rt, &method);
         rt.verify();
         assert_eq!(U256::from_big_endian(&result), expected);
         rt.reset();
@@ -155,7 +155,7 @@ non_existent:
     let method = util::dispatch_num_word(3);
     let expected = U256::from(0x00);
     {
-        let result = util::invoke_contract(&mut rt, &method);
+        let result = util::invoke_contract(&rt, &method);
         rt.verify();
         assert_eq!(U256::from_big_endian(&result), expected);
         rt.reset();
@@ -165,7 +165,7 @@ non_existent:
     let method = util::dispatch_num_word(5);
     let expected = U256::from(0x00);
     {
-        let result = util::invoke_contract(&mut rt, &method);
+        let result = util::invoke_contract(&rt, &method);
         rt.verify();
         assert_eq!(U256::from_big_endian(&result), expected);
         rt.reset();
@@ -175,7 +175,7 @@ non_existent:
     let method = util::dispatch_num_word(4);
     let expected = U256::from(0x00);
     {
-        let result = util::invoke_contract(&mut rt, &method);
+        let result = util::invoke_contract(&rt, &method);
         rt.verify();
         assert_eq!(U256::from_big_endian(&result), expected);
         rt.reset();
@@ -227,7 +227,7 @@ account:
         asm::new_contract("extcodehash", init, body).unwrap()
     };
 
-    let mut rt = util::construct_and_verify(bytecode);
+    let rt = util::construct_and_verify(bytecode);
 
     // 0x88 is an EVM actor
     let evm_target = FILAddress::new_id(0x88);
@@ -261,13 +261,13 @@ account:
     );
 
     // Evm code
-    let result = util::invoke_contract(&mut rt, &util::dispatch_num_word(0));
+    let result = util::invoke_contract(&rt, &util::dispatch_num_word(0));
     rt.verify();
     assert_eq!(U256::from_big_endian(&result), U256::from(bytecode_hash));
     rt.reset();
 
     // Native code is keccak256([0xfe])
-    let result = util::invoke_contract(&mut rt, &util::dispatch_num_word(1));
+    let result = util::invoke_contract(&rt, &util::dispatch_num_word(1));
     rt.verify();
     assert_eq!(
         U256::from_big_endian(&result),
@@ -276,13 +276,13 @@ account:
     rt.reset();
 
     // Non-existing contracts are 0
-    let result = util::invoke_contract(&mut rt, &util::dispatch_num_word(2));
+    let result = util::invoke_contract(&rt, &util::dispatch_num_word(2));
     rt.verify();
     assert_eq!(U256::from_big_endian(&result), U256::from(0));
     rt.reset();
 
     // _All_ existing accounts are empty hash
-    let result = util::invoke_contract(&mut rt, &util::dispatch_num_word(3));
+    let result = util::invoke_contract(&rt, &util::dispatch_num_word(3));
     rt.verify();
     assert_eq!(
         U256::from_big_endian(&result).to_bytes(),
@@ -380,7 +380,7 @@ precompile:
         asm::new_contract("extcodecopy", init, body).unwrap()
     };
 
-    let mut rt = util::construct_and_verify(bytecode);
+    let rt = util::construct_and_verify(bytecode);
 
     // 0x88 is an EVM actor
     let evm_target = FILAddress::new_id(0x88);
@@ -407,24 +407,24 @@ precompile:
         None,
     );
 
-    let result = util::invoke_contract(&mut rt, &util::dispatch_num_word(0));
+    let result = util::invoke_contract(&rt, &util::dispatch_num_word(0));
     rt.verify();
     assert_eq!(other_bytecode.as_slice(), result);
     rt.reset();
 
     // calling code copy on native actors return "invalid" instruction from EIP-141
-    let result = util::invoke_contract(&mut rt, &util::dispatch_num_word(1));
+    let result = util::invoke_contract(&rt, &util::dispatch_num_word(1));
     rt.verify();
     assert_eq!(vec![0xFE], result);
     rt.reset();
 
     // invalid addresses are flattened
-    let result = util::invoke_contract(&mut rt, &util::dispatch_num_word(2));
+    let result = util::invoke_contract(&rt, &util::dispatch_num_word(2));
     rt.verify();
     assert_eq!(U256::from_big_endian(&result), U256::from(0));
 
     // precompile addresses are flattened
-    let result = util::invoke_contract(&mut rt, &util::dispatch_num_word(3));
+    let result = util::invoke_contract(&rt, &util::dispatch_num_word(3));
     rt.verify();
     assert_eq!(U256::from_big_endian(&result), U256::from(0));
 }
@@ -470,7 +470,7 @@ init_extsize:
         asm::new_contract("ext_initcode", init, body).unwrap()
     };
 
-    let mut rt = util::init_construct_and_verify(bytecode, |rt| {
+    let rt = util::init_construct_and_verify(bytecode, |rt| {
         rt.expect_send(
             CONTRACT_ID,
             evm::Method::GetBytecodeHash as u64,
@@ -498,12 +498,12 @@ init_extsize:
     });
 
     // codehash
-    let result = util::invoke_contract(&mut rt, &util::dispatch_num_word(0));
+    let result = util::invoke_contract(&rt, &util::dispatch_num_word(0));
     rt.verify();
     assert_eq!(BytecodeHash::EMPTY.as_slice(), result);
 
     // codesize
-    let result = util::invoke_contract(&mut rt, &util::dispatch_num_word(1));
+    let result = util::invoke_contract(&rt, &util::dispatch_num_word(1));
     rt.verify();
     assert_eq!(U256::zero(), U256::from_big_endian(&result));
 }

--- a/actors/evm/tests/ext_opcodes.rs
+++ b/actors/evm/tests/ext_opcodes.rs
@@ -241,7 +241,7 @@ account:
     let native_target = FILAddress::new_id(0x8A);
     rt.set_address_actor_type(native_target, *PLACEHOLDER_ACTOR_CODE_ID);
 
-    let empty_hash = empty_bytecode_hash(&mut rt);
+    let empty_hash = empty_bytecode_hash(&rt);
 
     // a random hash value
     let bytecode = b"foo bar boxy";
@@ -296,7 +296,7 @@ account:
 
 #[test]
 fn test_getbytecodehash_method() {
-    let mut rt = util::construct_and_verify(Vec::new());
+    let rt = util::construct_and_verify(Vec::new());
     rt.expect_validate_caller_any();
 
     let res: BytecodeHash = rt
@@ -305,11 +305,11 @@ fn test_getbytecodehash_method() {
         .unwrap()
         .deserialize()
         .unwrap();
-    assert_eq!(<[u8; 32]>::from(res), empty_bytecode_hash(&mut rt))
+    assert_eq!(<[u8; 32]>::from(res), empty_bytecode_hash(&rt))
 }
 
 /// Keccak256 hash of &[]
-fn empty_bytecode_hash(rt: &mut impl Runtime) -> [u8; 32] {
+fn empty_bytecode_hash(rt: &impl Runtime) -> [u8; 32] {
     rt.hash(SupportedHashes::Keccak256, &[]).try_into().unwrap()
 }
 

--- a/actors/evm/tests/misc.rs
+++ b/actors/evm/tests/misc.rs
@@ -27,7 +27,7 @@ return
 
     let mut rt = util::construct_and_verify(contract);
     rt.tipset_timestamp = 123;
-    let result = util::invoke_contract(&mut rt, &[]);
+    let result = util::invoke_contract(&rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(123));
 }
 
@@ -57,29 +57,29 @@ return
         .collect();
 
     rt.epoch.replace(0xffff + 2);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let result = util::invoke_contract(&rt, &[]);
     assert_eq!(
         String::from_utf8_lossy(&result.to_vec()),
         String::from_utf8_lossy(rt.tipset_cids[0xffff].hash().digest())
     );
 
     rt.epoch.replace(0xffff + 256);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let result = util::invoke_contract(&rt, &[]);
     assert_eq!(
         String::from_utf8_lossy(&result.to_vec()),
         String::from_utf8_lossy(rt.tipset_cids[0xffff].hash().digest())
     );
 
     rt.epoch.replace(0xffff);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let result = util::invoke_contract(&rt, &[]);
     assert_eq!(&result, &[0u8; 32]);
 
     rt.epoch.replace(0xffff - 1);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let result = util::invoke_contract(&rt, &[]);
     assert_eq!(&result, &[0u8; 32]);
 
     rt.epoch.replace(0xffff + 257);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let result = util::invoke_contract(&rt, &[]);
     assert_eq!(&result, &[0u8; 32]);
 }
 
@@ -101,7 +101,7 @@ return
 
     let mut rt = util::construct_and_verify(contract);
     rt.chain_id = ChainID::from(1989);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let result = util::invoke_contract(&rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(1989));
 }
 
@@ -121,8 +121,8 @@ return
     )
     .unwrap();
 
-    let mut rt = util::construct_and_verify(contract);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let rt = util::construct_and_verify(contract);
+    let result = util::invoke_contract(&rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(10_000_000_000u64));
 }
 
@@ -145,7 +145,7 @@ return
     let mut rt = util::construct_and_verify(contract);
     rt.base_fee.replace(TokenAmount::from_atto(123));
     rt.gas_premium = TokenAmount::from_atto(345);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let result = util::invoke_contract(&rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(123 + 345));
 }
 
@@ -176,7 +176,7 @@ return
     let mut input_data = vec![0u8; 32];
     input_data[12] = 0xff;
     input_data[31] = 0x64;
-    let result = util::invoke_contract(&mut rt, &input_data);
+    let result = util::invoke_contract(&rt, &input_data);
     assert_eq!(U256::from_big_endian(&result), U256::from(123));
 }
 
@@ -202,10 +202,10 @@ return
     )
     .unwrap();
 
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
     let mut input_data = vec![0u8; 32];
     input_data[31] = 123;
-    let result = util::invoke_contract(&mut rt, &input_data);
+    let result = util::invoke_contract(&rt, &input_data);
     assert_eq!(U256::from_big_endian(&result), U256::from(0));
 }
 
@@ -226,8 +226,8 @@ return
     )
     .unwrap();
 
-    let mut rt = util::construct_and_verify(contract);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let rt = util::construct_and_verify(contract);
+    let result = util::invoke_contract(&rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(0));
 }
 
@@ -247,9 +247,9 @@ return
     )
     .unwrap();
 
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
     rt.expect_gas_available(123);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let result = util::invoke_contract(&rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(123));
 }
 
@@ -270,8 +270,8 @@ return
     )
     .unwrap();
 
-    let mut rt = util::construct_and_verify(contract);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let rt = util::construct_and_verify(contract);
+    let result = util::invoke_contract(&rt, &[]);
     let eth_address = &result[12..];
     // Make sure we get an actual eth address, not an embedded ID address.
     assert_eq!(&eth_address, &util::CONTRACT_ADDRESS);
@@ -294,8 +294,8 @@ return
     )
     .unwrap();
 
-    let mut rt = util::construct_and_verify(contract);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let rt = util::construct_and_verify(contract);
+    let result = util::invoke_contract(&rt, &[]);
     let eth_address = &result[12..];
     // The caller's address should be the init actor in this case.
     assert_eq!(&eth_address, &EthAddress::from_id(1).0);
@@ -318,10 +318,10 @@ return
     )
     .unwrap();
 
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
     // set the _id_ address here (ensures we resolve it correctly internally).
     rt.caller.replace(Address::new_id(0));
-    let result = util::invoke_contract(&mut rt, &[]);
+    let result = util::invoke_contract(&rt, &[]);
     let eth_address = &result[12..];
     // Make sure we prefer the eth address, if we have one.
     assert_eq!(eth_address, util::CONTRACT_ADDRESS);
@@ -344,9 +344,9 @@ return
     )
     .unwrap();
 
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
     rt.origin.replace(Address::new_id(10));
-    let result = util::invoke_contract(&mut rt, &[]);
+    let result = util::invoke_contract(&rt, &[]);
     let eth_address = &result[12..];
     // Make sure we prefer the eth address, if we have one.
     assert_eq!(eth_address, &EthAddress::from_id(10).0);
@@ -369,8 +369,8 @@ return
     )
     .unwrap();
 
-    let mut rt = util::construct_and_verify(contract);
-    let result = util::invoke_contract(&mut rt, &[]);
+    let rt = util::construct_and_verify(contract);
+    let result = util::invoke_contract(&rt, &[]);
     let eth_address = &result[12..];
     // Make sure we prefer the eth address, if we have one.
     assert_eq!(eth_address, util::CONTRACT_ADDRESS);

--- a/actors/evm/tests/misc.rs
+++ b/actors/evm/tests/misc.rs
@@ -56,29 +56,29 @@ return
         })
         .collect();
 
-    rt.epoch = 0xffff + 2;
+    rt.epoch.replace(0xffff + 2);
     let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(
         String::from_utf8_lossy(&result.to_vec()),
         String::from_utf8_lossy(rt.tipset_cids[0xffff].hash().digest())
     );
 
-    rt.epoch = 0xffff + 256;
+    rt.epoch.replace(0xffff + 256);
     let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(
         String::from_utf8_lossy(&result.to_vec()),
         String::from_utf8_lossy(rt.tipset_cids[0xffff].hash().digest())
     );
 
-    rt.epoch = 0xffff;
+    rt.epoch.replace(0xffff);
     let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(&result, &[0u8; 32]);
 
-    rt.epoch = 0xffff - 1;
+    rt.epoch.replace(0xffff - 1);
     let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(&result, &[0u8; 32]);
 
-    rt.epoch = 0xffff + 257;
+    rt.epoch.replace(0xffff + 257);
     let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(&result, &[0u8; 32]);
 }
@@ -143,7 +143,7 @@ return
     .unwrap();
 
     let mut rt = util::construct_and_verify(contract);
-    rt.base_fee = TokenAmount::from_atto(123);
+    rt.base_fee.replace(TokenAmount::from_atto(123));
     rt.gas_premium = TokenAmount::from_atto(345);
     let result = util::invoke_contract(&mut rt, &[]);
     assert_eq!(U256::from_big_endian(&result), U256::from(123 + 345));
@@ -320,7 +320,7 @@ return
 
     let mut rt = util::construct_and_verify(contract);
     // set the _id_ address here (ensures we resolve it correctly internally).
-    rt.caller = Address::new_id(0);
+    rt.caller.replace(Address::new_id(0));
     let result = util::invoke_contract(&mut rt, &[]);
     let eth_address = &result[12..];
     // Make sure we prefer the eth address, if we have one.
@@ -345,7 +345,7 @@ return
     .unwrap();
 
     let mut rt = util::construct_and_verify(contract);
-    rt.origin = Address::new_id(10);
+    rt.origin.replace(Address::new_id(10));
     let result = util::invoke_contract(&mut rt, &[]);
     let eth_address = &result[12..];
     // Make sure we prefer the eth address, if we have one.

--- a/actors/evm/tests/revert.rs
+++ b/actors/evm/tests/revert.rs
@@ -20,7 +20,7 @@ revert
     )
     .unwrap();
 
-    let mut rt = util::construct_and_verify(contract);
+    let rt = util::construct_and_verify(contract);
     rt.expect_validate_caller_any();
 
     let result = rt.call::<evm::EvmContractActor>(evm::Method::InvokeContract as u64, None);

--- a/actors/evm/tests/selfdestruct.rs
+++ b/actors/evm/tests/selfdestruct.rs
@@ -26,7 +26,7 @@ fn test_selfdestruct() {
     let token_amount = TokenAmount::from_whole(2);
 
     let mut rt = util::init_construct_and_verify(bytecode.clone(), |rt| {
-        rt.actor_code_cids.insert(contract, *EVM_ACTOR_CODE_ID);
+        rt.actor_code_cids.borrow_mut().insert(contract, *EVM_ACTOR_CODE_ID);
         rt.set_origin(contract);
         rt.set_balance(token_amount.clone());
     });
@@ -107,8 +107,8 @@ fn test_selfdestruct_missing_beneficiary() {
     let contract = Address::new_id(100);
     let beneficiary = Address::new_id(1001);
 
-    let mut rt = util::init_construct_and_verify(bytecode, |rt| {
-        rt.actor_code_cids.insert(contract, *EVM_ACTOR_CODE_ID);
+    let rt = util::init_construct_and_verify(bytecode, |rt| {
+        rt.actor_code_cids.borrow_mut().insert(contract, *EVM_ACTOR_CODE_ID);
         rt.set_origin(contract);
     });
 

--- a/actors/evm/tests/selfdestruct.rs
+++ b/actors/evm/tests/selfdestruct.rs
@@ -25,7 +25,7 @@ fn test_selfdestruct() {
 
     let token_amount = TokenAmount::from_whole(2);
 
-    let mut rt = util::init_construct_and_verify(bytecode.clone(), |rt| {
+    let rt = util::init_construct_and_verify(bytecode.clone(), |rt| {
         rt.actor_code_cids.borrow_mut().insert(contract, *EVM_ACTOR_CODE_ID);
         rt.set_origin(contract);
         rt.set_balance(token_amount.clone());
@@ -41,16 +41,13 @@ fn test_selfdestruct() {
 
     rt.expect_send_simple(beneficiary, METHOD_SEND, None, token_amount, None, ExitCode::OK);
 
-    assert!(util::invoke_contract(&mut rt, &selfdestruct_params).is_empty());
+    assert!(util::invoke_contract(&rt, &selfdestruct_params).is_empty());
     let state: State = rt.get_state();
     assert_eq!(state.tombstone, Some(Tombstone { origin: 100, nonce: 0 }));
     rt.verify();
 
     // Calls still work.
-    assert_eq!(
-        U256::from_big_endian(&util::invoke_contract(&mut rt, &returnone_params)),
-        U256::ONE
-    );
+    assert_eq!(U256::from_big_endian(&util::invoke_contract(&rt, &returnone_params)), U256::ONE);
     rt.verify();
 
     // Try to resurrect during the same "epoch". This should be forbidden.
@@ -70,14 +67,14 @@ fn test_selfdestruct() {
     // remaining funds, again).
     rt.expect_validate_caller_any();
     rt.expect_send_simple(beneficiary, METHOD_SEND, None, TokenAmount::zero(), None, ExitCode::OK);
-    assert!(util::invoke_contract(&mut rt, &selfdestruct_params).is_empty());
+    assert!(util::invoke_contract(&rt, &selfdestruct_params).is_empty());
     rt.verify();
 
     // Ok, call from a different origin so that the tombstone prevents any calls.
     rt.set_origin(beneficiary);
 
     // All calls should now do nothing (but still work).
-    assert!(util::invoke_contract(&mut rt, &returnone_params).is_empty());
+    assert!(util::invoke_contract(&rt, &returnone_params).is_empty());
     rt.verify();
 
     // We should now be able to resurrect.
@@ -93,10 +90,7 @@ fn test_selfdestruct() {
     rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR); // doesn't really matter
 
     // And calls should work again.
-    assert_eq!(
-        U256::from_big_endian(&util::invoke_contract(&mut rt, &returnone_params)),
-        U256::ONE
-    );
+    assert_eq!(U256::from_big_endian(&util::invoke_contract(&rt, &returnone_params)), U256::ONE);
     rt.verify();
 }
 

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -27,11 +27,11 @@ pub const CONTRACT_ADDRESS: [u8; 20] =
 #[allow(unused)]
 pub const CONTRACT_ID: Address = Address::new_id(0);
 
-pub fn init_construct_and_verify<F: FnOnce(&mut MockRuntime)>(
+pub fn init_construct_and_verify<F: FnOnce(&MockRuntime)>(
     initcode: Vec<u8>,
     initrt: F,
 ) -> MockRuntime {
-    let mut rt = MockRuntime::default();
+    let rt = MockRuntime::default();
 
     // enable logging to std
     test_utils::init_logging().ok();
@@ -39,7 +39,7 @@ pub fn init_construct_and_verify<F: FnOnce(&mut MockRuntime)>(
     // construct EVM actor
     rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
     rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
-    initrt(&mut rt);
+    initrt(&rt);
 
     // first actor created is 0
     rt.set_delegated_address(0, Address::new_delegated(EAM_ACTOR_ID, &CONTRACT_ADDRESS).unwrap());
@@ -66,7 +66,7 @@ pub fn init_construct_and_verify<F: FnOnce(&mut MockRuntime)>(
 }
 
 #[allow(dead_code)]
-pub fn invoke_contract(rt: &mut MockRuntime, input_data: &[u8]) -> Vec<u8> {
+pub fn invoke_contract(rt: &MockRuntime, input_data: &[u8]) -> Vec<u8> {
     rt.expect_validate_caller_any();
     let BytesDe(res) = rt
         .call::<evm::EvmContractActor>(
@@ -183,7 +183,7 @@ impl Debug for PrecompileTest {
 
 impl PrecompileTest {
     #[allow(dead_code)]
-    pub fn run_test(&self, rt: &mut MockRuntime) {
+    pub fn run_test(&self, rt: &MockRuntime) {
         rt.expect_gas_available(self.gas_avaliable);
         log::trace!("{:#?}", &self);
         // first byte is precompile number, second is output buffer size, rest is input to precompile
@@ -218,7 +218,7 @@ impl PrecompileTest {
     #[allow(dead_code)]
     pub fn run_test_expecting<T: Into<Vec<u8>>>(
         &mut self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         expecting: T,
         call_exit: PrecompileExit,
     ) {

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -38,7 +38,7 @@ pub struct Actor;
 
 impl Actor {
     /// Init actor constructor
-    pub fn constructor(rt: &mut impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
+    pub fn constructor(rt: &impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
         let sys_ref: &Address = &SYSTEM_ACTOR_ADDR;
         rt.validate_immediate_caller_is(std::iter::once(sys_ref))?;
         let state = State::new(rt.store(), params.network_name)?;
@@ -48,7 +48,7 @@ impl Actor {
     }
 
     /// Exec init actor
-    pub fn exec(rt: &mut impl Runtime, params: ExecParams) -> Result<ExecReturn, ActorError> {
+    pub fn exec(rt: &impl Runtime, params: ExecParams) -> Result<ExecReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
 
         log::trace!("called exec; params.code_cid: {:?}", &params.code_cid);
@@ -108,7 +108,7 @@ impl Actor {
     }
 
     /// Exec4 init actor
-    pub fn exec4(rt: &mut impl Runtime, params: Exec4Params) -> Result<Exec4Return, ActorError> {
+    pub fn exec4(rt: &impl Runtime, params: Exec4Params) -> Result<Exec4Return, ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&EAM_ACTOR_ADDR))?;
         // Compute the f4 address.
         let caller_id = rt.message().caller().id().unwrap();

--- a/actors/init/tests/init_actor_test.rs
+++ b/actors/init/tests/init_actor_test.rs
@@ -40,22 +40,21 @@ fn construct_runtime() -> MockRuntime {
 // Test to make sure we abort actors that can not call the exec function
 #[test]
 fn abort_cant_call_exec() {
-    let mut rt = construct_runtime();
-    construct_and_verify(&mut rt);
+    let rt = construct_runtime();
+    construct_and_verify(&rt);
     let anne = Address::new_id(1001);
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
 
-    let err =
-        exec_and_verify(&mut rt, *POWER_ACTOR_CODE_ID, &"").expect_err("Exec should have failed");
+    let err = exec_and_verify(&rt, *POWER_ACTOR_CODE_ID, &"").expect_err("Exec should have failed");
     assert_eq!(err.exit_code(), ExitCode::USR_FORBIDDEN);
     check_state(&rt);
 }
 
 #[test]
 fn repeated_robust_address() {
-    let mut rt = construct_runtime();
-    construct_and_verify(&mut rt);
+    let rt = construct_runtime();
+    construct_and_verify(&rt);
 
     // setup one msig actor
     let unique_address = Address::new_actor(b"multisig");
@@ -83,7 +82,7 @@ fn repeated_robust_address() {
         );
 
         // Return should have been successful. Check the returned addresses
-        let exec_ret = exec_and_verify(&mut rt, *MULTISIG_ACTOR_CODE_ID, &fake_params).unwrap();
+        let exec_ret = exec_and_verify(&rt, *MULTISIG_ACTOR_CODE_ID, &fake_params).unwrap();
         assert_eq!(unique_address, exec_ret.robust_address, "Robust address does not macth");
         assert_eq!(expected_id_addr, exec_ret.id_address, "Id address does not match");
         check_state(&rt);
@@ -112,8 +111,8 @@ fn repeated_robust_address() {
 
 #[test]
 fn create_2_payment_channels() {
-    let mut rt = construct_runtime();
-    construct_and_verify(&mut rt);
+    let rt = construct_runtime();
+    construct_and_verify(&rt);
     let anne = Address::new_id(1001);
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
@@ -146,7 +145,7 @@ fn create_2_payment_channels() {
             ExitCode::OK,
         );
 
-        let exec_ret = exec_and_verify(&mut rt, *PAYCH_ACTOR_CODE_ID, &fake_params).unwrap();
+        let exec_ret = exec_and_verify(&rt, *PAYCH_ACTOR_CODE_ID, &fake_params).unwrap();
         assert_eq!(unique_address, exec_ret.robust_address, "Robust Address does not match");
         assert_eq!(expected_id_addr, exec_ret.id_address, "Id address does not match");
 
@@ -163,8 +162,8 @@ fn create_2_payment_channels() {
 
 #[test]
 fn create_storage_miner() {
-    let mut rt = construct_runtime();
-    construct_and_verify(&mut rt);
+    let rt = construct_runtime();
+    construct_and_verify(&rt);
 
     // only the storage power actor can create a miner
     rt.set_caller(*POWER_ACTOR_CODE_ID, STORAGE_POWER_ACTOR_ADDR);
@@ -187,7 +186,7 @@ fn create_storage_miner() {
         ExitCode::OK,
     );
 
-    let exec_ret = exec_and_verify(&mut rt, *MINER_ACTOR_CODE_ID, &fake_params).unwrap();
+    let exec_ret = exec_and_verify(&rt, *MINER_ACTOR_CODE_ID, &fake_params).unwrap();
     assert_eq!(unique_address, exec_ret.robust_address);
     assert_eq!(expected_id_addr, exec_ret.id_address);
 
@@ -209,8 +208,8 @@ fn create_storage_miner() {
 
 #[test]
 fn create_multisig_actor() {
-    let mut rt = construct_runtime();
-    construct_and_verify(&mut rt);
+    let rt = construct_runtime();
+    construct_and_verify(&rt);
 
     // Actor creating multisig actor
     let some_acc_actor = Address::new_id(1234);
@@ -237,7 +236,7 @@ fn create_multisig_actor() {
     );
 
     // Return should have been successful. Check the returned addresses
-    let exec_ret = exec_and_verify(&mut rt, *MULTISIG_ACTOR_CODE_ID, &fake_params).unwrap();
+    let exec_ret = exec_and_verify(&rt, *MULTISIG_ACTOR_CODE_ID, &fake_params).unwrap();
     assert_eq!(unique_address, exec_ret.robust_address, "Robust address does not macth");
     assert_eq!(expected_id_addr, exec_ret.id_address, "Id address does not match");
     check_state(&rt);
@@ -245,8 +244,8 @@ fn create_multisig_actor() {
 
 #[test]
 fn sending_constructor_failure() {
-    let mut rt = construct_runtime();
-    construct_and_verify(&mut rt);
+    let rt = construct_runtime();
+    construct_and_verify(&rt);
 
     // Only the storage power actor can create a miner
     rt.set_caller(*POWER_ACTOR_CODE_ID, STORAGE_POWER_ACTOR_ADDR);
@@ -270,7 +269,7 @@ fn sending_constructor_failure() {
         ExitCode::USR_ILLEGAL_STATE,
     );
 
-    let error = exec_and_verify(&mut rt, *MINER_ACTOR_CODE_ID, &fake_params)
+    let error = exec_and_verify(&rt, *MINER_ACTOR_CODE_ID, &fake_params)
         .expect_err("sending constructor should have failed");
 
     let error_exit_code = error.exit_code();
@@ -290,8 +289,8 @@ fn sending_constructor_failure() {
 
 #[test]
 fn call_exec4() {
-    let mut rt = construct_runtime();
-    construct_and_verify(&mut rt);
+    let rt = construct_runtime();
+    construct_and_verify(&rt);
 
     // Assign addresses
     let unique_address = Address::new_actor(b"test");
@@ -320,8 +319,7 @@ fn call_exec4() {
 
     // Return should have been successful. Check the returned addresses
     let exec_ret =
-        exec4_and_verify(&mut rt, namespace, subaddr, *MULTISIG_ACTOR_CODE_ID, &fake_params)
-            .unwrap();
+        exec4_and_verify(&rt, namespace, subaddr, *MULTISIG_ACTOR_CODE_ID, &fake_params).unwrap();
 
     assert_eq!(unique_address, exec_ret.robust_address, "Robust address does not macth");
     assert_eq!(expected_id_addr, exec_ret.id_address, "Id address does not match");
@@ -338,9 +336,8 @@ fn call_exec4() {
     // Try again and expect it to fail with "forbidden".
     let unique_address = Address::new_actor(b"test2");
     rt.new_actor_addr.replace(Some(unique_address));
-    let exec_err =
-        exec4_and_verify(&mut rt, namespace, subaddr, *MULTISIG_ACTOR_CODE_ID, &fake_params)
-            .unwrap_err();
+    let exec_err = exec4_and_verify(&rt, namespace, subaddr, *MULTISIG_ACTOR_CODE_ID, &fake_params)
+        .unwrap_err();
 
     assert_eq!(exec_err.exit_code(), ExitCode::USR_FORBIDDEN);
 
@@ -348,9 +345,8 @@ fn call_exec4() {
     rt.actor_code_cids.borrow_mut().remove(&resolved_id);
     let unique_address = Address::new_actor(b"test2");
     rt.new_actor_addr.replace(Some(unique_address));
-    let exec_err =
-        exec4_and_verify(&mut rt, namespace, subaddr, *MULTISIG_ACTOR_CODE_ID, &fake_params)
-            .unwrap_err();
+    let exec_err = exec4_and_verify(&rt, namespace, subaddr, *MULTISIG_ACTOR_CODE_ID, &fake_params)
+        .unwrap_err();
 
     assert_eq!(exec_err.exit_code(), ExitCode::USR_FORBIDDEN);
 }
@@ -358,8 +354,8 @@ fn call_exec4() {
 // Try turning a placeholder into an f4 actor.
 #[test]
 fn call_exec4_placeholder() {
-    let mut rt = construct_runtime();
-    construct_and_verify(&mut rt);
+    let rt = construct_runtime();
+    construct_and_verify(&rt);
 
     // Assign addresses
     let unique_address = Address::new_actor(b"test");
@@ -400,8 +396,7 @@ fn call_exec4_placeholder() {
 
     // Return should have been successful. Check the returned addresses
     let exec_ret =
-        exec4_and_verify(&mut rt, namespace, subaddr, *MULTISIG_ACTOR_CODE_ID, &fake_params)
-            .unwrap();
+        exec4_and_verify(&rt, namespace, subaddr, *MULTISIG_ACTOR_CODE_ID, &fake_params).unwrap();
 
     assert_eq!(unique_address, exec_ret.robust_address, "Robust address does not macth");
     assert_eq!(expected_id_addr, exec_ret.id_address, "Id address does not match");
@@ -416,7 +411,7 @@ fn call_exec4_placeholder() {
     assert_eq!(expected_id_addr, resolved_id, "f4 address not assigned to the right actor");
 }
 
-fn construct_and_verify(rt: &mut MockRuntime) {
+fn construct_and_verify(rt: &MockRuntime) {
     rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
     let params = ConstructorParams { network_name: "mock".to_string() };
@@ -441,7 +436,7 @@ fn construct_and_verify(rt: &mut MockRuntime) {
 }
 
 fn exec_and_verify<S: Serialize>(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     code_id: Cid,
     params: &S,
 ) -> Result<ExecReturn, ActorError>
@@ -461,7 +456,7 @@ where
 }
 
 fn exec4_and_verify<S: Serialize>(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     namespace: ActorID,
     subaddr: &[u8],
     code_id: Cid,

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -99,7 +99,7 @@ pub enum Method {
 pub struct Actor;
 
 impl Actor {
-    pub fn constructor(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    pub fn constructor(rt: &impl Runtime) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
         let st = State::new(rt.store())?;
@@ -108,7 +108,7 @@ impl Actor {
     }
 
     /// Deposits the received value into the balance held in escrow.
-    fn add_balance(rt: &mut impl Runtime, params: AddBalanceParams) -> Result<(), ActorError> {
+    fn add_balance(rt: &impl Runtime, params: AddBalanceParams) -> Result<(), ActorError> {
         let msg_value = rt.message().value_received();
 
         if msg_value <= TokenAmount::zero() {
@@ -134,7 +134,7 @@ impl Actor {
     /// Attempt to withdraw the specified amount from the balance held in escrow.
     /// If less than the specified amount is available, yields the entire available balance.
     fn withdraw_balance(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: WithdrawBalanceParams,
     ) -> Result<WithdrawBalanceReturn, ActorError> {
         if params.amount < TokenAmount::zero() {
@@ -164,7 +164,7 @@ impl Actor {
 
     /// Returns the escrow balance and locked amount for an address.
     fn get_balance(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: GetBalanceParams,
     ) -> Result<GetBalanceReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -192,7 +192,7 @@ impl Actor {
 
     /// Publish a new set of storage deals (not yet included in a sector).
     fn publish_storage_deals(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: PublishStorageDealsParams,
     ) -> Result<PublishStorageDealsReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -488,7 +488,7 @@ impl Actor {
     /// Verify that a given set of storage deals is valid for a sector currently being PreCommitted
     /// and return UnsealedCID for the set of deals.
     fn verify_deals_for_activation(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: VerifyDealsForActivationParams,
     ) -> Result<VerifyDealsForActivationReturn, ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
@@ -528,7 +528,7 @@ impl Actor {
     }
     /// Activate a set of deals, returning the combined deal space and extra info for verified deals.
     fn activate_deals(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ActivateDealsParams,
     ) -> Result<ActivateDealsResult, ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
@@ -622,7 +622,7 @@ impl Actor {
     /// Slash provider collateral, refund client collateral, and refund partial unpaid escrow
     /// amount to client.
     fn on_miner_sectors_terminate(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: OnMinerSectorsTerminateParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
@@ -684,7 +684,7 @@ impl Actor {
     }
 
     fn compute_data_commitment(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ComputeDataCommitmentParams,
     ) -> Result<ComputeDataCommitmentReturn, ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
@@ -705,7 +705,7 @@ impl Actor {
         Ok(ComputeDataCommitmentReturn { commds })
     }
 
-    fn cron_tick(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    fn cron_tick(rt: &impl Runtime) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&CRON_ACTOR_ADDR))?;
 
         let mut amount_slashed = TokenAmount::zero();
@@ -885,7 +885,7 @@ impl Actor {
     /// This will be available after the deal is published (whether or not is is activated)
     /// and up until some undefined period after it is terminated.
     fn get_deal_data_commitment(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: GetDealDataCommitmentParams,
     ) -> Result<GetDealDataCommitmentReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -895,7 +895,7 @@ impl Actor {
 
     /// Returns the client of a deal proposal.
     fn get_deal_client(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: GetDealClientParams,
     ) -> Result<GetDealClientReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -905,7 +905,7 @@ impl Actor {
 
     /// Returns the provider of a deal proposal.
     fn get_deal_provider(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: GetDealProviderParams,
     ) -> Result<GetDealProviderReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -915,7 +915,7 @@ impl Actor {
 
     /// Returns the label of a deal proposal.
     fn get_deal_label(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: GetDealLabelParams,
     ) -> Result<GetDealLabelReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -925,7 +925,7 @@ impl Actor {
 
     /// Returns the start epoch and duration (in epochs) of a deal proposal.
     fn get_deal_term(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: GetDealTermParams,
     ) -> Result<GetDealTermReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -935,7 +935,7 @@ impl Actor {
 
     /// Returns the total price that will be paid from the client to the provider for this deal.
     fn get_deal_total_price(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: GetDealTotalPriceParams,
     ) -> Result<GetDealTotalPriceReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -945,7 +945,7 @@ impl Actor {
 
     /// Returns the client collateral requirement for a deal proposal.
     fn get_deal_client_collateral(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: GetDealClientCollateralParams,
     ) -> Result<GetDealClientCollateralReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -955,7 +955,7 @@ impl Actor {
 
     /// Returns the provider collateral requirement for a deal proposal.
     fn get_deal_provider_collateral(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: GetDealProviderCollateralParams,
     ) -> Result<GetDealProviderCollateralReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -967,7 +967,7 @@ impl Actor {
     /// Note that the source of truth for verified allocations and claims is
     /// the verified registry actor.
     fn get_deal_verified(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: GetDealVerifiedParams,
     ) -> Result<GetDealVerifiedReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -981,7 +981,7 @@ impl Actor {
     /// Returns USR_NOT_FOUND if the deal doesn't exist (yet), or EX_DEAL_EXPIRED if the deal
     /// has been removed from state.
     fn get_deal_activation(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: GetDealActivationParams,
     ) -> Result<GetDealActivationReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -1147,7 +1147,7 @@ fn datacap_transfer_request(
 
 // Invokes transfer_from on the data cap token actor.
 fn transfer_from(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     params: TransferFromParams,
 ) -> Result<Vec<AllocationID>, ActorError> {
     let ret = extract_send_result(rt.send_simple(
@@ -1166,7 +1166,7 @@ fn transfer_from(
 }
 
 // Invokes BalanceOf on the data cap token actor.
-fn balance_of(rt: &mut impl Runtime, owner: &Address) -> Result<TokenAmount, ActorError> {
+fn balance_of(rt: &impl Runtime, owner: &Address) -> Result<TokenAmount, ActorError> {
     let params = IpldBlock::serialize_cbor(owner)?;
     let ret = extract_send_result(rt.send_simple(
         &DATACAP_TOKEN_ACTOR_ADDR,
@@ -1362,7 +1362,7 @@ pub(crate) fn deal_cid(proposal: &DealProposal) -> Result<Cid, ActorError> {
 }
 
 fn request_miner_control_addrs(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     miner_id: ActorID,
 ) -> Result<(Address, Address, Vec<Address>), ActorError> {
     let addrs: ext::miner::GetControlAddressesReturnParams =
@@ -1379,7 +1379,7 @@ fn request_miner_control_addrs(
 /// Resolves a provider or client address to the canonical form against which a balance should be held, and
 /// the designated recipient address of withdrawals (which is the same, for simple account parties).
 fn escrow_address(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     addr: &Address,
 ) -> Result<(Address, Address, Vec<Address>), ActorError> {
     // Resolve the provided address to the canonical form against which the balance is held.
@@ -1403,7 +1403,7 @@ fn escrow_address(
 }
 
 /// Requests the current epoch target block reward from the reward actor.
-fn request_current_baseline_power(rt: &mut impl Runtime) -> Result<StoragePower, ActorError> {
+fn request_current_baseline_power(rt: &impl Runtime) -> Result<StoragePower, ActorError> {
     let ret: ThisEpochRewardReturn = deserialize_block(extract_send_result(rt.send_simple(
         &REWARD_ACTOR_ADDR,
         ext::reward::THIS_EPOCH_REWARD_METHOD,
@@ -1416,7 +1416,7 @@ fn request_current_baseline_power(rt: &mut impl Runtime) -> Result<StoragePower,
 /// Requests the current network total power and pledge from the power actor.
 /// Returns a tuple of (raw_power, qa_power).
 fn request_current_network_power(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
 ) -> Result<(StoragePower, StoragePower), ActorError> {
     let ret: ext::power::CurrentTotalPowerReturnParams =
         deserialize_block(extract_send_result(rt.send_simple(

--- a/actors/market/tests/activate_deal_failures.rs
+++ b/actors/market/tests/activate_deal_failures.rs
@@ -22,10 +22,10 @@ fn fail_when_caller_is_not_the_provider_of_the_deal() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
 
-    let mut rt = setup();
+    let rt = setup();
     let provider2_addr = Address::new_id(201);
     let addrs = MinerAddresses { provider: provider2_addr, ..MinerAddresses::default() };
-    let deal_id = generate_and_publish_deal(&mut rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch);
+    let deal_id = generate_and_publish_deal(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch);
 
     let params = ActivateDealsParams { deal_ids: vec![deal_id], sector_expiry };
 
@@ -87,15 +87,15 @@ fn fail_when_deal_has_already_been_activated() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
 
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id]);
 
     rt.expect_validate_caller_type(vec![Type::Miner]);
     rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
@@ -118,16 +118,16 @@ fn fail_when_deal_has_already_been_expired() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
 
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
 
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     let current = end_epoch + 25;
     rt.set_epoch(current);
@@ -140,9 +140,9 @@ fn fail_when_deal_has_already_been_expired() {
         ExitCode::OK,
     );
 
-    cron_tick(&mut rt);
+    cron_tick(&rt);
 
-    assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal);
 
     let mut st: State = rt.get_state::<State>();
     st.next_id = deal_id + 1;
@@ -150,6 +150,6 @@ fn fail_when_deal_has_already_been_expired() {
     expect_abort_contains_message(
         EX_DEAL_EXPIRED,
         "expired",
-        activate_deals_raw(&mut rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id]),
+        activate_deals_raw(&rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id]),
     );
 }

--- a/actors/market/tests/activate_deal_failures.rs
+++ b/actors/market/tests/activate_deal_failures.rs
@@ -45,7 +45,7 @@ fn fail_when_caller_is_not_the_provider_of_the_deal() {
 
 #[test]
 fn fail_when_caller_is_not_a_storage_miner_actor() {
-    let mut rt = setup();
+    let rt = setup();
     rt.expect_validate_caller_type(vec![Type::Miner]);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, PROVIDER_ADDR);
 
@@ -64,7 +64,7 @@ fn fail_when_caller_is_not_a_storage_miner_actor() {
 
 #[test]
 fn fail_when_deal_has_not_been_published_before() {
-    let mut rt = setup();
+    let rt = setup();
     let params = ActivateDealsParams { deal_ids: vec![DealID::from(42u32)], sector_expiry: 0 };
 
     rt.expect_validate_caller_type(vec![Type::Miner]);

--- a/actors/market/tests/compute_data_commitment.rs
+++ b/actors/market/tests/compute_data_commitment.rs
@@ -87,7 +87,7 @@ mod compute_data_commitment {
 
     #[test]
     fn success_on_empty_piece_info() {
-        let mut rt = setup();
+        let rt = setup();
         let input =
             SectorDataSpec { deal_ids: vec![], sector_type: RegisteredSealProof::StackedDRG8MiBV1 };
         let param = ComputeDataCommitmentParams { inputs: vec![input] };
@@ -197,7 +197,7 @@ mod compute_data_commitment {
 
     #[test]
     fn fail_when_deal_proposal_is_absent() {
-        let mut rt = setup();
+        let rt = setup();
         let input = SectorDataSpec {
             deal_ids: vec![1],
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,

--- a/actors/market/tests/compute_data_commitment.rs
+++ b/actors/market/tests/compute_data_commitment.rs
@@ -28,24 +28,24 @@ mod compute_data_commitment {
         let start_epoch = 10;
         let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
 
-        let mut rt = setup();
+        let rt = setup();
         let deal_id1 = generate_and_publish_deal(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             start_epoch,
             end_epoch,
         );
-        let d1 = get_deal_proposal(&mut rt, deal_id1);
+        let d1 = get_deal_proposal(&rt, deal_id1);
 
         let deal_id2 = generate_and_publish_deal(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             start_epoch,
             end_epoch + 1,
         );
-        let d2 = get_deal_proposal(&mut rt, deal_id2);
+        let d2 = get_deal_proposal(&rt, deal_id2);
 
         let input = SectorDataSpec {
             deal_ids: vec![deal_id1, deal_id2],
@@ -124,24 +124,24 @@ mod compute_data_commitment {
         let start_epoch = 10;
         let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
 
-        let mut rt = setup();
+        let rt = setup();
         let deal_id1 = generate_and_publish_deal(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             start_epoch,
             end_epoch,
         );
-        let d1 = get_deal_proposal(&mut rt, deal_id1);
+        let d1 = get_deal_proposal(&rt, deal_id1);
 
         let deal_id2 = generate_and_publish_deal(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             start_epoch,
             end_epoch + 1,
         );
-        let d2 = get_deal_proposal(&mut rt, deal_id2);
+        let d2 = get_deal_proposal(&rt, deal_id2);
 
         let param = ComputeDataCommitmentParams {
             inputs: vec![
@@ -220,15 +220,15 @@ mod compute_data_commitment {
         let start_epoch = 10;
         let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
 
-        let mut rt = setup();
+        let rt = setup();
         let deal_id = generate_and_publish_deal(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             start_epoch,
             end_epoch,
         );
-        let d = get_deal_proposal(&mut rt, deal_id);
+        let d = get_deal_proposal(&rt, deal_id);
         let input = SectorDataSpec {
             deal_ids: vec![deal_id],
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
@@ -260,9 +260,9 @@ mod compute_data_commitment {
         let start_epoch = 10;
         let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
 
-        let mut rt = setup();
+        let rt = setup();
         let deal_id1 = generate_and_publish_deal(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             start_epoch,
@@ -306,16 +306,16 @@ mod compute_data_commitment {
         let start_epoch = 10;
         let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
 
-        let mut rt = setup();
+        let rt = setup();
         let deal_id1 = generate_and_publish_deal(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             start_epoch,
             end_epoch,
         );
         let deal_id2 = generate_and_publish_deal(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             start_epoch,

--- a/actors/market/tests/cron_tick_deal_expiry.rs
+++ b/actors/market/tests/cron_tick_deal_expiry.rs
@@ -14,9 +14,9 @@ const SECTOR_EXPIRY: ChainEpoch = END_EPOCH + 400;
 
 #[test]
 fn deal_is_correctly_processed_if_first_cron_after_expiry() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
@@ -24,30 +24,30 @@ fn deal_is_correctly_processed_if_first_cron_after_expiry() {
         0,
         SECTOR_EXPIRY,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     // move the current epoch to startEpoch
     let current = START_EPOCH;
     rt.set_epoch(current);
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert!(pay.is_zero());
     assert!(slashed.is_zero());
     // assert deal exists
-    let _found = get_deal_proposal(&mut rt, deal_id);
+    let _found = get_deal_proposal(&rt, deal_id);
 
     // move the epoch to endEpoch+5(anything greater than endEpoch)
     // total payment = (end - start)
     let current = END_EPOCH + 5;
     rt.set_epoch(current);
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     let duration = END_EPOCH - START_EPOCH;
     assert_eq!(duration * &deal_proposal.storage_price_per_epoch, pay);
     assert!(slashed.is_zero());
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal);
     check_state(&rt);
 }
 
@@ -55,9 +55,9 @@ fn deal_is_correctly_processed_if_first_cron_after_expiry() {
 fn regular_payments_till_deal_expires_and_then_locked_funds_are_unlocked() {
     // start epoch should equal first processing epoch for logic to work
     let start_epoch = Policy::default().deal_updates_interval;
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -65,40 +65,40 @@ fn regular_payments_till_deal_expires_and_then_locked_funds_are_unlocked() {
         0,
         SECTOR_EXPIRY,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     // move the current epoch to startEpoch + 5 so payment is made
     let current = start_epoch + 5;
     rt.set_epoch(current);
     // assert payment
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(5 * &deal_proposal.storage_price_per_epoch, pay);
     assert!(slashed.is_zero());
 
     // Setting the current epoch to anything less than next schedule wont make any payment
     let current = current + Policy::default().deal_updates_interval - 1;
     rt.set_epoch(current);
-    cron_tick_no_change(&mut rt, CLIENT_ADDR, PROVIDER_ADDR);
+    cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     // however setting the current epoch to next schedle will make the payment
     let current = current + 1;
     rt.set_epoch(current);
     let duration = Policy::default().deal_updates_interval;
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(duration * &deal_proposal.storage_price_per_epoch, pay);
     assert!(slashed.is_zero());
 
     // a second cron tick for the same epoch should not change anything
-    cron_tick_no_change(&mut rt, CLIENT_ADDR, PROVIDER_ADDR);
+    cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     // next epoch schedule
     let current = current + Policy::default().deal_updates_interval;
     rt.set_epoch(current);
     let duration = Policy::default().deal_updates_interval;
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(duration * &deal_proposal.storage_price_per_epoch, pay);
     assert!(slashed.is_zero());
 
@@ -107,12 +107,12 @@ fn regular_payments_till_deal_expires_and_then_locked_funds_are_unlocked() {
     let current = END_EPOCH + 300;
     rt.set_epoch(current);
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(duration * &deal_proposal.storage_price_per_epoch, pay);
     assert!(slashed.is_zero());
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal);
     check_state(&rt);
 }
 
@@ -121,9 +121,9 @@ fn payment_for_a_deal_if_deal_is_already_expired_before_a_cron_tick() {
     let start = 5;
     let end = start + 200 * EPOCHS_IN_DAY;
 
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start,
@@ -131,29 +131,29 @@ fn payment_for_a_deal_if_deal_is_already_expired_before_a_cron_tick() {
         0,
         SECTOR_EXPIRY,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     let current = end + 25;
     rt.set_epoch(current);
 
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!((end - start) * &deal_proposal.storage_price_per_epoch, pay);
     assert!(slashed.is_zero());
 
-    assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal);
 
     // running cron tick again doesn't do anything
-    cron_tick_no_change(&mut rt, CLIENT_ADDR, PROVIDER_ADDR);
+    cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
     check_state(&rt);
 }
 
 #[test]
 fn expired_deal_should_unlock_the_remaining_client_and_provider_locked_balance_after_payment_and_deal_should_be_deleted(
 ) {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
@@ -161,36 +161,36 @@ fn expired_deal_should_unlock_the_remaining_client_and_provider_locked_balance_a
         0,
         SECTOR_EXPIRY,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
-    let c_escrow = get_balance(&mut rt, &CLIENT_ADDR).balance;
-    let p_escrow = get_balance(&mut rt, &PROVIDER_ADDR).balance;
+    let c_escrow = get_balance(&rt, &CLIENT_ADDR).balance;
+    let p_escrow = get_balance(&rt, &PROVIDER_ADDR).balance;
 
     // move the current epoch so that deal is expired
     rt.set_epoch(END_EPOCH + 1000);
-    cron_tick(&mut rt);
+    cron_tick(&rt);
 
     // assert balances
     let payment = deal_proposal.total_storage_fee();
 
-    let client_acct = get_balance(&mut rt, &CLIENT_ADDR);
+    let client_acct = get_balance(&rt, &CLIENT_ADDR);
     assert_eq!(c_escrow - &payment, client_acct.balance);
     assert!(client_acct.locked.is_zero());
 
-    let provider_acct = get_balance(&mut rt, &PROVIDER_ADDR);
+    let provider_acct = get_balance(&rt, &PROVIDER_ADDR);
     assert_eq!(p_escrow + &payment, provider_acct.balance);
     assert!(provider_acct.locked.is_zero());
 
     // deal should be deleted
-    assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal);
     check_state(&rt);
 }
 
 #[test]
 fn all_payments_are_made_for_a_deal_client_withdraws_collateral_and_client_account_is_removed() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
@@ -198,20 +198,20 @@ fn all_payments_are_made_for_a_deal_client_withdraws_collateral_and_client_accou
         0,
         SECTOR_EXPIRY,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     // move the current epoch so that deal is expired
     rt.set_epoch(END_EPOCH + 100);
-    cron_tick(&mut rt);
-    assert_eq!(deal_proposal.client_collateral, get_balance(&mut rt, &CLIENT_ADDR).balance);
+    cron_tick(&rt);
+    assert_eq!(deal_proposal.client_collateral, get_balance(&rt, &CLIENT_ADDR).balance);
 
     // client withdraws collateral -> account should be removed as it now has zero balance
     withdraw_client_balance(
-        &mut rt,
+        &rt,
         deal_proposal.client_collateral.clone(),
         deal_proposal.client_collateral,
         CLIENT_ADDR,
     );
-    assert_account_zero(&mut rt, CLIENT_ADDR);
+    assert_account_zero(&rt, CLIENT_ADDR);
     check_state(&rt);
 }

--- a/actors/market/tests/cron_tick_deal_slashing.rs
+++ b/actors/market/tests/cron_tick_deal_slashing.rs
@@ -72,12 +72,12 @@ fn deal_is_slashed() {
     ];
     for tc in cases {
         eprintln!("Running testcase: {}", tc.name);
-        let mut rt = setup();
+        let rt = setup();
 
         // publish and activate
         rt.set_epoch(tc.activation_epoch);
         let deal_id = publish_and_activate_deal(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             tc.deal_start,
@@ -85,18 +85,18 @@ fn deal_is_slashed() {
             tc.activation_epoch,
             SECTOR_EXPIRY,
         );
-        let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+        let deal_proposal = get_deal_proposal(&rt, deal_id);
 
         // terminate
         rt.set_epoch(tc.termination_epoch);
-        terminate_deals(&mut rt, PROVIDER_ADDR, &[deal_id]);
+        terminate_deals(&rt, PROVIDER_ADDR, &[deal_id]);
 
         // cron tick
         let cron_tick_epoch = process_epoch(tc.deal_start, deal_id);
         rt.set_epoch(cron_tick_epoch);
 
         let (pay, slashed) = cron_tick_and_assert_balances(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             PROVIDER_ADDR,
             cron_tick_epoch,
@@ -104,7 +104,7 @@ fn deal_is_slashed() {
         );
         assert_eq!(tc.payment, pay);
         assert_eq!(deal_proposal.provider_collateral, slashed);
-        assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+        assert_deal_deleted(&rt, deal_id, deal_proposal);
 
         check_state(&rt);
     }
@@ -115,9 +115,9 @@ const END_EPOCH: ChainEpoch = 50 + 200 * EPOCHS_IN_DAY;
 
 #[test]
 fn deal_is_slashed_at_the_end_epoch_should_not_be_slashed_and_should_be_considered_expired() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
@@ -125,25 +125,25 @@ fn deal_is_slashed_at_the_end_epoch_should_not_be_slashed_and_should_be_consider
         0,
         SECTOR_EXPIRY,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     // set current epoch to deal end epoch and attempt to slash it -> should not be slashed
     // as deal is considered to be expired.
 
     rt.set_epoch(END_EPOCH);
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal_id]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id]);
 
     // on the next cron tick, it will be processed as expired
     let current = END_EPOCH + 300;
     rt.set_epoch(current);
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     let duration = END_EPOCH - START_EPOCH;
     assert_eq!(duration * &deal_proposal.storage_price_per_epoch, pay);
     assert!(slashed.is_zero());
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal);
 
     check_state(&rt);
 }
@@ -152,9 +152,9 @@ fn deal_is_slashed_at_the_end_epoch_should_not_be_slashed_and_should_be_consider
 fn deal_payment_and_slashing_correctly_processed_in_same_crontick() {
     // start epoch should equal first processing epoch for logic to work
     let start_epoch: ChainEpoch = Policy::default().deal_updates_interval;
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -162,41 +162,41 @@ fn deal_payment_and_slashing_correctly_processed_in_same_crontick() {
         0,
         SECTOR_EXPIRY,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     // move the current epoch to startEpoch so next cron epoch will be start + Interval
     let current = process_epoch(start_epoch, deal_id);
     rt.set_epoch(current);
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert!(pay.is_zero());
     assert!(slashed.is_zero());
 
     // set slash epoch of deal
     let slash_epoch = current + Policy::default().deal_updates_interval + 1;
     rt.set_epoch(slash_epoch);
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal_id]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id]);
 
     let duration = slash_epoch - current;
     let current = current + Policy::default().deal_updates_interval + 2;
     rt.set_epoch(current);
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(duration * &deal_proposal.storage_price_per_epoch, pay);
     assert_eq!(deal_proposal.provider_collateral, slashed);
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal);
     check_state(&rt);
 }
 
 #[test]
 fn slash_multiple_deals_in_the_same_epoch() {
-    let mut rt = setup();
+    let rt = setup();
 
     // three deals for slashing
     let deal_id1 = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
@@ -204,10 +204,10 @@ fn slash_multiple_deals_in_the_same_epoch() {
         0,
         SECTOR_EXPIRY,
     );
-    let deal_proposal1 = get_deal_proposal(&mut rt, deal_id1);
+    let deal_proposal1 = get_deal_proposal(&rt, deal_id1);
 
     let deal_id2 = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
@@ -215,10 +215,10 @@ fn slash_multiple_deals_in_the_same_epoch() {
         0,
         SECTOR_EXPIRY,
     );
-    let deal_proposal2 = get_deal_proposal(&mut rt, deal_id2);
+    let deal_proposal2 = get_deal_proposal(&rt, deal_id2);
 
     let deal_id3 = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
@@ -226,11 +226,11 @@ fn slash_multiple_deals_in_the_same_epoch() {
         0,
         SECTOR_EXPIRY,
     );
-    let deal_proposal3 = get_deal_proposal(&mut rt, deal_id3);
+    let deal_proposal3 = get_deal_proposal(&rt, deal_id3);
 
     // set slash epoch of deal at 100 epochs past last process epoch
     rt.set_epoch(process_epoch(START_EPOCH, deal_id3) + 100);
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal_id1, deal_id2, deal_id3]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id1, deal_id2, deal_id3]);
 
     // process slashing of deals 200 epochs later
     rt.set_epoch(process_epoch(START_EPOCH, deal_id3) + 300);
@@ -245,19 +245,19 @@ fn slash_multiple_deals_in_the_same_epoch() {
         None,
         ExitCode::OK,
     );
-    cron_tick(&mut rt);
+    cron_tick(&rt);
 
-    assert_deal_deleted(&mut rt, deal_id1, deal_proposal1);
-    assert_deal_deleted(&mut rt, deal_id2, deal_proposal2);
-    assert_deal_deleted(&mut rt, deal_id3, deal_proposal3);
+    assert_deal_deleted(&rt, deal_id1, deal_proposal1);
+    assert_deal_deleted(&rt, deal_id2, deal_proposal2);
+    assert_deal_deleted(&rt, deal_id3, deal_proposal3);
     check_state(&rt);
 }
 
 #[test]
 fn regular_payments_till_deal_is_slashed_and_then_slashing_is_processed() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
@@ -265,7 +265,7 @@ fn regular_payments_till_deal_is_slashed_and_then_slashing_is_processed() {
         0,
         SECTOR_EXPIRY,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     // move the current epoch to the process epoch + 5 so payment is made
     let process_start = process_epoch(START_EPOCH, deal_id);
@@ -274,7 +274,7 @@ fn regular_payments_till_deal_is_slashed_and_then_slashing_is_processed() {
 
     // assert payment
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(pay, (5 + process_start - START_EPOCH) * &deal_proposal.storage_price_per_epoch);
     assert!(slashed.is_zero());
 
@@ -282,52 +282,52 @@ fn regular_payments_till_deal_is_slashed_and_then_slashing_is_processed() {
     // is still not scheduled
     let current = current + Policy::default().deal_updates_interval - 1;
     rt.set_epoch(current);
-    cron_tick_no_change(&mut rt, CLIENT_ADDR, PROVIDER_ADDR);
+    cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     // a second cron tick for the same epoch should not change anything
-    cron_tick_no_change(&mut rt, CLIENT_ADDR, PROVIDER_ADDR);
+    cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     // make another payment
     let current = current + 1;
     rt.set_epoch(current);
     let duration = Policy::default().deal_updates_interval;
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(pay, duration * &deal_proposal.storage_price_per_epoch);
     assert!(slashed.is_zero());
 
     // a second cron tick for the same epoch should not change anything
-    cron_tick_no_change(&mut rt, CLIENT_ADDR, PROVIDER_ADDR);
+    cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     // now terminate the deal
     let slash_epoch = current + 1;
     rt.set_epoch(slash_epoch);
     let duration = slash_epoch - current;
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal_id]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id]);
 
     // Setting the epoch to anything less than next schedule will not make any change even though the deal is slashed
     let current = current + Policy::default().deal_updates_interval - 1;
     rt.set_epoch(current);
-    cron_tick_no_change(&mut rt, CLIENT_ADDR, PROVIDER_ADDR);
+    cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     // next epoch for cron schedule  -> payment will be made and deal will be slashed
     let current = current + 1;
     rt.set_epoch(current);
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(pay, duration * &deal_proposal.storage_price_per_epoch);
     assert_eq!(slashed, deal_proposal.provider_collateral);
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal);
     check_state(&rt);
 }
 
 #[test]
 fn regular_payments_till_deal_expires_and_then_we_attempt_to_slash_it_but_it_will_not_be_slashed() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
@@ -335,14 +335,14 @@ fn regular_payments_till_deal_expires_and_then_we_attempt_to_slash_it_but_it_wil
         0,
         SECTOR_EXPIRY,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     // move the current epoch to processEpoch + 5 so payment is made and assert payment
     let process_start = process_epoch(START_EPOCH, deal_id);
     let current = process_start + 5;
     rt.set_epoch(current);
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(pay, (5 + process_start - START_EPOCH) * &deal_proposal.storage_price_per_epoch);
     assert!(slashed.is_zero());
 
@@ -351,7 +351,7 @@ fn regular_payments_till_deal_expires_and_then_we_attempt_to_slash_it_but_it_wil
     rt.set_epoch(current);
     let duration = Policy::default().deal_updates_interval;
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(pay, duration * &deal_proposal.storage_price_per_epoch);
     assert!(slashed.is_zero());
 
@@ -359,7 +359,7 @@ fn regular_payments_till_deal_expires_and_then_we_attempt_to_slash_it_but_it_wil
     // as deal is considered to be expired.
     let duration = END_EPOCH - current;
     rt.set_epoch(END_EPOCH);
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal_id]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id]);
 
     // next epoch for cron schedule is endEpoch + 300 ->
     // setting epoch to higher than that will cause deal to be expired, payment will be made
@@ -367,11 +367,11 @@ fn regular_payments_till_deal_expires_and_then_we_attempt_to_slash_it_but_it_wil
     let current = END_EPOCH + 300;
     rt.set_epoch(current);
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(pay, duration * &deal_proposal.storage_price_per_epoch);
     assert!(slashed.is_zero());
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal);
     check_state(&rt);
 }

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -92,7 +92,7 @@ pub fn setup() -> MockRuntime {
         (CLIENT_ADDR, *ACCOUNT_ACTOR_CODE_ID),
     ]);
 
-    let mut rt = MockRuntime {
+    let rt = MockRuntime {
         receiver: STORAGE_MARKET_ACTOR_ADDR,
         caller: RefCell::new(SYSTEM_ACTOR_ADDR),
         caller_type: RefCell::new(*INIT_ACTOR_CODE_ID),
@@ -101,7 +101,7 @@ pub fn setup() -> MockRuntime {
         ..Default::default()
     };
 
-    construct_and_verify(&mut rt);
+    construct_and_verify(&rt);
 
     rt
 }
@@ -129,14 +129,14 @@ pub fn check_state_with_expected(rt: &MockRuntime, expected_patterns: &[Regex]) 
     acc.assert_expected(expected_patterns);
 }
 
-pub fn construct_and_verify(rt: &mut MockRuntime) {
+pub fn construct_and_verify(rt: &MockRuntime) {
     rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
     assert!(rt.call::<MarketActor>(METHOD_CONSTRUCTOR, None).unwrap().is_none());
     rt.verify();
 }
 
-pub fn get_balance(rt: &mut MockRuntime, addr: &Address) -> GetBalanceReturn {
+pub fn get_balance(rt: &MockRuntime, addr: &Address) -> GetBalanceReturn {
     rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1234));
     rt.expect_validate_caller_any();
     let ret: GetBalanceReturn = rt
@@ -153,7 +153,7 @@ pub fn get_balance(rt: &mut MockRuntime, addr: &Address) -> GetBalanceReturn {
 }
 
 pub fn expect_get_control_addresses(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     provider: Address,
     owner: Address,
     worker: Address,
@@ -172,7 +172,7 @@ pub fn expect_get_control_addresses(
 }
 
 pub fn expect_provider_control_address(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     provider: Address,
     owner: Address,
     worker: Address,
@@ -181,7 +181,7 @@ pub fn expect_provider_control_address(
 }
 
 pub fn expect_provider_is_control_address(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     provider: Address,
     caller: Address,
     is_controlling: bool,
@@ -199,7 +199,7 @@ pub fn expect_provider_is_control_address(
     )
 }
 
-pub fn add_provider_funds(rt: &mut MockRuntime, amount: TokenAmount, addrs: &MinerAddresses) {
+pub fn add_provider_funds(rt: &MockRuntime, amount: TokenAmount, addrs: &MinerAddresses) {
     rt.set_received(amount.clone());
     rt.set_address_actor_type(addrs.provider, *MINER_ACTOR_CODE_ID);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addrs.owner);
@@ -218,7 +218,7 @@ pub fn add_provider_funds(rt: &mut MockRuntime, amount: TokenAmount, addrs: &Min
     rt.add_balance(amount);
 }
 
-pub fn add_participant_funds(rt: &mut MockRuntime, addr: Address, amount: TokenAmount) {
+pub fn add_participant_funds(rt: &MockRuntime, addr: Address, amount: TokenAmount) {
     rt.set_received(amount.clone());
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addr);
@@ -234,7 +234,7 @@ pub fn add_participant_funds(rt: &mut MockRuntime, addr: Address, amount: TokenA
 }
 
 pub fn withdraw_provider_balance(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     withdraw_amount: TokenAmount,
     expected_send: TokenAmount,
     provider: Address,
@@ -267,7 +267,7 @@ pub fn withdraw_provider_balance(
 }
 
 pub fn withdraw_client_balance(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     withdraw_amount: TokenAmount,
     expected_send: TokenAmount,
     client: Address,
@@ -297,7 +297,7 @@ pub fn withdraw_client_balance(
 }
 
 pub fn activate_deals(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     sector_expiry: ChainEpoch,
     provider: Address,
     current_epoch: ChainEpoch,
@@ -308,7 +308,7 @@ pub fn activate_deals(
 }
 
 pub fn activate_deals_raw(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     sector_expiry: ChainEpoch,
     provider: Address,
     current_epoch: ChainEpoch,
@@ -333,14 +333,14 @@ pub fn activate_deals_raw(
     Ok(ret)
 }
 
-pub fn get_deal_proposal(rt: &mut MockRuntime, deal_id: DealID) -> DealProposal {
+pub fn get_deal_proposal(rt: &MockRuntime, deal_id: DealID) -> DealProposal {
     let st: State = rt.get_state();
     let deals = DealArray::load(&st.proposals, &rt.store).unwrap();
     let d = deals.get(deal_id).unwrap();
     d.unwrap().clone()
 }
 
-pub fn get_pending_deal_allocation(rt: &mut MockRuntime, deal_id: DealID) -> AllocationID {
+pub fn get_pending_deal_allocation(rt: &MockRuntime, deal_id: DealID) -> AllocationID {
     let st: State = rt.get_state();
     let pending_allocations =
         make_map_with_root_and_bitwidth(&st.pending_deal_allocation_ids, &rt.store, HAMT_BIT_WIDTH)
@@ -349,14 +349,14 @@ pub fn get_pending_deal_allocation(rt: &mut MockRuntime, deal_id: DealID) -> All
     *pending_allocations.get(&deal_id_key(deal_id)).unwrap().unwrap_or(&NO_ALLOCATION_ID)
 }
 
-pub fn get_deal_state(rt: &mut MockRuntime, deal_id: DealID) -> DealState {
+pub fn get_deal_state(rt: &MockRuntime, deal_id: DealID) -> DealState {
     let st: State = rt.get_state();
     let states = DealMetaArray::load(&st.states, &rt.store).unwrap();
     let s = states.get(deal_id).unwrap();
     *s.unwrap()
 }
 
-pub fn update_last_updated(rt: &mut MockRuntime, deal_id: DealID, new_last_updated: ChainEpoch) {
+pub fn update_last_updated(rt: &MockRuntime, deal_id: DealID, new_last_updated: ChainEpoch) {
     let st: State = rt.get_state();
     let mut states = DealMetaArray::load(&st.states, &rt.store).unwrap();
     let s = *states.get(deal_id).unwrap().unwrap();
@@ -366,7 +366,7 @@ pub fn update_last_updated(rt: &mut MockRuntime, deal_id: DealID, new_last_updat
     rt.replace_state(&State { states: root, ..st })
 }
 
-pub fn delete_deal_proposal(rt: &mut MockRuntime, deal_id: DealID) {
+pub fn delete_deal_proposal(rt: &MockRuntime, deal_id: DealID) {
     let mut st: State = rt.get_state();
     let mut deals = DealArray::load(&st.proposals, &rt.store).unwrap();
     deals.delete(deal_id).unwrap();
@@ -379,7 +379,7 @@ pub fn delete_deal_proposal(rt: &mut MockRuntime, deal_id: DealID) {
 // if this is the first crontick for the deal, it's next tick will be scheduled at `desiredNextEpoch`
 // if this is not the first crontick, the `desiredNextEpoch` param is ignored.
 pub fn cron_tick_and_assert_balances(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     client_addr: Address,
     provider_addr: Address,
     current_epoch: ChainEpoch,
@@ -446,7 +446,7 @@ pub fn cron_tick_and_assert_balances(
     (payment, amount_slashed)
 }
 
-pub fn cron_tick_no_change(rt: &mut MockRuntime, client_addr: Address, provider_addr: Address) {
+pub fn cron_tick_no_change(rt: &MockRuntime, client_addr: Address, provider_addr: Address) {
     let st: State = rt.get_state();
     let epoch_cid = st.deal_ops_by_epoch;
 
@@ -465,7 +465,7 @@ pub fn cron_tick_no_change(rt: &mut MockRuntime, client_addr: Address, provider_
 }
 
 pub fn publish_deals(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     addrs: &MinerAddresses,
     publish_deals: &[DealProposal],
     clients_datacap_balance: TokenAmount,
@@ -655,7 +655,7 @@ pub fn publish_deals(
 }
 
 pub fn publish_deals_expect_abort(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     miner_addresses: &MinerAddresses,
     proposal: DealProposal,
     expected_exit_code: ExitCode,
@@ -701,7 +701,7 @@ pub fn publish_deals_expect_abort(
     rt.verify();
 }
 
-pub fn assert_deals_not_activated(rt: &mut MockRuntime, _epoch: ChainEpoch, deal_ids: &[DealID]) {
+pub fn assert_deals_not_activated(rt: &MockRuntime, _epoch: ChainEpoch, deal_ids: &[DealID]) {
     let st: State = rt.get_state();
 
     let states = DealMetaArray::load(&st.states, &rt.store).unwrap();
@@ -712,19 +712,19 @@ pub fn assert_deals_not_activated(rt: &mut MockRuntime, _epoch: ChainEpoch, deal
     }
 }
 
-pub fn cron_tick(rt: &mut MockRuntime) {
+pub fn cron_tick(rt: &MockRuntime) {
     assert!(cron_tick_raw(rt).unwrap().is_none());
     rt.verify()
 }
 
-pub fn cron_tick_raw(rt: &mut MockRuntime) -> Result<Option<IpldBlock>, ActorError> {
+pub fn cron_tick_raw(rt: &MockRuntime) -> Result<Option<IpldBlock>, ActorError> {
     rt.expect_validate_caller_addr(vec![CRON_ACTOR_ADDR]);
     rt.set_caller(*CRON_ACTOR_CODE_ID, CRON_ACTOR_ADDR);
 
     rt.call::<MarketActor>(Method::CronTick as u64, None)
 }
 
-pub fn expect_query_network_info(rt: &mut MockRuntime) {
+pub fn expect_query_network_info(rt: &MockRuntime) {
     //networkQAPower
     //networkBaselinePower
     let reward = TokenAmount::from_whole(10);
@@ -774,21 +774,21 @@ where
     assert_eq!(n, count, "unexpected deal count at epoch {}", epoch);
 }
 
-pub fn assert_deals_terminated(rt: &mut MockRuntime, epoch: ChainEpoch, deal_ids: &[DealID]) {
+pub fn assert_deals_terminated(rt: &MockRuntime, epoch: ChainEpoch, deal_ids: &[DealID]) {
     for &deal_id in deal_ids {
         let s = get_deal_state(rt, deal_id);
         assert_eq!(s.slash_epoch, epoch);
     }
 }
 
-pub fn assert_deals_not_terminated(rt: &mut MockRuntime, deal_ids: &[DealID]) {
+pub fn assert_deals_not_terminated(rt: &MockRuntime, deal_ids: &[DealID]) {
     for &deal_id in deal_ids {
         let s = get_deal_state(rt, deal_id);
         assert_eq!(s.slash_epoch, EPOCH_UNDEFINED);
     }
 }
 
-pub fn assert_deal_deleted(rt: &mut MockRuntime, deal_id: DealID, p: DealProposal) {
+pub fn assert_deal_deleted(rt: &MockRuntime, deal_id: DealID, p: DealProposal) {
     use cid::multihash::Code;
     use cid::multihash::MultihashDigest;
     use fil_actors_runtime::Map;
@@ -820,16 +820,16 @@ pub fn assert_deal_deleted(rt: &mut MockRuntime, deal_id: DealID, p: DealProposa
 
 pub fn assert_deal_failure<F>(add_funds: bool, post_setup: F, exit_code: ExitCode, sig_valid: bool)
 where
-    F: FnOnce(&mut MockRuntime, &mut DealProposal),
+    F: FnOnce(&MockRuntime, &mut DealProposal),
 {
     let current_epoch = ChainEpoch::from(5);
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
 
-    let mut rt = setup();
+    let rt = setup();
     let mut deal_proposal = if add_funds {
         generate_deal_and_add_funds(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             start_epoch,
@@ -839,11 +839,11 @@ where
         generate_deal_proposal(CLIENT_ADDR, PROVIDER_ADDR, start_epoch, end_epoch)
     };
     rt.set_epoch(current_epoch);
-    post_setup(&mut rt, &mut deal_proposal);
+    post_setup(&rt, &mut deal_proposal);
 
     rt.expect_validate_caller_any();
-    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
-    expect_query_network_info(&mut rt);
+    expect_provider_is_control_address(&rt, PROVIDER_ADDR, WORKER_ADDR, true);
+    expect_query_network_info(&rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
 
     let buf = RawBytes::serialize(deal_proposal.clone()).expect("failed to marshal deal proposal");
@@ -895,7 +895,7 @@ pub fn process_epoch(start_epoch: ChainEpoch, deal_id: DealID) -> ChainEpoch {
 }
 
 pub fn publish_and_activate_deal(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     client: Address,
     addrs: &MinerAddresses,
     start_epoch: ChainEpoch,
@@ -911,7 +911,7 @@ pub fn publish_and_activate_deal(
 }
 
 pub fn generate_and_publish_deal(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     client: Address,
     addrs: &MinerAddresses,
     start_epoch: ChainEpoch,
@@ -924,7 +924,7 @@ pub fn generate_and_publish_deal(
 }
 
 pub fn generate_and_publish_verified_deal(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     client: Address,
     addrs: &MinerAddresses,
     start_epoch: ChainEpoch,
@@ -945,7 +945,7 @@ pub fn generate_and_publish_verified_deal(
 }
 
 pub fn generate_and_publish_deal_for_piece(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     client: Address,
     addrs: &MinerAddresses,
     start_epoch: ChainEpoch,
@@ -983,7 +983,7 @@ pub fn generate_and_publish_deal_for_piece(
 }
 
 pub fn generate_deal_and_add_funds(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     client: Address,
     addrs: &MinerAddresses,
     start_epoch: ChainEpoch,
@@ -996,7 +996,7 @@ pub fn generate_deal_and_add_funds(
 }
 
 pub fn generate_deal_with_collateral_and_add_funds(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     client: Address,
     addrs: &MinerAddresses,
     provider_collateral: TokenAmount,
@@ -1061,14 +1061,14 @@ pub fn generate_deal_proposal(
     )
 }
 
-pub fn terminate_deals(rt: &mut MockRuntime, miner_addr: Address, deal_ids: &[DealID]) {
+pub fn terminate_deals(rt: &MockRuntime, miner_addr: Address, deal_ids: &[DealID]) {
     let ret = terminate_deals_raw(rt, miner_addr, deal_ids).unwrap();
     assert!(ret.is_none());
     rt.verify();
 }
 
 pub fn terminate_deals_raw(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     miner_addr: Address,
     deal_ids: &[DealID],
 ) -> Result<Option<IpldBlock>, ActorError> {
@@ -1084,14 +1084,14 @@ pub fn terminate_deals_raw(
     )
 }
 
-pub fn assert_account_zero(rt: &mut MockRuntime, addr: Address) {
+pub fn assert_account_zero(rt: &MockRuntime, addr: Address) {
     let account = get_balance(rt, &addr);
     assert!(account.balance.is_zero());
     assert!(account.locked.is_zero());
 }
 
 pub fn verify_deals_for_activation<F>(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     provider: Address,
     sector_deals: Vec<SectorDeals>,
     piece_info_override: F,

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -191,13 +191,13 @@ fn adds_to_provider_escrow_funds() {
     ];
 
     for caller_addr in &[OWNER_ADDR, WORKER_ADDR] {
-        let mut rt = setup();
+        let rt = setup();
 
         for tc in &test_cases {
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *caller_addr);
             rt.set_received(TokenAmount::from_atto(tc.delta));
             rt.expect_validate_caller_any();
-            expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+            expect_provider_control_address(&rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 
             assert!(rt
                 .call::<MarketActor>(
@@ -209,7 +209,7 @@ fn adds_to_provider_escrow_funds() {
 
             rt.verify();
 
-            let acct = get_balance(&mut rt, &PROVIDER_ADDR);
+            let acct = get_balance(&rt, &PROVIDER_ADDR);
             assert_eq!(acct.balance, TokenAmount::from_atto(tc.total));
             assert_eq!(acct.locked, TokenAmount::zero());
             check_state(&rt);
@@ -219,11 +219,11 @@ fn adds_to_provider_escrow_funds() {
 
 #[test]
 fn fails_if_withdraw_from_non_provider_funds_is_not_initiated_by_the_recipient() {
-    let mut rt = setup();
+    let rt = setup();
 
-    add_participant_funds(&mut rt, CLIENT_ADDR, TokenAmount::from_atto(20u8));
+    add_participant_funds(&rt, CLIENT_ADDR, TokenAmount::from_atto(20u8));
 
-    assert_eq!(TokenAmount::from_atto(20u8), get_balance(&mut rt, &CLIENT_ADDR).balance);
+    assert_eq!(TokenAmount::from_atto(20u8), get_balance(&rt, &CLIENT_ADDR).balance);
 
     rt.expect_validate_caller_addr(vec![CLIENT_ADDR]);
 
@@ -244,7 +244,7 @@ fn fails_if_withdraw_from_non_provider_funds_is_not_initiated_by_the_recipient()
     rt.verify();
 
     // verify there was no withdrawal
-    assert_eq!(TokenAmount::from_atto(20u8), get_balance(&mut rt, &CLIENT_ADDR).balance);
+    assert_eq!(TokenAmount::from_atto(20u8), get_balance(&rt, &CLIENT_ADDR).balance);
 
     check_state(&rt);
 }
@@ -255,37 +255,32 @@ fn balance_after_withdrawal_must_always_be_greater_than_or_equal_to_locked_amoun
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let publish_epoch = ChainEpoch::from(5);
 
-    let mut rt = setup();
+    let rt = setup();
 
     // publish the deal so that client AND provider collateral is locked
     rt.set_epoch(publish_epoch);
     let deal_id = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
-    let deal = get_deal_proposal(&mut rt, deal_id);
-    let provider_acct = get_balance(&mut rt, &PROVIDER_ADDR);
+    let deal = get_deal_proposal(&rt, deal_id);
+    let provider_acct = get_balance(&rt, &PROVIDER_ADDR);
     assert_eq!(deal.provider_collateral, provider_acct.balance);
     assert_eq!(deal.provider_collateral, provider_acct.locked);
-    let client_acct = get_balance(&mut rt, &CLIENT_ADDR);
+    let client_acct = get_balance(&rt, &CLIENT_ADDR);
     assert_eq!(deal.client_balance_requirement(), client_acct.balance);
     assert_eq!(deal.client_balance_requirement(), client_acct.locked);
 
     let withdraw_amount = TokenAmount::from_atto(1u8);
     let withdrawable_amount = TokenAmount::zero();
     // client cannot withdraw any funds since all it's balance is locked
-    withdraw_client_balance(
-        &mut rt,
-        withdraw_amount.clone(),
-        withdrawable_amount.clone(),
-        CLIENT_ADDR,
-    );
+    withdraw_client_balance(&rt, withdraw_amount.clone(), withdrawable_amount.clone(), CLIENT_ADDR);
     // provider cannot withdraw any funds since all it's balance is locked
     withdraw_provider_balance(
-        &mut rt,
+        &rt,
         withdraw_amount,
         withdrawable_amount,
         PROVIDER_ADDR,
@@ -297,13 +292,13 @@ fn balance_after_withdrawal_must_always_be_greater_than_or_equal_to_locked_amoun
     let withdraw_amount = TokenAmount::from_atto(30u8);
     let withdrawable_amount = TokenAmount::from_atto(25u8);
 
-    add_provider_funds(&mut rt, withdrawable_amount.clone(), &MinerAddresses::default());
-    let provider_acct = get_balance(&mut rt, &PROVIDER_ADDR);
+    add_provider_funds(&rt, withdrawable_amount.clone(), &MinerAddresses::default());
+    let provider_acct = get_balance(&rt, &PROVIDER_ADDR);
     assert_eq!(&deal.provider_collateral + &withdrawable_amount, provider_acct.balance);
     assert_eq!(deal.provider_collateral, provider_acct.locked);
 
     withdraw_provider_balance(
-        &mut rt,
+        &rt,
         withdraw_amount.clone(),
         withdrawable_amount.clone(),
         PROVIDER_ADDR,
@@ -312,12 +307,12 @@ fn balance_after_withdrawal_must_always_be_greater_than_or_equal_to_locked_amoun
     );
 
     // add some more funds to the client & ensure withdrawal is limited by the locked funds
-    add_participant_funds(&mut rt, CLIENT_ADDR, withdrawable_amount.clone());
-    let client_acct = get_balance(&mut rt, &CLIENT_ADDR);
+    add_participant_funds(&rt, CLIENT_ADDR, withdrawable_amount.clone());
+    let client_acct = get_balance(&rt, &CLIENT_ADDR);
     assert_eq!(deal.client_balance_requirement() + &withdrawable_amount, client_acct.balance);
     assert_eq!(deal.client_balance_requirement(), client_acct.locked);
 
-    withdraw_client_balance(&mut rt, withdraw_amount, withdrawable_amount, CLIENT_ADDR);
+    withdraw_client_balance(&rt, withdraw_amount, withdrawable_amount, CLIENT_ADDR);
     check_state(&rt);
 }
 
@@ -327,12 +322,12 @@ fn worker_balance_after_withdrawal_must_account_for_slashed_funds() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let publish_epoch = ChainEpoch::from(5);
 
-    let mut rt = setup();
+    let rt = setup();
 
     // publish deal
     rt.set_epoch(publish_epoch);
     let deal_id = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -340,21 +335,21 @@ fn worker_balance_after_withdrawal_must_account_for_slashed_funds() {
     );
 
     // activate the deal
-    activate_deals(&mut rt, end_epoch + 1, PROVIDER_ADDR, publish_epoch, &[deal_id]);
-    let st = get_deal_state(&mut rt, deal_id);
+    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, publish_epoch, &[deal_id]);
+    let st = get_deal_state(&rt, deal_id);
     assert_eq!(publish_epoch, st.sector_start_epoch);
 
     // slash the deal
     rt.set_epoch(publish_epoch + 1);
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal_id]);
-    let st = get_deal_state(&mut rt, deal_id);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id]);
+    let st = get_deal_state(&rt, deal_id);
     assert_eq!(publish_epoch + 1, st.slash_epoch);
 
     // provider cannot withdraw any funds since all it's balance is locked
     let withdraw_amount = TokenAmount::from_atto(1);
     let actual_withdrawn = TokenAmount::zero();
     withdraw_provider_balance(
-        &mut rt,
+        &rt,
         withdraw_amount,
         actual_withdrawn,
         PROVIDER_ADDR,
@@ -363,12 +358,12 @@ fn worker_balance_after_withdrawal_must_account_for_slashed_funds() {
     );
 
     // add some more funds to the provider & ensure withdrawal is limited by the locked funds
-    add_provider_funds(&mut rt, TokenAmount::from_atto(25), &MinerAddresses::default());
+    add_provider_funds(&rt, TokenAmount::from_atto(25), &MinerAddresses::default());
     let withdraw_amount = TokenAmount::from_atto(30);
     let actual_withdrawn = TokenAmount::from_atto(25);
 
     withdraw_provider_balance(
-        &mut rt,
+        &rt,
         withdraw_amount,
         actual_withdrawn,
         PROVIDER_ADDR,
@@ -391,7 +386,7 @@ fn adds_to_non_provider_funds() {
     ];
 
     for caller_addr in &[CLIENT_ADDR, WORKER_ADDR] {
-        let mut rt = setup();
+        let rt = setup();
 
         for tc in &test_cases {
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *caller_addr);
@@ -407,7 +402,7 @@ fn adds_to_non_provider_funds() {
 
             rt.verify();
 
-            assert_eq!(get_balance(&mut rt, caller_addr).balance, TokenAmount::from_atto(tc.total));
+            assert_eq!(get_balance(&rt, caller_addr).balance, TokenAmount::from_atto(tc.total));
             check_state(&rt);
         }
     }
@@ -415,17 +410,17 @@ fn adds_to_non_provider_funds() {
 
 #[test]
 fn withdraws_from_provider_escrow_funds_and_sends_to_owner() {
-    let mut rt = setup();
+    let rt = setup();
 
     let amount = TokenAmount::from_atto(20);
-    add_provider_funds(&mut rt, amount.clone(), &MinerAddresses::default());
+    add_provider_funds(&rt, amount.clone(), &MinerAddresses::default());
 
-    assert_eq!(amount, get_balance(&mut rt, &PROVIDER_ADDR).balance);
+    assert_eq!(amount, get_balance(&rt, &PROVIDER_ADDR).balance);
 
     // worker calls WithdrawBalance, balance is transferred to owner
     let withdraw_amount = TokenAmount::from_atto(1);
     withdraw_provider_balance(
-        &mut rt,
+        &rt,
         withdraw_amount.clone(),
         withdraw_amount,
         PROVIDER_ADDR,
@@ -433,67 +428,60 @@ fn withdraws_from_provider_escrow_funds_and_sends_to_owner() {
         WORKER_ADDR,
     );
 
-    assert_eq!(TokenAmount::from_atto(19), get_balance(&mut rt, &PROVIDER_ADDR).balance);
+    assert_eq!(TokenAmount::from_atto(19), get_balance(&rt, &PROVIDER_ADDR).balance);
     check_state(&rt);
 }
 
 #[test]
 fn withdraws_from_non_provider_escrow_funds() {
-    let mut rt = setup();
+    let rt = setup();
 
     let amount = TokenAmount::from_atto(20);
-    add_participant_funds(&mut rt, CLIENT_ADDR, amount.clone());
+    add_participant_funds(&rt, CLIENT_ADDR, amount.clone());
 
-    assert_eq!(get_balance(&mut rt, &CLIENT_ADDR).balance, amount);
+    assert_eq!(get_balance(&rt, &CLIENT_ADDR).balance, amount);
 
     let withdraw_amount = TokenAmount::from_atto(1);
-    withdraw_client_balance(&mut rt, withdraw_amount.clone(), withdraw_amount, CLIENT_ADDR);
+    withdraw_client_balance(&rt, withdraw_amount.clone(), withdraw_amount, CLIENT_ADDR);
 
-    assert_eq!(get_balance(&mut rt, &CLIENT_ADDR).balance, TokenAmount::from_atto(19));
+    assert_eq!(get_balance(&rt, &CLIENT_ADDR).balance, TokenAmount::from_atto(19));
     check_state(&rt);
 }
 
 #[test]
 fn client_withdrawing_more_than_escrow_balance_limits_to_available_funds() {
-    let mut rt = setup();
+    let rt = setup();
 
     let amount = TokenAmount::from_atto(20);
-    add_participant_funds(&mut rt, CLIENT_ADDR, amount.clone());
+    add_participant_funds(&rt, CLIENT_ADDR, amount.clone());
 
     // withdraw amount greater than escrow balance
     let withdraw_amount = TokenAmount::from_atto(25);
-    withdraw_client_balance(&mut rt, withdraw_amount, amount, CLIENT_ADDR);
+    withdraw_client_balance(&rt, withdraw_amount, amount, CLIENT_ADDR);
 
-    assert_eq!(get_balance(&mut rt, &CLIENT_ADDR).balance, TokenAmount::zero());
+    assert_eq!(get_balance(&rt, &CLIENT_ADDR).balance, TokenAmount::zero());
     check_state(&rt);
 }
 
 #[test]
 fn worker_withdrawing_more_than_escrow_balance_limits_to_available_funds() {
-    let mut rt = setup();
+    let rt = setup();
 
     let amount = TokenAmount::from_atto(20);
-    add_provider_funds(&mut rt, amount.clone(), &MinerAddresses::default());
+    add_provider_funds(&rt, amount.clone(), &MinerAddresses::default());
 
-    assert_eq!(get_balance(&mut rt, &PROVIDER_ADDR).balance, amount);
+    assert_eq!(get_balance(&rt, &PROVIDER_ADDR).balance, amount);
 
     let withdraw_amount = TokenAmount::from_atto(25);
-    withdraw_provider_balance(
-        &mut rt,
-        withdraw_amount,
-        amount,
-        PROVIDER_ADDR,
-        OWNER_ADDR,
-        WORKER_ADDR,
-    );
+    withdraw_provider_balance(&rt, withdraw_amount, amount, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 
-    assert_eq!(get_balance(&mut rt, &PROVIDER_ADDR).balance, TokenAmount::zero());
+    assert_eq!(get_balance(&rt, &PROVIDER_ADDR).balance, TokenAmount::zero());
     check_state(&rt);
 }
 
 #[test]
 fn fail_when_balance_is_zero() {
-    let mut rt = setup();
+    let rt = setup();
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
     rt.set_received(TokenAmount::zero());
@@ -533,12 +521,12 @@ fn fails_with_a_negative_withdraw_amount() {
 
 #[test]
 fn fails_if_withdraw_from_provider_funds_is_not_initiated_by_the_owner_or_worker() {
-    let mut rt = setup();
+    let rt = setup();
 
     let amount = TokenAmount::from_atto(20u8);
-    add_provider_funds(&mut rt, amount.clone(), &MinerAddresses::default());
+    add_provider_funds(&rt, amount.clone(), &MinerAddresses::default());
 
-    assert_eq!(get_balance(&mut rt, &PROVIDER_ADDR).balance, amount);
+    assert_eq!(get_balance(&rt, &PROVIDER_ADDR).balance, amount);
 
     rt.expect_validate_caller_addr(vec![OWNER_ADDR, WORKER_ADDR]);
     let params = WithdrawBalanceParams {
@@ -548,7 +536,7 @@ fn fails_if_withdraw_from_provider_funds_is_not_initiated_by_the_owner_or_worker
 
     // caller is not owner or worker
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(909));
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_control_address(&rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 
     expect_abort(
         ExitCode::USR_FORBIDDEN,
@@ -560,7 +548,7 @@ fn fails_if_withdraw_from_provider_funds_is_not_initiated_by_the_owner_or_worker
     rt.verify();
 
     // verify there was no withdrawal
-    assert_eq!(get_balance(&mut rt, &PROVIDER_ADDR).balance, amount);
+    assert_eq!(get_balance(&rt, &PROVIDER_ADDR).balance, amount);
     check_state(&rt);
 }
 
@@ -571,13 +559,13 @@ fn deal_starts_on_day_boundary() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let publish_epoch = ChainEpoch::from(1);
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(publish_epoch);
 
     for i in 0..(3 * deal_updates_interval) {
         let piece_cid = make_piece_cid((format!("{i}")).as_bytes());
         let deal_id = generate_and_publish_deal_for_piece(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             start_epoch,
@@ -611,14 +599,14 @@ fn deal_starts_partway_through_day() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let publish_epoch = ChainEpoch::from(1);
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(publish_epoch);
 
     // First 1000 deals (start_epoch % update interval) scheduled starting in the next day
     for i in 0..1000 {
         let piece_cid = make_piece_cid((format!("{i}")).as_bytes());
         let deal_id = generate_and_publish_deal_for_piece(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             start_epoch,
@@ -643,7 +631,7 @@ fn deal_starts_partway_through_day() {
     for i in 1000..1500 {
         let piece_cid = make_piece_cid((format!("{i}")).as_bytes());
         let deal_id = generate_and_publish_deal_for_piece(
-            &mut rt,
+            &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
             start_epoch,
@@ -667,13 +655,13 @@ fn simple_deal() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let publish_epoch = ChainEpoch::from(1);
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(publish_epoch);
     let next_allocation_id = 1;
 
     // Publish from miner worker.
     let mut deal1 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -682,7 +670,7 @@ fn simple_deal() {
     deal1.verified_deal = false;
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     let deal1_id = publish_deals(
-        &mut rt,
+        &rt,
         &MinerAddresses::default(),
         &[deal1],
         TokenAmount::zero(),
@@ -691,7 +679,7 @@ fn simple_deal() {
 
     // Publish from miner control address.
     let mut deal2 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch + 1,
@@ -700,7 +688,7 @@ fn simple_deal() {
     deal2.verified_deal = true;
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, CONTROL_ADDR);
     let deal2_id = publish_deals(
-        &mut rt,
+        &rt,
         &MinerAddresses::default(),
         &[deal2.clone()],
         TokenAmount::from_whole(deal2.piece_size.0),
@@ -708,12 +696,12 @@ fn simple_deal() {
     )[0];
 
     // activate the deal
-    activate_deals(&mut rt, end_epoch + 1, PROVIDER_ADDR, publish_epoch, &[deal1_id, deal2_id]);
-    let deal1st = get_deal_state(&mut rt, deal1_id);
+    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, publish_epoch, &[deal1_id, deal2_id]);
+    let deal1st = get_deal_state(&rt, deal1_id);
     assert_eq!(publish_epoch, deal1st.sector_start_epoch);
     assert_eq!(NO_ALLOCATION_ID, deal1st.verified_claim);
 
-    let deal2st = get_deal_state(&mut rt, deal2_id);
+    let deal2st = get_deal_state(&rt, deal2_id);
     assert_eq!(publish_epoch, deal2st.sector_start_epoch);
     assert_eq!(next_allocation_id, deal2st.verified_claim);
 
@@ -726,13 +714,13 @@ fn deal_expires() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let publish_epoch = ChainEpoch::from(1);
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(publish_epoch);
     let next_allocation_id = 1;
 
     // Publish from miner worker.
     let mut deal = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -741,7 +729,7 @@ fn deal_expires() {
     deal.verified_deal = true;
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     let deal_id = publish_deals(
-        &mut rt,
+        &rt,
         &MinerAddresses::default(),
         &[deal.clone()],
         TokenAmount::from_whole(deal.piece_size.0),
@@ -757,7 +745,7 @@ fn deal_expires() {
         None,
         ExitCode::OK,
     );
-    cron_tick(&mut rt);
+    cron_tick(&rt);
 
     // No deal state for unactivated deal
     let st: State = rt.get_state();
@@ -790,7 +778,7 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
     let client_bls = Address::new_bls(&[90; BLS_PUB_LEN]).unwrap();
     let client_resolved = Address::new_id(333);
 
-    let mut rt = setup();
+    let rt = setup();
     rt.actor_code_cids.borrow_mut().insert(client_resolved, *ACCOUNT_ACTOR_CODE_ID);
     rt.actor_code_cids.borrow_mut().insert(provider_resolved, *MINER_ACTOR_CODE_ID);
 
@@ -821,13 +809,13 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
     rt.verify();
     rt.add_balance(amount);
 
-    assert_eq!(deal.client_balance_requirement(), get_balance(&mut rt, &client_resolved).balance);
+    assert_eq!(deal.client_balance_requirement(), get_balance(&rt, &client_resolved).balance);
 
     // add funds for provider using it's BLS address -> will be resolved and persisted
     rt.value_received.replace(deal.provider_collateral.clone());
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, provider_resolved, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_control_address(&rt, provider_resolved, OWNER_ADDR, WORKER_ADDR);
 
     assert!(rt
         .call::<MarketActor>(
@@ -838,14 +826,14 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
         .is_none());
     rt.verify();
     rt.add_balance(deal.provider_collateral.clone());
-    assert_eq!(deal.provider_collateral, get_balance(&mut rt, &provider_resolved).balance);
+    assert_eq!(deal.provider_collateral, get_balance(&rt, &provider_resolved).balance);
 
     // publish deal using the BLS addresses
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     rt.expect_validate_caller_any();
 
-    expect_provider_is_control_address(&mut rt, provider_resolved, WORKER_ADDR, true);
-    expect_query_network_info(&mut rt);
+    expect_provider_is_control_address(&rt, provider_resolved, WORKER_ADDR, true);
+    expect_query_network_info(&rt);
 
     //  create a client proposal with a valid signature
     let st: State = rt.get_state();
@@ -959,7 +947,7 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
     let deal_id = ret.ids[0];
 
     // assert that deal is persisted with the resolved addresses
-    let prop = get_deal_proposal(&mut rt, deal_id);
+    let prop = get_deal_proposal(&rt, deal_id);
     assert_eq!(client_resolved, prop.client);
     assert_eq!(provider_resolved, prop.provider);
 
@@ -968,7 +956,7 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
 
 #[test]
 fn datacap_transfers_batched() {
-    let mut rt = setup();
+    let rt = setup();
     let start_epoch = 42;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     rt.set_epoch(start_epoch);
@@ -978,21 +966,21 @@ fn datacap_transfers_batched() {
 
     // Propose two deals for client1, and one for client2.
     let mut deal1 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         client1_addr,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
     let mut deal2 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         client1_addr,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch + 1,
     );
     let mut deal3 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         client2_addr,
         &MinerAddresses::default(),
         start_epoch,
@@ -1004,13 +992,8 @@ fn datacap_transfers_batched() {
     let datacap_balance = TokenAmount::from_whole(deal1.piece_size.0 * 10);
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
-    let ids = publish_deals(
-        &mut rt,
-        &MinerAddresses::default(),
-        &[deal1, deal2, deal3],
-        datacap_balance,
-        1,
-    );
+    let ids =
+        publish_deals(&rt, &MinerAddresses::default(), &[deal1, deal2, deal3], datacap_balance, 1);
     assert_eq!(3, ids.len());
 
     check_state(&rt);
@@ -1018,21 +1001,21 @@ fn datacap_transfers_batched() {
 
 #[test]
 fn datacap_transfer_drops_deal_when_cap_insufficient() {
-    let mut rt = setup();
+    let rt = setup();
     let start_epoch = 42;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let client1_addr = Address::new_id(900);
     rt.set_epoch(start_epoch);
 
     let mut deal1 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         client1_addr,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
     let mut deal2 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         client1_addr,
         &MinerAddresses::default(),
         start_epoch,
@@ -1044,7 +1027,7 @@ fn datacap_transfer_drops_deal_when_cap_insufficient() {
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     let ids = publish_deals(
-        &mut rt,
+        &rt,
         &MinerAddresses::default(),
         &[deal1, deal2],
         datacap_balance,
@@ -1061,32 +1044,32 @@ fn publish_a_deal_after_activating_a_previous_deal_which_has_a_start_epoch_far_i
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let publish_epoch = ChainEpoch::from(1);
 
-    let mut rt = setup();
+    let rt = setup();
 
     // publish the deal and activate it
     rt.set_epoch(publish_epoch);
     let deal1 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
-    activate_deals(&mut rt, end_epoch, PROVIDER_ADDR, publish_epoch, &[deal1]);
-    let st = get_deal_state(&mut rt, deal1);
+    activate_deals(&rt, end_epoch, PROVIDER_ADDR, publish_epoch, &[deal1]);
+    let st = get_deal_state(&rt, deal1);
     assert_eq!(publish_epoch, st.sector_start_epoch);
 
     // now publish a second deal and activate it
     let new_epoch = publish_epoch + 1;
     rt.set_epoch(new_epoch);
     let deal2 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch + 1,
         end_epoch + 1,
     );
-    activate_deals(&mut rt, end_epoch + 1, PROVIDER_ADDR, new_epoch, &[deal2]);
+    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, new_epoch, &[deal2]);
     check_state(&rt);
 }
 
@@ -1098,7 +1081,7 @@ fn publish_a_deal_with_enough_collateral_when_circulating_supply_is_superior_to_
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let publish_epoch = ChainEpoch::from(1);
 
-    let mut rt = setup();
+    let rt = setup();
 
     let client_collateral = TokenAmount::from_atto(10u8); // min is zero so this is placeholder
 
@@ -1110,7 +1093,7 @@ fn publish_a_deal_with_enough_collateral_when_circulating_supply_is_superior_to_
     );
 
     let deal = generate_deal_with_collateral_and_add_funds(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         provider_collateral,
@@ -1124,7 +1107,7 @@ fn publish_a_deal_with_enough_collateral_when_circulating_supply_is_superior_to_
     // publish the deal successfully
     rt.set_epoch(publish_epoch);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
-    let ids = publish_deals(&mut rt, &MinerAddresses::default(), &[deal], TokenAmount::zero(), 1);
+    let ids = publish_deals(&rt, &MinerAddresses::default(), &[deal], TokenAmount::zero(), 1);
     assert_eq!(1, ids.len());
     check_state(&rt);
 }
@@ -1134,7 +1117,7 @@ fn publish_multiple_deals_for_different_clients_and_ensure_balances_are_correct(
     let start_epoch = 42;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
 
-    let mut rt = setup();
+    let rt = setup();
 
     let client1_addr = Address::new_id(900);
     let client2_addr = Address::new_id(901);
@@ -1142,7 +1125,7 @@ fn publish_multiple_deals_for_different_clients_and_ensure_balances_are_correct(
 
     // generate first deal for
     let deal1 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         client1_addr,
         &MinerAddresses::default(),
         start_epoch,
@@ -1151,7 +1134,7 @@ fn publish_multiple_deals_for_different_clients_and_ensure_balances_are_correct(
 
     // generate second deal
     let deal2 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         client2_addr,
         &MinerAddresses::default(),
         start_epoch,
@@ -1160,7 +1143,7 @@ fn publish_multiple_deals_for_different_clients_and_ensure_balances_are_correct(
 
     // generate third deal
     let deal3 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         client3_addr,
         &MinerAddresses::default(),
         start_epoch,
@@ -1169,7 +1152,7 @@ fn publish_multiple_deals_for_different_clients_and_ensure_balances_are_correct(
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     let ids = publish_deals(
-        &mut rt,
+        &rt,
         &MinerAddresses::default(),
         &[deal1.clone(), deal2.clone(), deal3.clone()],
         TokenAmount::zero(),
@@ -1180,13 +1163,13 @@ fn publish_multiple_deals_for_different_clients_and_ensure_balances_are_correct(
     // assert locked balance for all clients and provider
     let provider_locked_expected =
         &deal1.provider_collateral + &deal2.provider_collateral + &deal3.provider_collateral;
-    let client1_locked = get_balance(&mut rt, &client1_addr).locked;
-    let client2_locked = get_balance(&mut rt, &client2_addr).locked;
-    let client3_locked = get_balance(&mut rt, &client3_addr).locked;
+    let client1_locked = get_balance(&rt, &client1_addr).locked;
+    let client2_locked = get_balance(&rt, &client2_addr).locked;
+    let client3_locked = get_balance(&rt, &client3_addr).locked;
     assert_eq!(deal1.client_balance_requirement(), client1_locked);
     assert_eq!(deal2.client_balance_requirement(), client2_locked);
     assert_eq!(deal3.client_balance_requirement(), client3_locked);
-    assert_eq!(provider_locked_expected, get_balance(&mut rt, &PROVIDER_ADDR).locked);
+    assert_eq!(provider_locked_expected, get_balance(&rt, &PROVIDER_ADDR).locked);
 
     // assert locked funds dealStates
     let st: State = rt.get_state();
@@ -1200,14 +1183,14 @@ fn publish_multiple_deals_for_different_clients_and_ensure_balances_are_correct(
 
     // publish two more deals for same clients with same provider
     let deal4 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         client3_addr,
         &MinerAddresses::default(),
         1000,
         1000 + 200 * EPOCHS_IN_DAY,
     );
     let deal5 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         client3_addr,
         &MinerAddresses::default(),
         100,
@@ -1215,7 +1198,7 @@ fn publish_multiple_deals_for_different_clients_and_ensure_balances_are_correct(
     );
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     let ids = publish_deals(
-        &mut rt,
+        &rt,
         &MinerAddresses::default(),
         &[deal4.clone(), deal5.clone()],
         TokenAmount::zero(),
@@ -1226,16 +1209,16 @@ fn publish_multiple_deals_for_different_clients_and_ensure_balances_are_correct(
     // assert locked balances for clients and provider
     let provider_locked_expected =
         &provider_locked_expected + &deal4.provider_collateral + &deal5.provider_collateral;
-    assert_eq!(provider_locked_expected, get_balance(&mut rt, &PROVIDER_ADDR).locked);
+    assert_eq!(provider_locked_expected, get_balance(&rt, &PROVIDER_ADDR).locked);
 
-    let client3_locked_updated = get_balance(&mut rt, &client3_addr).locked;
+    let client3_locked_updated = get_balance(&rt, &client3_addr).locked;
     assert_eq!(
         &client3_locked + &deal4.client_balance_requirement() + &deal5.client_balance_requirement(),
         client3_locked_updated
     );
 
-    let client1_locked = get_balance(&mut rt, &client1_addr).locked;
-    let client2_locked = get_balance(&mut rt, &client2_addr).locked;
+    let client1_locked = get_balance(&rt, &client1_addr).locked;
+    let client2_locked = get_balance(&rt, &client2_addr).locked;
     assert_eq!(deal1.client_balance_requirement(), client1_locked);
     assert_eq!(deal2.client_balance_requirement(), client2_locked);
 
@@ -1256,30 +1239,29 @@ fn publish_multiple_deals_for_different_clients_and_ensure_balances_are_correct(
     // generate first deal for second provider
     let addrs = MinerAddresses { provider: provider2_addr, ..MinerAddresses::default() };
     let deal6 =
-        generate_deal_and_add_funds(&mut rt, client1_addr, &addrs, 20, 20 + 200 * EPOCHS_IN_DAY);
+        generate_deal_and_add_funds(&rt, client1_addr, &addrs, 20, 20 + 200 * EPOCHS_IN_DAY);
 
     // generate second deal for second provider
     let deal7 =
-        generate_deal_and_add_funds(&mut rt, client1_addr, &addrs, 25, 60 + 200 * EPOCHS_IN_DAY);
+        generate_deal_and_add_funds(&rt, client1_addr, &addrs, 25, 60 + 200 * EPOCHS_IN_DAY);
 
     // publish both the deals for the second provider
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
-    let ids =
-        publish_deals(&mut rt, &addrs, &[deal6.clone(), deal7.clone()], TokenAmount::zero(), 1);
+    let ids = publish_deals(&rt, &addrs, &[deal6.clone(), deal7.clone()], TokenAmount::zero(), 1);
     assert_eq!(2, ids.len());
 
     // assertions
     let st: State = rt.get_state();
     let provider2_locked = &deal6.provider_collateral + &deal7.provider_collateral;
-    assert_eq!(provider2_locked, get_balance(&mut rt, &provider2_addr).locked);
-    let client1_locked_updated = get_balance(&mut rt, &client1_addr).locked;
+    assert_eq!(provider2_locked, get_balance(&rt, &provider2_addr).locked);
+    let client1_locked_updated = get_balance(&rt, &client1_addr).locked;
     assert_eq!(
         &deal7.client_balance_requirement() + &client1_locked + &deal6.client_balance_requirement(),
         client1_locked_updated
     );
 
     // assert first provider's balance as well
-    assert_eq!(provider_locked_expected, get_balance(&mut rt, &PROVIDER_ADDR).locked);
+    assert_eq!(provider_locked_expected, get_balance(&rt, &PROVIDER_ADDR).locked);
 
     let total_client_collateral_locked =
         &total_client_collateral_locked + &deal6.client_collateral + &deal7.client_collateral;
@@ -1298,26 +1280,26 @@ fn active_deals_multiple_times_with_different_providers() {
     let current_epoch = ChainEpoch::from(5);
     let sector_expiry = end_epoch + 100;
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(current_epoch);
 
     // provider 1 publishes deals1 and deals2 and deal3
     let deal1 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
     let deal2 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch + 1,
     );
     let deal3 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -1327,20 +1309,20 @@ fn active_deals_multiple_times_with_different_providers() {
     // provider2 publishes deal4 and deal5
     let provider2_addr = Address::new_id(401);
     let addrs = MinerAddresses { provider: provider2_addr, ..MinerAddresses::default() };
-    let deal4 = generate_and_publish_deal(&mut rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch);
-    let deal5 = generate_and_publish_deal(&mut rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch + 1);
+    let deal4 = generate_and_publish_deal(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch);
+    let deal5 = generate_and_publish_deal(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch + 1);
 
     // provider1 activates deal1 and deal2 but that does not activate deal3 to deal5
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1, deal2]);
-    assert_deals_not_activated(&mut rt, current_epoch, &[deal3, deal4, deal5]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1, deal2]);
+    assert_deals_not_activated(&rt, current_epoch, &[deal3, deal4, deal5]);
 
     // provider2 activates deal5 but that does not activate deal3 or deal4
-    activate_deals(&mut rt, sector_expiry, provider2_addr, current_epoch, &[deal5]);
-    assert_deals_not_activated(&mut rt, current_epoch, &[deal3, deal4]);
+    activate_deals(&rt, sector_expiry, provider2_addr, current_epoch, &[deal5]);
+    assert_deals_not_activated(&rt, current_epoch, &[deal3, deal4]);
 
     // provider1 activates deal3
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal3]);
-    assert_deals_not_activated(&mut rt, current_epoch, &[deal4]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal3]);
+    assert_deals_not_activated(&rt, current_epoch, &[deal4]);
     check_state(&rt);
 }
 
@@ -1351,10 +1333,10 @@ fn fail_when_deal_is_activated_but_proposal_is_not_found() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
 
-    let mut rt = setup();
+    let rt = setup();
 
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -1364,10 +1346,10 @@ fn fail_when_deal_is_activated_but_proposal_is_not_found() {
     );
 
     // delete the deal proposal (this breaks state invariants)
-    delete_deal_proposal(&mut rt, deal_id);
+    delete_deal_proposal(&rt, deal_id);
 
     rt.set_epoch(process_epoch(start_epoch, deal_id));
-    expect_abort(EX_DEAL_EXPIRED, cron_tick_raw(&mut rt));
+    expect_abort(EX_DEAL_EXPIRED, cron_tick_raw(&rt));
 
     check_state_with_expected(
         &rt,
@@ -1387,10 +1369,10 @@ fn fail_when_deal_update_epoch_is_in_the_future() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
 
-    let mut rt = setup();
+    let rt = setup();
 
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -1402,15 +1384,15 @@ fn fail_when_deal_update_epoch_is_in_the_future() {
     // move the current epoch such that the deal's last updated field is set to the start epoch of the deal
     // and the next tick for it is scheduled at the endepoch.
     rt.set_epoch(process_epoch(start_epoch, deal_id));
-    cron_tick(&mut rt);
+    cron_tick(&rt);
 
     // update last updated to some time in the future (breaks state invariants)
-    update_last_updated(&mut rt, deal_id, end_epoch + 1000);
+    update_last_updated(&rt, deal_id, end_epoch + 1000);
 
     // set current epoch of the deal to the end epoch so it's picked up for "processing" in the next cron tick.
     rt.set_epoch(end_epoch);
 
-    expect_abort(ExitCode::USR_ILLEGAL_STATE, cron_tick_raw(&mut rt));
+    expect_abort(ExitCode::USR_ILLEGAL_STATE, cron_tick_raw(&rt));
 
     check_state_with_expected(
         &rt,
@@ -1426,9 +1408,9 @@ fn crontick_for_a_deal_at_its_start_epoch_results_in_zero_payment_and_no_slashin
 
     // set start epoch to coincide with processing (0 + 0 % 2880 = 0)
     let start_epoch = 0;
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -1441,13 +1423,13 @@ fn crontick_for_a_deal_at_its_start_epoch_results_in_zero_payment_and_no_slashin
     let current = process_epoch(start_epoch, deal_id);
     rt.set_epoch(current);
     let (pay, slashed) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     assert_eq!(TokenAmount::zero(), pay);
     assert_eq!(TokenAmount::zero(), slashed);
 
     // deal proposal and state should NOT be deleted
-    get_deal_proposal(&mut rt, deal_id);
-    get_deal_state(&mut rt, deal_id);
+    get_deal_proposal(&rt, deal_id);
+    get_deal_state(&rt, deal_id);
     check_state(&rt);
 }
 
@@ -1457,10 +1439,10 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
 
-    let mut rt = setup();
+    let rt = setup();
 
     let deal_id1 = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -1468,10 +1450,10 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
         0,
         sector_expiry,
     );
-    let d1 = get_deal_proposal(&mut rt, deal_id1);
+    let d1 = get_deal_proposal(&rt, deal_id1);
 
     let deal_id2 = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch + 1,
@@ -1483,7 +1465,7 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
     // slash deal1
     let slash_epoch = process_epoch(start_epoch, deal_id2) + ChainEpoch::from(100);
     rt.set_epoch(slash_epoch);
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal_id1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id1]);
 
     // cron tick will slash deal1 and make payment for deal2
     rt.expect_send_simple(
@@ -1494,10 +1476,10 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
         None,
         ExitCode::OK,
     );
-    cron_tick(&mut rt);
+    cron_tick(&rt);
 
-    assert_deal_deleted(&mut rt, deal_id1, d1);
-    let s2 = get_deal_state(&mut rt, deal_id2);
+    assert_deal_deleted(&rt, deal_id1, d1);
+    let s2 = get_deal_state(&rt, deal_id2);
     assert_eq!(slash_epoch, s2.last_updated_epoch);
     check_state(&rt);
 }
@@ -1508,18 +1490,12 @@ fn cannot_publish_the_same_deal_twice_before_a_cron_tick() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
 
     // Publish a deal
-    let mut rt = setup();
-    generate_and_publish_deal(
-        &mut rt,
-        CLIENT_ADDR,
-        &MinerAddresses::default(),
-        start_epoch,
-        end_epoch,
-    );
+    let rt = setup();
+    generate_and_publish_deal(&rt, CLIENT_ADDR, &MinerAddresses::default(), start_epoch, end_epoch);
 
     // now try to publish it again and it should fail because it will still be in pending state
     let d2 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -1531,8 +1507,8 @@ fn cannot_publish_the_same_deal_twice_before_a_cron_tick() {
         deals: vec![ClientDealProposal { proposal: d2.clone(), client_signature: sig }],
     };
     rt.expect_validate_caller_any();
-    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
-    expect_query_network_info(&mut rt);
+    expect_provider_is_control_address(&rt, PROVIDER_ADDR, WORKER_ADDR, true);
+    expect_query_network_info(&rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
 
     let auth_param = IpldBlock::serialize_cbor(&AuthenticateMessageParams {
@@ -1570,9 +1546,9 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
 
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -1600,9 +1576,9 @@ fn fail_when_end_epoch_of_deal_greater_than_sector_expiry() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
 
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -1630,19 +1606,19 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
 
-    let mut rt = setup();
+    let rt = setup();
     // activate deal1 so it fails later
     let deal_id1 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id1]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id1]);
 
     let deal_id2 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -1704,7 +1680,7 @@ fn locked_fund_tracking_states() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 400;
 
-    let mut rt = setup();
+    let rt = setup();
     rt.actor_code_cids.borrow_mut().insert(p1, *MINER_ACTOR_CODE_ID);
     rt.actor_code_cids.borrow_mut().insert(c1, *ACCOUNT_ACTOR_CODE_ID);
     let st: State = rt.get_state();
@@ -1715,14 +1691,14 @@ fn locked_fund_tracking_states() {
     assert!(st.total_client_storage_fee.is_zero());
 
     // Publish deal1, deal2, and deal3 with different client and provider
-    let deal_id1 = generate_and_publish_deal(&mut rt, c1, &m1, start_epoch, end_epoch);
-    let d1 = get_deal_proposal(&mut rt, deal_id1);
+    let deal_id1 = generate_and_publish_deal(&rt, c1, &m1, start_epoch, end_epoch);
+    let d1 = get_deal_proposal(&rt, deal_id1);
 
-    let deal_id2 = generate_and_publish_deal(&mut rt, c2, &m2, start_epoch, end_epoch);
-    let d2 = get_deal_proposal(&mut rt, deal_id2);
+    let deal_id2 = generate_and_publish_deal(&rt, c2, &m2, start_epoch, end_epoch);
+    let d2 = get_deal_proposal(&rt, deal_id2);
 
-    let deal_id3 = generate_and_publish_deal(&mut rt, c3, &m3, start_epoch, end_epoch);
-    let d3 = get_deal_proposal(&mut rt, deal_id3);
+    let deal_id3 = generate_and_publish_deal(&rt, c3, &m3, start_epoch, end_epoch);
+    let d3 = get_deal_proposal(&rt, deal_id3);
 
     let csf = d1.total_storage_fee() + d2.total_storage_fee() + d3.total_storage_fee();
     let plc = &d1.provider_collateral + d2.provider_collateral + &d3.provider_collateral;
@@ -1733,8 +1709,8 @@ fn locked_fund_tracking_states() {
     // activation doesn't change anything
     let curr = start_epoch - 1;
     rt.set_epoch(curr);
-    activate_deals(&mut rt, sector_expiry, p1, curr, &[deal_id1]);
-    activate_deals(&mut rt, sector_expiry, p2, curr, &[deal_id2]);
+    activate_deals(&rt, sector_expiry, p1, curr, &[deal_id1]);
+    activate_deals(&rt, sector_expiry, p2, curr, &[deal_id2]);
 
     assert_locked_fund_states(&rt, csf.clone(), plc.clone(), clc.clone());
 
@@ -1749,7 +1725,7 @@ fn locked_fund_tracking_states() {
         None,
         ExitCode::OK,
     );
-    cron_tick(&mut rt);
+    cron_tick(&rt);
     let duration = curr - start_epoch;
     let payment: TokenAmount = 2 * &d1.storage_price_per_epoch * duration;
     let mut csf = (csf - payment) - d3.total_storage_fee();
@@ -1761,7 +1737,7 @@ fn locked_fund_tracking_states() {
     let deal_updates_interval = Policy::default().deal_updates_interval;
     let curr = curr + deal_updates_interval - 1;
     rt.set_epoch(curr);
-    cron_tick(&mut rt);
+    cron_tick(&rt);
     assert_locked_fund_states(&rt, csf.clone(), plc.clone(), clc.clone());
 
     // one more round of payment for deal1 and deal2
@@ -1770,12 +1746,12 @@ fn locked_fund_tracking_states() {
     let duration = deal_updates_interval;
     let payment = 2 * d1.storage_price_per_epoch * duration;
     csf -= payment;
-    cron_tick(&mut rt);
+    cron_tick(&rt);
     assert_locked_fund_states(&rt, csf.clone(), plc.clone(), clc.clone());
 
     // slash deal1
     rt.set_epoch(curr + 1);
-    terminate_deals(&mut rt, m1.provider, &[deal_id1]);
+    terminate_deals(&rt, m1.provider, &[deal_id1]);
 
     // cron tick to slash deal1 and expire deal2
     rt.set_epoch(end_epoch);
@@ -1790,7 +1766,7 @@ fn locked_fund_tracking_states() {
         None,
         ExitCode::OK,
     );
-    cron_tick(&mut rt);
+    cron_tick(&rt);
     assert_locked_fund_states(&rt, csf, plc, clc);
     check_state(&rt);
 }
@@ -1810,7 +1786,7 @@ fn assert_locked_fund_states(
 
 #[allow(dead_code)]
 fn market_actor_deals() {
-    let mut rt = setup();
+    let rt = setup();
     let miner_addresses = MinerAddresses {
         owner: OWNER_ADDR,
         worker: WORKER_ADDR,
@@ -1820,22 +1796,22 @@ fn market_actor_deals() {
 
     // test adding provider funds
     let funds = TokenAmount::from_atto(20_000_000);
-    add_provider_funds(&mut rt, funds.clone(), &MinerAddresses::default());
-    assert_eq!(funds, get_balance(&mut rt, &PROVIDER_ADDR).balance);
+    add_provider_funds(&rt, funds.clone(), &MinerAddresses::default());
+    assert_eq!(funds, get_balance(&rt, &PROVIDER_ADDR).balance);
 
-    add_participant_funds(&mut rt, CLIENT_ADDR, funds);
+    add_participant_funds(&rt, CLIENT_ADDR, funds);
     let mut deal_proposal =
         generate_deal_proposal(CLIENT_ADDR, PROVIDER_ADDR, 1, 200 * EPOCHS_IN_DAY);
 
     // First attempt at publishing the deal should work
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     let ids =
-        publish_deals(&mut rt, &miner_addresses, &[deal_proposal.clone()], TokenAmount::zero(), 1);
+        publish_deals(&rt, &miner_addresses, &[deal_proposal.clone()], TokenAmount::zero(), 1);
     assert_eq!(1, ids.len());
 
     // Second attempt at publishing the same deal should fail
     publish_deals_expect_abort(
-        &mut rt,
+        &rt,
         &miner_addresses,
         deal_proposal.clone(),
         ExitCode::USR_ILLEGAL_ARGUMENT,
@@ -1844,14 +1820,14 @@ fn market_actor_deals() {
     // Same deal with a different label should work
     deal_proposal.label = Label::String("Cthulhu".to_owned());
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
-    let ids = publish_deals(&mut rt, &miner_addresses, &[deal_proposal], TokenAmount::zero(), 1);
+    let ids = publish_deals(&rt, &miner_addresses, &[deal_proposal], TokenAmount::zero(), 1);
     assert_eq!(1, ids.len());
     check_state(&rt);
 }
 
 #[test]
 fn max_deal_label_size() {
-    let mut rt = setup();
+    let rt = setup();
     let miner_addresses = MinerAddresses {
         owner: OWNER_ADDR,
         worker: WORKER_ADDR,
@@ -1861,10 +1837,10 @@ fn max_deal_label_size() {
 
     // Test adding provider funds from both worker and owner address
     let funds = TokenAmount::from_atto(20_000_000);
-    add_provider_funds(&mut rt, funds.clone(), &MinerAddresses::default());
-    assert_eq!(funds, get_balance(&mut rt, &PROVIDER_ADDR).balance);
+    add_provider_funds(&rt, funds.clone(), &MinerAddresses::default());
+    assert_eq!(funds, get_balance(&rt, &PROVIDER_ADDR).balance);
 
-    add_participant_funds(&mut rt, CLIENT_ADDR, funds);
+    add_participant_funds(&rt, CLIENT_ADDR, funds);
     let mut deal_proposal =
         generate_deal_proposal(CLIENT_ADDR, PROVIDER_ADDR, 1, 200 * EPOCHS_IN_DAY);
 
@@ -1872,13 +1848,13 @@ fn max_deal_label_size() {
     deal_proposal.label = Label::String("s".repeat(DEAL_MAX_LABEL_SIZE));
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     let ids =
-        publish_deals(&mut rt, &miner_addresses, &[deal_proposal.clone()], TokenAmount::zero(), 1);
+        publish_deals(&rt, &miner_addresses, &[deal_proposal.clone()], TokenAmount::zero(), 1);
     assert_eq!(1, ids.len());
 
     // over max should fail
     deal_proposal.label = Label::String("s".repeat(DEAL_MAX_LABEL_SIZE + 1));
     publish_deals_expect_abort(
-        &mut rt,
+        &rt,
         &miner_addresses,
         deal_proposal,
         ExitCode::USR_ILLEGAL_ARGUMENT,
@@ -1891,7 +1867,7 @@ fn max_deal_label_size() {
 /// Tests that if 2 deals are published, and the client can't cover collateral for the first deal,
 /// but can cover the second, then the first deal fails, but the second passes
 fn insufficient_client_balance_in_a_batch() {
-    let mut rt = setup();
+    let rt = setup();
     let st: State = rt.get_state();
     let next_deal_id = st.next_id;
 
@@ -1910,7 +1886,7 @@ fn insufficient_client_balance_in_a_batch() {
     deal1.client_collateral = &deal2.client_collateral + TokenAmount::from_atto(1);
 
     // Client gets enough funds for the 2nd deal
-    add_participant_funds(&mut rt, CLIENT_ADDR, deal2.client_balance_requirement());
+    add_participant_funds(&rt, CLIENT_ADDR, deal2.client_balance_requirement());
 
     // Provider has enough for both
     let provider_funds =
@@ -1918,7 +1894,7 @@ fn insufficient_client_balance_in_a_batch() {
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
     rt.set_received(provider_funds);
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_control_address(&rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 
     assert!(rt
         .call::<MarketActor>(
@@ -1930,10 +1906,10 @@ fn insufficient_client_balance_in_a_batch() {
 
     rt.verify();
 
-    assert_eq!(deal2.client_balance_requirement(), get_balance(&mut rt, &CLIENT_ADDR).balance);
+    assert_eq!(deal2.client_balance_requirement(), get_balance(&rt, &CLIENT_ADDR).balance);
     assert_eq!(
         deal1.provider_balance_requirement().add(deal2.provider_balance_requirement()),
-        get_balance(&mut rt, &PROVIDER_ADDR).balance
+        get_balance(&rt, &PROVIDER_ADDR).balance
     );
 
     let buf1 = RawBytes::serialize(&deal1).expect("failed to marshal deal proposal");
@@ -1949,8 +1925,8 @@ fn insufficient_client_balance_in_a_batch() {
     };
 
     rt.expect_validate_caller_any();
-    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
-    expect_query_network_info(&mut rt);
+    expect_provider_is_control_address(&rt, PROVIDER_ADDR, WORKER_ADDR, true);
+    expect_query_network_info(&rt);
 
     let authenticate_param1 = IpldBlock::serialize_cbor(&AuthenticateMessageParams {
         signature: buf1.to_vec(),
@@ -2025,7 +2001,7 @@ fn insufficient_client_balance_in_a_batch() {
 /// Tests that if 2 deals are published, and the provider can't cover collateral for the first deal,
 /// but can cover the second, then the first deal fails, but the second passes
 fn insufficient_provider_balance_in_a_batch() {
-    let mut rt = setup();
+    let rt = setup();
     let st: State = rt.get_state();
     let next_deal_id = st.next_id;
 
@@ -2045,7 +2021,7 @@ fn insufficient_provider_balance_in_a_batch() {
 
     // Client gets enough funds for both deals
     add_participant_funds(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         deal1.client_balance_requirement().add(deal2.client_balance_requirement()),
     );
@@ -2054,7 +2030,7 @@ fn insufficient_provider_balance_in_a_batch() {
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
     rt.set_received(deal2.provider_balance_requirement().clone());
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_control_address(&rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 
     assert!(rt
         .call::<MarketActor>(
@@ -2068,11 +2044,11 @@ fn insufficient_provider_balance_in_a_batch() {
 
     assert_eq!(
         deal1.client_balance_requirement().add(deal2.client_balance_requirement()),
-        get_balance(&mut rt, &CLIENT_ADDR).balance
+        get_balance(&rt, &CLIENT_ADDR).balance
     );
     assert_eq!(
         deal2.provider_balance_requirement().clone(),
-        get_balance(&mut rt, &PROVIDER_ADDR).balance
+        get_balance(&rt, &PROVIDER_ADDR).balance
     );
 
     let buf1 = RawBytes::serialize(&deal1).expect("failed to marshal deal proposal");
@@ -2089,8 +2065,8 @@ fn insufficient_provider_balance_in_a_batch() {
     };
 
     rt.expect_validate_caller_any();
-    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
-    expect_query_network_info(&mut rt);
+    expect_provider_is_control_address(&rt, PROVIDER_ADDR, WORKER_ADDR, true);
+    expect_query_network_info(&rt);
 
     let authenticate_param1 = IpldBlock::serialize_cbor(&AuthenticateMessageParams {
         signature: buf1.to_vec(),
@@ -2163,7 +2139,7 @@ fn insufficient_provider_balance_in_a_batch() {
 
 #[test]
 fn add_balance_restricted_correctly() {
-    let mut rt = setup();
+    let rt = setup();
     let amount = TokenAmount::from_atto(1000);
     rt.set_received(amount);
 
@@ -2193,7 +2169,7 @@ fn add_balance_restricted_correctly() {
 
 #[test]
 fn psd_restricted_correctly() {
-    let mut rt = setup();
+    let rt = setup();
     let st: State = rt.get_state();
     let next_deal_id = st.next_id;
 
@@ -2205,13 +2181,13 @@ fn psd_restricted_correctly() {
     );
 
     // Client gets enough funds
-    add_participant_funds(&mut rt, CLIENT_ADDR, deal.client_balance_requirement());
+    add_participant_funds(&rt, CLIENT_ADDR, deal.client_balance_requirement());
 
     // Provider has enough funds
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OWNER_ADDR);
     rt.set_received(deal.provider_balance_requirement().clone());
     rt.expect_validate_caller_any();
-    expect_provider_control_address(&mut rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
+    expect_provider_control_address(&rt, PROVIDER_ADDR, OWNER_ADDR, WORKER_ADDR);
 
     assert!(rt
         .call::<MarketActor>(
@@ -2255,8 +2231,8 @@ fn psd_restricted_correctly() {
     .unwrap();
 
     rt.expect_validate_caller_any();
-    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
-    expect_query_network_info(&mut rt);
+    expect_provider_is_control_address(&rt, PROVIDER_ADDR, WORKER_ADDR, true);
+    expect_query_network_info(&rt);
 
     rt.expect_send(
         deal.client,

--- a/actors/market/tests/on_miner_sectors_terminate.rs
+++ b/actors/market/tests/on_miner_sectors_terminate.rs
@@ -309,10 +309,10 @@ fn do_not_terminate_deal_if_end_epoch_is_equal_to_or_less_than_current_epoch() {
 // Converted from: https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/market/market_test.go#L1436
 #[test]
 fn fail_when_caller_is_not_a_storage_miner_actor() {
-    let mut rt = setup();
+    let rt = setup();
     rt.expect_validate_caller_type(vec![Type::Miner]);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, PROVIDER_ADDR);
-    let params = OnMinerSectorsTerminateParams { epoch: rt.epoch, deal_ids: vec![] };
+    let params = OnMinerSectorsTerminateParams { epoch: *rt.epoch.borrow(), deal_ids: vec![] };
 
     // XXX: Which exit code is correct: SYS_FORBIDDEN(8) or USR_FORBIDDEN(18)?
     assert_eq!(

--- a/actors/market/tests/on_miner_sectors_terminate.rs
+++ b/actors/market/tests/on_miner_sectors_terminate.rs
@@ -29,13 +29,13 @@ fn terminate_multiple_deals_from_multiple_providers() {
 
     let provider2 = Address::new_id(501);
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(current_epoch);
 
     let [deal1, deal2, deal3]: [DealID; 3] = (end_epoch..end_epoch + 3)
         .map(|epoch| {
             generate_and_publish_deal(
-                &mut rt,
+                &rt,
                 CLIENT_ADDR,
                 &MinerAddresses::default(),
                 start_epoch,
@@ -45,27 +45,27 @@ fn terminate_multiple_deals_from_multiple_providers() {
         .collect::<Vec<DealID>>()
         .try_into()
         .unwrap();
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1, deal2, deal3]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1, deal2, deal3]);
 
     let addrs = MinerAddresses { provider: provider2, ..MinerAddresses::default() };
-    let deal4 = generate_and_publish_deal(&mut rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch);
-    let deal5 = generate_and_publish_deal(&mut rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch + 1);
-    activate_deals(&mut rt, sector_expiry, provider2, current_epoch, &[deal4, deal5]);
+    let deal4 = generate_and_publish_deal(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch);
+    let deal5 = generate_and_publish_deal(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch + 1);
+    activate_deals(&rt, sector_expiry, provider2, current_epoch, &[deal4, deal5]);
 
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal1]);
-    assert_deals_terminated(&mut rt, current_epoch, &[deal1]);
-    assert_deals_not_terminated(&mut rt, &[deal2, deal3, deal4, deal5]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
+    assert_deals_terminated(&rt, current_epoch, &[deal1]);
+    assert_deals_not_terminated(&rt, &[deal2, deal3, deal4, deal5]);
 
-    terminate_deals(&mut rt, provider2, &[deal5]);
-    assert_deals_terminated(&mut rt, current_epoch, &[deal5]);
-    assert_deals_not_terminated(&mut rt, &[deal2, deal3, deal4]);
+    terminate_deals(&rt, provider2, &[deal5]);
+    assert_deals_terminated(&rt, current_epoch, &[deal5]);
+    assert_deals_not_terminated(&rt, &[deal2, deal3, deal4]);
 
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal2, deal3]);
-    assert_deals_terminated(&mut rt, current_epoch, &[deal2, deal3]);
-    assert_deals_not_terminated(&mut rt, &[deal4]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal2, deal3]);
+    assert_deals_terminated(&rt, current_epoch, &[deal2, deal3]);
+    assert_deals_not_terminated(&rt, &[deal4]);
 
-    terminate_deals(&mut rt, provider2, &[deal4]);
-    assert_deals_terminated(&mut rt, current_epoch, &[deal4]);
+    terminate_deals(&rt, provider2, &[deal4]);
+    assert_deals_terminated(&rt, current_epoch, &[deal4]);
     check_state(&rt);
 }
 
@@ -77,21 +77,21 @@ fn ignore_deal_proposal_that_does_not_exist() {
     let sector_expiry = end_epoch + 100;
     let current_epoch = 5;
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(current_epoch);
 
     let deal1 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
 
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal1, 42]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal1, 42]);
 
-    let s = get_deal_state(&mut rt, deal1);
+    let s = get_deal_state(&rt, deal1);
     assert_eq!(s.slash_epoch, current_epoch);
     check_state(&rt);
 }
@@ -104,38 +104,38 @@ fn terminate_valid_deals_along_with_just_expired_deal() {
     let sector_expiry = end_epoch + 100;
     let current_epoch = 5;
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(current_epoch);
 
     let deal1 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
     let deal2 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch + 1,
     );
     let deal3 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch - 1,
     );
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1, deal2, deal3]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1, deal2, deal3]);
 
     let new_epoch = end_epoch - 1;
     rt.set_epoch(new_epoch);
 
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal1, deal2, deal3]);
-    assert_deals_terminated(&mut rt, new_epoch, &[deal1, deal2]);
-    assert_deals_not_terminated(&mut rt, &[deal3]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal1, deal2, deal3]);
+    assert_deals_terminated(&rt, new_epoch, &[deal1, deal2]);
+    assert_deals_not_terminated(&rt, &[deal3]);
     check_state(&rt);
 }
 
@@ -148,18 +148,18 @@ fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
     let sector_expiry = end_epoch + 100;
     let current_epoch = 5;
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(current_epoch);
 
     let deal1 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
     let deal2 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -168,22 +168,22 @@ fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     let deal_ids = publish_deals(
-        &mut rt,
+        &rt,
         &MinerAddresses::default(),
         &[deal1, deal2.clone()],
         TokenAmount::zero(),
         1,
     );
     assert_eq!(2, deal_ids.len());
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, current_epoch, &deal_ids);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &deal_ids);
 
     let new_epoch = end_epoch - 1;
     rt.set_epoch(new_epoch);
-    cron_tick(&mut rt);
+    cron_tick(&rt);
 
-    terminate_deals(&mut rt, PROVIDER_ADDR, &deal_ids);
-    assert_deals_terminated(&mut rt, new_epoch, &deal_ids[0..0]);
-    assert_deal_deleted(&mut rt, deal_ids[1], deal2);
+    terminate_deals(&rt, PROVIDER_ADDR, &deal_ids);
+    assert_deals_terminated(&rt, new_epoch, &deal_ids[0..0]);
+    assert_deal_deleted(&rt, deal_ids[1], deal2);
     check_state(&rt);
 }
 
@@ -195,25 +195,25 @@ fn terminating_a_deal_the_second_time_does_not_change_its_slash_epoch() {
     let sector_expiry = end_epoch + 100;
     let current_epoch = 5;
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(current_epoch);
 
     let deal1 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
 
     // terminating the deal so slash epoch is the current epoch
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
 
     // set a new epoch and terminate again -> however slash epoch will still be the old epoch.
     rt.set_epoch(current_epoch + 1);
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal1]);
-    let s = get_deal_state(&mut rt, deal1);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
+    let s = get_deal_state(&rt, deal1);
     assert_eq!(s.slash_epoch, current_epoch);
     check_state(&rt);
 }
@@ -226,7 +226,7 @@ fn terminating_new_deals_and_an_already_terminated_deal_only_terminates_the_new_
     let sector_expiry = end_epoch + 100;
     let current_epoch = 5;
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(current_epoch);
 
     // provider1 publishes deal1 and 2 and deal3 -> deal3 has the lowest endepoch
@@ -234,7 +234,7 @@ fn terminating_new_deals_and_an_already_terminated_deal_only_terminates_the_new_
         .iter()
         .map(|&epoch| {
             generate_and_publish_deal(
-                &mut rt,
+                &rt,
                 CLIENT_ADDR,
                 &MinerAddresses::default(),
                 start_epoch,
@@ -243,23 +243,23 @@ fn terminating_new_deals_and_an_already_terminated_deal_only_terminates_the_new_
         })
         .collect();
     let [deal1, deal2, deal3]: [DealID; 3] = deals.as_slice().try_into().unwrap();
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, current_epoch, &deals);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &deals);
 
     // terminating the deal so slash epoch is the current epoch
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
 
     // set a new epoch and terminate again -> however slash epoch will still be the old epoch.
     let new_epoch = current_epoch + 1;
     rt.set_epoch(new_epoch);
-    terminate_deals(&mut rt, PROVIDER_ADDR, &deals);
+    terminate_deals(&rt, PROVIDER_ADDR, &deals);
 
-    let s1 = get_deal_state(&mut rt, deal1);
+    let s1 = get_deal_state(&rt, deal1);
     assert_eq!(s1.slash_epoch, current_epoch);
 
-    let s2 = get_deal_state(&mut rt, deal2);
+    let s2 = get_deal_state(&rt, deal2);
     assert_eq!(s2.slash_epoch, new_epoch);
 
-    let s3 = get_deal_state(&mut rt, deal3);
+    let s3 = get_deal_state(&rt, deal3);
     assert_eq!(s3.slash_epoch, new_epoch);
 
     check_state(&rt);
@@ -273,35 +273,35 @@ fn do_not_terminate_deal_if_end_epoch_is_equal_to_or_less_than_current_epoch() {
     let sector_expiry = end_epoch + 100;
     let current_epoch = 5;
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(current_epoch);
 
     // deal1 has endepoch equal to current epoch when terminate is called
     let deal1 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
     rt.set_epoch(end_epoch);
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal1]);
-    assert_deals_not_terminated(&mut rt, &[deal1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
+    assert_deals_not_terminated(&rt, &[deal1]);
 
     // deal2 has end epoch less than current epoch when terminate is called
     rt.set_epoch(current_epoch);
     let deal2 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch + 1,
         end_epoch,
     );
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal2]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal2]);
     rt.set_epoch(end_epoch + 1);
-    terminate_deals(&mut rt, PROVIDER_ADDR, &[deal2]);
-    assert_deals_not_terminated(&mut rt, &[deal2]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[deal2]);
+    assert_deals_not_terminated(&rt, &[deal2]);
 
     check_state(&rt);
 }
@@ -338,20 +338,20 @@ fn fail_when_caller_is_not_the_provider_of_the_deal() {
 
     let provider2 = Address::new_id(501);
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(current_epoch);
 
     let deal = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal]);
 
     // XXX: Difference between go messages: 't0501' has turned into 'f0501'.
-    let ret = terminate_deals_raw(&mut rt, provider2, &[deal]);
+    let ret = terminate_deals_raw(&rt, provider2, &[deal]);
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_STATE,
         "caller f0501 is not the provider f0102 of deal 0",
@@ -368,18 +368,18 @@ fn fail_when_deal_has_been_published_but_not_activated() {
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let current_epoch = 5;
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(current_epoch);
 
     let deal = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
 
-    let ret = terminate_deals_raw(&mut rt, PROVIDER_ADDR, &[deal]);
+    let ret = terminate_deals_raw(&rt, PROVIDER_ADDR, &[deal]);
     expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "no state for deal", ret);
     rt.verify();
     check_state(&rt);
@@ -393,31 +393,31 @@ fn termination_of_all_deals_should_fail_when_one_deal_fails() {
     let sector_expiry = end_epoch + 100;
     let current_epoch = 5;
 
-    let mut rt = setup();
+    let rt = setup();
     rt.set_epoch(current_epoch);
 
     // deal1 would terminate but deal2 will fail because deal2 has not been activated
     let deal1 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch,
     );
-    activate_deals(&mut rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
     let deal2 = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
         end_epoch + 1,
     );
 
-    let ret = terminate_deals_raw(&mut rt, PROVIDER_ADDR, &[deal1, deal2]);
+    let ret = terminate_deals_raw(&rt, PROVIDER_ADDR, &[deal1, deal2]);
     expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "no state for deal", ret);
     rt.verify();
 
     // verify deal1 has not been terminated
-    assert_deals_not_terminated(&mut rt, &[deal1]);
+    assert_deals_not_terminated(&rt, &[deal1]);
     check_state(&rt);
 }

--- a/actors/market/tests/publish_storage_deals_failures.rs
+++ b/actors/market/tests/publish_storage_deals_failures.rs
@@ -32,7 +32,7 @@ use num_traits::Zero;
 
 #[test]
 fn deal_end_after_deal_start() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.start_epoch = 10;
         d.end_epoch = 9;
     };
@@ -41,7 +41,7 @@ fn deal_end_after_deal_start() {
 
 #[test]
 fn current_epoch_greater_than_start_epoch() {
-    let f = |rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |rt: &MockRuntime, d: &mut DealProposal| {
         d.start_epoch = *rt.epoch.borrow() - 1;
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -49,7 +49,7 @@ fn current_epoch_greater_than_start_epoch() {
 
 #[test]
 fn deal_duration_greater_than_max_deal_duration() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.start_epoch = ChainEpoch::from(10);
         d.end_epoch = d.start_epoch + (540 * EPOCHS_IN_DAY) + 1
     };
@@ -58,7 +58,7 @@ fn deal_duration_greater_than_max_deal_duration() {
 
 #[test]
 fn negative_price_per_epoch() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.storage_price_per_epoch = TokenAmount::from_atto(-1);
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -66,7 +66,7 @@ fn negative_price_per_epoch() {
 
 #[test]
 fn price_per_epoch_greater_than_total_filecoin() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.storage_price_per_epoch = &*TOTAL_FILECOIN + TokenAmount::from_atto(1);
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -74,7 +74,7 @@ fn price_per_epoch_greater_than_total_filecoin() {
 
 #[test]
 fn negative_provider_collateral() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.provider_collateral = TokenAmount::from_atto(-1);
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -82,7 +82,7 @@ fn negative_provider_collateral() {
 
 #[test]
 fn provider_collateral_greater_than_max_collateral() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.provider_collateral = &*TOTAL_FILECOIN + TokenAmount::from_atto(1);
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -90,7 +90,7 @@ fn provider_collateral_greater_than_max_collateral() {
 
 #[test]
 fn provider_collateral_less_than_bound() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         let circ_supply = TokenAmount::from_atto(1i64 << 50);
         let (provider_min, _) = deal_provider_collateral_bounds(
             &Policy::default(),
@@ -106,7 +106,7 @@ fn provider_collateral_less_than_bound() {
 
 #[test]
 fn negative_client_collateral() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.client_collateral = TokenAmount::from_atto(-1);
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -114,7 +114,7 @@ fn negative_client_collateral() {
 
 #[test]
 fn client_collateral_greater_than_max_collateral() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.client_collateral = &*TOTAL_FILECOIN + TokenAmount::from_atto(1);
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -122,7 +122,7 @@ fn client_collateral_greater_than_max_collateral() {
 
 #[test]
 fn client_does_not_have_enough_balance_for_collateral() {
-    let f = |rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |rt: &MockRuntime, d: &mut DealProposal| {
         add_participant_funds(
             rt,
             CLIENT_ADDR,
@@ -135,7 +135,7 @@ fn client_does_not_have_enough_balance_for_collateral() {
 
 #[test]
 fn provider_does_not_have_enough_balance_for_collateral() {
-    let f = |rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |rt: &MockRuntime, d: &mut DealProposal| {
         add_participant_funds(rt, CLIENT_ADDR, d.client_balance_requirement());
         add_provider_funds(
             rt,
@@ -148,7 +148,7 @@ fn provider_does_not_have_enough_balance_for_collateral() {
 
 #[test]
 fn client_address_does_not_exist() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.client = Address::new_id(1);
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -156,7 +156,7 @@ fn client_address_does_not_exist() {
 
 #[test]
 fn unable_to_resolve_client_address() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.client = new_bls_addr(1);
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -164,13 +164,13 @@ fn unable_to_resolve_client_address() {
 
 #[test]
 fn signature_is_invalid() {
-    let f = |_rt: &mut MockRuntime, _d: &mut DealProposal| {};
+    let f = |_rt: &MockRuntime, _d: &mut DealProposal| {};
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, false);
 }
 
 #[test]
 fn no_entry_for_client_in_locked_balance_table() {
-    let f = |rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |rt: &MockRuntime, d: &mut DealProposal| {
         add_provider_funds(rt, d.provider_collateral.clone(), &MinerAddresses::default());
     };
     assert_deal_failure(false, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -178,7 +178,7 @@ fn no_entry_for_client_in_locked_balance_table() {
 
 #[test]
 fn no_entry_for_provider_in_locked_balance_table() {
-    let f = |rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |rt: &MockRuntime, d: &mut DealProposal| {
         add_participant_funds(rt, CLIENT_ADDR, d.client_balance_requirement());
     };
     assert_deal_failure(false, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -186,7 +186,7 @@ fn no_entry_for_provider_in_locked_balance_table() {
 
 #[test]
 fn bad_piece_cid() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.piece_cid = Cid::default();
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -194,7 +194,7 @@ fn bad_piece_cid() {
 
 #[test]
 fn zero_piece_size() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.piece_size = PaddedPieceSize(0u64);
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -202,7 +202,7 @@ fn zero_piece_size() {
 
 #[test]
 fn piece_size_less_than_128_bytes() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.piece_size = PaddedPieceSize(64u64);
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -210,7 +210,7 @@ fn piece_size_less_than_128_bytes() {
 
 #[test]
 fn piece_size_is_not_a_power_of_2() {
-    let f = |_rt: &mut MockRuntime, d: &mut DealProposal| {
+    let f = |_rt: &MockRuntime, d: &mut DealProposal| {
         d.piece_size = PaddedPieceSize(254u64);
     };
     assert_deal_failure(true, f, ExitCode::USR_ILLEGAL_ARGUMENT, true);
@@ -218,17 +218,17 @@ fn piece_size_is_not_a_power_of_2() {
 
 #[test]
 fn fail_when_client_has_some_funds_but_not_enough_for_a_deal() {
-    let mut rt = setup();
+    let rt = setup();
 
     let amount = TokenAmount::from_atto(100u8);
-    add_participant_funds(&mut rt, CLIENT_ADDR, amount.clone());
+    add_participant_funds(&rt, CLIENT_ADDR, amount.clone());
     let start_epoch = 42;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let deal1 = generate_deal_proposal(CLIENT_ADDR, PROVIDER_ADDR, start_epoch, end_epoch);
     assert!(amount < deal1.client_balance_requirement());
-    add_provider_funds(&mut rt, deal1.clone().provider_collateral, &MinerAddresses::default());
+    add_provider_funds(&rt, deal1.clone().provider_collateral, &MinerAddresses::default());
     publish_deals_expect_abort(
-        &mut rt,
+        &rt,
         &MinerAddresses::default(),
         deal1,
         ExitCode::USR_ILLEGAL_ARGUMENT,
@@ -242,13 +242,13 @@ fn fail_when_provider_has_some_funds_but_not_enough_for_a_deal() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
 
-    let mut rt = setup();
+    let rt = setup();
 
     let amount = TokenAmount::from_atto(1u8);
-    add_provider_funds(&mut rt, amount.clone(), &MinerAddresses::default());
+    add_provider_funds(&rt, amount.clone(), &MinerAddresses::default());
     let deal1 = generate_deal_proposal(CLIENT_ADDR, PROVIDER_ADDR, start_epoch, end_epoch);
     assert!(amount < deal1.client_balance_requirement());
-    add_participant_funds(&mut rt, CLIENT_ADDR, deal1.client_balance_requirement());
+    add_participant_funds(&rt, CLIENT_ADDR, deal1.client_balance_requirement());
 
     let buf = RawBytes::serialize(deal1.clone()).expect("failed to marshal deal proposal");
     let sig = Signature::new_bls(buf.to_vec());
@@ -257,8 +257,8 @@ fn fail_when_provider_has_some_funds_but_not_enough_for_a_deal() {
     };
 
     rt.expect_validate_caller_any();
-    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
-    expect_query_network_info(&mut rt);
+    expect_provider_is_control_address(&rt, PROVIDER_ADDR, WORKER_ADDR, true);
+    expect_query_network_info(&rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
 
     let auth_param = IpldBlock::serialize_cbor(&AuthenticateMessageParams {
@@ -296,12 +296,12 @@ fn fail_when_deals_have_different_providers() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
 
-    let mut rt = setup();
+    let rt = setup();
     let st: State = rt.get_state();
     let next_deal_id = st.next_id;
 
     let deal1 = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         start_epoch,
@@ -309,7 +309,7 @@ fn fail_when_deals_have_different_providers() {
     );
     let m2 = MinerAddresses { provider: Address::new_id(1000), ..MinerAddresses::default() };
 
-    let deal2 = generate_deal_and_add_funds(&mut rt, CLIENT_ADDR, &m2, 1, end_epoch);
+    let deal2 = generate_deal_and_add_funds(&rt, CLIENT_ADDR, &m2, 1, end_epoch);
 
     let buf1 = RawBytes::serialize(deal1.clone()).expect("failed to marshal deal proposal");
     let buf2 = RawBytes::serialize(deal2.clone()).expect("failed to marshal deal proposal");
@@ -323,8 +323,8 @@ fn fail_when_deals_have_different_providers() {
     };
 
     rt.expect_validate_caller_any();
-    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, WORKER_ADDR, true);
-    expect_query_network_info(&mut rt);
+    expect_provider_is_control_address(&rt, PROVIDER_ADDR, WORKER_ADDR, true);
+    expect_query_network_info(&rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     let authenticate_param1 = IpldBlock::serialize_cbor(&AuthenticateMessageParams {
         signature: buf1.to_vec(),
@@ -439,7 +439,7 @@ fn caller_is_not_the_same_as_the_worker_address_for_miner() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
 
-    let mut rt = setup();
+    let rt = setup();
     let deal = generate_deal_proposal(CLIENT_ADDR, PROVIDER_ADDR, start_epoch, end_epoch);
     let sig = Signature::new_bls("does not matter".as_bytes().to_vec());
     let params = PublishStorageDealsParams {
@@ -447,7 +447,7 @@ fn caller_is_not_the_same_as_the_worker_address_for_miner() {
     };
 
     rt.expect_validate_caller_any();
-    expect_provider_is_control_address(&mut rt, PROVIDER_ADDR, Address::new_id(999), false);
+    expect_provider_is_control_address(&rt, PROVIDER_ADDR, Address::new_id(999), false);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(999));
     expect_abort(
         ExitCode::USR_FORBIDDEN,
@@ -491,10 +491,10 @@ fn fails_if_provider_is_not_a_storage_miner_actor() {
 
 #[test]
 fn fails_if_notify_deal_fails() {
-    let mut rt = setup();
+    let rt = setup();
 
     let deal = generate_deal_and_add_funds(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         ChainEpoch::from(42),
@@ -522,7 +522,7 @@ fn fails_if_notify_deal_fails() {
             .unwrap(),
         ExitCode::OK,
     );
-    expect_query_network_info(&mut rt);
+    expect_query_network_info(&rt);
 
     rt.expect_send(
         CLIENT_ADDR,

--- a/actors/market/tests/random_cron_epoch_during_publish.rs
+++ b/actors/market/tests/random_cron_epoch_during_publish.rs
@@ -19,36 +19,30 @@ const SECTOR_EXPIRY: ChainEpoch = END_EPOCH + 1;
 
 #[test]
 fn cron_processing_happens_at_processing_epoch_not_start_epoch() {
-    let mut rt = setup();
+    let rt = setup();
 
     let deal_id = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
         END_EPOCH,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     // activate the deal
     rt.set_epoch(START_EPOCH - 1);
-    activate_deals(
-        &mut rt,
-        SECTOR_EXPIRY,
-        PROVIDER_ADDR,
-        deal_proposal.start_epoch - 1,
-        &[deal_id],
-    );
+    activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, deal_proposal.start_epoch - 1, &[deal_id]);
 
     // cron tick at deal start epoch does not do anything
     rt.set_epoch(START_EPOCH);
-    cron_tick_no_change(&mut rt, CLIENT_ADDR, PROVIDER_ADDR);
+    cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     // first cron tick at process epoch will make payment and schedule the deal for next epoch
     let deal_epoch = process_epoch(START_EPOCH, deal_id);
     rt.set_epoch(deal_epoch);
     let (pay, _) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, deal_epoch, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, deal_epoch, deal_id);
     let duration = deal_epoch - START_EPOCH;
     assert_eq!(duration * &deal_proposal.storage_price_per_epoch, pay);
 
@@ -56,7 +50,7 @@ fn cron_processing_happens_at_processing_epoch_not_start_epoch() {
     let new_epoch = deal_epoch + Policy::default().deal_updates_interval;
     rt.set_epoch(new_epoch);
     let (pay, _) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, new_epoch, deal_id);
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, new_epoch, deal_id);
     let duration = new_epoch - deal_epoch;
     assert_eq!(duration * &deal_proposal.storage_price_per_epoch, pay);
 
@@ -65,56 +59,48 @@ fn cron_processing_happens_at_processing_epoch_not_start_epoch() {
 
 #[test]
 fn deals_are_scheduled_for_expiry_later_than_the_end_epoch() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
         END_EPOCH,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     rt.set_epoch(START_EPOCH - 1);
-    activate_deals(
-        &mut rt,
-        SECTOR_EXPIRY,
-        PROVIDER_ADDR,
-        deal_proposal.start_epoch - 1,
-        &[deal_id],
-    );
+    activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, deal_proposal.start_epoch - 1, &[deal_id]);
 
     // a cron tick at end epoch -1 schedules the deal for later than end epoch
     let curr = END_EPOCH - 1;
     rt.set_epoch(curr);
     let duration = curr - START_EPOCH;
-    let (pay, _) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, curr, deal_id);
+    let (pay, _) = cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, curr, deal_id);
     assert_eq!(duration * &deal_proposal.storage_price_per_epoch, pay);
 
     // cron tick at end epoch does NOT expire the deal
     rt.set_epoch(END_EPOCH);
-    cron_tick_no_change(&mut rt, CLIENT_ADDR, PROVIDER_ADDR);
-    let _found = get_deal_proposal(&mut rt, deal_id);
+    cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
+    let _found = get_deal_proposal(&rt, deal_id);
 
     // cron tick at nextEpoch expires the deal -> payment is ONLY for one epoch
     let curr = curr + Policy::default().deal_updates_interval;
     rt.set_epoch(curr);
-    let (pay, _) =
-        cron_tick_and_assert_balances(&mut rt, CLIENT_ADDR, PROVIDER_ADDR, curr, deal_id);
+    let (pay, _) = cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, curr, deal_id);
     assert_eq!(&deal_proposal.storage_price_per_epoch, &pay);
-    assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal);
     check_state(&rt);
 }
 
 #[test]
 fn deal_is_processed_after_its_end_epoch_should_expire_correctly() {
-    let mut rt = setup();
+    let rt = setup();
 
     let activation_epoch = START_EPOCH - 1;
     rt.set_epoch(activation_epoch);
     let deal_id = publish_and_activate_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
@@ -122,28 +108,23 @@ fn deal_is_processed_after_its_end_epoch_should_expire_correctly() {
         activation_epoch,
         SECTOR_EXPIRY,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     rt.set_epoch(END_EPOCH + 100);
-    let (pay, slashed) = cron_tick_and_assert_balances(
-        &mut rt,
-        CLIENT_ADDR,
-        PROVIDER_ADDR,
-        END_EPOCH + 100,
-        deal_id,
-    );
+    let (pay, slashed) =
+        cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, END_EPOCH + 100, deal_id);
     assert!(slashed.is_zero());
     let duration = END_EPOCH - START_EPOCH;
     assert_eq!(duration * &deal_proposal.storage_price_per_epoch, pay);
-    assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal);
     check_state(&rt);
 }
 
 #[test]
 fn activation_after_deal_start_epoch_but_before_it_is_processed_fails() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
@@ -156,22 +137,22 @@ fn activation_after_deal_start_epoch_but_before_it_is_processed_fails() {
 
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
-        activate_deals_raw(&mut rt, SECTOR_EXPIRY, PROVIDER_ADDR, curr_epoch, &[deal_id]),
+        activate_deals_raw(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, curr_epoch, &[deal_id]),
     );
     check_state(&rt);
 }
 
 #[test]
 fn cron_processing_of_deal_after_missed_activation_should_fail_and_slash() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id = generate_and_publish_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
         START_EPOCH,
         END_EPOCH,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     rt.set_epoch(process_epoch(START_EPOCH, deal_id));
 
@@ -184,8 +165,8 @@ fn cron_processing_of_deal_after_missed_activation_should_fail_and_slash() {
         None,
         ExitCode::OK,
     );
-    cron_tick(&mut rt);
+    cron_tick(&rt);
 
-    assert_deal_deleted(&mut rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal);
     check_state(&rt);
 }

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -192,7 +192,7 @@ fn fail_when_caller_is_not_a_storage_miner_actor() {
 
 #[test]
 fn fail_when_deal_proposal_is_not_found() {
-    let mut rt = setup();
+    let rt = setup();
 
     let params = VerifyDealsForActivationParams {
         sectors: vec![SectorDeals {

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -121,7 +121,7 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
     let datacap_required =
         TokenAmount::from_whole(verified_deal_1.piece_size.0 + verified_deal_2.piece_size.0);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
-    let deal_ids = publish_deals(&rt, &MINER_ADDRESSES, &deals.clone(), datacap_required, 1);
+    let deal_ids = publish_deals(&rt, &MINER_ADDRESSES, &deals, datacap_required, 1);
     assert_eq!(4, deal_ids.len());
 
     let response = verify_deals_for_activation(

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -34,13 +34,13 @@ const MINER_ADDRESSES: MinerAddresses = MinerAddresses {
 
 #[test]
 fn verify_deal_and_activate_to_get_deal_space_for_unverified_deal_proposal() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id =
-        generate_and_publish_deal(&mut rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+        generate_and_publish_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     let v_response = verify_deals_for_activation(
-        &mut rt,
+        &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
             sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
@@ -49,7 +49,7 @@ fn verify_deal_and_activate_to_get_deal_space_for_unverified_deal_proposal() {
         }],
         |_| None,
     );
-    let a_response = activate_deals(&mut rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
+    let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
     assert_eq!(1, v_response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), v_response.sectors[0].commd);
     assert!(a_response.verified_infos.is_empty());
@@ -60,20 +60,20 @@ fn verify_deal_and_activate_to_get_deal_space_for_unverified_deal_proposal() {
 
 #[test]
 fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
-    let mut rt = setup();
+    let rt = setup();
     let next_allocation_id = 1;
     let deal_id = generate_and_publish_verified_deal(
-        &mut rt,
+        &rt,
         CLIENT_ADDR,
         &MINER_ADDRESSES,
         START_EPOCH,
         END_EPOCH,
         next_allocation_id,
     );
-    let deal_proposal = get_deal_proposal(&mut rt, deal_id);
+    let deal_proposal = get_deal_proposal(&rt, deal_id);
 
     let response = verify_deals_for_activation(
-        &mut rt,
+        &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
             sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
@@ -83,7 +83,7 @@ fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
         |_| None,
     );
 
-    let a_response = activate_deals(&mut rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
+    let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
 
     assert_eq!(1, response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), response.sectors[0].commd);
@@ -100,15 +100,10 @@ fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
 
 #[test]
 fn verification_and_weights_for_verified_and_unverified_deals() {
-    let mut rt = setup();
+    let rt = setup();
     let mut create_deal = |end_epoch, verified| {
-        let mut deal = generate_deal_and_add_funds(
-            &mut rt,
-            CLIENT_ADDR,
-            &MINER_ADDRESSES,
-            START_EPOCH,
-            end_epoch,
-        );
+        let mut deal =
+            generate_deal_and_add_funds(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, end_epoch);
         deal.verified_deal = verified;
         deal
     };
@@ -126,11 +121,11 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
     let datacap_required =
         TokenAmount::from_whole(verified_deal_1.piece_size.0 + verified_deal_2.piece_size.0);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
-    let deal_ids = publish_deals(&mut rt, &MINER_ADDRESSES, &deals.clone(), datacap_required, 1);
+    let deal_ids = publish_deals(&rt, &MINER_ADDRESSES, &deals.clone(), datacap_required, 1);
     assert_eq!(4, deal_ids.len());
 
     let response = verify_deals_for_activation(
-        &mut rt,
+        &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
@@ -151,7 +146,7 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
     let unverified_space =
         BigInt::from(unverified_deal_1.piece_size.0 + unverified_deal_2.piece_size.0);
 
-    let a_response = activate_deals(&mut rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &deal_ids);
+    let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &deal_ids);
 
     assert_eq!(1, response.sectors.len());
     let returned_verified_space: BigInt =
@@ -164,9 +159,9 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
 
 #[test]
 fn fail_when_caller_is_not_a_storage_miner_actor() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id =
-        generate_and_publish_deal(&mut rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
+        generate_and_publish_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     rt.expect_validate_caller_type(vec![Type::Miner]);
@@ -217,9 +212,9 @@ fn fail_when_deal_proposal_is_not_found() {
 
 #[test]
 fn fail_when_caller_is_not_the_provider() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id =
-        generate_and_publish_deal(&mut rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
+        generate_and_publish_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
 
     rt.set_caller(*MINER_ACTOR_CODE_ID, Address::new_id(205));
     rt.expect_validate_caller_type(vec![Type::Miner]);
@@ -245,9 +240,9 @@ fn fail_when_caller_is_not_the_provider() {
 
 #[test]
 fn fail_when_current_epoch_is_greater_than_proposal_start_epoch() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id =
-        generate_and_publish_deal(&mut rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
+        generate_and_publish_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
     rt.set_epoch(START_EPOCH + 1);
 
     rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
@@ -274,9 +269,9 @@ fn fail_when_current_epoch_is_greater_than_proposal_start_epoch() {
 
 #[test]
 fn fail_when_deal_end_epoch_is_greater_than_sector_expiration() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id =
-        generate_and_publish_deal(&mut rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
+        generate_and_publish_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
 
     rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
     rt.expect_validate_caller_type(vec![Type::Miner]);
@@ -302,9 +297,9 @@ fn fail_when_deal_end_epoch_is_greater_than_sector_expiration() {
 
 #[test]
 fn fail_when_the_same_deal_id_is_passed_multiple_times() {
-    let mut rt = setup();
+    let rt = setup();
     let deal_id =
-        generate_and_publish_deal(&mut rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
+        generate_and_publish_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
 
     rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
     rt.expect_validate_caller_type(vec![Type::Miner]);

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -101,7 +101,7 @@ fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
 #[test]
 fn verification_and_weights_for_verified_and_unverified_deals() {
     let rt = setup();
-    let mut create_deal = |end_epoch, verified| {
+    let create_deal = |end_epoch, verified| {
         let mut deal =
             generate_deal_and_add_funds(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, end_epoch);
         deal.verified_deal = verified;

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -153,7 +153,7 @@ pub struct Actor;
 
 impl Actor {
     pub fn constructor(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: MinerConstructorParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&INIT_ACTOR_ADDR))?;
@@ -230,7 +230,7 @@ impl Actor {
     }
 
     /// Returns the "controlling" addresses: the owner, the worker, and all control addresses
-    fn control_addresses(rt: &mut impl Runtime) -> Result<GetControlAddressesReturn, ActorError> {
+    fn control_addresses(rt: &impl Runtime) -> Result<GetControlAddressesReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let state: State = rt.state()?;
         let info = get_miner_info(rt.store(), &state)?;
@@ -242,7 +242,7 @@ impl Actor {
     }
 
     /// Returns the owner address, as well as the proposed new owner (if any).
-    fn get_owner(rt: &mut impl Runtime) -> Result<GetOwnerReturn, ActorError> {
+    fn get_owner(rt: &impl Runtime) -> Result<GetOwnerReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let state: State = rt.state()?;
         let info = get_miner_info(rt.store(), &state)?;
@@ -252,7 +252,7 @@ impl Actor {
     /// Returns whether the provided address is "controlling".
     /// The "controlling" addresses are the Owner, the Worker, and all Control Addresses.
     fn is_controlling_address(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: IsControllingAddressParam,
     ) -> Result<IsControllingAddressReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -273,7 +273,7 @@ impl Actor {
     }
 
     /// Returns the miner's sector size.
-    fn get_sector_size(rt: &mut impl Runtime) -> Result<GetSectorSizeReturn, ActorError> {
+    fn get_sector_size(rt: &impl Runtime) -> Result<GetSectorSizeReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let state: State = rt.state()?;
         let sector_size = get_miner_info(rt.store(), &state)?.sector_size;
@@ -283,9 +283,7 @@ impl Actor {
     /// Returns the available balance of this miner.
     /// This is calculated as actor balance - (vesting funds + pre-commit deposit + ip requirement + fee debt)
     /// Can go negative if the miner is in IP debt.
-    fn get_available_balance(
-        rt: &mut impl Runtime,
-    ) -> Result<GetAvailableBalanceReturn, ActorError> {
+    fn get_available_balance(rt: &impl Runtime) -> Result<GetAvailableBalanceReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let state: State = rt.state()?;
         let available_balance =
@@ -296,7 +294,7 @@ impl Actor {
     }
 
     /// Returns the funds vesting in this miner as a list of (vesting_epoch, vesting_amount) tuples.
-    fn get_vesting_funds(rt: &mut impl Runtime) -> Result<GetVestingFundsReturn, ActorError> {
+    fn get_vesting_funds(rt: &impl Runtime) -> Result<GetVestingFundsReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let state: State = rt.state()?;
         let vesting_funds = state
@@ -310,7 +308,7 @@ impl Actor {
     /// If an empty addresses vector is passed, the control addresses will be cleared.
     /// A worker change will be scheduled if the worker passed in the params is different from the existing worker.
     fn change_worker_address(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ChangeWorkerAddressParams,
     ) -> Result<(), ActorError> {
         check_control_addresses(rt.policy(), &params.new_control_addresses)?;
@@ -355,7 +353,7 @@ impl Actor {
     }
 
     /// Triggers a worker address change if a change has been requested and its effective epoch has arrived.
-    fn confirm_change_worker_address(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    fn confirm_change_worker_address(rt: &impl Runtime) -> Result<(), ActorError> {
         rt.transaction(|state: &mut State, rt| {
             let mut info = get_miner_info(rt.store(), state)?;
 
@@ -373,7 +371,7 @@ impl Actor {
     /// If invoked by the previously proposed address, with the same proposal, changes the current owner address to be
     /// that proposed address.
     fn change_owner_address(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ChangeOwnerAddressParams,
     ) -> Result<(), ActorError> {
         let new_address = params.new_owner;
@@ -429,14 +427,14 @@ impl Actor {
     }
 
     /// Returns the Peer ID for this miner.
-    fn get_peer_id(rt: &mut impl Runtime) -> Result<GetPeerIDReturn, ActorError> {
+    fn get_peer_id(rt: &impl Runtime) -> Result<GetPeerIDReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let state: State = rt.state()?;
         let peer_id = get_miner_info(rt.store(), &state)?.peer_id;
         Ok(GetPeerIDReturn { peer_id })
     }
 
-    fn change_peer_id(rt: &mut impl Runtime, params: ChangePeerIDParams) -> Result<(), ActorError> {
+    fn change_peer_id(rt: &impl Runtime, params: ChangePeerIDParams) -> Result<(), ActorError> {
         let policy = rt.policy();
         check_peer_info(policy, &params.new_id, &[])?;
 
@@ -458,7 +456,7 @@ impl Actor {
     }
 
     /// Returns the multiaddresses set for this miner.
-    fn get_multiaddresses(rt: &mut impl Runtime) -> Result<GetMultiaddrsReturn, ActorError> {
+    fn get_multiaddresses(rt: &impl Runtime) -> Result<GetMultiaddrsReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let state: State = rt.state()?;
         let multi_addrs = get_miner_info(rt.store(), &state)?.multi_address;
@@ -466,7 +464,7 @@ impl Actor {
     }
 
     fn change_multiaddresses(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ChangeMultiaddrsParams,
     ) -> Result<(), ActorError> {
         let policy = rt.policy();
@@ -491,7 +489,7 @@ impl Actor {
 
     /// Invoked by miner's worker address to submit their fallback post
     fn submit_windowed_post(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         mut params: SubmitWindowedPoStParams,
     ) -> Result<(), ActorError> {
         let current_epoch = rt.curr_epoch();
@@ -763,7 +761,7 @@ impl Actor {
     /// of these sectors. If valid, the sectors' deals are activated, sectors are assigned a deadline and charged pledge
     /// and precommit state is removed.
     fn prove_commit_aggregate(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ProveCommitAggregateParams,
     ) -> Result<(), ActorError> {
         let sector_numbers = params.sector_numbers.validate().map_err(|e| {
@@ -940,7 +938,7 @@ impl Actor {
     }
 
     fn prove_replica_updates<RT>(
-        rt: &mut RT,
+        rt: &RT,
         params: ProveReplicaUpdatesParams,
     ) -> Result<BitField, ActorError>
     where
@@ -969,7 +967,7 @@ impl Actor {
     }
 
     fn prove_replica_updates2<RT>(
-        rt: &mut RT,
+        rt: &RT,
         params: ProveReplicaUpdatesParams2,
     ) -> Result<BitField, ActorError>
     where
@@ -995,7 +993,7 @@ impl Actor {
         Self::prove_replica_updates_inner(rt, updates)
     }
     fn prove_replica_updates_inner<RT>(
-        rt: &mut RT,
+        rt: &RT,
         updates: Vec<ReplicaUpdateInner>,
     ) -> Result<BitField, ActorError>
     where
@@ -1459,7 +1457,7 @@ impl Actor {
     }
 
     fn dispute_windowed_post(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: DisputeWindowedPoStParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -1672,7 +1670,7 @@ impl Actor {
     /// Pledges to seal and commit a single sector.
     /// See PreCommitSectorBatch for details.
     fn pre_commit_sector(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: PreCommitSectorParams,
     ) -> Result<(), ActorError> {
         Self::pre_commit_sector_batch(rt, PreCommitSectorBatchParams { sectors: vec![params] })
@@ -1687,7 +1685,7 @@ impl Actor {
     /// This method calculates the sector's power, locks a pre-commit deposit for the sector, stores information about the
     /// sector in state and waits for it to be proven or expire.
     fn pre_commit_sector_batch(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: PreCommitSectorBatchParams,
     ) -> Result<(), ActorError> {
         let sectors = params
@@ -1724,7 +1722,7 @@ impl Actor {
     /// This method calculates the sector's power, locks a pre-commit deposit for the sector, stores information about the
     /// sector in state and waits for it to be proven or expire.
     fn pre_commit_sector_batch2(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: PreCommitSectorBatchParams2,
     ) -> Result<(), ActorError> {
         Self::pre_commit_sector_batch_inner(
@@ -1749,7 +1747,7 @@ impl Actor {
     /// This function combines old and new flows for PreCommit with use Option<CommpactCommD>
     /// The old PreCommits will call this with None, new ones with Some(CompactCommD).
     fn pre_commit_sector_batch_inner(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         sectors: Vec<SectorPreCommitInfoInner>,
     ) -> Result<(), ActorError> {
         let curr_epoch = rt.curr_epoch();
@@ -2011,7 +2009,7 @@ impl Actor {
     /// by the power actor.
     /// If valid, the power actor will call ConfirmSectorProofsValid at the end of the same epoch as this message.
     fn prove_commit_sector(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ProveCommitSectorParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -2095,7 +2093,7 @@ impl Actor {
     }
 
     fn confirm_sector_proofs_valid(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ConfirmSectorProofsParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(iter::once(&STORAGE_POWER_ACTOR_ADDR))?;
@@ -2129,7 +2127,7 @@ impl Actor {
     }
 
     fn check_sector_proven(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: CheckSectorProvenParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -2157,7 +2155,7 @@ impl Actor {
     /// The sector's power is recomputed for the new expiration.
     /// This method is legacy and should be replaced with calls to extend_sector_expiration2
     fn extend_sector_expiration(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ExtendSectorExpirationParams,
     ) -> Result<(), ActorError> {
         let extend_expiration_inner =
@@ -2173,7 +2171,7 @@ impl Actor {
     // with FIL+ claims. Extension is only allowed if all claim max terms extend past new expiration
     // or claims are dropped.  Power only changes when claims are dropped.
     fn extend_sector_expiration2(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ExtendSectorExpiration2Params,
     ) -> Result<(), ActorError> {
         let extend_expiration_inner = validate_extension_declarations(rt, params.extensions)?;
@@ -2185,7 +2183,7 @@ impl Actor {
     }
 
     fn extend_sector_expiration_inner(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         inner: ExtendExpirationsInner,
         kind: ExtensionKind,
     ) -> Result<(), ActorError> {
@@ -2407,7 +2405,7 @@ impl Actor {
     /// This function may be invoked with no new sectors to explicitly process the
     /// next batch of sectors.
     fn terminate_sectors(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: TerminateSectorsParams,
     ) -> Result<TerminateSectorsReturn, ActorError> {
         // Note: this cannot terminate pre-committed but un-proven sectors.
@@ -2559,10 +2557,7 @@ impl Actor {
         Ok(TerminateSectorsReturn { done: !more })
     }
 
-    fn declare_faults(
-        rt: &mut impl Runtime,
-        params: DeclareFaultsParams,
-    ) -> Result<(), ActorError> {
+    fn declare_faults(rt: &impl Runtime, params: DeclareFaultsParams) -> Result<(), ActorError> {
         {
             let policy = rt.policy();
             if params.faults.len() as u64 > policy.declarations_max {
@@ -2699,7 +2694,7 @@ impl Actor {
     }
 
     fn declare_faults_recovered(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: DeclareFaultsRecoveredParams,
     ) -> Result<(), ActorError> {
         {
@@ -2840,7 +2835,7 @@ impl Actor {
     /// Removed sectors are removed from state entirely.
     /// May not be invoked if the deadline has any un-processed early terminations.
     fn compact_partitions(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: CompactPartitionsParams,
     ) -> Result<(), ActorError> {
         {
@@ -2977,7 +2972,7 @@ impl Actor {
     /// For example, if sectors 1-99 and 101-200 have been allocated, sector number
     /// 99 can be masked out to collapse these two ranges into one.
     fn compact_sector_numbers(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: CompactSectorNumbersParams,
     ) -> Result<(), ActorError> {
         let mask_sector_numbers = params
@@ -3016,7 +3011,7 @@ impl Actor {
     }
 
     /// Locks up some amount of a the miner's unlocked balance (including funds received alongside the invoking message).
-    fn apply_rewards(rt: &mut impl Runtime, params: ApplyRewardParams) -> Result<(), ActorError> {
+    fn apply_rewards(rt: &impl Runtime, params: ApplyRewardParams) -> Result<(), ActorError> {
         if params.reward.is_negative() {
             return Err(actor_error!(
                 illegal_argument,
@@ -3094,7 +3089,7 @@ impl Actor {
     }
 
     fn report_consensus_fault(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ReportConsensusFaultParams,
     ) -> Result<(), ActorError> {
         // Note: only the first report of any fault is processed because it sets the
@@ -3199,7 +3194,7 @@ impl Actor {
     }
 
     fn withdraw_balance(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: WithdrawBalanceParams,
     ) -> Result<WithdrawBalanceReturn, ActorError> {
         if params.amount_requested.is_negative() {
@@ -3305,7 +3300,7 @@ impl Actor {
     /// if applicable, any current beneficiary that has time and quota remaining.
     //// See FIP-0029, https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0029.md
     fn change_beneficiary(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ChangeBeneficiaryParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -3434,7 +3429,7 @@ impl Actor {
     // GetBeneficiary retrieves the currently active and proposed beneficiary information.
     // This method is for use by other actors (such as those acting as beneficiaries),
     // and to abstract the state representation for clients.
-    fn get_beneficiary(rt: &mut impl Runtime) -> Result<GetBeneficiaryReturn, ActorError> {
+    fn get_beneficiary(rt: &impl Runtime) -> Result<GetBeneficiaryReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let st: State = rt.state()?;
         let info = get_miner_info(rt.store(), &st)?;
@@ -3448,7 +3443,7 @@ impl Actor {
         })
     }
 
-    fn repay_debt(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    fn repay_debt(rt: &impl Runtime) -> Result<(), ActorError> {
         let (from_vesting, from_balance, state) = rt.transaction(|state: &mut State, rt| {
             let info = get_miner_info(rt.store(), state)?;
             rt.validate_immediate_caller_is(
@@ -3478,7 +3473,7 @@ impl Actor {
     }
 
     fn on_deferred_cron_event(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: DeferredCronEventParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&STORAGE_POWER_ACTOR_ADDR))?;
@@ -3616,7 +3611,7 @@ fn validate_legacy_extension_declarations(
 }
 
 fn validate_extension_declarations(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     extensions: Vec<ExpirationExtension2>,
 ) -> Result<ExtendExpirationsInner, ActorError> {
     let mut claim_space_by_sector = BTreeMap::<SectorNumber, (u64, u64)>::new();
@@ -3829,7 +3824,7 @@ fn extend_non_simple_qap_sector(
 // should use the power/reward at the time of termination.
 // https://github.com/filecoin-project/specs-actors/v6/pull/648
 fn process_early_terminations(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     reward_smoothed: &FilterEstimate,
     quality_adj_power_smoothed: &FilterEstimate,
 ) -> Result</* more */ bool, ActorError> {
@@ -3952,7 +3947,7 @@ fn process_early_terminations(
 
 /// Invoked at the end of the last epoch for each proving deadline.
 fn handle_proving_deadline(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     reward_smoothed: &FilterEstimate,
     quality_adj_power_smoothed: &FilterEstimate,
 ) -> Result<(), ActorError> {
@@ -4144,7 +4139,7 @@ fn validate_expiration(
 }
 
 fn enroll_cron_event(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     event_epoch: ChainEpoch,
     cb: CronEventPayload,
 ) -> Result<(), ActorError> {
@@ -4161,7 +4156,7 @@ fn enroll_cron_event(
     Ok(())
 }
 
-fn request_update_power(rt: &mut impl Runtime, delta: PowerPair) -> Result<(), ActorError> {
+fn request_update_power(rt: &impl Runtime, delta: PowerPair) -> Result<(), ActorError> {
     if delta.is_zero() {
         return Ok(());
     }
@@ -4183,7 +4178,7 @@ fn request_update_power(rt: &mut impl Runtime, delta: PowerPair) -> Result<(), A
 }
 
 fn request_terminate_deals(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     epoch: ChainEpoch,
     deal_ids: Vec<DealID>,
 ) -> Result<(), ActorError> {
@@ -4212,7 +4207,7 @@ fn request_terminate_deals(
     Ok(())
 }
 
-fn schedule_early_termination_work(rt: &mut impl Runtime) -> Result<(), ActorError> {
+fn schedule_early_termination_work(rt: &impl Runtime) -> Result<(), ActorError> {
     info!("scheduling early terminations with cron...");
     enroll_cron_event(
         rt,
@@ -4274,7 +4269,7 @@ fn verify_windowed_post(
 }
 
 fn get_verify_info(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     params: SealVerifyParams,
     unsealed_cid: CompactCommD,
 ) -> Result<SealVerifyInfo, ActorError> {
@@ -4318,7 +4313,7 @@ fn get_verify_info(
 }
 
 fn request_deal_data(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     sectors: &[ext::market::SectorDeals],
 ) -> Result<ext::market::VerifyDealsForActivationReturn, ActorError> {
     // Short-circuit if there are no deals in any of the sectors.
@@ -4343,7 +4338,7 @@ fn request_deal_data(
 /// Requests the current epoch target block reward from the reward actor.
 /// return value includes reward, smoothed estimate of reward, and baseline power
 fn request_current_epoch_block_reward(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
 ) -> Result<ThisEpochRewardReturn, ActorError> {
     deserialize_block(
         extract_send_result(rt.send_simple(
@@ -4358,7 +4353,7 @@ fn request_current_epoch_block_reward(
 
 /// Requests the current network total power and pledge from the power actor.
 fn request_current_total_power(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
 ) -> Result<ext::power::CurrentTotalPowerReturn, ActorError> {
     deserialize_block(
         extract_send_result(rt.send_simple(
@@ -4373,7 +4368,7 @@ fn request_current_total_power(
 
 /// Resolves an address to an ID address and verifies that it is address of an account actor with an associated BLS key.
 /// The worker must be BLS since the worker key will be used alongside a BLS-VRF.
-fn resolve_worker_address(rt: &mut impl Runtime, raw: Address) -> Result<ActorID, ActorError> {
+fn resolve_worker_address(rt: &impl Runtime, raw: Address) -> Result<ActorID, ActorError> {
     let resolved = rt
         .resolve_address(&raw)
         .ok_or_else(|| actor_error!(illegal_argument, "unable to resolve address: {}", raw))?;
@@ -4408,7 +4403,7 @@ fn resolve_worker_address(rt: &mut impl Runtime, raw: Address) -> Result<ActorID
     Ok(resolved)
 }
 
-fn burn_funds(rt: &mut impl Runtime, amount: TokenAmount) -> Result<(), ActorError> {
+fn burn_funds(rt: &impl Runtime, amount: TokenAmount) -> Result<(), ActorError> {
     log::debug!("storage provder {} burning {}", rt.message().receiver(), amount);
     if amount.is_positive() {
         extract_send_result(rt.send_simple(&BURNT_FUNDS_ACTOR_ADDR, METHOD_SEND, None, amount))?;
@@ -4416,10 +4411,7 @@ fn burn_funds(rt: &mut impl Runtime, amount: TokenAmount) -> Result<(), ActorErr
     Ok(())
 }
 
-fn notify_pledge_changed(
-    rt: &mut impl Runtime,
-    pledge_delta: &TokenAmount,
-) -> Result<(), ActorError> {
+fn notify_pledge_changed(rt: &impl Runtime, pledge_delta: &TokenAmount) -> Result<(), ActorError> {
     if !pledge_delta.is_zero() {
         extract_send_result(rt.send_simple(
             &STORAGE_POWER_ACTOR_ADDR,
@@ -4432,7 +4424,7 @@ fn notify_pledge_changed(
 }
 
 fn get_claims(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     ids: &Vec<ext::verifreg::ClaimID>,
 ) -> Result<Vec<ext::verifreg::Claim>, ActorError> {
     let params = ext::verifreg::GetClaimsParams {
@@ -4700,7 +4692,7 @@ fn check_peer_info(
 }
 
 fn confirm_sector_proofs_valid_internal(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     pre_commits: Vec<SectorPreCommitOnChainInfo>,
     this_epoch_baseline_power: &BigInt,
     this_epoch_reward_smoothed: &FilterEstimate,
@@ -4883,7 +4875,7 @@ fn confirm_sector_proofs_valid_internal(
 // returns an error in case of a fatal programmer error
 // returns Ok(None) in case deal activation or verified allocation claim fails
 fn activate_deals_and_claim_allocations(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     deal_ids: Vec<DealID>,
     sector_expiry: ChainEpoch,
     sector_number: SectorNumber,

--- a/actors/miner/tests/aggregate_prove_commit.rs
+++ b/actors/miner/tests/aggregate_prove_commit.rs
@@ -94,7 +94,7 @@ fn valid_precommits_then_aggregate_provecommit() {
     let verified_deal_weight = deal_spaces.verified_deal_space * duration;
     let qa_power = qa_power_for_weight(
         actor.sector_size,
-        expiration - rt.epoch,
+        expiration - *rt.epoch.borrow(),
         &deal_weight,
         &verified_deal_weight,
     );
@@ -117,7 +117,7 @@ fn valid_precommits_then_aggregate_provecommit() {
         assert_eq!(verified_deal_weight, sector.verified_deal_weight);
 
         // expect activation epoch to be current epoch
-        assert_eq!(rt.epoch, sector.activation);
+        assert_eq!(*rt.epoch.borrow(), sector.activation);
 
         // expect initial pledge of sector to be set
         assert_eq!(expected_initial_pledge, sector.initial_pledge);

--- a/actors/miner/tests/aggregate_prove_commit.rs
+++ b/actors/miner/tests/aggregate_prove_commit.rs
@@ -23,11 +23,11 @@ fn valid_precommits_then_aggregate_provecommit() {
     let period_offset = ChainEpoch::from(100);
 
     let actor = ActorHarness::new(period_offset);
-    let mut rt = actor.new_runtime();
+    let rt = actor.new_runtime();
     rt.add_balance(BIG_BALANCE.clone());
     let precommit_epoch = period_offset + 1;
     rt.set_epoch(precommit_epoch);
-    actor.construct_and_verify(&mut rt);
+    actor.construct_and_verify(&rt);
     let dl_info = actor.deadline(&rt);
 
     // make a good commitment for the proof to target
@@ -51,7 +51,7 @@ fn valid_precommits_then_aggregate_provecommit() {
         let precommit_params =
             actor.make_pre_commit_params(i, precommit_epoch - 1, expiration, vec![1]);
         let config = PreCommitConfig::new(Some(make_piece_cid("1".as_bytes())));
-        let precommit = actor.pre_commit_sector_and_get(&mut rt, precommit_params, config, i == 0);
+        let precommit = actor.pre_commit_sector_and_get(&rt, precommit_params, config, i == 0);
         precommits.push(precommit);
     }
 
@@ -69,7 +69,7 @@ fn valid_precommits_then_aggregate_provecommit() {
 
     actor
         .prove_commit_aggregate_sector(
-            &mut rt,
+            &rt,
             pcc,
             precommits,
             make_prove_commit_aggregate(&sector_nos_bf),

--- a/actors/miner/tests/apply_rewards.rs
+++ b/actors/miner/tests/apply_rewards.rs
@@ -27,12 +27,12 @@ const PERIOD_OFFSET: ChainEpoch = 1808;
 #[test]
 fn funds_are_locked() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let rwd = TokenAmount::from_atto(1_000_000);
-    h.apply_rewards(&mut rt, rwd, TokenAmount::zero());
+    h.apply_rewards(&rt, rwd, TokenAmount::zero());
 
     let expected = TokenAmount::from_atto(750_000);
     assert_eq!(expected, h.get_locked_funds(&rt));
@@ -41,9 +41,9 @@ fn funds_are_locked() {
 #[test]
 fn funds_vest() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let st = h.get_state(&rt);
 
     let vesting_funds = st.load_vesting_funds(&rt.store).unwrap();
@@ -54,7 +54,7 @@ fn funds_vest() {
 
     // Lock some funds with AddLockedFund
     let amt = TokenAmount::from_atto(600_000);
-    h.apply_rewards(&mut rt, amt.clone(), TokenAmount::zero());
+    h.apply_rewards(&rt, amt.clone(), TokenAmount::zero());
     let st = h.get_state(&rt);
     let vesting_funds = st.load_vesting_funds(&rt.store).unwrap();
 
@@ -88,14 +88,14 @@ fn funds_vest() {
 #[test]
 fn penalty_is_burnt() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let rwd = TokenAmount::from_atto(600_000);
     let penalty = TokenAmount::from_atto(300_000);
     rt.add_balance(rwd.clone());
-    h.apply_rewards(&mut rt, rwd.clone(), penalty.clone());
+    h.apply_rewards(&rt, rwd.clone(), penalty.clone());
 
     let (mut expected_lock_amt, _) = locked_reward_from_reward(rwd);
     expected_lock_amt -= penalty;
@@ -110,9 +110,9 @@ fn penalty_is_burnt() {
 #[test]
 fn penalty_is_partially_burnt_and_stored_as_fee_debt() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let st = h.get_state(&rt);
     assert!(st.fee_debt.is_zero());
 
@@ -159,20 +159,20 @@ fn penalty_is_partially_burnt_and_stored_as_fee_debt() {
 #[test]
 fn rewards_pay_back_fee_debt() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let mut st = h.get_state(&rt);
 
     assert!(st.locked_funds.is_zero());
 
     let amt = rt.get_balance();
-    let available_before = h.get_available_balance(&mut rt).unwrap();
+    let available_before = h.get_available_balance(&rt).unwrap();
     assert!(available_before.is_positive());
     let init_fee_debt: TokenAmount = 2 * &amt; // FeeDebt twice total balance
     st.fee_debt = init_fee_debt.clone();
     rt.replace_state(&st);
-    let available_after = h.get_available_balance(&mut rt).unwrap();
+    let available_after = h.get_available_balance(&rt).unwrap();
     assert!(available_after.is_negative());
 
     rt.replace_state(&st);
@@ -219,7 +219,7 @@ fn rewards_pay_back_fee_debt() {
     let st = h.get_state(&rt);
     // balance funds used to pay off fee debt
     // available balance should be 2
-    let available_balance = h.get_available_balance(&mut rt).unwrap();
+    let available_balance = h.get_available_balance(&rt).unwrap();
     assert_eq!(available_before + reward - init_fee_debt - &remaining_locked, available_balance);
     assert!(!st.fee_debt.is_positive());
     // remaining funds locked in vesting table

--- a/actors/miner/tests/apply_rewards.rs
+++ b/actors/miner/tests/apply_rewards.rs
@@ -63,7 +63,7 @@ fn funds_vest() {
     // Vested FIL pays out on epochs with expected offset
     let quant_spec = QuantSpec { unit: REWARD_VESTING_SPEC.quantization, offset: PERIOD_OFFSET };
 
-    let curr_epoch = rt.epoch;
+    let curr_epoch = *rt.epoch.borrow();
     for (i, vf) in vesting_funds.funds.iter().enumerate() {
         let step =
             REWARD_VESTING_SPEC.initial_delay + (i as i64 + 1) * REWARD_VESTING_SPEC.step_duration;

--- a/actors/miner/tests/batch_method_network_fees_test.rs
+++ b/actors/miner/tests/batch_method_network_fees_test.rs
@@ -19,11 +19,11 @@ lazy_static! {
 #[test]
 fn insufficient_funds_for_aggregated_prove_commit_network_fee() {
     let actor = ActorHarness::new(*PERIOD_OFFSET);
-    let mut rt = actor.new_runtime();
+    let rt = actor.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
     let precommit_epoch = *PERIOD_OFFSET + 1;
     rt.set_epoch(precommit_epoch);
-    actor.construct_and_verify(&mut rt);
+    actor.construct_and_verify(&rt);
     let dl_info = actor.deadline(&rt);
 
     // make a good commitment for the proof to target
@@ -39,7 +39,7 @@ fn insufficient_funds_for_aggregated_prove_commit_network_fee() {
         let precommit_params =
             actor.make_pre_commit_params(i, precommit_epoch - 1, expiration, vec![1]);
         let precommit = actor.pre_commit_sector_and_get(
-            &mut rt,
+            &rt,
             precommit_params,
             PreCommitConfig::empty(),
             i == 0,
@@ -56,7 +56,7 @@ fn insufficient_funds_for_aggregated_prove_commit_network_fee() {
     assert!(aggregate_prove_commit_network_fee(precommits.len() as i64, &base_fee) > balance);
 
     let res = actor.prove_commit_aggregate_sector(
-        &mut rt,
+        &rt,
         ProveCommitConfig::empty(),
         precommits,
         make_prove_commit_aggregate(&sector_nos_bf),
@@ -70,11 +70,11 @@ fn insufficient_funds_for_aggregated_prove_commit_network_fee() {
 #[test]
 fn insufficient_funds_for_batch_precommit_network_fee() {
     let actor = ActorHarness::new(*PERIOD_OFFSET);
-    let mut rt = actor.new_runtime();
+    let rt = actor.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
     let precommit_epoch = *PERIOD_OFFSET + 1;
     rt.set_epoch(precommit_epoch);
-    actor.construct_and_verify(&mut rt);
+    actor.construct_and_verify(&rt);
     let dl_info = actor.deadline(&rt);
     // something on deadline boundary but > 180 days
     let expiration =
@@ -96,7 +96,7 @@ fn insufficient_funds_for_batch_precommit_network_fee() {
     assert!(aggregate_pre_commit_network_fee(precommits.len() as i64, &base_fee) > balance);
 
     let res = actor.pre_commit_sector_batch(
-        &mut rt,
+        &rt,
         PreCommitSectorBatchParams { sectors: precommits },
         &PreCommitBatchConfig { first_for_miner: true, ..Default::default() },
         &base_fee,
@@ -119,11 +119,11 @@ fn insufficient_funds_for_batch_precommit_network_fee() {
 #[test]
 fn insufficient_funds_for_batch_precommit_in_combination_of_fee_debt_and_network_fee() {
     let actor = ActorHarness::new(*PERIOD_OFFSET);
-    let mut rt = actor.new_runtime();
+    let rt = actor.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
     let precommit_epoch = *PERIOD_OFFSET + 1;
     rt.set_epoch(precommit_epoch);
-    actor.construct_and_verify(&mut rt);
+    actor.construct_and_verify(&rt);
     let dl_info = actor.deadline(&rt);
     // something on deadline boundary but > 180 days
     let expiration =
@@ -152,7 +152,7 @@ fn insufficient_funds_for_batch_precommit_in_combination_of_fee_debt_and_network
     rt.set_balance(balance);
 
     let res = actor.pre_commit_sector_batch(
-        &mut rt,
+        &rt,
         PreCommitSectorBatchParams { sectors: precommits },
         &PreCommitBatchConfig { first_for_miner: true, ..Default::default() },
         &base_fee,
@@ -175,11 +175,11 @@ fn insufficient_funds_for_batch_precommit_in_combination_of_fee_debt_and_network
 #[test]
 fn enough_funds_for_fee_debt_and_network_fee_but_not_for_pcd() {
     let actor = ActorHarness::new(*PERIOD_OFFSET);
-    let mut rt = actor.new_runtime();
+    let rt = actor.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
     let precommit_epoch = *PERIOD_OFFSET + 1;
     rt.set_epoch(precommit_epoch);
-    actor.construct_and_verify(&mut rt);
+    actor.construct_and_verify(&rt);
     let dl_info = actor.deadline(&rt);
     // something on deadline boundary but > 180 days
     let expiration =
@@ -207,7 +207,7 @@ fn enough_funds_for_fee_debt_and_network_fee_but_not_for_pcd() {
     rt.set_balance(balance);
 
     let res = actor.pre_commit_sector_batch(
-        &mut rt,
+        &rt,
         PreCommitSectorBatchParams { sectors: precommits },
         &PreCommitBatchConfig { first_for_miner: true, ..Default::default() },
         &base_fee,
@@ -230,11 +230,11 @@ fn enough_funds_for_fee_debt_and_network_fee_but_not_for_pcd() {
 #[test]
 fn enough_funds_for_everything() {
     let actor = ActorHarness::new(*PERIOD_OFFSET);
-    let mut rt = actor.new_runtime();
+    let rt = actor.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
     let precommit_epoch = *PERIOD_OFFSET + 1;
     rt.set_epoch(precommit_epoch);
-    actor.construct_and_verify(&mut rt);
+    actor.construct_and_verify(&rt);
     let dl_info = actor.deadline(&rt);
     // something on deadline boundary but > 180 days
     let expiration =
@@ -270,7 +270,7 @@ fn enough_funds_for_everything() {
 
     actor
         .pre_commit_sector_batch(
-            &mut rt,
+            &rt,
             PreCommitSectorBatchParams { sectors: precommits },
             &PreCommitBatchConfig { first_for_miner: true, ..Default::default() },
             &base_fee,

--- a/actors/miner/tests/batch_method_network_fees_test.rs
+++ b/actors/miner/tests/batch_method_network_fees_test.rs
@@ -52,7 +52,7 @@ fn insufficient_funds_for_aggregated_prove_commit_network_fee() {
     let balance = TokenAmount::from_whole(1000);
     rt.set_balance(balance.clone());
     let base_fee = TokenAmount::from_atto(10u64.pow(16));
-    rt.base_fee = base_fee.clone();
+    rt.base_fee.replace(base_fee.clone());
     assert!(aggregate_prove_commit_network_fee(precommits.len() as i64, &base_fee) > balance);
 
     let res = actor.prove_commit_aggregate_sector(
@@ -92,7 +92,7 @@ fn insufficient_funds_for_batch_precommit_network_fee() {
     let balance = TokenAmount::from_whole(1000);
     rt.set_balance(balance.clone());
     let base_fee = TokenAmount::from_atto(10u64.pow(16));
-    rt.base_fee = base_fee.clone();
+    rt.base_fee.replace(base_fee.clone());
     assert!(aggregate_pre_commit_network_fee(precommits.len() as i64, &base_fee) > balance);
 
     let res = actor.pre_commit_sector_batch(
@@ -139,7 +139,7 @@ fn insufficient_funds_for_batch_precommit_in_combination_of_fee_debt_and_network
 
     // set base fee extremely high so AggregateProveCommitNetworkFee is > 1000 FIL. Set balance to 1000 FIL to easily cover PCD but not network fee
     let base_fee = TokenAmount::from_atto(10u64.pow(16));
-    rt.base_fee = base_fee.clone();
+    rt.base_fee.replace(base_fee.clone());
     let net_fee = aggregate_pre_commit_network_fee(precommits.len() as i64, &base_fee);
 
     // setup miner to have fee debt equal to net fee
@@ -195,7 +195,7 @@ fn enough_funds_for_fee_debt_and_network_fee_but_not_for_pcd() {
 
     // set base fee and fee debt high
     let base_fee = TokenAmount::from_atto(10u64.pow(16));
-    rt.base_fee = base_fee.clone();
+    rt.base_fee.replace(base_fee.clone());
     let net_fee = aggregate_pre_commit_network_fee(precommits.len() as i64, &base_fee);
     // setup miner to have feed debt equal to net fee
     let mut state: State = rt.get_state();
@@ -250,7 +250,7 @@ fn enough_funds_for_everything() {
 
     // set base fee extremely high so AggregateProveCommitNetworkFee is > 1000 FIL. Set balance to 1000 FIL to easily cover PCD but not network fee
     let base_fee = TokenAmount::from_atto(10u64.pow(16));
-    rt.base_fee = base_fee.clone();
+    rt.base_fee.replace(base_fee.clone());
     let net_fee = aggregate_pre_commit_network_fee(precommits.len() as i64, &base_fee);
 
     // setup miner to have fee debt equal to net fee

--- a/actors/miner/tests/change_beneficiary_test.rs
+++ b/actors/miner/tests/change_beneficiary_test.rs
@@ -446,7 +446,7 @@ fn successfully_get_beneficiary() {
 
 #[test]
 fn get_beneficiary_correctly_restricted() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     // set caller to not-builtin
     rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1000));

--- a/actors/miner/tests/change_beneficiary_test.rs
+++ b/actors/miner/tests/change_beneficiary_test.rs
@@ -14,8 +14,8 @@ fn setup() -> (ActorHarness, MockRuntime) {
     let period_offset = 100;
 
     let h = ActorHarness::new(period_offset);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
     rt.balance.replace(TokenAmount::from_atto(big_balance));
 
     (h, rt)
@@ -23,7 +23,7 @@ fn setup() -> (ActorHarness, MockRuntime) {
 
 #[test]
 fn successfully_change_owner_to_another_address_two_message() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let first_beneficiary_id = Address::new_id(999);
 
     let beneficiary_change = BeneficiaryChange::new(
@@ -32,22 +32,22 @@ fn successfully_change_owner_to_another_address_two_message() {
         ChainEpoch::from(200),
     );
     // proposal beneficiary change
-    h.change_beneficiary(&mut rt, h.owner, &beneficiary_change, None).unwrap();
+    h.change_beneficiary(&rt, h.owner, &beneficiary_change, None).unwrap();
     // assert change has been made in state
-    let mut beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    let mut beneficiary_return = h.get_beneficiary(&rt).unwrap();
     let pending_beneficiary_term = beneficiary_return.proposed.unwrap();
     assert_eq!(beneficiary_change, BeneficiaryChange::from_pending(&pending_beneficiary_term));
 
     //confirm proposal
     h.change_beneficiary(
-        &mut rt,
+        &rt,
         first_beneficiary_id,
         &beneficiary_change,
         Some(first_beneficiary_id),
     )
     .unwrap();
 
-    beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    beneficiary_return = h.get_beneficiary(&rt).unwrap();
     assert_eq!(None, beneficiary_return.proposed);
     assert_eq!(beneficiary_change, BeneficiaryChange::from_active(&beneficiary_return.active));
 
@@ -56,7 +56,7 @@ fn successfully_change_owner_to_another_address_two_message() {
 
 #[test]
 fn successfully_change_from_not_owner_beneficiary_to_another_address_three_message() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let first_beneficiary_id = Address::new_id(999);
     let second_beneficiary_id = Address::new_id(1001);
 
@@ -65,7 +65,7 @@ fn successfully_change_from_not_owner_beneficiary_to_another_address_three_messa
         TokenAmount::zero(),
         ChainEpoch::from(200),
     );
-    h.propose_approve_initial_beneficiary(&mut rt, first_beneficiary_id, first_beneficiary_term)
+    h.propose_approve_initial_beneficiary(&rt, first_beneficiary_id, first_beneficiary_term)
         .unwrap();
 
     let second_beneficiary_change = BeneficiaryChange::new(
@@ -73,8 +73,8 @@ fn successfully_change_from_not_owner_beneficiary_to_another_address_three_messa
         TokenAmount::from_atto(101),
         ChainEpoch::from(201),
     );
-    h.change_beneficiary(&mut rt, h.owner, &second_beneficiary_change, None).unwrap();
-    let mut beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    h.change_beneficiary(&rt, h.owner, &second_beneficiary_change, None).unwrap();
+    let mut beneficiary_return = h.get_beneficiary(&rt).unwrap();
     assert_eq!(first_beneficiary_id, beneficiary_return.active.beneficiary);
 
     let mut pending_beneficiary_term = beneficiary_return.proposed.unwrap();
@@ -85,8 +85,8 @@ fn successfully_change_from_not_owner_beneficiary_to_another_address_three_messa
     assert!(!pending_beneficiary_term.approved_by_beneficiary);
     assert!(!pending_beneficiary_term.approved_by_nominee);
 
-    h.change_beneficiary(&mut rt, second_beneficiary_id, &second_beneficiary_change, None).unwrap();
-    beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    h.change_beneficiary(&rt, second_beneficiary_id, &second_beneficiary_change, None).unwrap();
+    beneficiary_return = h.get_beneficiary(&rt).unwrap();
     assert_eq!(first_beneficiary_id, beneficiary_return.active.beneficiary);
 
     pending_beneficiary_term = beneficiary_return.proposed.unwrap();
@@ -97,8 +97,8 @@ fn successfully_change_from_not_owner_beneficiary_to_another_address_three_messa
     assert!(!pending_beneficiary_term.approved_by_beneficiary);
     assert!(pending_beneficiary_term.approved_by_nominee);
 
-    h.change_beneficiary(&mut rt, first_beneficiary_id, &second_beneficiary_change, None).unwrap();
-    beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    h.change_beneficiary(&rt, first_beneficiary_id, &second_beneficiary_change, None).unwrap();
+    beneficiary_return = h.get_beneficiary(&rt).unwrap();
     assert_eq!(None, beneficiary_return.proposed);
     assert_eq!(
         second_beneficiary_change,
@@ -110,14 +110,14 @@ fn successfully_change_from_not_owner_beneficiary_to_another_address_three_messa
 #[test]
 fn successfully_change_from_not_owner_beneficiary_to_another_address_when_beneficiary_inefficient_two_message(
 ) {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let first_beneficiary_id = Address::new_id(999);
     let second_beneficiary_id = Address::new_id(1000);
 
     let quota = TokenAmount::from_atto(100);
     let expiration = ChainEpoch::from(200);
     h.propose_approve_initial_beneficiary(
-        &mut rt,
+        &rt,
         first_beneficiary_id,
         BeneficiaryTerm::new(quota, TokenAmount::zero(), expiration),
     )
@@ -128,18 +128,17 @@ fn successfully_change_from_not_owner_beneficiary_to_another_address_when_benefi
     let another_expiration = ChainEpoch::from(3);
     let another_beneficiary_change =
         BeneficiaryChange::new(second_beneficiary_id, another_quota, another_expiration);
-    h.change_beneficiary(&mut rt, h.owner, &another_beneficiary_change, None).unwrap();
+    h.change_beneficiary(&rt, h.owner, &another_beneficiary_change, None).unwrap();
 
-    let mut beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    let mut beneficiary_return = h.get_beneficiary(&rt).unwrap();
     let pending_beneficiary_term = beneficiary_return.proposed.unwrap();
     assert_eq!(
         another_beneficiary_change,
         BeneficiaryChange::from_pending(&pending_beneficiary_term)
     );
 
-    h.change_beneficiary(&mut rt, second_beneficiary_id, &another_beneficiary_change, None)
-        .unwrap();
-    beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    h.change_beneficiary(&rt, second_beneficiary_id, &another_beneficiary_change, None).unwrap();
+    beneficiary_return = h.get_beneficiary(&rt).unwrap();
     assert_eq!(None, beneficiary_return.proposed);
     assert_eq!(
         another_beneficiary_change,
@@ -151,7 +150,7 @@ fn successfully_change_from_not_owner_beneficiary_to_another_address_when_benefi
 
 #[test]
 fn successfully_owner_immediate_revoking_unapproved_proposal() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let first_beneficiary_id = Address::new_id(999);
 
     let beneficiary_change = BeneficiaryChange::new(
@@ -160,18 +159,18 @@ fn successfully_owner_immediate_revoking_unapproved_proposal() {
         ChainEpoch::from(200),
     );
     // proposal beneficiary change
-    h.change_beneficiary(&mut rt, h.owner, &beneficiary_change, None).unwrap();
+    h.change_beneficiary(&rt, h.owner, &beneficiary_change, None).unwrap();
     // assert change has been made in state
-    let mut beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    let mut beneficiary_return = h.get_beneficiary(&rt).unwrap();
     let pending_beneficiary_term = beneficiary_return.proposed.unwrap();
     assert_eq!(beneficiary_change, BeneficiaryChange::from_pending(&pending_beneficiary_term));
 
     //revoking unapprovel proposal
     let back_owner_beneficiary_change =
         BeneficiaryChange::new(h.owner, TokenAmount::zero(), ChainEpoch::from(0));
-    h.change_beneficiary(&mut rt, h.owner, &back_owner_beneficiary_change, Some(h.owner)).unwrap();
+    h.change_beneficiary(&rt, h.owner, &back_owner_beneficiary_change, Some(h.owner)).unwrap();
 
-    beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    beneficiary_return = h.get_beneficiary(&rt).unwrap();
     assert_eq!(None, beneficiary_return.proposed);
     assert_eq!(
         back_owner_beneficiary_change,
@@ -184,24 +183,24 @@ fn successfully_owner_immediate_revoking_unapproved_proposal() {
 
 #[test]
 fn successfully_immediately_change_back_to_owner_address_while_used_up_quota() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let first_beneficiary_id = Address::new_id(999);
 
     let quota = TokenAmount::from_atto(100);
     let expiration = ChainEpoch::from(200);
     h.propose_approve_initial_beneficiary(
-        &mut rt,
+        &rt,
         first_beneficiary_id,
         BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), expiration),
     )
     .unwrap();
 
-    h.withdraw_funds(&mut rt, h.beneficiary, &quota, &quota, &TokenAmount::zero()).unwrap();
+    h.withdraw_funds(&rt, h.beneficiary, &quota, &quota, &TokenAmount::zero()).unwrap();
     let back_owner_beneficiary_change =
         BeneficiaryChange::new(h.owner, TokenAmount::zero(), ChainEpoch::from(0));
-    h.change_beneficiary(&mut rt, h.owner, &back_owner_beneficiary_change, Some(h.owner)).unwrap();
+    h.change_beneficiary(&rt, h.owner, &back_owner_beneficiary_change, Some(h.owner)).unwrap();
 
-    let beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    let beneficiary_return = h.get_beneficiary(&rt).unwrap();
     assert_eq!(None, beneficiary_return.proposed);
     assert_eq!(
         back_owner_beneficiary_change,
@@ -213,13 +212,13 @@ fn successfully_immediately_change_back_to_owner_address_while_used_up_quota() {
 
 #[test]
 fn successfully_immediately_change_back_to_owner_while_expired() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let first_beneficiary_id = Address::new_id(999);
 
     let quota = TokenAmount::from_atto(100);
     let expiration = ChainEpoch::from(200);
     h.propose_approve_initial_beneficiary(
-        &mut rt,
+        &rt,
         first_beneficiary_id,
         BeneficiaryTerm::new(quota, TokenAmount::zero(), expiration),
     )
@@ -228,9 +227,9 @@ fn successfully_immediately_change_back_to_owner_while_expired() {
     rt.set_epoch(201);
     let back_owner_beneficiary_change =
         BeneficiaryChange::new(h.owner, TokenAmount::zero(), ChainEpoch::from(0));
-    h.change_beneficiary(&mut rt, h.owner, &back_owner_beneficiary_change, Some(h.owner)).unwrap();
+    h.change_beneficiary(&rt, h.owner, &back_owner_beneficiary_change, Some(h.owner)).unwrap();
 
-    let beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    let beneficiary_return = h.get_beneficiary(&rt).unwrap();
     assert_eq!(None, beneficiary_return.proposed);
     assert_eq!(
         back_owner_beneficiary_change,
@@ -242,32 +241,32 @@ fn successfully_immediately_change_back_to_owner_while_expired() {
 
 #[test]
 fn successfully_change_quota_and_test_withdraw() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let first_beneficiary_id = Address::new_id(999);
     let beneficiary_term = BeneficiaryTerm::new(
         TokenAmount::from_atto(100),
         TokenAmount::zero(),
         ChainEpoch::from(200),
     );
-    h.propose_approve_initial_beneficiary(&mut rt, first_beneficiary_id, beneficiary_term.clone())
+    h.propose_approve_initial_beneficiary(&rt, first_beneficiary_id, beneficiary_term.clone())
         .unwrap();
 
     let withdraw_fund = TokenAmount::from_atto(80);
-    h.withdraw_funds(&mut rt, h.beneficiary, &withdraw_fund, &withdraw_fund, &TokenAmount::zero())
+    h.withdraw_funds(&rt, h.beneficiary, &withdraw_fund, &withdraw_fund, &TokenAmount::zero())
         .unwrap();
     //decrease quota
     let decrease_quota = TokenAmount::from_atto(50);
     let decrease_beneficiary_change =
         BeneficiaryChange::new(first_beneficiary_id, decrease_quota, beneficiary_term.expiration);
-    h.change_beneficiary(&mut rt, h.owner, &decrease_beneficiary_change, None).unwrap();
+    h.change_beneficiary(&rt, h.owner, &decrease_beneficiary_change, None).unwrap();
     h.change_beneficiary(
-        &mut rt,
+        &rt,
         first_beneficiary_id,
         &decrease_beneficiary_change,
         Some(first_beneficiary_id),
     )
     .unwrap();
-    let mut beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    let mut beneficiary_return = h.get_beneficiary(&rt).unwrap();
     assert_eq!(
         decrease_beneficiary_change,
         BeneficiaryChange::from_active(&beneficiary_return.active)
@@ -277,7 +276,7 @@ fn successfully_change_quota_and_test_withdraw() {
     //withdraw 0 zero
     let withdraw_left = TokenAmount::from_atto(20);
     let ret = h.withdraw_funds(
-        &mut rt,
+        &rt,
         h.beneficiary,
         &withdraw_left,
         &TokenAmount::zero(),
@@ -289,16 +288,16 @@ fn successfully_change_quota_and_test_withdraw() {
     let increase_beneficiary_change =
         BeneficiaryChange::new(first_beneficiary_id, increase_quota, beneficiary_term.expiration);
 
-    h.change_beneficiary(&mut rt, h.owner, &increase_beneficiary_change, None).unwrap();
+    h.change_beneficiary(&rt, h.owner, &increase_beneficiary_change, None).unwrap();
     h.change_beneficiary(
-        &mut rt,
+        &rt,
         first_beneficiary_id,
         &increase_beneficiary_change,
         Some(first_beneficiary_id),
     )
     .unwrap();
 
-    beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    beneficiary_return = h.get_beneficiary(&rt).unwrap();
     assert_eq!(
         increase_beneficiary_change,
         BeneficiaryChange::from_active(&beneficiary_return.active)
@@ -307,21 +306,21 @@ fn successfully_change_quota_and_test_withdraw() {
 
     //success withdraw 40 atto fil
     let withdraw_left = TokenAmount::from_atto(40);
-    h.withdraw_funds(&mut rt, h.beneficiary, &withdraw_left, &withdraw_left, &TokenAmount::zero())
+    h.withdraw_funds(&rt, h.beneficiary, &withdraw_left, &withdraw_left, &TokenAmount::zero())
         .unwrap();
     h.check_state(&rt);
 }
 
 #[test]
 fn fails_approval_message_with_invalidate_params() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let first_beneficiary_id = Address::new_id(999);
 
     // proposal beneficiary
     let beneficiary_change =
         &BeneficiaryChange::new(first_beneficiary_id, TokenAmount::from_atto(100), 200);
-    h.change_beneficiary(&mut rt, h.owner, beneficiary_change, None).unwrap();
-    let beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    h.change_beneficiary(&rt, h.owner, beneficiary_change, None).unwrap();
+    let beneficiary_return = h.get_beneficiary(&rt).unwrap();
     assert_eq!(
         beneficiary_change,
         &BeneficiaryChange::from_pending(&beneficiary_return.proposed.unwrap())
@@ -331,7 +330,7 @@ fn fails_approval_message_with_invalidate_params() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         h.change_beneficiary(
-            &mut rt,
+            &rt,
             first_beneficiary_id,
             &BeneficiaryChange::new(first_beneficiary_id, TokenAmount::from_atto(100), 201),
             None,
@@ -342,7 +341,7 @@ fn fails_approval_message_with_invalidate_params() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         h.change_beneficiary(
-            &mut rt,
+            &rt,
             first_beneficiary_id,
             &BeneficiaryChange::new(first_beneficiary_id, TokenAmount::from_atto(101), 200),
             None,
@@ -354,7 +353,7 @@ fn fails_approval_message_with_invalidate_params() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         h.change_beneficiary(
-            &mut rt,
+            &rt,
             first_beneficiary_id,
             &BeneficiaryChange::new(second_beneficiary_id, TokenAmount::from_atto(100), 200),
             None,
@@ -364,14 +363,14 @@ fn fails_approval_message_with_invalidate_params() {
 
 #[test]
 fn fails_proposal_beneficiary_with_invalidate_params() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let first_beneficiary_id = Address::new_id(999);
 
     //not-call unable to proposal beneficiary
     expect_abort(
         ExitCode::USR_FORBIDDEN,
         h.change_beneficiary(
-            &mut rt,
+            &rt,
             first_beneficiary_id,
             &BeneficiaryChange::new(first_beneficiary_id, TokenAmount::from_atto(100), 200),
             None,
@@ -382,7 +381,7 @@ fn fails_proposal_beneficiary_with_invalidate_params() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         h.change_beneficiary(
-            &mut rt,
+            &rt,
             h.owner,
             &BeneficiaryChange::new(first_beneficiary_id, TokenAmount::zero(), 200),
             None,
@@ -393,7 +392,7 @@ fn fails_proposal_beneficiary_with_invalidate_params() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         h.change_beneficiary(
-            &mut rt,
+            &rt,
             h.owner,
             &BeneficiaryChange::new(h.owner, TokenAmount::from_atto(20), 0),
             None,
@@ -404,7 +403,7 @@ fn fails_proposal_beneficiary_with_invalidate_params() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         h.change_beneficiary(
-            &mut rt,
+            &rt,
             h.owner,
             &BeneficiaryChange::new(h.owner, TokenAmount::zero(), 1),
             None,
@@ -414,8 +413,8 @@ fn fails_proposal_beneficiary_with_invalidate_params() {
 
 #[test]
 fn successfully_get_beneficiary() {
-    let (mut h, mut rt) = setup();
-    let mut beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    let (mut h, rt) = setup();
+    let mut beneficiary_return = h.get_beneficiary(&rt).unwrap();
     assert_eq!(h.owner, beneficiary_return.active.beneficiary);
     assert_eq!(BeneficiaryTerm::default(), beneficiary_return.active.term);
 
@@ -425,9 +424,9 @@ fn successfully_get_beneficiary() {
         TokenAmount::zero(),
         ChainEpoch::from(200),
     );
-    h.propose_approve_initial_beneficiary(&mut rt, first_beneficiary_id, beneficiary_term).unwrap();
+    h.propose_approve_initial_beneficiary(&rt, first_beneficiary_id, beneficiary_term).unwrap();
 
-    let beneficiary = h.get_beneficiary(&mut rt).unwrap();
+    let beneficiary = h.get_beneficiary(&rt).unwrap();
     let mut info = h.get_info(&rt);
     assert_eq!(beneficiary.active.beneficiary, info.beneficiary);
     assert_eq!(beneficiary.active.term.expiration, info.beneficiary_term.expiration);
@@ -435,10 +434,10 @@ fn successfully_get_beneficiary() {
     assert_eq!(beneficiary.active.term.used_quota, info.beneficiary_term.used_quota);
 
     let withdraw_fund = TokenAmount::from_atto(40);
-    h.withdraw_funds(&mut rt, h.beneficiary, &withdraw_fund, &withdraw_fund, &TokenAmount::zero())
+    h.withdraw_funds(&rt, h.beneficiary, &withdraw_fund, &withdraw_fund, &TokenAmount::zero())
         .unwrap();
 
-    beneficiary_return = h.get_beneficiary(&mut rt).unwrap();
+    beneficiary_return = h.get_beneficiary(&rt).unwrap();
     info = h.get_info(&rt);
     assert_eq!(beneficiary_return.active.beneficiary, info.beneficiary);
     assert_eq!(beneficiary_return.active.term, info.beneficiary_term);

--- a/actors/miner/tests/change_owner_address_test.rs
+++ b/actors/miner/tests/change_owner_address_test.rs
@@ -18,8 +18,8 @@ fn setup() -> (ActorHarness, MockRuntime) {
     let period_offset = 100;
 
     let h = ActorHarness::new(period_offset);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
     rt.balance.replace(BIG_BALANCE.clone());
 
     (h, rt)
@@ -27,11 +27,11 @@ fn setup() -> (ActorHarness, MockRuntime) {
 
 #[test]
 fn successful_change() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, OTHER_ADDRESS);
     h.change_beneficiary(
-        &mut rt,
+        &rt,
         h.owner,
         &BeneficiaryChange::new(OTHER_ADDRESS, TokenAmount::from_atto(100), 100),
         None,
@@ -39,7 +39,7 @@ fn successful_change() {
     .unwrap();
 
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
-    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+    h.change_owner_address(&rt, NEW_ADDRESS).unwrap();
 
     // Set to non-builtin caller to confirm exported correctly
     rt.set_caller(*EVM_ACTOR_CODE_ID, OTHER_ADDRESS);
@@ -55,7 +55,7 @@ fn successful_change() {
     assert_eq!(NEW_ADDRESS, ret.proposed.unwrap());
 
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, NEW_ADDRESS);
-    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+    h.change_owner_address(&rt, NEW_ADDRESS).unwrap();
 
     let info = h.get_info(&rt);
     assert_eq!(NEW_ADDRESS, info.owner);
@@ -108,17 +108,17 @@ fn change_owner_address_restricted_correctly() {
 
 #[test]
 fn successful_keep_beneficiary_when_change_owner() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
     h.change_beneficiary(
-        &mut rt,
+        &rt,
         h.owner,
         &BeneficiaryChange::new(OTHER_ADDRESS, TokenAmount::from_atto(100), 100),
         None,
     )
     .unwrap();
     h.change_beneficiary(
-        &mut rt,
+        &rt,
         OTHER_ADDRESS,
         &BeneficiaryChange::new(OTHER_ADDRESS, TokenAmount::from_atto(100), 100),
         None,
@@ -126,9 +126,9 @@ fn successful_keep_beneficiary_when_change_owner() {
     .unwrap();
 
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
-    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+    h.change_owner_address(&rt, NEW_ADDRESS).unwrap();
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, NEW_ADDRESS);
-    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+    h.change_owner_address(&rt, NEW_ADDRESS).unwrap();
 
     let info = h.get_info(&rt);
     assert_eq!(NEW_ADDRESS, info.owner);
@@ -140,7 +140,7 @@ fn successful_keep_beneficiary_when_change_owner() {
 
 #[test]
 fn proposed_must_be_valid() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let nominees = vec![
         Address::new_actor(b"Cthulhu"),
@@ -151,7 +151,7 @@ fn proposed_must_be_valid() {
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
 
     for nominee in nominees {
-        let result = h.change_owner_address(&mut rt, nominee);
+        let result = h.change_owner_address(&rt, nominee);
         expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
         rt.reset();
     }
@@ -161,12 +161,12 @@ fn proposed_must_be_valid() {
 
 #[test]
 fn withdraw_proposal() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
-    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+    h.change_owner_address(&rt, NEW_ADDRESS).unwrap();
 
     // revert it
-    h.change_owner_address(&mut rt, h.owner).unwrap();
+    h.change_owner_address(&rt, h.owner).unwrap();
 
     let info = h.get_info(&rt);
     assert_eq!(h.owner, info.owner);
@@ -174,7 +174,7 @@ fn withdraw_proposal() {
 
     // new address cannot confirm
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, NEW_ADDRESS);
-    let result = h.change_owner_address(&mut rt, NEW_ADDRESS);
+    let result = h.change_owner_address(&rt, NEW_ADDRESS);
     expect_abort(ExitCode::USR_FORBIDDEN, result);
 
     h.check_state(&rt);
@@ -182,14 +182,14 @@ fn withdraw_proposal() {
 
 #[test]
 fn only_owner_can_propose() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
-    let result = h.change_owner_address(&mut rt, NEW_ADDRESS);
+    let result = h.change_owner_address(&rt, NEW_ADDRESS);
     expect_abort(ExitCode::USR_FORBIDDEN, result);
 
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, OTHER_ADDRESS);
-    let result = h.change_owner_address(&mut rt, NEW_ADDRESS);
+    let result = h.change_owner_address(&rt, NEW_ADDRESS);
     expect_abort(ExitCode::USR_FORBIDDEN, result);
 
     h.check_state(&rt);
@@ -197,23 +197,23 @@ fn only_owner_can_propose() {
 
 #[test]
 fn only_owner_can_change_proposal() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     // make a proposal
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
-    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+    h.change_owner_address(&rt, NEW_ADDRESS).unwrap();
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
-    let result = h.change_owner_address(&mut rt, OTHER_ADDRESS);
+    let result = h.change_owner_address(&rt, OTHER_ADDRESS);
     expect_abort(ExitCode::USR_FORBIDDEN, result);
 
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, OTHER_ADDRESS);
-    let result = h.change_owner_address(&mut rt, OTHER_ADDRESS);
+    let result = h.change_owner_address(&rt, OTHER_ADDRESS);
     expect_abort(ExitCode::USR_FORBIDDEN, result);
 
     // owner can change it
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
-    h.change_owner_address(&mut rt, OTHER_ADDRESS).unwrap();
+    h.change_owner_address(&rt, OTHER_ADDRESS).unwrap();
 
     let info = h.get_info(&rt);
     assert_eq!(h.owner, info.owner);
@@ -224,29 +224,29 @@ fn only_owner_can_change_proposal() {
 
 #[test]
 fn only_nominee_can_confirm() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     // make a proposal
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
-    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+    h.change_owner_address(&rt, NEW_ADDRESS).unwrap();
 
     // owner re-proposing some address doesn't confirm it
-    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+    h.change_owner_address(&rt, NEW_ADDRESS).unwrap();
     let info = h.get_info(&rt);
     assert_eq!(h.owner, info.owner);
     assert_eq!(NEW_ADDRESS, info.pending_owner_address.unwrap());
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
-    let result = h.change_owner_address(&mut rt, OTHER_ADDRESS);
+    let result = h.change_owner_address(&rt, OTHER_ADDRESS);
     expect_abort(ExitCode::USR_FORBIDDEN, result);
 
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, OTHER_ADDRESS);
-    let result = h.change_owner_address(&mut rt, OTHER_ADDRESS);
+    let result = h.change_owner_address(&rt, OTHER_ADDRESS);
     expect_abort(ExitCode::USR_FORBIDDEN, result);
 
     // new address can confirm itself
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, NEW_ADDRESS);
-    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+    h.change_owner_address(&rt, NEW_ADDRESS).unwrap();
 
     let info = h.get_info(&rt);
     assert_eq!(NEW_ADDRESS, info.owner);
@@ -257,17 +257,17 @@ fn only_nominee_can_confirm() {
 
 #[test]
 fn nominee_must_confirm_self_explicitly() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     // make a proposal
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, h.owner);
-    h.change_owner_address(&mut rt, NEW_ADDRESS).unwrap();
+    h.change_owner_address(&rt, NEW_ADDRESS).unwrap();
 
     // Not own address, should fail
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, NEW_ADDRESS);
-    let result = h.change_owner_address(&mut rt, h.owner);
+    let result = h.change_owner_address(&rt, h.owner);
     expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
-    let result = h.change_owner_address(&mut rt, OTHER_ADDRESS);
+    let result = h.change_owner_address(&rt, OTHER_ADDRESS);
     expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
 
     h.check_state(&rt);

--- a/actors/miner/tests/change_owner_address_test.rs
+++ b/actors/miner/tests/change_owner_address_test.rs
@@ -67,7 +67,7 @@ fn successful_change() {
 
 #[test]
 fn change_owner_address_restricted_correctly() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let params = IpldBlock::serialize_cbor(&NEW_ADDRESS).unwrap();
     rt.set_caller(*EVM_ACTOR_CODE_ID, h.owner);

--- a/actors/miner/tests/change_peer_id_test.rs
+++ b/actors/miner/tests/change_peer_id_test.rs
@@ -33,7 +33,7 @@ fn successfully_change_peer_id() {
 
 #[test]
 fn change_peer_id_restricted_correctly() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let new_id = b"cthulhu".to_vec();
 

--- a/actors/miner/tests/change_peer_id_test.rs
+++ b/actors/miner/tests/change_peer_id_test.rs
@@ -14,8 +14,8 @@ fn setup() -> (ActorHarness, MockRuntime) {
     let precommit_epoch = 1;
 
     let h = ActorHarness::new(period_offset);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
     rt.balance.replace(BIG_BALANCE.clone());
     rt.set_epoch(precommit_epoch);
 
@@ -24,9 +24,9 @@ fn setup() -> (ActorHarness, MockRuntime) {
 
 #[test]
 fn successfully_change_peer_id() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
     let new_pid = b"cthulhu".to_vec();
-    h.change_peer_id(&mut rt, new_pid);
+    h.change_peer_id(&rt, new_pid);
 
     h.check_state(&rt);
 }

--- a/actors/miner/tests/change_worker_address_test.rs
+++ b/actors/miner/tests/change_worker_address_test.rs
@@ -125,7 +125,8 @@ fn change_and_confirm_worker_address_restricted_correctly() {
     // confirmation time
 
     // move to deadline containing effective epoch
-    rt.set_epoch(*rt.epoch.borrow() + rt.policy.worker_key_change_delay);
+    let epoch = *rt.epoch.borrow();
+    rt.set_epoch(epoch + rt.policy.worker_key_change_delay);
 
     // fail to call the unexported method
 

--- a/actors/miner/tests/change_worker_address_test.rs
+++ b/actors/miner/tests/change_worker_address_test.rs
@@ -125,7 +125,7 @@ fn change_and_confirm_worker_address_restricted_correctly() {
     // confirmation time
 
     // move to deadline containing effective epoch
-    rt.set_epoch(rt.epoch + rt.policy.worker_key_change_delay);
+    rt.set_epoch(*rt.epoch.borrow() + rt.policy.worker_key_change_delay);
 
     // fail to call the unexported method
 
@@ -307,7 +307,7 @@ fn fails_if_worker_public_key_is_not_bls_but_secp() {
 
 #[test]
 fn fails_if_new_worker_address_does_not_have_a_code() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let new_worker = Address::new_id(5001);
 
@@ -326,7 +326,7 @@ fn fails_if_new_worker_address_does_not_have_a_code() {
 
 #[test]
 fn fails_if_new_worker_is_not_account_actor() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let new_worker = Address::new_id(999);
     rt.set_address_actor_type(new_worker, *MINER_ACTOR_CODE_ID);
@@ -345,7 +345,7 @@ fn fails_if_new_worker_is_not_account_actor() {
 
 #[test]
 fn fails_when_caller_is_not_the_owner() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let new_worker = Address::new_id(999);
     rt.set_address_actor_type(new_worker, *ACCOUNT_ACTOR_CODE_ID);

--- a/actors/miner/tests/check_sector_proven_test.rs
+++ b/actors/miner/tests/check_sector_proven_test.rs
@@ -8,8 +8,8 @@ fn setup() -> (ActorHarness, MockRuntime) {
     let period_offset = 100;
 
     let h = ActorHarness::new(period_offset);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
     rt.balance.replace(BIG_BALANCE.clone());
 
     (h, rt)
@@ -17,20 +17,20 @@ fn setup() -> (ActorHarness, MockRuntime) {
 
 #[test]
 fn successfully_check_sector_is_proven() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
     let sectors =
-        h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![vec![10]], true);
-    h.check_sector_proven(&mut rt, sectors[0].sector_number).unwrap();
+        h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![vec![10]], true);
+    h.check_sector_proven(&rt, sectors[0].sector_number).unwrap();
 
     h.check_state(&rt);
 }
 
 #[test]
 fn fails_if_sector_is_not_found() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
-    let result = h.check_sector_proven(&mut rt, 1);
+    let result = h.check_sector_proven(&rt, 1);
     expect_abort(ExitCode::USR_NOT_FOUND, result);
 
     h.check_state(&rt);

--- a/actors/miner/tests/compact_partitions_test.rs
+++ b/actors/miner/tests/compact_partitions_test.rs
@@ -68,7 +68,8 @@ fn compacting_a_partition_with_both_live_and_dead_sectors_removes_dead_sectors_r
     let sectors = sectors_info.iter().map(|info| info.sector_number).collect_vec();
 
     // terminate sector 1
-    rt.set_epoch(*rt.epoch.borrow() + 100);
+    let epoch = *rt.epoch.borrow();
+    rt.set_epoch(epoch + 100);
     h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
 
     let terminated_sector = &sectors_info[0];

--- a/actors/miner/tests/compact_partitions_test.rs
+++ b/actors/miner/tests/compact_partitions_test.rs
@@ -18,8 +18,8 @@ const PERIOD_OFFSET: ChainEpoch = 100;
 
 fn setup() -> (ActorHarness, MockRuntime) {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
     rt.balance.replace(BIG_BALANCE.clone());
 
     (h, rt)
@@ -50,26 +50,26 @@ fn assert_sectors_not_found(rt: &MockRuntime, sector_number: SectorNumber) {
 #[test]
 fn compacting_a_partition_with_both_live_and_dead_sectors_removes_dead_sectors_retains_live_sectors(
 ) {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     rt.set_epoch(200);
 
     // create 4 sectors in partition 0
     let sectors_info = h.commit_and_prove_sectors(
-        &mut rt,
+        &rt,
         4,
         DEFAULT_SECTOR_EXPIRATION,
         vec![vec![10], vec![20], vec![30], vec![40]],
         true,
     );
 
-    h.advance_and_submit_posts(&mut rt, &sectors_info);
+    h.advance_and_submit_posts(&rt, &sectors_info);
 
     assert_eq!(sectors_info.len(), 4);
     let sectors = sectors_info.iter().map(|info| info.sector_number).collect_vec();
 
     // terminate sector 1
     rt.set_epoch(*rt.epoch.borrow() + 100);
-    h.apply_rewards(&mut rt, BIG_REWARDS.clone(), TokenAmount::zero());
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
 
     let terminated_sector = &sectors_info[0];
     let sector_size = terminated_sector.seal_proof.sector_size().unwrap();
@@ -98,17 +98,17 @@ fn compacting_a_partition_with_both_live_and_dead_sectors_removes_dead_sectors_r
         0,
     );
 
-    h.terminate_sectors(&mut rt, &bitfield_from_slice(&[sectors[0]]), expected_fee);
+    h.terminate_sectors(&rt, &bitfield_from_slice(&[sectors[0]]), expected_fee);
 
     // Wait WPoStProofChallengePeriod epochs so we can compact the sector.
     let target_epoch = *rt.epoch.borrow() + rt.policy().wpost_dispute_window;
-    h.advance_to_epoch_with_cron(&mut rt, target_epoch);
+    h.advance_to_epoch_with_cron(&rt, target_epoch);
 
     // compacting partition will remove sector 1 but retain sector 2,3 and 4
     let deadline_id = 0;
     let partition_id = 0;
     let partitions = bitfield_from_slice(&[partition_id]);
-    h.compact_partitions(&mut rt, deadline_id, partitions).unwrap();
+    h.compact_partitions(&rt, deadline_id, partitions).unwrap();
 
     assert_sectors_not_found(&rt, sectors[0]);
     assert_sectors_exists(&rt, sectors[1], partition_id, deadline_id);
@@ -120,30 +120,30 @@ fn compacting_a_partition_with_both_live_and_dead_sectors_removes_dead_sectors_r
 
 #[test]
 fn fail_to_compact_partitions_with_faults() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     rt.set_epoch(200);
 
     // create 2 sectors in partition 0
     let sectors_info = h.commit_and_prove_sectors(
-        &mut rt,
+        &rt,
         2,
         DEFAULT_SECTOR_EXPIRATION,
         vec![vec![10], vec![20]],
         true,
     );
-    h.advance_and_submit_posts(&mut rt, &sectors_info);
+    h.advance_and_submit_posts(&rt, &sectors_info);
 
     // fault sector 1
-    h.declare_faults(&mut rt, &sectors_info[0..1]);
+    h.declare_faults(&rt, &sectors_info[0..1]);
 
     // Wait WPoStProofChallengePeriod epochs so we can compact the sector.
     let target_epoch = *rt.epoch.borrow() + rt.policy().wpost_dispute_window;
-    h.advance_to_epoch_with_cron(&mut rt, target_epoch);
+    h.advance_to_epoch_with_cron(&rt, target_epoch);
 
     let partition_id = 0;
     let deadline_id = 0;
 
-    let result = h.compact_partitions(&mut rt, deadline_id, bitfield_from_slice(&[partition_id]));
+    let result = h.compact_partitions(&rt, deadline_id, bitfield_from_slice(&[partition_id]));
     expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "failed to remove partitions from deadline 0: while removing partitions: cannot remove partition 0: has faults", result);
 
     h.check_state(&rt);
@@ -151,7 +151,7 @@ fn fail_to_compact_partitions_with_faults() {
 
 #[test]
 fn fails_to_compact_partitions_with_unproven_sectors() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
     // Wait until deadline 0 (the one to which we'll assign the
     // sector) has elapsed. That'll let us commit, prove, then wait
@@ -164,22 +164,16 @@ fn fails_to_compact_partitions_with_unproven_sectors() {
     rt.set_epoch(deadline_epoch);
 
     // create 2 sectors in partition 0
-    h.commit_and_prove_sectors(
-        &mut rt,
-        2,
-        DEFAULT_SECTOR_EXPIRATION,
-        vec![vec![10], vec![20]],
-        true,
-    );
+    h.commit_and_prove_sectors(&rt, 2, DEFAULT_SECTOR_EXPIRATION, vec![vec![10], vec![20]], true);
 
     // Wait WPoStProofChallengePeriod epochs so we can compact the sector.
     let target_epoch = *rt.epoch.borrow() + rt.policy().wpost_dispute_window;
-    h.advance_to_epoch_with_cron(&mut rt, target_epoch);
+    h.advance_to_epoch_with_cron(&rt, target_epoch);
 
     let partition_id = 0;
     let deadline_id = 0;
 
-    let result = h.compact_partitions(&mut rt, deadline_id, bitfield_from_slice(&[partition_id]));
+    let result = h.compact_partitions(&rt, deadline_id, bitfield_from_slice(&[partition_id]));
     expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "failed to remove partitions from deadline 0: while removing partitions: cannot remove partition 0: has unproven sectors", result);
 
     h.check_state(&rt);
@@ -187,9 +181,9 @@ fn fails_to_compact_partitions_with_unproven_sectors() {
 
 #[test]
 fn fails_if_deadline_out_of_range() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
     let w_post_period_deadlines = rt.policy().wpost_period_deadlines;
-    let result = h.compact_partitions(&mut rt, w_post_period_deadlines, BitField::default());
+    let result = h.compact_partitions(&rt, w_post_period_deadlines, BitField::default());
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         &format!("invalid deadline {w_post_period_deadlines}"),
@@ -201,11 +195,11 @@ fn fails_if_deadline_out_of_range() {
 
 #[test]
 fn fails_if_deadline_is_open_for_challenging() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
     rt.set_epoch(PERIOD_OFFSET);
     assert_eq!(h.current_deadline(&rt).index, 0);
 
-    let result = h.compact_partitions(&mut rt, 0, BitField::default());
+    let result = h.compact_partitions(&rt, 0, BitField::default());
     expect_abort(ExitCode::USR_FORBIDDEN, result);
 
     h.check_state(&rt);
@@ -213,10 +207,10 @@ fn fails_if_deadline_is_open_for_challenging() {
 
 #[test]
 fn fails_if_deadline_is_next_up_to_be_challenged() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
     rt.set_epoch(PERIOD_OFFSET);
     let current_deadline = h.current_deadline(&rt).index;
-    let result = h.compact_partitions(&mut rt, current_deadline + 1, BitField::default());
+    let result = h.compact_partitions(&rt, current_deadline + 1, BitField::default());
     expect_abort(ExitCode::USR_FORBIDDEN, result);
 
     h.check_state(&rt);
@@ -224,20 +218,20 @@ fn fails_if_deadline_is_next_up_to_be_challenged() {
 
 #[test]
 fn deadline_after_next_deadline_should_still_be_open_for_compaction() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
     rt.set_epoch(PERIOD_OFFSET);
     let current_deadline = h.current_deadline(&rt).index;
-    h.compact_partitions(&mut rt, current_deadline + 2, BitField::default()).unwrap();
+    h.compact_partitions(&rt, current_deadline + 2, BitField::default()).unwrap();
     h.check_state(&rt);
 }
 
 #[test]
 fn deadlines_challenged_last_proving_period_should_still_be_in_dispute_window() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
     rt.set_epoch(PERIOD_OFFSET);
     // (curr_deadline - 1) % wpost_period_deadlines
     let last_proving_period = rt.policy().wpost_period_deadlines - 1;
-    let result = h.compact_partitions(&mut rt, last_proving_period, BitField::default());
+    let result = h.compact_partitions(&rt, last_proving_period, BitField::default());
     expect_abort(ExitCode::USR_FORBIDDEN, result);
 
     h.check_state(&rt);
@@ -245,13 +239,13 @@ fn deadlines_challenged_last_proving_period_should_still_be_in_dispute_window() 
 
 #[test]
 fn compaction_should_be_forbidden_during_the_dispute_window() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let dispute_end =
         PERIOD_OFFSET + rt.policy().wpost_challenge_window + rt.policy().wpost_dispute_window - 1;
     rt.set_epoch(dispute_end);
 
-    let result = h.compact_partitions(&mut rt, 0, BitField::default());
+    let result = h.compact_partitions(&rt, 0, BitField::default());
     expect_abort(ExitCode::USR_FORBIDDEN, result);
 
     h.check_state(&rt);
@@ -259,25 +253,25 @@ fn compaction_should_be_forbidden_during_the_dispute_window() {
 
 #[test]
 fn compaction_should_be_allowed_following_the_dispute_window() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let dispute_end =
         PERIOD_OFFSET + rt.policy().wpost_challenge_window + rt.policy().wpost_dispute_window - 1;
     rt.set_epoch(dispute_end + 1);
 
-    h.compact_partitions(&mut rt, 0, BitField::default()).unwrap();
+    h.compact_partitions(&rt, 0, BitField::default()).unwrap();
 
     h.check_state(&rt);
 }
 
 #[test]
 fn fails_if_partition_count_is_above_limit() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     // partition limit is 4 for the default construction
     let partitions = bitfield_from_slice(&[1, 2, 3, 4, 5]);
 
-    let result = h.compact_partitions(&mut rt, 1, partitions);
+    let result = h.compact_partitions(&rt, 1, partitions);
     expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
 
     h.check_state(&rt);

--- a/actors/miner/tests/compact_sector_numbers_tests.rs
+++ b/actors/miner/tests/compact_sector_numbers_tests.rs
@@ -10,8 +10,8 @@ const PERIOD_OFFSET: ChainEpoch = 100;
 
 fn setup() -> (ActorHarness, MockRuntime) {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
     rt.balance.replace(BIG_BALANCE.clone());
 
     (h, rt)
@@ -23,13 +23,13 @@ mod compact_sector_numbers_test {
     #[test]
     fn compact_sector_numbers_then_pre_commit() {
         // Create a sector.
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
         let all_sectors =
-            h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+            h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
 
         let target_sector_num = all_sectors[0].sector_number;
         h.compact_sector_numbers(
-            &mut rt,
+            &rt,
             h.worker,
             bitfield_from_slice(&[target_sector_num, target_sector_num + 1]),
         );
@@ -49,7 +49,7 @@ mod compact_sector_numbers_test {
             );
             expect_abort(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
-                h.pre_commit_sector(&mut rt, precommit, util::PreCommitConfig::default(), false),
+                h.pre_commit_sector(&rt, precommit, util::PreCommitConfig::default(), false),
             );
         }
 
@@ -60,8 +60,7 @@ mod compact_sector_numbers_test {
                 expiration,
                 vec![],
             );
-            h.pre_commit_sector(&mut rt, precommit, util::PreCommitConfig::default(), false)
-                .unwrap();
+            h.pre_commit_sector(&rt, precommit, util::PreCommitConfig::default(), false).unwrap();
         }
         check_state_invariants_from_mock_runtime(&rt);
     }
@@ -69,13 +68,13 @@ mod compact_sector_numbers_test {
     #[test]
     fn owner_can_also_compact_sectors() {
         // Create a sector.
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
         let all_sectors =
-            h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+            h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
 
         let target_sector_num = all_sectors[0].sector_number;
         h.compact_sector_numbers(
-            &mut rt,
+            &rt,
             h.owner,
             bitfield_from_slice(&[target_sector_num, target_sector_num + 1]),
         );
@@ -85,13 +84,13 @@ mod compact_sector_numbers_test {
     #[test]
     fn one_of_the_control_addresses_can_also_compact_sectors() {
         // Create a sector.
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
         let all_sectors =
-            h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+            h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
 
         let target_sector_num = all_sectors[0].sector_number;
         h.compact_sector_numbers(
-            &mut rt,
+            &rt,
             h.caller_addrs()[0],
             bitfield_from_slice(&[target_sector_num, target_sector_num + 1]),
         );
@@ -101,9 +100,9 @@ mod compact_sector_numbers_test {
     #[test]
     fn fail_if_caller_is_not_among_caller_worker_or_control_addresses() {
         // Create a sector.
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
         let all_sectors =
-            h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+            h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
 
         let target_sector_num = all_sectors[0].sector_number;
         let r_addr = Address::new_id(1005);
@@ -111,7 +110,7 @@ mod compact_sector_numbers_test {
         expect_abort(
             ExitCode::USR_FORBIDDEN,
             h.compact_sector_numbers_raw(
-                &mut rt,
+                &rt,
                 r_addr,
                 bitfield_from_slice(&[target_sector_num, target_sector_num + 1]),
             ),
@@ -122,15 +121,15 @@ mod compact_sector_numbers_test {
 
     #[test]
     fn sector_number_range_limits() {
-        let (h, mut rt) = setup();
+        let (h, rt) = setup();
         // Limits ok
-        h.compact_sector_numbers(&mut rt, h.worker, bitfield_from_slice(&[0, MAX_SECTOR_NUMBER]));
+        h.compact_sector_numbers(&rt, h.worker, bitfield_from_slice(&[0, MAX_SECTOR_NUMBER]));
 
         // Out of range fails
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
             h.compact_sector_numbers_raw(
-                &mut rt,
+                &rt,
                 h.worker,
                 bitfield_from_slice(&[MAX_SECTOR_NUMBER + 1]),
             ),
@@ -141,11 +140,11 @@ mod compact_sector_numbers_test {
 
     #[test]
     fn compacting_no_sector_numbers_aborts() {
-        let (h, mut rt) = setup();
+        let (h, rt) = setup();
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
             // compact nothing
-            h.compact_sector_numbers_raw(&mut rt, h.worker, bitfield_from_slice(&[])),
+            h.compact_sector_numbers_raw(&rt, h.worker, bitfield_from_slice(&[])),
         );
         rt.reset();
         check_state_invariants_from_mock_runtime(&rt);

--- a/actors/miner/tests/compact_sector_numbers_tests.rs
+++ b/actors/miner/tests/compact_sector_numbers_tests.rs
@@ -34,7 +34,7 @@ mod compact_sector_numbers_test {
             bitfield_from_slice(&[target_sector_num, target_sector_num + 1]),
         );
 
-        let precommit_epoch = rt.epoch;
+        let precommit_epoch = *rt.epoch.borrow();
         let deadline = h.deadline(&rt);
         let expiration = deadline.period_end()
             + DEFAULT_SECTOR_EXPIRATION as i64 * rt.policy.wpost_proving_period;

--- a/actors/miner/tests/confirm_update_worker_key_test.rs
+++ b/actors/miner/tests/confirm_update_worker_key_test.rs
@@ -15,8 +15,8 @@ fn setup() -> (ActorHarness, MockRuntime) {
     let current_epoch = 5;
 
     let h = ActorHarness::new(period_offset);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
     rt.balance.replace(BIG_BALANCE.clone());
     rt.set_epoch(current_epoch);
 
@@ -25,14 +25,14 @@ fn setup() -> (ActorHarness, MockRuntime) {
 
 #[test]
 fn successfully_changes_the_worker_address() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let effective_epoch = *rt.epoch.borrow() + rt.policy().worker_key_change_delay;
-    h.change_worker_address(&mut rt, NEW_WORKER, h.control_addrs.clone()).unwrap();
+    h.change_worker_address(&rt, NEW_WORKER, h.control_addrs.clone()).unwrap();
 
     // confirm at effective epoch
     rt.set_epoch(effective_epoch);
-    h.confirm_change_worker_address(&mut rt).unwrap();
+    h.confirm_change_worker_address(&rt).unwrap();
 
     let state: State = rt.get_state();
     let info = state.get_info(rt.store()).unwrap();
@@ -45,14 +45,14 @@ fn successfully_changes_the_worker_address() {
 
 #[test]
 fn does_nothing_before_the_effective_date() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let effective_epoch = *rt.epoch.borrow() + rt.policy().worker_key_change_delay;
-    h.change_worker_address(&mut rt, NEW_WORKER, h.control_addrs.clone()).unwrap();
+    h.change_worker_address(&rt, NEW_WORKER, h.control_addrs.clone()).unwrap();
 
     // confirm right before the effective epoch
     rt.set_epoch(effective_epoch - 1);
-    h.confirm_change_worker_address(&mut rt).unwrap();
+    h.confirm_change_worker_address(&rt).unwrap();
 
     let state: State = rt.get_state();
     let info = state.get_info(rt.store()).unwrap();
@@ -68,9 +68,9 @@ fn does_nothing_before_the_effective_date() {
 
 #[test]
 fn does_nothing_when_no_update_is_set() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
-    h.confirm_change_worker_address(&mut rt).unwrap();
+    h.confirm_change_worker_address(&rt).unwrap();
 
     let state: State = rt.get_state();
     let info = state.get_info(rt.store()).unwrap();

--- a/actors/miner/tests/confirm_update_worker_key_test.rs
+++ b/actors/miner/tests/confirm_update_worker_key_test.rs
@@ -27,7 +27,7 @@ fn setup() -> (ActorHarness, MockRuntime) {
 fn successfully_changes_the_worker_address() {
     let (h, mut rt) = setup();
 
-    let effective_epoch = rt.epoch + rt.policy().worker_key_change_delay;
+    let effective_epoch = *rt.epoch.borrow() + rt.policy().worker_key_change_delay;
     h.change_worker_address(&mut rt, NEW_WORKER, h.control_addrs.clone()).unwrap();
 
     // confirm at effective epoch
@@ -47,7 +47,7 @@ fn successfully_changes_the_worker_address() {
 fn does_nothing_before_the_effective_date() {
     let (h, mut rt) = setup();
 
-    let effective_epoch = rt.epoch + rt.policy().worker_key_change_delay;
+    let effective_epoch = *rt.epoch.borrow() + rt.policy().worker_key_change_delay;
     h.change_worker_address(&mut rt, NEW_WORKER, h.control_addrs.clone()).unwrap();
 
     // confirm right before the effective epoch

--- a/actors/miner/tests/deadline_cron.rs
+++ b/actors/miner/tests/deadline_cron.rs
@@ -23,9 +23,9 @@ const PERIOD_OFFSET: ChainEpoch = 100;
 #[test]
 fn cron_on_inactive_state() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let st = h.get_state(&rt);
     assert_eq!(PERIOD_OFFSET - rt.policy.wpost_proving_period, st.proving_period_start);
@@ -34,7 +34,7 @@ fn cron_on_inactive_state() {
     // cron does nothing and does not enroll another cron
     let deadline = h.deadline(&rt);
     rt.set_epoch(deadline.last());
-    h.on_deadline_cron(&mut rt, CronConfig { no_enrollment: true, ..CronConfig::default() });
+    h.on_deadline_cron(&rt, CronConfig { no_enrollment: true, ..CronConfig::default() });
 
     h.check_state(&rt);
 }
@@ -42,14 +42,14 @@ fn cron_on_inactive_state() {
 #[test]
 fn sector_expires() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let sectors =
-        h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
+        h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
     // advance cron to activate power.
-    h.advance_and_submit_posts(&mut rt, &sectors);
+    h.advance_and_submit_posts(&rt, &sectors);
     let active_power = power_for_sectors(h.sector_size, &sectors);
 
     let mut st = h.get_state(&rt);
@@ -73,7 +73,7 @@ fn sector_expires() {
 
     // because we skip forward in state the sector is detected faulty, no penalty
     h.advance_deadline(
-        &mut rt,
+        &rt,
         CronConfig {
             no_enrollment: true,
             expired_sectors_power_delta: Some(power_delta),
@@ -89,14 +89,14 @@ fn sector_expires() {
 #[test]
 fn sector_expires_and_repays_fee_debt() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let sectors =
-        h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
+        h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
     // advance cron to activate power.
-    h.advance_and_submit_posts(&mut rt, &sectors);
+    h.advance_and_submit_posts(&rt, &sectors);
     let active_power = power_for_sectors(h.sector_size, &sectors);
 
     let mut st = h.get_state(&rt);
@@ -129,7 +129,7 @@ fn sector_expires_and_repays_fee_debt() {
     // because we skip forward in state and don't check post, there's no penalty.
     // this is the first time the sector is detected faulty
     h.advance_deadline(
-        &mut rt,
+        &rt,
         CronConfig {
             no_enrollment: true,
             expired_sectors_power_delta: Some(power_delta),
@@ -146,25 +146,25 @@ fn sector_expires_and_repays_fee_debt() {
 #[test]
 fn detects_and_penalizes_faults() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let active_sectors =
-        h.commit_and_prove_sectors(&mut rt, 2, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
+        h.commit_and_prove_sectors(&rt, 2, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
     // advance cron to activate power.
-    h.advance_and_submit_posts(&mut rt, &active_sectors);
+    h.advance_and_submit_posts(&rt, &active_sectors);
     let active_power = power_for_sectors(h.sector_size, &active_sectors);
 
     let unproven_sectors =
-        h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], false);
+        h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], false);
     let unproven_power = power_for_sectors(h.sector_size, &unproven_sectors);
 
     let total_power = &unproven_power + &active_power;
     let all_sectors = [active_sectors.clone(), unproven_sectors].concat();
 
     // add lots of funds so penalties come from vesting funds
-    h.apply_rewards(&mut rt, BIG_REWARDS.clone(), TokenAmount::zero());
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
 
     let st = h.get_state(&rt);
     let (dl_idx, p_idx) =
@@ -173,13 +173,13 @@ fn detects_and_penalizes_faults() {
     // advance to next deadline where we expect the first sectors to appear
     let mut dl_info = h.deadline(&rt);
     while dl_info.index != dl_idx {
-        dl_info = h.advance_deadline(&mut rt, CronConfig::default());
+        dl_info = h.advance_deadline(&rt, CronConfig::default());
     }
 
     // Skip to end of the deadline, cron detects sectors as faulty
     let active_power_delta = active_power.neg();
     h.advance_deadline(
-        &mut rt,
+        &rt,
         CronConfig { detected_faults_power_delta: Some(active_power_delta), ..Default::default() },
     );
 
@@ -188,12 +188,12 @@ fn detects_and_penalizes_faults() {
     assert_eq!(total_power, deadline.faulty_power);
 
     // advance 3 deadlines
-    h.advance_deadline(&mut rt, CronConfig::default());
-    h.advance_deadline(&mut rt, CronConfig::default());
-    dl_info = h.advance_deadline(&mut rt, CronConfig::default());
+    h.advance_deadline(&rt, CronConfig::default());
+    h.advance_deadline(&rt, CronConfig::default());
+    dl_info = h.advance_deadline(&rt, CronConfig::default());
 
     h.declare_recoveries(
-        &mut rt,
+        &rt,
         dl_idx,
         p_idx,
         sector_info_as_bitfield(&all_sectors[1..]),
@@ -203,7 +203,7 @@ fn detects_and_penalizes_faults() {
 
     // Skip to end of proving period for sectors, cron detects all sectors as faulty
     while dl_info.index != dl_idx {
-        dl_info = h.advance_deadline(&mut rt, CronConfig::default());
+        dl_info = h.advance_deadline(&rt, CronConfig::default());
     }
 
     // Un-recovered faults (incl failed recovery) are charged as ongoing faults
@@ -215,7 +215,7 @@ fn detects_and_penalizes_faults() {
     );
 
     h.advance_deadline(
-        &mut rt,
+        &rt,
         CronConfig { continued_faults_penalty: ongoing_penalty, ..Default::default() },
     );
 
@@ -236,19 +236,19 @@ fn detects_and_penalizes_faults() {
 #[test]
 fn test_cron_run_trigger_faults() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     // add lots of funds so we can pay penalties without going into debt
-    h.apply_rewards(&mut rt, BIG_REWARDS.clone(), TokenAmount::zero());
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
 
     // create enough sectors that one will be in a different partition
     let all_sectors =
-        h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
+        h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
 
     // advance cron to activate power.
-    h.advance_and_submit_posts(&mut rt, &all_sectors);
+    h.advance_and_submit_posts(&rt, &all_sectors);
 
     let st = h.get_state(&rt);
     let (dl_idx, _) = st.find_sector(&rt.policy, &rt.store, all_sectors[0].sector_number).unwrap();
@@ -256,7 +256,7 @@ fn test_cron_run_trigger_faults() {
     // advance to deadline prior to first
     let mut dl_info = h.deadline(&rt);
     while dl_info.index != dl_idx {
-        dl_info = h.advance_deadline(&mut rt, CronConfig::default());
+        dl_info = h.advance_deadline(&rt, CronConfig::default());
     }
 
     rt.set_epoch(dl_info.last());
@@ -271,7 +271,7 @@ fn test_cron_run_trigger_faults() {
     let next_cron = dl_info.last() + rt.policy.wpost_challenge_window;
 
     h.on_deadline_cron(
-        &mut rt,
+        &rt,
         CronConfig {
             expected_enrollment: next_cron,
             detected_faults_power_delta: Some(power_delta_claim),

--- a/actors/miner/tests/deadline_cron_defers_stops_restarts.rs
+++ b/actors/miner/tests/deadline_cron_defers_stops_restarts.rs
@@ -8,23 +8,23 @@ const PERIOD_OFFSET: ChainEpoch = 100;
 #[test]
 fn cron_enrolls_on_precommit_prove_commits_and_continues_enrolling() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let cron_ctrl = CronControl::default();
     let long_expiration = 500;
 
     cron_ctrl.require_cron_inactive(&h, &rt);
-    let sectors = h.commit_and_prove_sectors(&mut rt, 1, long_expiration, vec![], true);
+    let sectors = h.commit_and_prove_sectors(&rt, 1, long_expiration, vec![], true);
     cron_ctrl.require_cron_active(&h, &rt);
 
     // advance cron to activate power.
-    h.advance_and_submit_posts(&mut rt, &sectors);
+    h.advance_and_submit_posts(&rt, &sectors);
     // advance 499 days of deadline (1 before expiration occurrs)
     // this asserts that cron continues to enroll within advanceAndSubmitPoSt
     for _ in 0..499 {
-        h.advance_and_submit_posts(&mut rt, &sectors);
+        h.advance_and_submit_posts(&rt, &sectors);
     }
     h.check_state(&rt);
     let st = h.get_state(&rt);
@@ -34,47 +34,47 @@ fn cron_enrolls_on_precommit_prove_commits_and_continues_enrolling() {
 #[test]
 fn cron_enrolls_on_precommit_expires_on_pcd_expiration_re_enrolls_on_new_precommit_immediately() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
     let epoch = PERIOD_OFFSET + 1;
     rt.set_epoch(epoch);
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let mut cron_ctrl = CronControl::default();
 
-    let epoch = cron_ctrl.pre_commit_start_cron_expire_stop_cron(&h, &mut rt, epoch);
-    cron_ctrl.pre_commit_to_start_cron(&h, &mut rt, epoch);
+    let epoch = cron_ctrl.pre_commit_start_cron_expire_stop_cron(&h, &rt, epoch);
+    cron_ctrl.pre_commit_to_start_cron(&h, &rt, epoch);
 }
 
 #[test]
 fn cron_enrolls_on_precommit_expires_on_pcd_expiration_re_enrolls_on_new_precommit_after_falling_out_of_date(
 ) {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
     let mut epoch = PERIOD_OFFSET + 1;
     rt.set_epoch(epoch);
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let mut cron_ctrl = CronControl::default();
 
-    epoch = cron_ctrl.pre_commit_start_cron_expire_stop_cron(&h, &mut rt, epoch);
+    epoch = cron_ctrl.pre_commit_start_cron_expire_stop_cron(&h, &rt, epoch);
     // Advance some epochs to fall several pp out of date, then precommit again reenrolling cron
     epoch += 200 * rt.policy.wpost_proving_period;
-    epoch = cron_ctrl.pre_commit_start_cron_expire_stop_cron(&h, &mut rt, epoch);
+    epoch = cron_ctrl.pre_commit_start_cron_expire_stop_cron(&h, &rt, epoch);
     // Stay within the same deadline but advance an epoch
     epoch += 1;
-    cron_ctrl.pre_commit_to_start_cron(&h, &mut rt, epoch);
+    cron_ctrl.pre_commit_to_start_cron(&h, &rt, epoch);
 }
 
 #[test]
 fn enroll_pcd_expire_re_enroll_x_3() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
     let mut epoch = PERIOD_OFFSET + 1;
     rt.set_epoch(epoch);
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let mut cron_ctrl = CronControl::default();
     for _ in 1..3 {
-        epoch = cron_ctrl.pre_commit_start_cron_expire_stop_cron(&h, &mut rt, epoch) + 42;
+        epoch = cron_ctrl.pre_commit_start_cron_expire_stop_cron(&h, &rt, epoch) + 42;
     }
 }

--- a/actors/miner/tests/declare_faults.rs
+++ b/actors/miner/tests/declare_faults.rs
@@ -21,25 +21,25 @@ fn declare_fault_pays_fee_at_window_post() {
 
     // Get sector into proving state
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let all_sectors =
-        h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
+        h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
     let pwr = power_for_sectors(h.sector_size, &all_sectors);
 
     // add lots of funds so penalties come from vesting funds
-    h.apply_rewards(&mut rt, big_rewards, TokenAmount::zero());
+    h.apply_rewards(&rt, big_rewards, TokenAmount::zero());
 
     // find deadline for sector
     let st = h.get_state(&rt);
     let (dl_idx, _) = st.find_sector(&rt.policy, &rt.store, all_sectors[0].sector_number).unwrap();
 
     // advance to first proving period and submit so we'll have time to declare the fault next cycle
-    h.advance_and_submit_posts(&mut rt, &all_sectors);
+    h.advance_and_submit_posts(&rt, &all_sectors);
 
     // Declare the sector as faulted
-    h.declare_faults(&mut rt, &all_sectors);
+    h.declare_faults(&rt, &all_sectors);
 
     // faults are recorded in state
     let dl = h.get_deadline(&rt, dl_idx);
@@ -48,7 +48,7 @@ fn declare_fault_pays_fee_at_window_post() {
     // Skip to end of proving period.
     let mut dl_info = h.deadline(&rt);
     while dl_info.index != dl_idx {
-        dl_info = h.advance_deadline(&mut rt, CronConfig::default());
+        dl_info = h.advance_deadline(&rt, CronConfig::default());
     }
 
     // faults are charged at ongoing rate and no additional power is removed
@@ -59,7 +59,7 @@ fn declare_fault_pays_fee_at_window_post() {
         &ongoing_pwr.qa,
     );
     h.advance_deadline(
-        &mut rt,
+        &rt,
         CronConfig { continued_faults_penalty: ongoing_penalty, ..Default::default() },
     );
     h.check_state(&rt);

--- a/actors/miner/tests/declare_recoveries.rs
+++ b/actors/miner/tests/declare_recoveries.rs
@@ -129,7 +129,7 @@ fn recovery_fails_during_active_consensus_fault() {
 
     // consensus fault
     let test_addr = Address::new_id(1234);
-    let epoch = rt.epoch;
+    let epoch = *rt.epoch.borrow();
     h.report_consensus_fault(
         &mut rt,
         test_addr,

--- a/actors/miner/tests/declare_recoveries.rs
+++ b/actors/miner/tests/declare_recoveries.rs
@@ -19,22 +19,22 @@ const PERIOD_OFFSET: ChainEpoch = 100;
 
 #[test]
 fn recovery_happy_path() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let one_sector =
-        h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
+        h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
 
     // advance to first proving period and submit so we'll have time to declare the fault next cycle
-    h.advance_and_submit_posts(&mut rt, &one_sector);
+    h.advance_and_submit_posts(&rt, &one_sector);
 
     // Declare the sector as faulted
-    h.declare_faults(&mut rt, &one_sector);
+    h.declare_faults(&rt, &one_sector);
 
     // Declare recoveries updates state
     let st = h.get_state(&rt);
     let (dl_idx, p_idx) =
         st.find_sector(&rt.policy, &rt.store, one_sector[0].sector_number).unwrap();
     h.declare_recoveries(
-        &mut rt,
+        &rt,
         dl_idx,
         p_idx,
         BitField::try_from_bits([one_sector[0].sector_number]).unwrap(),
@@ -50,25 +50,25 @@ fn recovery_happy_path() {
 
 #[test]
 fn recovery_must_pay_back_fee_debt() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let one_sector =
-        h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
+        h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
 
     // advance to first proving period and submit so we'll have time to declare the fault next cycle
-    h.advance_and_submit_posts(&mut rt, &one_sector);
+    h.advance_and_submit_posts(&rt, &one_sector);
 
     // Fault will take miner into fee debt
     let mut st = h.get_state(&rt);
     rt.set_balance(&st.pre_commit_deposits + &st.initial_pledge + &st.locked_funds);
 
-    h.declare_faults(&mut rt, &one_sector);
+    h.declare_faults(&rt, &one_sector);
 
     st = h.get_state(&rt);
     let (dl_idx, p_idx) =
         st.find_sector(&rt.policy, &rt.store, one_sector[0].sector_number).unwrap();
 
     // Skip to end of proving period
-    h.advance_to_deadline(&mut rt, dl_idx);
+    h.advance_to_deadline(&rt, dl_idx);
 
     // Can't pay during this deadline so miner goes into fee debt
     let ongoing_pwr = power_for_sectors(h.sector_size, &one_sector);
@@ -78,7 +78,7 @@ fn recovery_must_pay_back_fee_debt() {
         &ongoing_pwr.qa,
     );
     h.advance_deadline(
-        &mut rt,
+        &rt,
         CronConfig {
             continued_faults_penalty: TokenAmount::zero(), // fee is instead added to debt
             ..Default::default()
@@ -93,7 +93,7 @@ fn recovery_must_pay_back_fee_debt() {
         ExitCode::USR_INSUFFICIENT_FUNDS,
         "unlocked balance can not repay fee debt",
         h.declare_recoveries(
-            &mut rt,
+            &rt,
             dl_idx,
             p_idx,
             BitField::try_from_bits([one_sector[0].sector_number]).unwrap(),
@@ -105,7 +105,7 @@ fn recovery_must_pay_back_fee_debt() {
     let funds = &ff + st.initial_pledge + st.locked_funds + st.pre_commit_deposits;
     rt.set_balance(funds);
     h.declare_recoveries(
-        &mut rt,
+        &rt,
         dl_idx,
         p_idx,
         BitField::try_from_bits([one_sector[0].sector_number]).unwrap(),
@@ -123,15 +123,15 @@ fn recovery_must_pay_back_fee_debt() {
 
 #[test]
 fn recovery_fails_during_active_consensus_fault() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let one_sector =
-        h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
+        h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
 
     // consensus fault
     let test_addr = Address::new_id(1234);
     let epoch = *rt.epoch.borrow();
     h.report_consensus_fault(
-        &mut rt,
+        &rt,
         test_addr,
         Some(ConsensusFault {
             target: h.receiver,
@@ -142,10 +142,10 @@ fn recovery_fails_during_active_consensus_fault() {
     .unwrap();
 
     // advance to first proving period and submit so we'll have time to declare the fault next cycle
-    h.advance_and_submit_posts(&mut rt, &one_sector);
+    h.advance_and_submit_posts(&rt, &one_sector);
 
     // Declare the sector as faulted
-    h.declare_faults(&mut rt, &one_sector);
+    h.declare_faults(&rt, &one_sector);
     let st = h.get_state(&rt);
     let (dl_idx, p_idx) =
         st.find_sector(&rt.policy, &rt.store, one_sector[0].sector_number).unwrap();
@@ -153,7 +153,7 @@ fn recovery_fails_during_active_consensus_fault() {
         ExitCode::USR_FORBIDDEN,
         "recovery not allowed during active consensus fault",
         h.declare_recoveries(
-            &mut rt,
+            &rt,
             dl_idx,
             p_idx,
             BitField::try_from_bits([one_sector[0].sector_number]).unwrap(),
@@ -165,8 +165,8 @@ fn recovery_fails_during_active_consensus_fault() {
 
 fn setup() -> (ActorHarness, MockRuntime) {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
     rt.set_balance(BIG_BALANCE.clone());
 
     (h, rt)

--- a/actors/miner/tests/exported_getters.rs
+++ b/actors/miner/tests/exported_getters.rs
@@ -22,9 +22,9 @@ const DEFAULT_SECTOR_EXPIRATION: ChainEpoch = 220;
 #[test]
 fn info_getters() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     // set caller to not-builtin
     rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1234));
@@ -96,13 +96,13 @@ fn info_getters() {
 #[test]
 fn collateral_getters() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.balance.replace(BIG_BALANCE.clone());
 
     let precommit_epoch = PERIOD_OFFSET + 1;
     rt.set_epoch(precommit_epoch);
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let dl_info = h.deadline(&rt);
 
     // Precommit a sector
@@ -115,7 +115,7 @@ fn collateral_getters() {
     let precommit_params =
         h.make_pre_commit_params(sector_no, precommit_epoch - 1, expiration, vec![]);
     let precommit =
-        h.pre_commit_sector_and_get(&mut rt, precommit_params, PreCommitConfig::empty(), true);
+        h.pre_commit_sector_and_get(&rt, precommit_params, PreCommitConfig::empty(), true);
 
     // run prove commit logic
     rt.set_epoch(prove_commit_epoch);
@@ -125,7 +125,7 @@ fn collateral_getters() {
 
     let sector = h
         .prove_commit_sector_and_confirm(
-            &mut rt,
+            &rt,
             &precommit,
             h.make_prove_commit_params(sector_no),
             pcc,

--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -39,14 +39,14 @@ fn setup() -> (ActorHarness, MockRuntime) {
     // reduce the partition size
     // if changed to V1P1 the rejects_extension_past_max_for_seal_proof test fails
     h.set_proof_type(RegisteredSealProof::StackedDRG512MiBV1);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.balance.replace(BIG_BALANCE.clone());
     rt.set_epoch(precommit_epoch);
 
     (h, rt)
 }
 
-fn commit_sector(h: &mut ActorHarness, rt: &mut MockRuntime) -> SectorOnChainInfo {
+fn commit_sector(h: &mut ActorHarness, rt: &MockRuntime) -> SectorOnChainInfo {
     h.construct_and_verify(rt);
 
     h.commit_and_prove_sectors(rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, Vec::new(), true)[0]
@@ -56,8 +56,8 @@ fn commit_sector(h: &mut ActorHarness, rt: &mut MockRuntime) -> SectorOnChainInf
 #[test_case(false; "v1")]
 #[test_case(true; "v2")]
 fn rejects_negative_extensions(v2: bool) {
-    let (mut h, mut rt) = setup();
-    let sector = commit_sector(&mut h, &mut rt);
+    let (mut h, rt) = setup();
+    let sector = commit_sector(&mut h, &rt);
 
     // attempt to shorten epoch
     let new_expiration = sector.expiration - rt.policy().wpost_proving_period;
@@ -76,7 +76,7 @@ fn rejects_negative_extensions(v2: bool) {
         }],
     };
 
-    let res = h.extend_sectors_versioned(&mut rt, params, v2);
+    let res = h.extend_sectors_versioned(&rt, params, v2);
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         &format!("cannot reduce sector {} expiration", sector.sector_number),
@@ -88,8 +88,8 @@ fn rejects_negative_extensions(v2: bool) {
 #[test_case(false; "v1")]
 #[test_case(true; "v2")]
 fn rejects_extension_too_far_in_future(v2: bool) {
-    let (mut h, mut rt) = setup();
-    let sector = commit_sector(&mut h, &mut rt);
+    let (mut h, rt) = setup();
+    let sector = commit_sector(&mut h, &rt);
 
     // extend by even proving period after max
     rt.set_epoch(sector.expiration);
@@ -110,7 +110,7 @@ fn rejects_extension_too_far_in_future(v2: bool) {
         }],
     };
 
-    let res = h.extend_sectors_versioned(&mut rt, params, v2);
+    let res = h.extend_sectors_versioned(&rt, params, v2);
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         &format!(
@@ -125,10 +125,10 @@ fn rejects_extension_too_far_in_future(v2: bool) {
 #[test_case(false; "v1")]
 #[test_case(true; "v2")]
 fn rejects_extension_past_max_for_seal_proof(v2: bool) {
-    let (mut h, mut rt) = setup();
-    let mut sector = commit_sector(&mut h, &mut rt);
+    let (mut h, rt) = setup();
+    let mut sector = commit_sector(&mut h, &rt);
     // and prove it once to activate it.
-    h.advance_and_submit_posts(&mut rt, &vec![sector.clone()]);
+    h.advance_and_submit_posts(&rt, &vec![sector.clone()]);
 
     let max_lifetime = seal_proof_sector_maximum_lifetime(sector.seal_proof).unwrap();
 
@@ -150,7 +150,7 @@ fn rejects_extension_past_max_for_seal_proof(v2: bool) {
                 new_expiration: expiration,
             }],
         };
-        h.extend_sectors(&mut rt, params).unwrap();
+        h.extend_sectors(&rt, params).unwrap();
         sector.expiration = expiration;
 
         expiration += extension;
@@ -166,7 +166,7 @@ fn rejects_extension_past_max_for_seal_proof(v2: bool) {
         }],
     };
 
-    let res = h.extend_sectors_versioned(&mut rt, params, v2);
+    let res = h.extend_sectors_versioned(&rt, params, v2);
     expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "total sector lifetime", res);
     h.check_state(&rt);
 }
@@ -174,9 +174,9 @@ fn rejects_extension_past_max_for_seal_proof(v2: bool) {
 #[test_case(false; "v1")]
 #[test_case(true; "v2")]
 fn updates_expiration_with_valid_params(v2: bool) {
-    let (mut h, mut rt) = setup();
-    let old_sector = commit_sector(&mut h, &mut rt);
-    h.advance_and_submit_posts(&mut rt, &vec![old_sector.clone()]);
+    let (mut h, rt) = setup();
+    let old_sector = commit_sector(&mut h, &rt);
+    h.advance_and_submit_posts(&rt, &vec![old_sector.clone()]);
 
     let state: State = rt.get_state();
 
@@ -195,7 +195,7 @@ fn updates_expiration_with_valid_params(v2: bool) {
         }],
     };
 
-    h.extend_sectors_versioned(&mut rt, params, v2).unwrap();
+    h.extend_sectors_versioned(&rt, params, v2).unwrap();
 
     // assert sector expiration is set to the new value
     let new_sector = h.get_sector(&rt, old_sector.sector_number);
@@ -221,20 +221,20 @@ fn updates_expiration_with_valid_params(v2: bool) {
 #[test_case(false; "v1")]
 #[test_case(true; "v2")]
 fn updates_many_sectors(v2: bool) {
-    let (mut h, mut rt) = setup();
-    h.construct_and_verify(&mut rt);
+    let (mut h, rt) = setup();
+    h.construct_and_verify(&rt);
 
     let sector_count = 4;
 
     // commit a bunch of sectors to ensure that we get multiple partitions
     let sector_infos = h.commit_and_prove_sectors(
-        &mut rt,
+        &rt,
         sector_count as usize,
         DEFAULT_SECTOR_EXPIRATION as u64,
         Vec::new(),
         true,
     );
-    h.advance_and_submit_posts(&mut rt, &sector_infos);
+    h.advance_and_submit_posts(&rt, &sector_infos);
 
     let new_expiration = sector_infos[0].expiration + 42 * rt.policy().wpost_proving_period;
     let mut extensions: Vec<ExpirationExtension> = Vec::new();
@@ -272,7 +272,7 @@ fn updates_many_sectors(v2: bool) {
     assert!(extensions.len() >= 2, "test error: this test should touch more than one partition");
     let params = ExtendSectorExpirationParams { extensions };
 
-    h.extend_sectors_versioned(&mut rt, params, v2).unwrap();
+    h.extend_sectors_versioned(&rt, params, v2).unwrap();
     let state: State = rt.get_state();
     let deadlines = state.load_deadlines(rt.store()).unwrap();
 
@@ -307,9 +307,9 @@ fn updates_many_sectors(v2: bool) {
 #[test_case(false; "v1")]
 #[test_case(true; "v2")]
 fn supports_extensions_off_deadline_boundary(v2: bool) {
-    let (mut h, mut rt) = setup();
-    let old_sector = commit_sector(&mut h, &mut rt);
-    h.advance_and_submit_posts(&mut rt, &vec![old_sector.clone()]);
+    let (mut h, rt) = setup();
+    let old_sector = commit_sector(&mut h, &rt);
+    h.advance_and_submit_posts(&rt, &vec![old_sector.clone()]);
 
     let state: State = rt.get_state();
     let (deadline_index, partition_index) =
@@ -327,7 +327,7 @@ fn supports_extensions_off_deadline_boundary(v2: bool) {
         }],
     };
 
-    h.extend_sectors_versioned(&mut rt, params, v2).unwrap();
+    h.extend_sectors_versioned(&rt, params, v2).unwrap();
 
     // assert sector expiration is set to the new value
     let mut state: State = rt.get_state();
@@ -346,11 +346,11 @@ fn supports_extensions_off_deadline_boundary(v2: bool) {
     assert_ne!(deadline_index, deadline_info.index);
 
     // advance to deadline and submit one last PoSt
-    let deadline_info = h.advance_to_deadline(&mut rt, deadline_index);
+    let deadline_info = h.advance_to_deadline(&rt, deadline_index);
 
     let partitions = vec![PoStPartition { index: partition_index, skipped: BitField::default() }];
     h.submit_window_post(
-        &mut rt,
+        &rt,
         &deadline_info,
         partitions,
         vec![new_sector.clone()],
@@ -364,7 +364,7 @@ fn supports_extensions_off_deadline_boundary(v2: bool) {
     cron_config.expired_sectors_power_delta = Some(power);
     cron_config.expired_sectors_pledge_delta = -new_sector.initial_pledge;
 
-    h.advance_deadline(&mut rt, cron_config);
+    h.advance_deadline(&rt, cron_config);
 
     let state: State = rt.get_state();
     assert!(!state.deadline_cron_active);
@@ -374,14 +374,14 @@ fn supports_extensions_off_deadline_boundary(v2: bool) {
 
 #[test]
 fn update_expiration2_multiple_claims() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     // add in verified deal
     let verified_deals = vec![
         test_verified_deal(h.sector_size as u64 / 2),
         test_verified_deal(h.sector_size as u64 / 2),
     ];
-    let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &mut rt);
-    h.advance_and_submit_posts(&mut rt, &vec![old_sector.clone()]);
+    let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &rt);
+    h.advance_and_submit_posts(&rt, &vec![old_sector.clone()]);
 
     let state: State = rt.get_state();
 
@@ -431,12 +431,12 @@ fn update_expiration2_multiple_claims() {
         }],
     };
 
-    h.extend_sectors2(&mut rt, params, claims).unwrap();
+    h.extend_sectors2(&rt, params, claims).unwrap();
 
     // assert sector expiration is set to the new value
     check_for_expiration(
         &mut h,
-        &mut rt,
+        &rt,
         new_expiration,
         old_sector.sector_number,
         deadline_index,
@@ -446,14 +446,14 @@ fn update_expiration2_multiple_claims() {
 
 #[test]
 fn update_expiration2_failure_cases() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     // add in verified deal
     let verified_deals = vec![
         test_verified_deal(h.sector_size as u64 / 2),
         test_verified_deal(h.sector_size as u64 / 2),
     ];
-    let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &mut rt);
-    h.advance_and_submit_posts(&mut rt, &vec![old_sector.clone()]);
+    let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &rt);
+    h.advance_and_submit_posts(&rt, &vec![old_sector.clone()]);
 
     let state: State = rt.get_state();
 
@@ -504,7 +504,7 @@ fn update_expiration2_failure_cases() {
             }],
         };
 
-        let res = h.extend_sectors2(&mut rt, params, claims);
+        let res = h.extend_sectors2(&rt, params, claims);
         expect_abort_contains_message(
             ExitCode::USR_ILLEGAL_ARGUMENT,
             "does not match verified deal space",
@@ -513,7 +513,7 @@ fn update_expiration2_failure_cases() {
         // assert sector expiration is same as the old value
         check_for_expiration(
             &mut h,
-            &mut rt,
+            &rt,
             old_sector.expiration,
             old_sector.sector_number,
             deadline_index,
@@ -543,7 +543,7 @@ fn update_expiration2_failure_cases() {
             }],
         };
 
-        let res = h.extend_sectors2(&mut rt, params, claims);
+        let res = h.extend_sectors2(&rt, params, claims);
         expect_abort_contains_message(
             ExitCode::USR_ILLEGAL_ARGUMENT,
             "failed to get claims for sector",
@@ -552,7 +552,7 @@ fn update_expiration2_failure_cases() {
         // assert sector expiration is set to the new value
         check_for_expiration(
             &mut h,
-            &mut rt,
+            &rt,
             old_sector.expiration,
             old_sector.sector_number,
             deadline_index,
@@ -582,7 +582,7 @@ fn update_expiration2_failure_cases() {
             }],
         };
 
-        let res = h.extend_sectors2(&mut rt, params, claims);
+        let res = h.extend_sectors2(&rt, params, claims);
         expect_abort_contains_message(
             ExitCode::USR_FORBIDDEN,
             &format!(
@@ -595,7 +595,7 @@ fn update_expiration2_failure_cases() {
         // assert sector expiration is set to the new value
         check_for_expiration(
             &mut h,
-            &mut rt,
+            &rt,
             old_sector.expiration,
             old_sector.sector_number,
             deadline_index,
@@ -608,15 +608,15 @@ fn update_expiration2_failure_cases() {
 
 #[test]
 fn extend_expiration2_drop_claims() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     // add in verified deal
     let verified_deals = vec![
         test_verified_deal(h.sector_size as u64 / 2),
         test_verified_deal(h.sector_size as u64 / 2),
     ];
     let policy = Policy::default();
-    let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &mut rt);
-    h.advance_and_submit_posts(&mut rt, &vec![old_sector.clone()]);
+    let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &rt);
+    h.advance_and_submit_posts(&rt, &vec![old_sector.clone()]);
 
     let state: State = rt.get_state();
 
@@ -666,22 +666,17 @@ fn extend_expiration2_drop_claims() {
         }],
     };
     rt.set_epoch(old_sector.expiration - policy.end_of_life_claim_drop_period);
-    h.extend_sectors2(&mut rt, params, claims).unwrap();
+    h.extend_sectors2(&rt, params, claims).unwrap();
     check_for_expiration(
         &mut h,
-        &mut rt,
+        &rt,
         new_expiration,
         old_sector.sector_number,
         deadline_index,
         partition_index,
     );
 
-    assert_sector_verified_space(
-        &mut h,
-        &mut rt,
-        old_sector.sector_number,
-        verified_deals[0].size.0,
-    );
+    assert_sector_verified_space(&mut h, &rt, old_sector.sector_number, verified_deals[0].size.0);
 
     // only claim0 stored in verifreg now
     let mut claims = HashMap::new();
@@ -700,7 +695,7 @@ fn extend_expiration2_drop_claims() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "claim missing from declaration for sector",
-        h.extend_sectors2(&mut rt, bad_params2, claims.clone()),
+        h.extend_sectors2(&rt, bad_params2, claims.clone()),
     );
     rt.reset();
 
@@ -718,34 +713,29 @@ fn extend_expiration2_drop_claims() {
             }],
         }],
     };
-    h.extend_sectors2(&mut rt, params2, claims).unwrap();
+    h.extend_sectors2(&rt, params2, claims).unwrap();
     check_for_expiration(
         &mut h,
-        &mut rt,
+        &rt,
         second_expiration,
         old_sector.sector_number,
         deadline_index,
         partition_index,
     );
 
-    assert_sector_verified_space(
-        &mut h,
-        &mut rt,
-        old_sector.sector_number,
-        verified_deals[0].size.0,
-    );
+    assert_sector_verified_space(&mut h, &rt, old_sector.sector_number, verified_deals[0].size.0);
 }
 
 #[test]
 fn update_expiration_legacy_fails_on_new_sector_with_deals() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     // add in verified deal
     let verified_deals = vec![
         test_verified_deal(h.sector_size as u64 / 2),
         test_verified_deal(h.sector_size as u64 / 2),
     ];
-    let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &mut rt);
-    h.advance_and_submit_posts(&mut rt, &vec![old_sector.clone()]);
+    let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &rt);
+    h.advance_and_submit_posts(&rt, &vec![old_sector.clone()]);
 
     let state: State = rt.get_state();
 
@@ -768,12 +758,12 @@ fn update_expiration_legacy_fails_on_new_sector_with_deals() {
     expect_abort_contains_message(
         ExitCode::USR_FORBIDDEN,
         "cannot use legacy sector extension for simple qa power with deal weight",
-        h.extend_sectors(&mut rt, params),
+        h.extend_sectors(&rt, params),
     );
     rt.reset();
     check_for_expiration(
         &mut h,
-        &mut rt,
+        &rt,
         old_sector.expiration,
         old_sector.sector_number,
         deadline_index,
@@ -783,15 +773,15 @@ fn update_expiration_legacy_fails_on_new_sector_with_deals() {
 
 #[test]
 fn update_expiration2_drop_claims_failure_cases() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
     let policy = Policy::default();
     // add in verified deal
     let verified_deals = vec![
         test_verified_deal(h.sector_size as u64 / 2),
         test_verified_deal(h.sector_size as u64 / 2),
     ];
-    let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &mut rt);
-    h.advance_and_submit_posts(&mut rt, &vec![old_sector.clone()]);
+    let old_sector = commit_sector_verified_deals(&verified_deals, &mut h, &rt);
+    h.advance_and_submit_posts(&rt, &vec![old_sector.clone()]);
 
     let state: State = rt.get_state();
 
@@ -846,7 +836,7 @@ fn update_expiration2_drop_claims_failure_cases() {
     expect_abort_contains_message(
         ExitCode::USR_FORBIDDEN,
         "attempt to drop claims with 86401 epochs > end of life claim drop period 86400 remaining",
-        h.extend_sectors2(&mut rt, params.clone(), claims.clone()),
+        h.extend_sectors2(&rt, params.clone(), claims.clone()),
     );
     rt.reset();
     rt.set_epoch(old_sector.expiration - policy.end_of_life_claim_drop_period);
@@ -858,7 +848,7 @@ fn update_expiration2_drop_claims_failure_cases() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "failed to get claims for sector",
-        h.extend_sectors2(&mut rt, params.clone(), claims.clone()),
+        h.extend_sectors2(&rt, params.clone(), claims.clone()),
     );
     rt.reset();
 
@@ -874,7 +864,7 @@ fn update_expiration2_drop_claims_failure_cases() {
             h.receiver.id().unwrap(),
             h.receiver.id().unwrap() + 7
         ),
-        h.extend_sectors2(&mut rt, params.clone(), claims.clone()),
+        h.extend_sectors2(&rt, params.clone(), claims.clone()),
     );
     rt.reset();
     claim1.provider = h.receiver.id().unwrap(); // reset
@@ -891,7 +881,7 @@ fn update_expiration2_drop_claims_failure_cases() {
             old_sector.sector_number,
             old_sector.sector_number + 7
         ),
-        h.extend_sectors2(&mut rt, params, claims.clone()),
+        h.extend_sectors2(&rt, params, claims.clone()),
     );
     rt.reset();
     claim1.sector = old_sector.sector_number;
@@ -900,7 +890,7 @@ fn update_expiration2_drop_claims_failure_cases() {
 fn commit_sector_verified_deals(
     verified_deals: &Vec<VerifiedDealInfo>,
     h: &mut ActorHarness,
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
 ) -> SectorOnChainInfo {
     h.construct_and_verify(rt);
     assert!(!verified_deals.is_empty());
@@ -923,7 +913,7 @@ fn commit_sector_verified_deals(
 // assert that state tracks an expiration at the provided epoch in the provided deadline and partition for the provided sector
 fn check_for_expiration(
     h: &mut ActorHarness,
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     expiration: ChainEpoch,
     sector_number: SectorNumber,
     deadline_index: u64,
@@ -949,7 +939,7 @@ fn check_for_expiration(
 
 fn assert_sector_verified_space(
     h: &mut ActorHarness,
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     sector_number: SectorNumber,
     v_deal_space: u64,
 ) {

--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -94,7 +94,7 @@ fn rejects_extension_too_far_in_future(v2: bool) {
     // extend by even proving period after max
     rt.set_epoch(sector.expiration);
     let extension = rt.policy().wpost_proving_period + rt.policy().max_sector_expiration_extension;
-    let new_expiration = rt.epoch + extension;
+    let new_expiration = *rt.epoch.borrow() + extension;
 
     // find deadline and partition
     let state: State = rt.get_state();
@@ -337,7 +337,8 @@ fn supports_extensions_off_deadline_boundary(v2: bool) {
     // advance clock to expiration
     rt.set_epoch(new_sector.expiration);
     state.proving_period_start += rt.policy().wpost_proving_period
-        * ((rt.epoch - state.proving_period_start) / rt.policy().wpost_proving_period + 1);
+        * ((*rt.epoch.borrow() - state.proving_period_start) / rt.policy().wpost_proving_period
+            + 1);
     rt.replace_state(&state);
 
     // confirm it is not in sector's deadline to make sure we're testing extensions off the deadline boundary"

--- a/actors/miner/tests/miner_actor_test_commitment.rs
+++ b/actors/miner/tests/miner_actor_test_commitment.rs
@@ -269,7 +269,8 @@ mod miner_actor_test_commitment {
 
         // Expires at current epoch
         {
-            let precommit_params = h.make_pre_commit_params(102, challenge_epoch, rt.epoch, vec![]);
+            let precommit_params =
+                h.make_pre_commit_params(102, challenge_epoch, *rt.epoch.borrow(), vec![]);
             let ret = h.pre_commit_sector(
                 &mut rt,
                 precommit_params,
@@ -287,7 +288,7 @@ mod miner_actor_test_commitment {
         // Expires before current epoch
         {
             let precommit_params =
-                h.make_pre_commit_params(102, challenge_epoch, rt.epoch - 1, vec![]);
+                h.make_pre_commit_params(102, challenge_epoch, *rt.epoch.borrow() - 1, vec![]);
             let ret = h.pre_commit_sector(
                 &mut rt,
                 precommit_params,
@@ -319,7 +320,7 @@ mod miner_actor_test_commitment {
 
         // Expires before min duration + max seal duration
         {
-            let expiration = rt.epoch
+            let expiration = *rt.epoch.borrow()
                 + rt.policy.min_sector_expiration
                 + max_prove_commit_duration(&rt.policy, h.seal_proof_type).unwrap()
                 - 1;
@@ -361,7 +362,7 @@ mod miner_actor_test_commitment {
         // Errors when expiry too far in the future (bis)
         {
             rt.set_epoch(precommit_epoch);
-            let expiration = rt.epoch + rt.policy.max_sector_expiration_extension + 1;
+            let expiration = *rt.epoch.borrow() + rt.policy.max_sector_expiration_extension + 1;
             let precommit_params =
                 h.make_pre_commit_params(102, challenge_epoch, expiration, vec![]);
             let ret = h.pre_commit_sector(
@@ -443,7 +444,7 @@ mod miner_actor_test_commitment {
             let st: State = rt.get_state();
             let fault = ConsensusFault {
                 target: h.receiver,
-                epoch: rt.epoch - 1,
+                epoch: *rt.epoch.borrow() - 1,
                 fault_type: ConsensusFaultType::DoubleForkMining,
             };
             let test_addr = Address::new_id(1234);
@@ -497,7 +498,7 @@ mod miner_actor_test_commitment {
                 deadline.period_end() + DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period;
             let precommit_params = h.make_pre_commit_params(
                 sector_number,
-                rt.epoch - 1,
+                *rt.epoch.borrow() - 1,
                 expiration,
                 make_deal_ids(limit + 1),
             );
@@ -518,7 +519,7 @@ mod miner_actor_test_commitment {
             let (mut rt, h, _) = setup(proof);
             let precommit_params = h.make_pre_commit_params(
                 sector_number,
-                rt.epoch - 1,
+                *rt.epoch.borrow() - 1,
                 expiration,
                 make_deal_ids(limit),
             );
@@ -599,14 +600,14 @@ mod miner_actor_test_commitment {
         let _ = st
             .add_locked_funds(
                 &rt.store,
-                rt.epoch,
+                *rt.epoch.borrow(),
                 &TokenAmount::from_atto(1000u16),
                 &VestSpec { initial_delay: 0, vest_period: 1, step_duration: 1, quantization: 1 },
             )
             .unwrap();
         rt.replace_state(&st);
 
-        rt.set_epoch(rt.epoch + 2);
+        rt.set_epoch(*rt.epoch.borrow() + 2);
 
         // Pre-commit with a deal in order to exercise non-zero deal weights.
         let precommit_params =

--- a/actors/miner/tests/miner_actor_test_commitment.rs
+++ b/actors/miner/tests/miner_actor_test_commitment.rs
@@ -545,7 +545,8 @@ mod miner_actor_test_commitment {
             .unwrap();
         rt.replace_state(&st);
 
-        rt.set_epoch(*rt.epoch.borrow() + 2);
+        let epoch = *rt.epoch.borrow();
+        rt.set_epoch(epoch + 2);
 
         // Pre-commit with a deal in order to exercise non-zero deal weights.
         let precommit_params =

--- a/actors/miner/tests/miner_actor_test_commitment.rs
+++ b/actors/miner/tests/miner_actor_test_commitment.rs
@@ -30,13 +30,13 @@ fn assert_simple_pre_commit(sector_number: SectorNumber, deal_ids: &[DealID]) {
 
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG64GiBV1);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
     rt.set_received(TokenAmount::zero());
 
     let precommit_epoch = period_offset + 1;
     rt.set_epoch(precommit_epoch);
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let dl_info = h.deadline(&rt);
 
     let expiration =
@@ -44,7 +44,7 @@ fn assert_simple_pre_commit(sector_number: SectorNumber, deal_ids: &[DealID]) {
     let precommit_params =
         h.make_pre_commit_params(sector_number, precommit_epoch - 1, expiration, deal_ids.to_vec());
     let precommit = h.pre_commit_sector_and_get(
-        &mut rt,
+        &rt,
         precommit_params.clone(),
         util::PreCommitConfig::default(),
         true,
@@ -111,14 +111,14 @@ mod miner_actor_test_commitment {
 
         let mut h = ActorHarness::new(period_offset);
         h.set_proof_type(RegisteredSealProof::StackedDRG64GiBV1);
-        let mut rt = h.new_runtime();
+        let rt = h.new_runtime();
 
         rt.set_balance(insufficient_balance);
         rt.set_received(TokenAmount::zero());
 
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
-        h.construct_and_verify(&mut rt);
+        h.construct_and_verify(&rt);
         let deadline = h.deadline(&rt);
         let challenge_epoch = precommit_epoch - 1;
         let expiration =
@@ -128,7 +128,7 @@ mod miner_actor_test_commitment {
 
         expect_abort(
             ExitCode::USR_INSUFFICIENT_FUNDS,
-            h.pre_commit_sector(&mut rt, precommit_params, util::PreCommitConfig::default(), true),
+            h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), true),
         );
         rt.reset();
         h.check_state(&rt);
@@ -140,13 +140,13 @@ mod miner_actor_test_commitment {
 
         let mut h = ActorHarness::new(period_offset);
         h.set_proof_type(RegisteredSealProof::StackedDRG64GiBV1);
-        let mut rt = h.new_runtime();
+        let rt = h.new_runtime();
         rt.set_balance(BIG_BALANCE.clone());
         rt.set_received(TokenAmount::zero());
 
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
-        h.construct_and_verify(&mut rt);
+        h.construct_and_verify(&rt);
         let deadline = h.deadline(&rt);
         let challenge_epoch = precommit_epoch - 1;
         let expiration =
@@ -158,8 +158,7 @@ mod miner_actor_test_commitment {
 
         let precommit_params = h.make_pre_commit_params(101, challenge_epoch, expiration, vec![1]);
 
-        h.pre_commit_sector(&mut rt, precommit_params, util::PreCommitConfig::default(), true)
-            .unwrap();
+        h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), true).unwrap();
         let st: State = rt.get_state();
         assert_eq!(TokenAmount::zero(), st.fee_debt);
         h.check_state(&rt);
@@ -170,20 +169,19 @@ mod miner_actor_test_commitment {
         let period_offset = ChainEpoch::from(100);
 
         let mut h = ActorHarness::new(period_offset);
-        let mut rt = h.new_runtime();
+        let rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
         rt.set_received(TokenAmount::zero());
 
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
-        h.construct_and_verify(&mut rt);
+        h.construct_and_verify(&rt);
         let deadline = h.deadline(&rt);
         let challenge_epoch = precommit_epoch - 1;
 
         let old_sector =
-            &h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true)
-                [0];
+            &h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true)[0];
         let st: State = rt.get_state();
         assert!(st.deadline_cron_active);
 
@@ -195,18 +193,14 @@ mod miner_actor_test_commitment {
             let precommit_params =
                 h.make_pre_commit_params(101, challenge_epoch, expiration, vec![]);
             h.pre_commit_sector_and_get(
-                &mut rt,
+                &rt,
                 precommit_params.clone(),
                 util::PreCommitConfig::default(),
                 false,
             );
             // Duplicate pre-commit sector ID
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "already allocated", ret);
             rt.reset();
         }
@@ -219,12 +213,8 @@ mod miner_actor_test_commitment {
                 expiration,
                 vec![],
             );
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "already allocated", ret);
             rt.reset();
         }
@@ -234,12 +224,8 @@ mod miner_actor_test_commitment {
             let mut precommit_params =
                 h.make_pre_commit_params(102, challenge_epoch, deadline.period_end(), vec![]);
             precommit_params.sealed_cid = make_cid_poseidon("Random Data".as_bytes(), 0);
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "sealed CID had wrong prefix",
@@ -253,12 +239,8 @@ mod miner_actor_test_commitment {
             let mut precommit_params =
                 h.make_pre_commit_params(102, challenge_epoch, deadline.period_end(), vec![]);
             precommit_params.seal_proof = RegisteredSealProof::StackedDRG8MiBV1;
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "unsupported seal proof type",
@@ -271,12 +253,8 @@ mod miner_actor_test_commitment {
         {
             let precommit_params =
                 h.make_pre_commit_params(102, challenge_epoch, *rt.epoch.borrow(), vec![]);
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "must be after activation",
@@ -289,12 +267,8 @@ mod miner_actor_test_commitment {
         {
             let precommit_params =
                 h.make_pre_commit_params(102, challenge_epoch, *rt.epoch.borrow() - 1, vec![]);
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "must be after activation",
@@ -308,12 +282,8 @@ mod miner_actor_test_commitment {
             let early_expiration = rt.policy.min_sector_expiration - EPOCHS_IN_DAY;
             let precommit_params =
                 h.make_pre_commit_params(102, challenge_epoch, early_expiration, vec![]);
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "must exceed", ret);
             rt.reset();
         }
@@ -326,12 +296,8 @@ mod miner_actor_test_commitment {
                 - 1;
             let precommit_params =
                 h.make_pre_commit_params(102, challenge_epoch, expiration, vec![]);
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "must exceed", ret);
             rt.reset();
         }
@@ -345,12 +311,8 @@ mod miner_actor_test_commitment {
                         + 1);
             let precommit_params =
                 h.make_pre_commit_params(102, challenge_epoch, expiration, vec![]);
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "invalid expiration",
@@ -365,12 +327,8 @@ mod miner_actor_test_commitment {
             let expiration = *rt.epoch.borrow() + rt.policy.max_sector_expiration_extension + 1;
             let precommit_params =
                 h.make_pre_commit_params(102, challenge_epoch, expiration, vec![]);
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "invalid expiration",
@@ -387,12 +345,8 @@ mod miner_actor_test_commitment {
                 expiration,
                 vec![],
             );
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "out of range", ret);
             rt.reset();
         }
@@ -405,12 +359,8 @@ mod miner_actor_test_commitment {
                 - 1;
             let precommit_params =
                 h.make_pre_commit_params(102, too_old_challenge_epoch, expiration, vec![]);
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "too old", ret);
             rt.reset();
         }
@@ -422,12 +372,8 @@ mod miner_actor_test_commitment {
             rt.replace_state(&st);
             let precommit_params =
                 h.make_pre_commit_params(102, challenge_epoch, expiration, vec![]);
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(
                 ExitCode::USR_INSUFFICIENT_FUNDS,
                 "unlocked balance can not repay fee debt",
@@ -448,15 +394,11 @@ mod miner_actor_test_commitment {
                 fault_type: ConsensusFaultType::DoubleForkMining,
             };
             let test_addr = Address::new_id(1234);
-            h.report_consensus_fault(&mut rt, test_addr, Some(fault)).unwrap();
+            h.report_consensus_fault(&rt, test_addr, Some(fault)).unwrap();
             let precommit_params =
                 h.make_pre_commit_params(102, challenge_epoch, expiration, vec![]);
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                false,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), false);
             expect_abort_contains_message(ExitCode::USR_FORBIDDEN, "active consensus fault", ret);
             // reset state back to normal
             rt.replace_state(&st);
@@ -471,13 +413,13 @@ mod miner_actor_test_commitment {
 
             let mut h = ActorHarness::new(period_offset);
             h.set_proof_type(proof);
-            let mut rt = h.new_runtime();
+            let rt = h.new_runtime();
 
             rt.set_balance(BIG_BALANCE.clone());
             rt.set_received(TokenAmount::zero());
 
             rt.set_epoch(period_offset + 1);
-            h.construct_and_verify(&mut rt);
+            h.construct_and_verify(&rt);
             let deadline = h.deadline(&rt);
             (rt, h, deadline)
         };
@@ -493,7 +435,7 @@ mod miner_actor_test_commitment {
 
         for (proof, limit) in deal_limits {
             // attempt to pre-commmit a sector with too many deals
-            let (mut rt, h, deadline) = setup(proof);
+            let (rt, h, deadline) = setup(proof);
             let expiration =
                 deadline.period_end() + DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period;
             let precommit_params = h.make_pre_commit_params(
@@ -502,12 +444,8 @@ mod miner_actor_test_commitment {
                 expiration,
                 make_deal_ids(limit + 1),
             );
-            let ret = h.pre_commit_sector(
-                &mut rt,
-                precommit_params,
-                util::PreCommitConfig::default(),
-                true,
-            );
+            let ret =
+                h.pre_commit_sector(&rt, precommit_params, util::PreCommitConfig::default(), true);
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "too many deals for sector",
@@ -516,7 +454,7 @@ mod miner_actor_test_commitment {
             rt.reset();
 
             // sector at or below limit succeeds
-            let (mut rt, h, _) = setup(proof);
+            let (rt, h, _) = setup(proof);
             let precommit_params = h.make_pre_commit_params(
                 sector_number,
                 *rt.epoch.borrow() - 1,
@@ -524,7 +462,7 @@ mod miner_actor_test_commitment {
                 make_deal_ids(limit),
             );
             h.pre_commit_sector_and_get(
-                &mut rt,
+                &rt,
                 precommit_params,
                 util::PreCommitConfig::default(),
                 true,
@@ -538,12 +476,12 @@ mod miner_actor_test_commitment {
         let period_offset = ChainEpoch::from(100);
 
         let h = ActorHarness::new(period_offset);
-        let mut rt = h.new_runtime();
+        let rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
         rt.set_received(TokenAmount::zero());
 
-        h.construct_and_verify(&mut rt);
+        h.construct_and_verify(&rt);
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
         let deadline = h.deadline(&rt);
@@ -557,7 +495,7 @@ mod miner_actor_test_commitment {
             expect_abort(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 h.pre_commit_sector(
-                    &mut rt,
+                    &rt,
                     precommit_params.clone(),
                     util::PreCommitConfig::default(),
                     true,
@@ -566,7 +504,7 @@ mod miner_actor_test_commitment {
             rt.reset();
             precommit_params.seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
             h.pre_commit_sector_and_get(
-                &mut rt,
+                &rt,
                 precommit_params,
                 util::PreCommitConfig::default(),
                 true,
@@ -582,12 +520,12 @@ mod miner_actor_test_commitment {
 
         let mut h = ActorHarness::new(period_offset);
         h.set_proof_type(RegisteredSealProof::StackedDRG32GiBV1P1);
-        let mut rt = h.new_runtime();
+        let rt = h.new_runtime();
         rt.set_balance(BIG_BALANCE.clone());
         rt.set_received(TokenAmount::zero());
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
-        h.construct_and_verify(&mut rt);
+        h.construct_and_verify(&rt);
         let dl_info = h.deadline(&rt);
 
         // Make a good commitment for the proof to target.
@@ -613,11 +551,6 @@ mod miner_actor_test_commitment {
         let precommit_params =
             h.make_pre_commit_params(sector_number, precommit_epoch - 1, expiration, vec![1]);
         // The below call expects no pledge delta.
-        h.pre_commit_sector_and_get(
-            &mut rt,
-            precommit_params,
-            util::PreCommitConfig::default(),
-            true,
-        );
+        h.pre_commit_sector_and_get(&rt, precommit_params, util::PreCommitConfig::default(), true);
     }
 }

--- a/actors/miner/tests/miner_actor_test_ctl_addrs.rs
+++ b/actors/miner/tests/miner_actor_test_ctl_addrs.rs
@@ -4,12 +4,12 @@ mod util;
 
 #[test]
 fn test_control_addrs() {
-    let mut rt = MockRuntime::default();
+    let rt = MockRuntime::default();
     let h = util::ActorHarness::new(0);
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
-    let (owner, worker, control_addrs) = h.get_control_addresses(&mut rt);
+    let (owner, worker, control_addrs) = h.get_control_addresses(&rt);
     assert_eq!(h.owner, owner);
     assert_eq!(h.worker, worker);
     assert_eq!(h.control_addrs, control_addrs);

--- a/actors/miner/tests/miner_actor_test_peer_info.rs
+++ b/actors/miner/tests/miner_actor_test_peer_info.rs
@@ -9,85 +9,85 @@ mod util;
 
 #[test]
 fn test_can_set_peer_id() {
-    let mut rt = MockRuntime::default();
+    let rt = MockRuntime::default();
     let h = util::ActorHarness::new(0);
 
-    h.construct_and_verify(&mut rt);
-    h.set_peer_id(&mut rt, vec![1, 2, 3]);
+    h.construct_and_verify(&rt);
+    h.set_peer_id(&rt, vec![1, 2, 3]);
 
     h.check_state(&rt);
 }
 
 #[test]
 fn test_can_clear_peer_id() {
-    let mut rt = MockRuntime::default();
+    let rt = MockRuntime::default();
     let h = util::ActorHarness::new(0);
 
-    h.construct_and_verify(&mut rt);
-    h.set_peer_id(&mut rt, vec![]);
+    h.construct_and_verify(&rt);
+    h.set_peer_id(&rt, vec![]);
 
     h.check_state(&rt);
 }
 
 #[test]
 fn test_cant_set_large_peer_id() {
-    let mut rt = MockRuntime::default();
+    let rt = MockRuntime::default();
     let h = util::ActorHarness::new(0);
     let peer_id = vec![0; rt.policy.max_peer_id_length + 1];
 
-    h.construct_and_verify(&mut rt);
-    h.set_peer_id_fail(&mut rt, peer_id);
+    h.construct_and_verify(&rt);
+    h.set_peer_id_fail(&rt, peer_id);
 
     h.check_state(&rt);
 }
 
 #[test]
 fn can_set_multiaddrs() {
-    let mut rt = MockRuntime::default();
+    let rt = MockRuntime::default();
     let h = util::ActorHarness::new(0);
 
-    h.construct_and_verify(&mut rt);
-    h.set_multiaddr(&mut rt, vec![BytesDe(vec![1, 3, 3, 7])]);
+    h.construct_and_verify(&rt);
+    h.set_multiaddr(&rt, vec![BytesDe(vec![1, 3, 3, 7])]);
 
     h.check_state(&rt);
 }
 
 #[test]
 fn can_set_multiple_multiaddrs() {
-    let mut rt = MockRuntime::default();
+    let rt = MockRuntime::default();
     let h = util::ActorHarness::new(0);
 
-    h.construct_and_verify(&mut rt);
-    h.set_multiaddr(&mut rt, vec![BytesDe(vec![1, 3, 3, 7]), BytesDe(vec![2, 4, 4, 8])]);
+    h.construct_and_verify(&rt);
+    h.set_multiaddr(&rt, vec![BytesDe(vec![1, 3, 3, 7]), BytesDe(vec![2, 4, 4, 8])]);
 
     h.check_state(&rt);
 }
 
 #[test]
 fn can_set_clear_multiaddrs() {
-    let mut rt = MockRuntime::default();
+    let rt = MockRuntime::default();
     let h = util::ActorHarness::new(0);
 
-    h.construct_and_verify(&mut rt);
-    h.set_multiaddr(&mut rt, vec![]);
+    h.construct_and_verify(&rt);
+    h.set_multiaddr(&rt, vec![]);
 
     h.check_state(&rt);
 }
 
 #[test]
 fn cant_set_empty_multiaddrs() {
-    let mut rt = MockRuntime::default();
+    let rt = MockRuntime::default();
     let h = util::ActorHarness::new(0);
 
-    h.construct_and_verify(&mut rt);
-    h.set_multiaddr_fail(&mut rt, vec![BytesDe(vec![])]);
+    h.construct_and_verify(&rt);
+    h.set_multiaddr_fail(&rt, vec![BytesDe(vec![])]);
 
     h.check_state(&rt);
 }
 
 #[test]
 fn cant_set_large_multiaddrs() {
-    let mut rt = MockRuntime::default();
+    let rt = MockRuntime::default();
     let h = util::ActorHarness::new(0);
 
     let mut maddrs = Vec::new();
@@ -107,18 +107,18 @@ fn cant_set_large_multiaddrs() {
         ]));
     }
 
-    h.construct_and_verify(&mut rt);
-    h.set_multiaddr_fail(&mut rt, maddrs);
+    h.construct_and_verify(&rt);
+    h.set_multiaddr_fail(&rt, maddrs);
 
     h.check_state(&rt);
 }
 
 #[test]
 fn get_and_change_multiaddrs_restricted_correctly() {
-    let mut rt = MockRuntime::default();
+    let rt = MockRuntime::default();
     let h = util::ActorHarness::new(0);
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let new_multiaddrs = vec![BytesDe(vec![1, 3, 3, 7])];
 

--- a/actors/miner/tests/miner_actor_test_precommit_batch.rs
+++ b/actors/miner/tests/miner_actor_test_precommit_batch.rs
@@ -297,7 +297,7 @@ mod miner_actor_precommit_batch {
         let sectors = vec![
             h.make_pre_commit_params(100, precommit_epoch - 1, sector_expiration, vec![]),
             h.make_pre_commit_params(101, precommit_epoch - 1, sector_expiration, vec![]),
-            h.make_pre_commit_params(102, precommit_epoch - 1, rt.epoch, vec![]), // Expires too soon
+            h.make_pre_commit_params(102, precommit_epoch - 1, *rt.epoch.borrow(), vec![]), // Expires too soon
         ];
 
         expect_abort_contains_message(
@@ -415,7 +415,7 @@ mod miner_actor_precommit_batch {
             let dlinfo = new_deadline_info_from_offset_and_epoch(
                 &rt.policy,
                 state.proving_period_start,
-                rt.epoch,
+                *rt.epoch.borrow(),
             );
             let cron_params = make_deadline_cron_event_params(dlinfo.last());
             rt.expect_send_simple(

--- a/actors/miner/tests/miner_actor_test_precommit_batch.rs
+++ b/actors/miner/tests/miner_actor_test_precommit_batch.rs
@@ -48,11 +48,11 @@ fn assert_simple_batch(
         use_v2_pre_commit_and_replica_update: v2,
         proving_period_offset: period_offset,
     });
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
 
     let precommit_epoch = period_offset + 1;
     rt.set_epoch(precommit_epoch);
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let dl_info = h.deadline(&rt);
 
     let sector_nos: Vec<SectorNumber> = (0..batch_size).map(|x| x as u64 + 100).collect();
@@ -97,7 +97,7 @@ fn assert_simple_batch(
             exit_code,
             error_str,
             h.pre_commit_sector_batch(
-                &mut rt,
+                &rt,
                 PreCommitSectorBatchParams { sectors },
                 &conf,
                 &base_fee,
@@ -113,7 +113,7 @@ fn assert_simple_batch(
         return;
     }
     let precommits = h.pre_commit_sector_batch_and_get(
-        &mut rt,
+        &rt,
         PreCommitSectorBatchParams { sectors: sectors.clone() },
         &conf,
         &base_fee,
@@ -282,14 +282,14 @@ mod miner_actor_precommit_batch {
             proving_period_offset: period_offset,
         });
 
-        let mut rt = h.new_runtime();
+        let rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
         rt.set_received(TokenAmount::zero());
 
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
-        h.construct_and_verify(&mut rt);
+        h.construct_and_verify(&rt);
         let dl_info = h.deadline(&rt);
 
         let sector_expiration =
@@ -304,7 +304,7 @@ mod miner_actor_precommit_batch {
             ExitCode::USR_ILLEGAL_ARGUMENT,
             "sector expiration",
             h.pre_commit_sector_batch(
-                &mut rt,
+                &rt,
                 PreCommitSectorBatchParams { sectors },
                 &PreCommitBatchConfig { sector_deal_data: vec![], first_for_miner: true },
                 &TokenAmount::zero(),
@@ -322,14 +322,14 @@ mod miner_actor_precommit_batch {
             use_v2_pre_commit_and_replica_update: v2,
             proving_period_offset: period_offset,
         });
-        let mut rt = h.new_runtime();
+        let rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
         rt.set_received(TokenAmount::zero());
 
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
-        h.construct_and_verify(&mut rt);
+        h.construct_and_verify(&rt);
         let dl_info = h.deadline(&rt);
 
         let sector_expiration =
@@ -344,7 +344,7 @@ mod miner_actor_precommit_batch {
             ExitCode::USR_ILLEGAL_ARGUMENT,
             "duplicate sector number 100",
             h.pre_commit_sector_batch(
-                &mut rt,
+                &rt,
                 PreCommitSectorBatchParams { sectors },
                 &PreCommitBatchConfig { sector_deal_data: vec![], first_for_miner: true },
                 &TokenAmount::zero(),
@@ -361,14 +361,14 @@ mod miner_actor_precommit_batch {
             use_v2_pre_commit_and_replica_update: true,
             proving_period_offset: period_offset,
         });
-        let mut rt = h.new_runtime();
+        let rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
         rt.set_received(TokenAmount::zero());
 
         let precommit_epoch = period_offset + 1;
         rt.set_epoch(precommit_epoch);
-        h.construct_and_verify(&mut rt);
+        h.construct_and_verify(&rt);
         let dl_info = h.deadline(&rt);
 
         let sector_expiration =
@@ -385,7 +385,7 @@ mod miner_actor_precommit_batch {
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
             rt.expect_validate_caller_addr(h.caller_addrs());
 
-            h.expect_query_network_info(&mut rt);
+            h.expect_query_network_info(&rt);
             let mut sector_deals = Vec::new();
             let mut sector_deal_data = Vec::new();
             for sector in &sectors {

--- a/actors/miner/tests/miner_actor_test_wpost.rs
+++ b/actors/miner/tests/miner_actor_test_wpost.rs
@@ -30,27 +30,27 @@ fn basic_post_and_dispute() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
-    let sectors = h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+    let sectors = h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
     let sector = sectors[0].clone();
     let pwr = miner::power_for_sector(h.sector_size, &sector);
 
     // Skip to the right deadline
     let state = h.get_state(&rt);
     let (dlidx, pidx) = state.find_sector(&rt.policy, &rt.store, sector.sector_number).unwrap();
-    let dlinfo = h.advance_to_deadline(&mut rt, dlidx);
+    let dlinfo = h.advance_to_deadline(&rt, dlidx);
 
     // Submit PoSt
     let post_partitions =
         vec![miner::PoStPartition { index: pidx, skipped: make_empty_bitfield() }];
     let post_sectors = vec![sector.clone()];
     h.submit_window_post(
-        &mut rt,
+        &rt,
         &dlinfo,
         post_partitions,
         post_sectors,
@@ -67,7 +67,7 @@ fn basic_post_and_dispute() {
     assert_bitfield_equals(&posts[0].partitions, &deadline_bits);
 
     // Advance to end-of-deadline cron to verify no penalties.
-    h.advance_deadline(&mut rt, CronConfig::empty());
+    h.advance_deadline(&rt, CronConfig::empty());
     h.check_state(&rt);
 
     // Proofs should exist in snapshot.
@@ -79,7 +79,7 @@ fn basic_post_and_dispute() {
 
     // Try a failed dispute.
     let dispute_sectors = vec![sector];
-    h.dispute_window_post(&mut rt, &dlinfo, 0, &dispute_sectors, None);
+    h.dispute_window_post(&rt, &dlinfo, 0, &dispute_sectors, None);
 
     // Now a successful dispute.
     let expected_fee = miner::pledge_penalty_for_invalid_windowpost(
@@ -93,7 +93,7 @@ fn basic_post_and_dispute() {
         expected_reward: Some(miner::BASE_REWARD_FOR_DISPUTED_WINDOW_POST.clone()),
         expected_pledge_delta: None,
     };
-    h.dispute_window_post(&mut rt, &dlinfo, 0, &dispute_sectors, Some(expected_result));
+    h.dispute_window_post(&rt, &dlinfo, 0, &dispute_sectors, Some(expected_result));
 }
 
 #[test]
@@ -102,21 +102,21 @@ fn invalid_submissions() {
     let precommit_epoch = ChainEpoch::from(1);
 
     let mut h = ActorHarness::new(period_offset);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
 
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
-    let sectors = h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+    let sectors = h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
     let sector = sectors[0].clone();
     let pwr = miner::power_for_sector(h.sector_size, &sector);
 
     // Skip to the due deadline.
     let state = h.get_state(&rt);
     let (dlidx, pidx) = state.find_sector(&rt.policy, &rt.store, sector.sector_number).unwrap();
-    let dlinfo = h.advance_to_deadline(&mut rt, dlidx);
+    let dlinfo = h.advance_to_deadline(&rt, dlidx);
 
     // Invalid deadline.
     {
@@ -129,7 +129,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -150,7 +150,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -178,7 +178,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -203,7 +203,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -224,7 +224,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -249,7 +249,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -274,7 +274,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -299,7 +299,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -326,7 +326,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -351,7 +351,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(b"123456789012345678901234567890123".to_vec()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -377,7 +377,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -405,7 +405,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -430,7 +430,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -455,7 +455,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector.clone()],
             params,
@@ -480,7 +480,7 @@ fn invalid_submissions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             vec![sector],
             params,
@@ -499,28 +499,28 @@ fn duplicate_proof_rejected() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
 
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
-    let sectors = h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+    let sectors = h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
     let sector = sectors[0].clone();
     let pwr = miner::power_for_sector(h.sector_size, &sector);
 
     // Skip to the due deadline.
     let state = h.get_state(&rt);
     let (dlidx, pidx) = state.find_sector(&rt.policy, &rt.store, sector.sector_number).unwrap();
-    let dlinfo = h.advance_to_deadline(&mut rt, dlidx);
+    let dlinfo = h.advance_to_deadline(&rt, dlidx);
 
     // Submit PoSt
     let post_partitions =
         vec![miner::PoStPartition { index: pidx, skipped: make_empty_bitfield() }];
     let post_sectors = vec![sector.clone()];
     h.submit_window_post(
-        &mut rt,
+        &rt,
         &dlinfo,
         post_partitions,
         post_sectors,
@@ -549,7 +549,7 @@ fn duplicate_proof_rejected() {
         chain_commit_rand: Randomness(commit_rand.clone().into()),
     };
 
-    h.expect_query_network_info(&mut rt);
+    h.expect_query_network_info(&rt);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
 
     // From version 7, a duplicate is explicitly rejected.
@@ -573,7 +573,7 @@ fn duplicate_proof_rejected() {
     rt.reset();
 
     // Advance to end-of-deadline cron to verify no penalties.
-    h.advance_deadline(&mut rt, CronConfig::empty());
+    h.advance_deadline(&rt, CronConfig::empty());
     h.check_state(&rt);
 }
 
@@ -585,17 +585,17 @@ fn duplicate_proof_rejected_with_many_partitions() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
 
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     // Commit more sectors than fit in one partition in every eligible deadline, overflowing to a second partition.
     let sectors_to_commit = (rt.policy.wpost_period_deadlines - 2) * h.partition_size + 1;
     let sectors = h.commit_and_prove_sectors(
-        &mut rt,
+        &rt,
         sectors_to_commit as usize,
         DEFAULT_SECTOR_EXPIRATION,
         vec![],
@@ -606,7 +606,7 @@ fn duplicate_proof_rejected_with_many_partitions() {
     // Skip to the due deadline.
     let state = h.get_state(&rt);
     let (dlidx, _) = state.find_sector(&rt.policy, &rt.store, last_sector.sector_number).unwrap();
-    let dlinfo = h.advance_to_deadline(&mut rt, dlidx);
+    let dlinfo = h.advance_to_deadline(&rt, dlidx);
 
     {
         // Submit PoSt for partition 0 on its own.
@@ -616,7 +616,7 @@ fn duplicate_proof_rejected_with_many_partitions() {
             (0..h.partition_size).map(|i| sectors[i as usize].clone()).collect();
         let pwr = miner::power_for_sectors(h.sector_size, &sectors_to_prove);
         h.submit_window_post(
-            &mut rt,
+            &rt,
             &dlinfo,
             post_partitions,
             sectors_to_prove,
@@ -646,7 +646,7 @@ fn duplicate_proof_rejected_with_many_partitions() {
             chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
         };
         let result = h.submit_window_post_raw(
-            &mut rt,
+            &rt,
             &dlinfo,
             sectors_to_prove,
             params,
@@ -666,7 +666,7 @@ fn duplicate_proof_rejected_with_many_partitions() {
         let sectors_to_prove = vec![last_sector.clone()];
         let pwr = miner::power_for_sectors(h.sector_size, &sectors_to_prove);
         h.submit_window_post(
-            &mut rt,
+            &rt,
             &dlinfo,
             post_partitions,
             sectors_to_prove,
@@ -679,7 +679,7 @@ fn duplicate_proof_rejected_with_many_partitions() {
     }
 
     // Advance to end-of-deadline cron to verify no penalties.
-    h.advance_deadline(&mut rt, CronConfig::empty());
+    h.advance_deadline(&rt, CronConfig::empty());
     h.check_state(&rt);
 }
 
@@ -691,47 +691,47 @@ fn successful_recoveries_recover_power() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
-    let infos = h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+    let infos = h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
     let pwr = miner::power_for_sectors(h.sector_size, &infos);
 
-    h.apply_rewards(&mut rt, BIG_REWARDS.clone(), TokenAmount::zero());
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
     let initial_locked = h.get_locked_funds(&rt);
 
     // Submit first PoSt to ensure we are sufficiently early to add a fault
     // advance to next proving period
-    h.advance_and_submit_posts(&mut rt, &infos);
+    h.advance_and_submit_posts(&rt, &infos);
 
     // advance deadline and declare fault
-    h.advance_deadline(&mut rt, CronConfig::empty());
-    h.declare_faults(&mut rt, &infos);
+    h.advance_deadline(&rt, CronConfig::empty());
+    h.declare_faults(&rt, &infos);
 
     // advance a deadline and declare recovery
-    h.advance_deadline(&mut rt, CronConfig::empty());
+    h.advance_deadline(&rt, CronConfig::empty());
 
     // declare recovery
     let state = h.get_state(&rt);
     let (dlidx, pidx) = state.find_sector(&rt.policy, &rt.store, infos[0].sector_number).unwrap();
     let mut bf = BitField::new();
     bf.set(infos[0].sector_number);
-    h.declare_recoveries(&mut rt, dlidx, pidx, bf, TokenAmount::zero()).unwrap();
+    h.declare_recoveries(&rt, dlidx, pidx, bf, TokenAmount::zero()).unwrap();
 
     // advance to epoch when submitPoSt is due
     let mut dlinfo = h.deadline(&rt);
     while dlinfo.index != dlidx {
-        dlinfo = h.advance_deadline(&mut rt, CronConfig::empty());
+        dlinfo = h.advance_deadline(&rt, CronConfig::empty());
     }
 
     // Now submit PoSt
     // Power should return for recovered sector.
     let cfg = PoStConfig::with_expected_power_delta(&pwr);
     let partition = miner::PoStPartition { index: pidx, skipped: make_empty_bitfield() };
-    h.submit_window_post(&mut rt, &dlinfo, vec![partition], infos.clone(), cfg);
+    h.submit_window_post(&rt, &dlinfo, vec![partition], infos.clone(), cfg);
 
     // faulty power has been removed, partition no longer has faults or recoveries
     let (deadline, partition) = h.find_sector(&rt, infos[0].sector_number);
@@ -748,7 +748,7 @@ fn successful_recoveries_recover_power() {
     assert!(posts.is_empty());
 
     // Next deadline cron does not charge for the fault
-    h.advance_deadline(&mut rt, CronConfig::empty());
+    h.advance_deadline(&rt, CronConfig::empty());
 
     assert_eq!(initial_locked, h.get_locked_funds(&rt));
 
@@ -763,16 +763,16 @@ fn skipped_faults_adjust_power() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
 
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
-    let infos = h.commit_and_prove_sectors(&mut rt, 2, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+    let infos = h.commit_and_prove_sectors(&rt, 2, DEFAULT_SECTOR_EXPIRATION, vec![], true);
 
-    h.apply_rewards(&mut rt, BIG_REWARDS.clone(), TokenAmount::zero());
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
 
     // Skip to the due deadline.
     let state = h.get_state(&rt);
@@ -780,7 +780,7 @@ fn skipped_faults_adjust_power() {
     let (dlidx2, pidx2) = state.find_sector(&rt.policy, &rt.store, infos[1].sector_number).unwrap();
     assert_eq!(dlidx, dlidx2);
 
-    let mut dlinfo = h.advance_to_deadline(&mut rt, dlidx);
+    let mut dlinfo = h.advance_to_deadline(&rt, dlidx);
 
     // Now submit PoSt with a skipped fault for first sector
     // First sector's power should not be activated.
@@ -790,7 +790,7 @@ fn skipped_faults_adjust_power() {
     let partition =
         miner::PoStPartition { index: pidx, skipped: make_bitfield(&[infos1[0].sector_number]) };
     h.submit_window_post(
-        &mut rt,
+        &rt,
         &dlinfo,
         vec![partition],
         infos2.clone(),
@@ -799,11 +799,11 @@ fn skipped_faults_adjust_power() {
 
     // expect continued fault fee to be charged during cron
     let fault_fee = h.continued_fault_penalty(&infos1);
-    dlinfo = h.advance_deadline(&mut rt, CronConfig::with_continued_faults_penalty(fault_fee));
+    dlinfo = h.advance_deadline(&rt, CronConfig::with_continued_faults_penalty(fault_fee));
 
     // advance to next proving period, expect no fees
     while dlinfo.index != dlidx {
-        dlinfo = h.advance_deadline(&mut rt, CronConfig::empty());
+        dlinfo = h.advance_deadline(&rt, CronConfig::empty());
     }
 
     // Attempt to skip second sector
@@ -820,7 +820,7 @@ fn skipped_faults_adjust_power() {
 
     // Now all sectors are faulty so there's nothing to prove.
     let result = h.submit_window_post_raw(
-        &mut rt,
+        &rt,
         &dlinfo,
         infos2.clone(),
         params,
@@ -834,7 +834,7 @@ fn skipped_faults_adjust_power() {
     let pwr_delta = -miner::power_for_sectors(h.sector_size, &infos2);
     let fault_fee = h.continued_fault_penalty(&infos1);
     h.advance_deadline(
-        &mut rt,
+        &rt,
         CronConfig::with_detected_faults_power_delta_and_continued_faults_penalty(
             &pwr_delta, fault_fee,
         ),
@@ -851,15 +851,15 @@ fn skipping_all_sectors_in_a_partition_rejected() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
-    let infos = h.commit_and_prove_sectors(&mut rt, 2, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+    let infos = h.commit_and_prove_sectors(&rt, 2, DEFAULT_SECTOR_EXPIRATION, vec![], true);
 
-    h.apply_rewards(&mut rt, BIG_REWARDS.clone(), TokenAmount::zero());
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
 
     // Skip to the due deadline.
     let state = h.get_state(&rt);
@@ -868,7 +868,7 @@ fn skipping_all_sectors_in_a_partition_rejected() {
     assert_eq!(dlidx, dlidx2);
     assert_eq!(pidx, pidx2);
 
-    let dlinfo = h.advance_to_deadline(&mut rt, dlidx);
+    let dlinfo = h.advance_to_deadline(&rt, dlidx);
 
     // PoSt with all sectors skipped fails to validate, leaving power un-activated.
     let partition = miner::PoStPartition {
@@ -882,13 +882,12 @@ fn skipping_all_sectors_in_a_partition_rejected() {
         chain_commit_epoch: dlinfo.challenge,
         chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
     };
-    let result =
-        h.submit_window_post_raw(&mut rt, &dlinfo, infos.clone(), params, PoStConfig::empty());
+    let result = h.submit_window_post_raw(&rt, &dlinfo, infos.clone(), params, PoStConfig::empty());
     expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, result);
     rt.reset();
 
     // These sectors are detected faulty and pay no penalty this time.
-    h.advance_deadline(&mut rt, CronConfig::with_continued_faults_penalty(TokenAmount::zero()));
+    h.advance_deadline(&rt, CronConfig::with_continued_faults_penalty(TokenAmount::zero()));
     h.check_state(&rt);
 }
 
@@ -900,47 +899,47 @@ fn skipped_recoveries_are_penalized_and_do_not_recover_power() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
-    let infos = h.commit_and_prove_sectors(&mut rt, 2, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+    let infos = h.commit_and_prove_sectors(&rt, 2, DEFAULT_SECTOR_EXPIRATION, vec![], true);
 
-    h.apply_rewards(&mut rt, BIG_REWARDS.clone(), TokenAmount::zero());
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
 
     // Submit first PoSt to ensure we are sufficiently early to add a fault
     // advance to next proving period
-    h.advance_and_submit_posts(&mut rt, &infos);
+    h.advance_and_submit_posts(&rt, &infos);
 
     // advance deadline and declare fault on the first sector
     let infos1 = vec![infos[0].clone()];
-    h.advance_deadline(&mut rt, CronConfig::empty());
-    h.declare_faults(&mut rt, &infos1);
+    h.advance_deadline(&rt, CronConfig::empty());
+    h.declare_faults(&rt, &infos1);
 
     // advance a deadline and declare recovery
-    h.advance_deadline(&mut rt, CronConfig::empty());
+    h.advance_deadline(&rt, CronConfig::empty());
 
     // declare recovery
     let state = h.get_state(&rt);
     let (dlidx, pidx) = state.find_sector(&rt.policy, &rt.store, infos[0].sector_number).unwrap();
     let mut bf = BitField::new();
     bf.set(infos[0].sector_number);
-    h.declare_recoveries(&mut rt, dlidx, pidx, bf, TokenAmount::zero()).unwrap();
+    h.declare_recoveries(&rt, dlidx, pidx, bf, TokenAmount::zero()).unwrap();
 
     // Skip to the due deadline.
-    let dlinfo = h.advance_to_deadline(&mut rt, dlidx);
+    let dlinfo = h.advance_to_deadline(&rt, dlidx);
 
     // Now submit PoSt and skip recovered sector.
     // No power should be returned
     let partition =
         miner::PoStPartition { index: pidx, skipped: make_bitfield(&[infos[0].sector_number]) };
-    h.submit_window_post(&mut rt, &dlinfo, vec![partition], infos.clone(), PoStConfig::empty());
+    h.submit_window_post(&rt, &dlinfo, vec![partition], infos.clone(), PoStConfig::empty());
 
     // sector will be charged ongoing fee at proving period cron
     let ongoing_fee = h.continued_fault_penalty(&infos1);
-    h.advance_deadline(&mut rt, CronConfig::with_continued_faults_penalty(ongoing_fee));
+    h.advance_deadline(&rt, CronConfig::with_continued_faults_penalty(ongoing_fee));
 
     h.check_state(&rt);
 }
@@ -953,23 +952,23 @@ fn skipping_a_fault_from_the_wrong_partition_is_an_error() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     // create enough sectors that one will be in a different partition
     // TODO: remove magic number and derive from seal proof based parameter
     const N: usize = 95;
-    let infos = h.commit_and_prove_sectors(&mut rt, N, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+    let infos = h.commit_and_prove_sectors(&rt, N, DEFAULT_SECTOR_EXPIRATION, vec![], true);
 
     // Skip to the due deadline.
     let state = h.get_state(&rt);
     let (dlidx0, pidx0) = state.find_sector(&rt.policy, &rt.store, infos[0].sector_number).unwrap();
     let (dlidx1, pidx1) =
         state.find_sector(&rt.policy, &rt.store, infos[N - 1].sector_number).unwrap();
-    let dlinfo = h.advance_to_deadline(&mut rt, dlidx0);
+    let dlinfo = h.advance_to_deadline(&rt, dlidx0);
 
     // if these assertions no longer hold, the test must be changed
     assert!(dlidx0 < dlidx1);
@@ -987,7 +986,7 @@ fn skipping_a_fault_from_the_wrong_partition_is_an_error() {
         chain_commit_epoch: dlinfo.challenge,
         chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
     };
-    let result = h.submit_window_post_raw(&mut rt, &dlinfo, infos, params, PoStConfig::empty());
+    let result = h.submit_window_post_raw(&rt, &dlinfo, infos, params, PoStConfig::empty());
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "skipped faults contains sectors outside partition",
@@ -1005,25 +1004,25 @@ fn cannot_dispute_posts_when_the_challenge_window_is_open() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
-    let infos = h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+    let infos = h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
     let sector = infos[0].clone();
     let pwr = miner::power_for_sector(h.sector_size, &sector);
 
     // Skip to the due deadline.
     let state = h.get_state(&rt);
     let (dlidx, pidx) = state.find_sector(&rt.policy, &rt.store, sector.sector_number).unwrap();
-    let dlinfo = h.advance_to_deadline(&mut rt, dlidx);
+    let dlinfo = h.advance_to_deadline(&rt, dlidx);
 
     // Submit PoSt
     let partition = miner::PoStPartition { index: pidx, skipped: make_empty_bitfield() };
     h.submit_window_post(
-        &mut rt,
+        &rt,
         &dlinfo,
         vec![partition],
         infos,
@@ -1035,7 +1034,7 @@ fn cannot_dispute_posts_when_the_challenge_window_is_open() {
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
     rt.expect_validate_caller_any();
-    h.expect_query_network_info(&mut rt);
+    h.expect_query_network_info(&rt);
 
     let result = rt.call::<miner::Actor>(
         miner::Method::DisputeWindowedPoSt as u64,
@@ -1057,13 +1056,13 @@ fn can_dispute_up_till_window_end_but_not_after() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
-    let infos = h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+    let infos = h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
     let sector = infos[0].clone();
 
     let state = h.get_state(&rt);
@@ -1081,13 +1080,13 @@ fn can_dispute_up_till_window_end_but_not_after() {
     )
     .next_not_elapsed();
 
-    h.advance_and_submit_posts(&mut rt, &infos);
+    h.advance_and_submit_posts(&rt, &infos);
     let window_end = nextdl.close + rt.policy.wpost_dispute_window;
 
     // first, try to dispute right before the window end.
     // We expect this to fail "normally" (fail to disprove).
     rt.epoch.replace(window_end - 1);
-    h.dispute_window_post(&mut rt, &nextdl, 0, &infos, None);
+    h.dispute_window_post(&rt, &nextdl, 0, &infos, None);
 
     // Now set the epoch at the window end. We expect a different error.
     rt.epoch.replace(window_end);
@@ -1096,7 +1095,7 @@ fn can_dispute_up_till_window_end_but_not_after() {
     let params = miner::DisputeWindowedPoStParams { deadline: dlidx, post_index: 0 };
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, h.worker);
     rt.expect_validate_caller_any();
-    h.expect_query_network_info(&mut rt);
+    h.expect_query_network_info(&rt);
 
     let result = rt.call::<miner::Actor>(
         miner::Method::DisputeWindowedPoSt as u64,
@@ -1118,11 +1117,11 @@ fn cant_dispute_up_with_an_invalid_deadline() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let params = miner::DisputeWindowedPoStParams { deadline: 50, post_index: 0 };
 
@@ -1145,11 +1144,11 @@ fn can_dispute_test_after_proving_period_changes() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let period_start = h.deadline(&rt).next_period_start();
 
@@ -1162,7 +1161,7 @@ fn can_dispute_test_after_proving_period_changes() {
     // creates a partition in every deadline except 0 and 47
     // TODO: when fixing last wpost test verify that this is true
     let sectors = h.commit_and_prove_sectors(
-        &mut rt,
+        &rt,
         num_sectors as usize,
         DEFAULT_SECTOR_EXPIRATION,
         vec![],
@@ -1171,7 +1170,7 @@ fn can_dispute_test_after_proving_period_changes() {
 
     // prove every sector once to activate power. This
     // simplifies the test a bit.
-    h.advance_and_submit_posts(&mut rt, &sectors);
+    h.advance_and_submit_posts(&rt, &sectors);
 
     // Make sure we're in the correct deadline. We should
     // finish at deadline 2 because precommit takes some
@@ -1220,7 +1219,7 @@ fn can_dispute_test_after_proving_period_changes() {
         rt.policy.fault_declaration_cutoff,
     );
 
-    h.dispute_window_post(&mut rt, &target_dlinfo, 0, &target_sectors, Some(post_dispute_result));
+    h.dispute_window_post(&rt, &target_dlinfo, 0, &target_sectors, Some(post_dispute_result));
 }
 
 #[test]
@@ -1231,17 +1230,17 @@ fn bad_post_fails_when_verified() {
     let mut h = ActorHarness::new(period_offset);
     h.set_proof_type(RegisteredSealProof::StackedDRG2KiBV1P1);
 
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.epoch.replace(precommit_epoch);
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
-    let infos = h.commit_and_prove_sectors(&mut rt, 2, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+    let infos = h.commit_and_prove_sectors(&rt, 2, DEFAULT_SECTOR_EXPIRATION, vec![], true);
     let power_for_sectors =
         &miner::power_for_sectors(h.sector_size, &vec![infos[0].clone(), infos[1].clone()]);
 
-    h.apply_rewards(&mut rt, BIG_REWARDS.clone(), TokenAmount::zero());
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
 
     let state = h.get_state(&rt);
     let (dlidx, pidx) = state.find_sector(&rt.policy, &rt.store, infos[0].sector_number).unwrap();
@@ -1251,13 +1250,13 @@ fn bad_post_fails_when_verified() {
 
     // Become faulty
 
-    h.advance_to_deadline(&mut rt, dlidx);
-    h.advance_deadline(&mut rt, CronConfig::empty());
-    h.advance_to_deadline(&mut rt, dlidx);
+    h.advance_to_deadline(&rt, dlidx);
+    h.advance_deadline(&rt, CronConfig::empty());
+    h.advance_to_deadline(&rt, dlidx);
 
     let fault_fee = h.continued_fault_penalty(&vec![infos[0].clone(), infos[1].clone()]);
     h.advance_deadline(
-        &mut rt,
+        &rt,
         CronConfig::with_detected_faults_power_delta_and_continued_faults_penalty(
             &PowerPair::zero(),
             fault_fee,
@@ -1269,10 +1268,10 @@ fn bad_post_fails_when_verified() {
     let mut bf = BitField::new();
     bf.set(infos[0].sector_number);
     bf.set(infos[1].sector_number);
-    h.declare_recoveries(&mut rt, dlidx, pidx, bf, TokenAmount::zero()).unwrap();
+    h.declare_recoveries(&rt, dlidx, pidx, bf, TokenAmount::zero()).unwrap();
 
     // Now submit a PoSt, but a BAD one
-    let dlinfo = h.advance_to_deadline(&mut rt, dlidx);
+    let dlinfo = h.advance_to_deadline(&rt, dlidx);
 
     let partition = miner::PoStPartition { index: pidx, skipped: make_bitfield(&[]) };
     let mut post_config = PoStConfig::with_expected_power_delta(power_for_sectors);
@@ -1286,7 +1285,7 @@ fn bad_post_fails_when_verified() {
         chain_commit_epoch: dlinfo.challenge,
         chain_commit_rand: Randomness(TEST_RANDOMNESS_ARRAY_FROM_ONE.into()),
     };
-    let result = h.submit_window_post_raw(&mut rt, &dlinfo, infos, params, post_config);
+    let result = h.submit_window_post_raw(&rt, &dlinfo, infos, params, post_config);
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "invalid post was submitted",

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -584,8 +584,7 @@ fn sector_with_non_positive_lifetime_is_skipped_in_confirmation() {
 
     // it fails up to the miniumum expiration
     rt.set_epoch(precommit.info.expiration - rt.policy.min_sector_expiration + 1);
-    h.confirm_sector_proofs_valid(&rt, ProveCommitConfig::empty(), vec![precommit])
-        .unwrap();
+    h.confirm_sector_proofs_valid(&rt, ProveCommitConfig::empty(), vec![precommit]).unwrap();
     let st = h.get_state(&rt);
     assert!(st.get_sector(&rt.store, sector_no).unwrap().is_none());
     h.check_state(&rt);

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -584,7 +584,7 @@ fn sector_with_non_positive_lifetime_is_skipped_in_confirmation() {
 
     // it fails up to the miniumum expiration
     rt.set_epoch(precommit.info.expiration - rt.policy.min_sector_expiration + 1);
-    h.confirm_sector_proofs_valid(&rt, ProveCommitConfig::empty(), vec![precommit.clone()])
+    h.confirm_sector_proofs_valid(&rt, ProveCommitConfig::empty(), vec![precommit])
         .unwrap();
     let st = h.get_state(&rt);
     assert!(st.get_sector(&rt.store, sector_no).unwrap().is_none());

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -30,13 +30,13 @@ const PERIOD_OFFSET: ChainEpoch = 100;
 #[test]
 fn prove_single_sector() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.balance.replace(BIG_BALANCE.clone());
 
     let precommit_epoch = PERIOD_OFFSET + 1;
     rt.set_epoch(precommit_epoch);
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let dl_info = h.deadline(&rt);
 
     // Make a good commitment for the proof to target.
@@ -56,7 +56,7 @@ fn prove_single_sector() {
     let precommit_params =
         h.make_pre_commit_params(sector_no, precommit_epoch - 1, expiration, vec![1]);
     let precommit =
-        h.pre_commit_sector_and_get(&mut rt, precommit_params, PreCommitConfig::empty(), true);
+        h.pre_commit_sector_and_get(&rt, precommit_params, PreCommitConfig::empty(), true);
 
     let pwr_estimate = qa_power_max(h.sector_size);
     let expected_deposit = pre_commit_deposit_for_power(
@@ -78,7 +78,7 @@ fn prove_single_sector() {
 
     let sector = h
         .prove_commit_sector_and_confirm(
-            &mut rt,
+            &rt,
             &precommit,
             h.make_prove_commit_params(sector_no),
             pcc,
@@ -159,13 +159,13 @@ fn prove_single_sector() {
 #[test]
 fn prove_sectors_from_batch_pre_commit() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.balance.replace(BIG_BALANCE.clone());
 
     let precommit_epoch = PERIOD_OFFSET + 1;
     rt.set_epoch(precommit_epoch);
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let dl_info = h.deadline(&rt);
 
     let sector_expiration =
@@ -196,7 +196,7 @@ fn prove_sectors_from_batch_pre_commit() {
     };
 
     let precommits = h.pre_commit_sector_batch_and_get(
-        &mut rt,
+        &rt,
         PreCommitSectorBatchParams { sectors },
         &conf,
         &TokenAmount::zero(),
@@ -239,7 +239,7 @@ fn prove_sectors_from_batch_pre_commit() {
         let precommit = &precommits[0];
         let sector = h
             .prove_commit_sector_and_confirm(
-                &mut rt,
+                &rt,
                 precommit,
                 h.make_prove_commit_params(precommit.info.sector_number),
                 ProveCommitConfig::default(),
@@ -266,7 +266,7 @@ fn prove_sectors_from_batch_pre_commit() {
         pcc.add_verified_deals(precommit.info.sector_number, vec![verified_deal1]);
         let sector = h
             .prove_commit_sector_and_confirm(
-                &mut rt,
+                &rt,
                 precommit,
                 h.make_prove_commit_params(precommit.info.sector_number),
                 pcc,
@@ -293,7 +293,7 @@ fn prove_sectors_from_batch_pre_commit() {
         pcc.add_verified_deals(precommit.info.sector_number, vec![verified_deal2, verified_deal3]);
         let sector = h
             .prove_commit_sector_and_confirm(
-                &mut rt,
+                &rt,
                 precommit,
                 h.make_prove_commit_params(precommit.info.sector_number),
                 pcc,
@@ -312,13 +312,13 @@ fn prove_sectors_from_batch_pre_commit() {
 #[test]
 fn invalid_proof_rejected() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.balance.replace(BIG_BALANCE.clone());
 
     let precommit_epoch = PERIOD_OFFSET + 1;
     rt.set_epoch(precommit_epoch);
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let deadline = h.deadline(&rt);
 
     // Make a good commitment for the proof to target.
@@ -329,14 +329,14 @@ fn invalid_proof_rejected() {
         deadline.period_end() + DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period,
         vec![1],
     );
-    let precommit = h.pre_commit_sector_and_get(&mut rt, params, PreCommitConfig::default(), true);
+    let precommit = h.pre_commit_sector_and_get(&rt, params, PreCommitConfig::default(), true);
 
     // Sector pre-commitment missing.
     rt.set_epoch(precommit_epoch + rt.policy.pre_commit_challenge_delay + 1);
     expect_abort(
         ExitCode::USR_NOT_FOUND,
         h.prove_commit_sector_and_confirm(
-            &mut rt,
+            &rt,
             &precommit,
             h.make_prove_commit_params(sector_no + 1),
             ProveCommitConfig::empty(),
@@ -353,7 +353,7 @@ fn invalid_proof_rejected() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         h.prove_commit_sector_and_confirm(
-            &mut rt,
+            &rt,
             &precommit,
             h.make_prove_commit_params(sector_no),
             ProveCommitConfig::empty(),
@@ -366,7 +366,7 @@ fn invalid_proof_rejected() {
     expect_abort(
         ExitCode::USR_FORBIDDEN,
         h.prove_commit_sector_and_confirm(
-            &mut rt,
+            &rt,
             &precommit,
             h.make_prove_commit_params(sector_no),
             ProveCommitConfig::empty(),
@@ -383,7 +383,7 @@ fn invalid_proof_rejected() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         h.prove_commit_sector_and_confirm(
-            &mut rt,
+            &rt,
             &precommit,
             h.make_prove_commit_params(sector_no),
             ProveCommitConfig { verify_deals_exit, ..Default::default() },
@@ -394,13 +394,8 @@ fn invalid_proof_rejected() {
     rt.balance.replace(TokenAmount::from_whole(1_000));
 
     let prove_commit = h.make_prove_commit_params(sector_no);
-    h.prove_commit_sector_and_confirm(
-        &mut rt,
-        &precommit,
-        prove_commit,
-        ProveCommitConfig::empty(),
-    )
-    .unwrap();
+    h.prove_commit_sector_and_confirm(&rt, &precommit, prove_commit, ProveCommitConfig::empty())
+        .unwrap();
     let st = h.get_state(&rt);
 
     // Verify new sectors
@@ -416,7 +411,7 @@ fn invalid_proof_rejected() {
     expect_abort(
         ExitCode::USR_NOT_FOUND,
         h.prove_commit_sector_and_confirm(
-            &mut rt,
+            &rt,
             &precommit,
             h.make_prove_commit_params(sector_no),
             ProveCommitConfig::empty(),
@@ -429,10 +424,10 @@ fn invalid_proof_rejected() {
 #[test]
 fn prove_commit_aborts_if_pledge_requirement_not_met() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     // Set the circulating supply high and expected reward low in order to coerce
     // pledge requirements (BR + share of money supply, but capped at 1FIL)
@@ -442,7 +437,7 @@ fn prove_commit_aborts_if_pledge_requirement_not_met() {
 
     // prove one sector to establish collateral and locked funds
     let sectors =
-        h.commit_and_prove_sectors(&mut rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
+        h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, vec![], true);
 
     // precommit another sector so we may prove it
     let expiration = DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period + PERIOD_OFFSET - 1;
@@ -450,7 +445,7 @@ fn prove_commit_aborts_if_pledge_requirement_not_met() {
     rt.set_epoch(precommit_epoch);
     let params =
         h.make_pre_commit_params(h.next_sector_no, *rt.epoch.borrow() - 1, expiration, vec![]);
-    let precommit = h.pre_commit_sector_and_get(&mut rt, params, PreCommitConfig::default(), false);
+    let precommit = h.pre_commit_sector_and_get(&rt, params, PreCommitConfig::default(), false);
 
     // Confirm the unlocked PCD will not cover the new IP
     assert!(sectors[0].initial_pledge > precommit.pre_commit_deposit);
@@ -465,7 +460,7 @@ fn prove_commit_aborts_if_pledge_requirement_not_met() {
     expect_abort(
         ExitCode::USR_INSUFFICIENT_FUNDS,
         h.prove_commit_sector_and_confirm(
-            &mut rt,
+            &rt,
             &precommit,
             h.make_prove_commit_params(h.next_sector_no),
             ProveCommitConfig::empty(),
@@ -478,7 +473,7 @@ fn prove_commit_aborts_if_pledge_requirement_not_met() {
         &st.pre_commit_deposits + &st.initial_pledge + &st.initial_pledge + &st.locked_funds,
     );
     h.prove_commit_sector_and_confirm(
-        &mut rt,
+        &rt,
         &precommit,
         h.make_prove_commit_params(h.next_sector_no),
         ProveCommitConfig::empty(),
@@ -490,10 +485,10 @@ fn prove_commit_aborts_if_pledge_requirement_not_met() {
 #[test]
 fn drop_invalid_prove_commit_while_processing_valid_one() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.balance.replace(BIG_BALANCE.clone());
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     // make two precommits
     let expiration = DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period + PERIOD_OFFSET - 1;
@@ -501,14 +496,13 @@ fn drop_invalid_prove_commit_while_processing_valid_one() {
     rt.set_epoch(precommit_epoch);
     let params_a =
         h.make_pre_commit_params(h.next_sector_no, *rt.epoch.borrow() - 1, expiration, vec![1]);
-    let pre_commit_a =
-        h.pre_commit_sector_and_get(&mut rt, params_a, PreCommitConfig::default(), true);
+    let pre_commit_a = h.pre_commit_sector_and_get(&rt, params_a, PreCommitConfig::default(), true);
     let sector_no_a = h.next_sector_no;
     h.next_sector_no += 1;
     let params_b =
         h.make_pre_commit_params(h.next_sector_no, *rt.epoch.borrow() - 1, expiration, vec![2]);
     let pre_commit_b =
-        h.pre_commit_sector_and_get(&mut rt, params_b, PreCommitConfig::default(), false);
+        h.pre_commit_sector_and_get(&rt, params_b, PreCommitConfig::default(), false);
     let sector_no_b = h.next_sector_no;
 
     // handle both prove commits in the same epoch
@@ -516,14 +510,14 @@ fn drop_invalid_prove_commit_while_processing_valid_one() {
         precommit_epoch + max_prove_commit_duration(&rt.policy, h.seal_proof_type).unwrap() - 1,
     );
 
-    h.prove_commit_sector(&mut rt, &pre_commit_a, h.make_prove_commit_params(sector_no_a)).unwrap();
-    h.prove_commit_sector(&mut rt, &pre_commit_b, h.make_prove_commit_params(sector_no_b)).unwrap();
+    h.prove_commit_sector(&rt, &pre_commit_a, h.make_prove_commit_params(sector_no_a)).unwrap();
+    h.prove_commit_sector(&rt, &pre_commit_b, h.make_prove_commit_params(sector_no_b)).unwrap();
 
     let conf = ProveCommitConfig {
         verify_deals_exit: HashMap::from([(sector_no_a, ExitCode::USR_ILLEGAL_ARGUMENT)]),
         ..Default::default()
     };
-    h.confirm_sector_proofs_valid(&mut rt, conf, vec![pre_commit_a, pre_commit_b]).unwrap();
+    h.confirm_sector_proofs_valid(&rt, conf, vec![pre_commit_a, pre_commit_b]).unwrap();
     let st = h.get_state(&rt);
     assert!(st.get_sector(&rt.store, sector_no_a).unwrap().is_none());
     assert!(st.get_sector(&rt.store, sector_no_b).unwrap().is_some());
@@ -533,34 +527,34 @@ fn drop_invalid_prove_commit_while_processing_valid_one() {
 #[test]
 fn prove_commit_just_after_period_start_permits_post() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.balance.replace(BIG_BALANCE.clone());
 
     // Epoch PERIOD_OFFSET+1 should be at the beginning of the miner's proving period so there will be time to commit
     // and PoSt a sector.
     rt.set_epoch(PERIOD_OFFSET + 1);
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     // Commit a sector the very next epoch
     rt.set_epoch(PERIOD_OFFSET + 2);
     let sector =
-        h.commit_and_prove_sector(&mut rt, MAX_SECTOR_NUMBER, DEFAULT_SECTOR_EXPIRATION, vec![]);
+        h.commit_and_prove_sector(&rt, MAX_SECTOR_NUMBER, DEFAULT_SECTOR_EXPIRATION, vec![]);
 
     // advance cron to activate power.
-    h.advance_and_submit_posts(&mut rt, &[sector]);
+    h.advance_and_submit_posts(&rt, &[sector]);
     h.check_state(&rt);
 }
 
 #[test]
 fn sector_with_non_positive_lifetime_is_skipped_in_confirmation() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.balance.replace(BIG_BALANCE.clone());
 
     let precommit_epoch = PERIOD_OFFSET + 1;
     rt.set_epoch(precommit_epoch);
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let deadline = h.deadline(&rt);
 
     let sector_no = 100;
@@ -570,26 +564,26 @@ fn sector_with_non_positive_lifetime_is_skipped_in_confirmation() {
         deadline.period_end() + DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period,
         vec![],
     );
-    let precommit = h.pre_commit_sector_and_get(&mut rt, params, PreCommitConfig::default(), true);
+    let precommit = h.pre_commit_sector_and_get(&rt, params, PreCommitConfig::default(), true);
 
     // precommit at correct epoch
     rt.set_epoch(*rt.epoch.borrow() + rt.policy.pre_commit_challenge_delay + 1);
-    h.prove_commit_sector(&mut rt, &precommit, h.make_prove_commit_params(sector_no)).unwrap();
+    h.prove_commit_sector(&rt, &precommit, h.make_prove_commit_params(sector_no)).unwrap();
 
     // confirm at sector expiration (this probably can't happen)
     rt.set_epoch(precommit.info.expiration);
     // sector skipped but no failure occurs
-    h.confirm_sector_proofs_valid(&mut rt, ProveCommitConfig::empty(), vec![precommit.clone()])
+    h.confirm_sector_proofs_valid(&rt, ProveCommitConfig::empty(), vec![precommit.clone()])
         .unwrap();
 
     // it still skips if sector lifetime is negative
     rt.set_epoch(precommit.info.expiration + 1);
-    h.confirm_sector_proofs_valid(&mut rt, ProveCommitConfig::empty(), vec![precommit.clone()])
+    h.confirm_sector_proofs_valid(&rt, ProveCommitConfig::empty(), vec![precommit.clone()])
         .unwrap();
 
     // it fails up to the miniumum expiration
     rt.set_epoch(precommit.info.expiration - rt.policy.min_sector_expiration + 1);
-    h.confirm_sector_proofs_valid(&mut rt, ProveCommitConfig::empty(), vec![precommit.clone()])
+    h.confirm_sector_proofs_valid(&rt, ProveCommitConfig::empty(), vec![precommit.clone()])
         .unwrap();
     let st = h.get_state(&rt);
     assert!(st.get_sector(&rt.store, sector_no).unwrap().is_none());
@@ -599,13 +593,13 @@ fn sector_with_non_positive_lifetime_is_skipped_in_confirmation() {
 #[test]
 fn verify_proof_does_not_vest_funds() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.balance.replace(BIG_BALANCE.clone());
 
     let precommit_epoch = PERIOD_OFFSET + 1;
     rt.set_epoch(precommit_epoch);
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     let deadline = h.deadline(&rt);
 
     // Make a good commitment for the proof to target.
@@ -616,7 +610,7 @@ fn verify_proof_does_not_vest_funds() {
         deadline.period_end() + DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period,
         vec![1],
     );
-    let precommit = h.pre_commit_sector_and_get(&mut rt, params, PreCommitConfig::default(), true);
+    let precommit = h.pre_commit_sector_and_get(&rt, params, PreCommitConfig::default(), true);
 
     // add 1000 tokens that vest immediately
     let mut st = h.get_state(&rt);
@@ -636,11 +630,6 @@ fn verify_proof_does_not_vest_funds() {
     let mut prove_commit = h.make_prove_commit_params(sector_no);
     prove_commit.proof.resize(192, 0);
     // The below call expects exactly the pledge delta for the proven sector, zero for any other vesting.
-    h.prove_commit_sector_and_confirm(
-        &mut rt,
-        &precommit,
-        prove_commit,
-        ProveCommitConfig::empty(),
-    )
-    .unwrap();
+    h.prove_commit_sector_and_confirm(&rt, &precommit, prove_commit, ProveCommitConfig::empty())
+        .unwrap();
 }

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -567,7 +567,8 @@ fn sector_with_non_positive_lifetime_is_skipped_in_confirmation() {
     let precommit = h.pre_commit_sector_and_get(&rt, params, PreCommitConfig::default(), true);
 
     // precommit at correct epoch
-    rt.set_epoch(*rt.epoch.borrow() + rt.policy.pre_commit_challenge_delay + 1);
+    let epoch = *rt.epoch.borrow();
+    rt.set_epoch(epoch + rt.policy.pre_commit_challenge_delay + 1);
     h.prove_commit_sector(&rt, &precommit, h.make_prove_commit_params(sector_no)).unwrap();
 
     // confirm at sector expiration (this probably can't happen)

--- a/actors/miner/tests/repay_debts.rs
+++ b/actors/miner/tests/repay_debts.rs
@@ -16,8 +16,8 @@ const PERIOD_OFFSET: ChainEpoch = 100;
 #[test]
 fn repay_with_no_available_funds_does_nothing() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
 
     // introduce fee debt
     let mut st = h.get_state(&rt);
@@ -25,8 +25,7 @@ fn repay_with_no_available_funds_does_nothing() {
     st.fee_debt = fee_debt.clone();
     rt.replace_state(&st);
 
-    h.repay_debts(&mut rt, &TokenAmount::zero(), &TokenAmount::zero(), &TokenAmount::zero())
-        .unwrap();
+    h.repay_debts(&rt, &TokenAmount::zero(), &TokenAmount::zero(), &TokenAmount::zero()).unwrap();
 
     let st = h.get_state(&rt);
     assert_eq!(fee_debt, st.fee_debt);
@@ -36,8 +35,8 @@ fn repay_with_no_available_funds_does_nothing() {
 #[test]
 fn pay_debt_entirely_from_balance() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
 
     // introduce fee debt
     let mut st = h.get_state(&rt);
@@ -46,7 +45,7 @@ fn pay_debt_entirely_from_balance() {
     rt.replace_state(&st);
 
     let debt_to_repay = 2 * &fee_debt;
-    h.repay_debts(&mut rt, &debt_to_repay, &TokenAmount::zero(), &fee_debt).unwrap();
+    h.repay_debts(&rt, &debt_to_repay, &TokenAmount::zero(), &fee_debt).unwrap();
 
     let st = h.get_state(&rt);
     assert!(st.fee_debt.is_zero());
@@ -56,8 +55,8 @@ fn pay_debt_entirely_from_balance() {
 #[test]
 fn repay_debt_restricted_correctly() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
 
     // introduce fee debt
     let mut st = h.get_state(&rt);
@@ -95,8 +94,8 @@ fn repay_debt_restricted_correctly() {
 #[test]
 fn partially_repay_debt() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
 
     // introduce fee debt
     let mut st = h.get_state(&rt);
@@ -105,7 +104,7 @@ fn partially_repay_debt() {
     rt.replace_state(&st);
 
     let debt_to_repay = 3 * (&fee_debt.div_floor(4));
-    h.repay_debts(&mut rt, &debt_to_repay, &TokenAmount::zero(), &debt_to_repay).unwrap();
+    h.repay_debts(&rt, &debt_to_repay, &TokenAmount::zero(), &debt_to_repay).unwrap();
 
     let st = h.get_state(&rt);
     assert_eq!(fee_debt.div_floor(4), st.fee_debt);
@@ -115,13 +114,13 @@ fn partially_repay_debt() {
 #[test]
 fn pay_debt_partially_from_vested_funds() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
-    h.construct_and_verify(&mut rt);
+    let rt = h.new_runtime();
+    h.construct_and_verify(&rt);
 
     let reward_amount: TokenAmount = 4 * &*BIG_BALANCE;
     let (amount_locked, _) = locked_reward_from_reward(reward_amount.clone());
     rt.set_balance(amount_locked.clone());
-    h.apply_rewards(&mut rt, reward_amount, TokenAmount::zero());
+    h.apply_rewards(&rt, reward_amount, TokenAmount::zero());
     assert_eq!(amount_locked, h.get_locked_funds(&rt));
 
     // introduce fee debt
@@ -131,7 +130,7 @@ fn pay_debt_partially_from_vested_funds() {
 
     // send 1 FIL and repay all debt from vesting funds and balance
     h.repay_debts(
-        &mut rt,
+        &rt,
         &BIG_BALANCE,   // send 1 FIL
         &amount_locked, // 3 FIL comes from vesting funds
         &BIG_BALANCE,   // 1 FIL sent from balance

--- a/actors/miner/tests/report_consensus_fault.rs
+++ b/actors/miner/tests/report_consensus_fault.rs
@@ -42,7 +42,7 @@ fn mistargeted_report_rejected() {
     rt.set_epoch(1);
 
     let test_addr = Address::new_id(1234);
-    let epoch = rt.epoch;
+    let epoch = *rt.epoch.borrow();
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         h.report_consensus_fault(
@@ -65,7 +65,7 @@ fn report_consensus_fault_pays_reward_and_charges_fee() {
     rt.set_epoch(1);
 
     let test_addr = Address::new_id(1234);
-    let epoch = rt.epoch;
+    let epoch = *rt.epoch.borrow();
     let receiver = rt.receiver;
     h.report_consensus_fault(
         &mut rt,
@@ -126,7 +126,7 @@ fn double_report_of_consensus_fault_fails() {
     let report_epoch = 333;
     rt.set_epoch(report_epoch);
 
-    let fault1 = rt.epoch - 1;
+    let fault1 = *rt.epoch.borrow() - 1;
     h.report_consensus_fault(
         &mut rt,
         test_addr,
@@ -192,7 +192,7 @@ fn double_report_of_consensus_fault_fails() {
     .unwrap();
     let end_info = h.get_info(&rt);
     assert_eq!(
-        rt.epoch + rt.policy.consensus_fault_ineligibility_duration,
+        *rt.epoch.borrow() + rt.policy.consensus_fault_ineligibility_duration,
         end_info.consensus_fault_elapsed
     );
 

--- a/actors/miner/tests/report_consensus_fault.rs
+++ b/actors/miner/tests/report_consensus_fault.rs
@@ -15,30 +15,27 @@ const PERIOD_OFFSET: ChainEpoch = 100;
 
 fn setup() -> (ActorHarness, MockRuntime) {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     (h, rt)
 }
 
 #[test]
 fn invalid_report_rejected() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     rt.set_epoch(1);
 
     let test_addr = Address::new_id(1234);
-    expect_abort(
-        ExitCode::USR_ILLEGAL_ARGUMENT,
-        h.report_consensus_fault(&mut rt, test_addr, None),
-    );
+    expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.report_consensus_fault(&rt, test_addr, None));
     rt.reset();
     check_state_invariants(rt.policy(), &h.get_state(&rt), rt.store(), &rt.get_balance());
 }
 
 #[test]
 fn mistargeted_report_rejected() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
     rt.set_epoch(1);
 
     let test_addr = Address::new_id(1234);
@@ -46,7 +43,7 @@ fn mistargeted_report_rejected() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         h.report_consensus_fault(
-            &mut rt,
+            &rt,
             test_addr,
             Some(ConsensusFault {
                 target: Address::new_id(1234), // Not receiver
@@ -61,14 +58,14 @@ fn mistargeted_report_rejected() {
 
 #[test]
 fn report_consensus_fault_pays_reward_and_charges_fee() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
     rt.set_epoch(1);
 
     let test_addr = Address::new_id(1234);
     let epoch = *rt.epoch.borrow();
     let receiver = rt.receiver;
     h.report_consensus_fault(
-        &mut rt,
+        &rt,
         test_addr,
         Some(ConsensusFault {
             target: receiver,
@@ -82,7 +79,7 @@ fn report_consensus_fault_pays_reward_and_charges_fee() {
 
 #[test]
 fn report_consensus_fault_updates_consensus_fault_reported_field() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
     rt.set_epoch(1);
 
     let test_addr = Address::new_id(1234);
@@ -95,7 +92,7 @@ fn report_consensus_fault_updates_consensus_fault_reported_field() {
     rt.set_epoch(report_epoch);
 
     h.report_consensus_fault(
-        &mut rt,
+        &rt,
         test_addr,
         Some(ConsensusFault {
             target: receiver,
@@ -114,7 +111,7 @@ fn report_consensus_fault_updates_consensus_fault_reported_field() {
 
 #[test]
 fn double_report_of_consensus_fault_fails() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
     rt.set_epoch(1);
 
     let test_addr = Address::new_id(1234);
@@ -128,7 +125,7 @@ fn double_report_of_consensus_fault_fails() {
 
     let fault1 = *rt.epoch.borrow() - 1;
     h.report_consensus_fault(
-        &mut rt,
+        &rt,
         test_addr,
         Some(ConsensusFault {
             target: receiver,
@@ -148,7 +145,7 @@ fn double_report_of_consensus_fault_fails() {
         ExitCode::USR_FORBIDDEN,
         "too old",
         h.report_consensus_fault(
-            &mut rt,
+            &rt,
             test_addr,
             Some(ConsensusFault {
                 target: receiver,
@@ -166,7 +163,7 @@ fn double_report_of_consensus_fault_fails() {
         ExitCode::USR_FORBIDDEN,
         "too old",
         h.report_consensus_fault(
-            &mut rt,
+            &rt,
             test_addr,
             Some(ConsensusFault {
                 target: receiver,
@@ -181,7 +178,7 @@ fn double_report_of_consensus_fault_fails() {
     rt.set_epoch(end_info.consensus_fault_elapsed + 1);
     let fault3 = end_info.consensus_fault_elapsed;
     h.report_consensus_fault(
-        &mut rt,
+        &rt,
         test_addr,
         Some(ConsensusFault {
             target: receiver,
@@ -202,7 +199,7 @@ fn double_report_of_consensus_fault_fails() {
         ExitCode::USR_FORBIDDEN,
         "too old",
         h.report_consensus_fault(
-            &mut rt,
+            &rt,
             test_addr,
             Some(ConsensusFault {
                 target: receiver,

--- a/actors/miner/tests/terminate_sectors_test.rs
+++ b/actors/miner/tests/terminate_sectors_test.rs
@@ -169,8 +169,11 @@ fn owner_cannot_terminate_if_market_cron_fails() {
     rt.expect_send_simple(
         STORAGE_MARKET_ACTOR_ADDR,
         ON_MINER_SECTORS_TERMINATE_METHOD,
-        IpldBlock::serialize_cbor(&OnMinerSectorsTerminateParams { epoch: rt.epoch, deal_ids })
-            .unwrap(),
+        IpldBlock::serialize_cbor(&OnMinerSectorsTerminateParams {
+            epoch: *rt.epoch.borrow(),
+            deal_ids,
+        })
+        .unwrap(),
         TokenAmount::zero(),
         None,
         ExitCode::USR_ILLEGAL_STATE,
@@ -253,7 +256,7 @@ fn calc_expected_fee_for_termination(
         &sector_power,
         INITIAL_PLEDGE_PROJECTION_PERIOD,
     );
-    let sector_age = rt.epoch - sector.activation;
+    let sector_age = *rt.epoch.borrow() - sector.activation;
     pledge_penalty_for_termination(
         &day_reward,
         sector_age,

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -121,10 +121,10 @@ lazy_static! {
 
 #[allow(dead_code)]
 pub fn setup() -> (ActorHarness, MockRuntime) {
-    let mut rt = MockRuntime::default();
+    let rt = MockRuntime::default();
     let h = ActorHarness::new(0);
 
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     (h, rt)
 }
 
@@ -242,7 +242,7 @@ impl ActorHarness {
         self.partition_size = proof_type.window_post_partitions_sector().unwrap();
     }
 
-    pub fn construct_and_verify(&self, rt: &mut MockRuntime) {
+    pub fn construct_and_verify(&self, rt: &MockRuntime) {
         let params = ConstructorParams {
             owner: self.owner,
             worker: self.worker,
@@ -276,7 +276,7 @@ impl ActorHarness {
         rt.verify();
     }
 
-    pub fn set_peer_id(&self, rt: &mut MockRuntime, new_id: Vec<u8>) {
+    pub fn set_peer_id(&self, rt: &MockRuntime, new_id: Vec<u8>) {
         let params = ChangePeerIDParams { new_id: new_id.clone() };
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
@@ -304,7 +304,7 @@ impl ActorHarness {
         assert_eq!(new_id, ret.peer_id);
     }
 
-    pub fn set_peer_id_fail(&self, rt: &mut MockRuntime, new_id: Vec<u8>) {
+    pub fn set_peer_id_fail(&self, rt: &MockRuntime, new_id: Vec<u8>) {
         let params = ChangePeerIDParams { new_id };
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
@@ -316,7 +316,7 @@ impl ActorHarness {
         rt.verify();
     }
 
-    pub fn set_multiaddr(&self, rt: &mut MockRuntime, new_multiaddrs: Vec<BytesDe>) {
+    pub fn set_multiaddr(&self, rt: &MockRuntime, new_multiaddrs: Vec<BytesDe>) {
         let params = ChangeMultiaddrsParams { new_multi_addrs: new_multiaddrs.clone() };
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
@@ -343,7 +343,7 @@ impl ActorHarness {
         assert_eq!(new_multiaddrs, ret.multi_addrs);
     }
 
-    pub fn set_multiaddr_fail(&self, rt: &mut MockRuntime, new_multiaddrs: Vec<BytesDe>) {
+    pub fn set_multiaddr_fail(&self, rt: &MockRuntime, new_multiaddrs: Vec<BytesDe>) {
         let params = ChangeMultiaddrsParams { new_multi_addrs: new_multiaddrs };
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
@@ -358,7 +358,7 @@ impl ActorHarness {
         rt.verify();
     }
 
-    pub fn get_control_addresses(&self, rt: &mut MockRuntime) -> (Address, Address, Vec<Address>) {
+    pub fn get_control_addresses(&self, rt: &MockRuntime) -> (Address, Address, Vec<Address>) {
         rt.expect_validate_caller_any();
 
         let result = rt.call::<Actor>(Method::ControlAddresses as u64, None).unwrap();
@@ -370,7 +370,7 @@ impl ActorHarness {
 
     pub fn commit_and_prove_sectors(
         &mut self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         num_sectors: usize,
         lifetime_periods: u64,
         deal_ids: Vec<Vec<DealID>>,
@@ -388,7 +388,7 @@ impl ActorHarness {
 
     pub fn commit_and_prove_sectors_with_cfgs(
         &mut self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         num_sectors: usize,
         lifetime_periods: u64,
         deal_ids: Vec<Vec<DealID>>,
@@ -445,7 +445,7 @@ impl ActorHarness {
 
     pub fn commit_and_prove_sector(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         sector_no: SectorNumber,
         lifetime_periods: i64,
         deal_ids: Vec<DealID>,
@@ -483,7 +483,7 @@ impl ActorHarness {
 
     pub fn compact_sector_numbers_raw(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         addr: Address,
         bf: BitField,
     ) -> Result<Option<IpldBlock>, ActorError> {
@@ -498,7 +498,7 @@ impl ActorHarness {
         )
     }
 
-    pub fn compact_sector_numbers(&self, rt: &mut MockRuntime, addr: Address, bf: BitField) {
+    pub fn compact_sector_numbers(&self, rt: &MockRuntime, addr: Address, bf: BitField) {
         self.compact_sector_numbers_raw(rt, addr, bf).unwrap();
         rt.verify();
     }
@@ -555,7 +555,7 @@ impl ActorHarness {
 
     pub fn pre_commit_sector_batch_v2(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         params: PreCommitSectorBatchParams2,
         first_for_miner: bool,
         base_fee: &TokenAmount,
@@ -604,7 +604,7 @@ impl ActorHarness {
     }
     pub fn pre_commit_sector_batch(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         params: PreCommitSectorBatchParams,
         conf: &PreCommitBatchConfig,
         base_fee: &TokenAmount,
@@ -647,7 +647,7 @@ impl ActorHarness {
 
     fn pre_commit_sector_batch_inner(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         sectors: &[SectorPreCommitInfo],
         method: MethodNum,
         param: impl Serialize,
@@ -725,7 +725,7 @@ impl ActorHarness {
 
     pub fn pre_commit_sector_batch_and_get(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         params: PreCommitSectorBatchParams,
         conf: &PreCommitBatchConfig,
         base_fee: &TokenAmount,
@@ -740,7 +740,7 @@ impl ActorHarness {
 
     pub fn pre_commit_sector(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         params: PreCommitSectorParams,
         conf: PreCommitConfig,
         first: bool,
@@ -808,7 +808,7 @@ impl ActorHarness {
 
     pub fn pre_commit_sector_and_get(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         params: PreCommitSectorParams,
         conf: PreCommitConfig,
         first: bool,
@@ -828,14 +828,14 @@ impl ActorHarness {
 
     pub fn get_precommit(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         sector_number: SectorNumber,
     ) -> SectorPreCommitOnChainInfo {
         let state = self.get_state(rt);
         state.get_precommitted_sector(&rt.store, sector_number).unwrap().unwrap()
     }
 
-    pub fn expect_query_network_info(&self, rt: &mut MockRuntime) {
+    pub fn expect_query_network_info(&self, rt: &MockRuntime) {
         let current_power = CurrentTotalPowerReturn {
             raw_byte_power: self.network_raw_power.clone(),
             quality_adj_power: self.network_qa_power.clone(),
@@ -866,7 +866,7 @@ impl ActorHarness {
 
     pub fn prove_commit_sector_and_confirm(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         pc: &SectorPreCommitOnChainInfo,
         params: ProveCommitSectorParams,
         cfg: ProveCommitConfig,
@@ -880,7 +880,7 @@ impl ActorHarness {
 
     pub fn prove_commit_sector(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         pc: &SectorPreCommitOnChainInfo,
         params: ProveCommitSectorParams,
     ) -> Result<(), ActorError> {
@@ -935,7 +935,7 @@ impl ActorHarness {
 
     pub fn prove_commit_aggregate_sector(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         config: ProveCommitConfig,
         precommits: Vec<SectorPreCommitOnChainInfo>,
         params: ProveCommitAggregateParams,
@@ -1018,7 +1018,7 @@ impl ActorHarness {
 
     pub fn confirm_sector_proofs_valid(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         cfg: ProveCommitConfig,
         pcs: Vec<SectorPreCommitOnChainInfo>,
     ) -> Result<(), ActorError> {
@@ -1048,7 +1048,7 @@ impl ActorHarness {
 
     fn confirm_sector_proofs_valid_internal(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         cfg: ProveCommitConfig,
         pcs: &[SectorPreCommitOnChainInfo],
     ) {
@@ -1179,7 +1179,7 @@ impl ActorHarness {
         state.get_sector(&rt.store, sector_number).unwrap().unwrap()
     }
 
-    pub fn advance_to_epoch_with_cron(&self, rt: &mut MockRuntime, epoch: ChainEpoch) {
+    pub fn advance_to_epoch_with_cron(&self, rt: &MockRuntime, epoch: ChainEpoch) {
         let mut deadline = self.get_deadline_info(rt);
         while deadline.last() < epoch {
             self.advance_deadline(rt, CronConfig::empty());
@@ -1188,7 +1188,7 @@ impl ActorHarness {
         rt.epoch.replace(epoch);
     }
 
-    pub fn advance_to_deadline(&self, rt: &mut MockRuntime, dlidx: u64) -> DeadlineInfo {
+    pub fn advance_to_deadline(&self, rt: &MockRuntime, dlidx: u64) -> DeadlineInfo {
         let mut dlinfo = self.deadline(rt);
         while dlinfo.index != dlidx {
             dlinfo = self.advance_deadline(rt, CronConfig::empty());
@@ -1201,7 +1201,7 @@ impl ActorHarness {
         state.recorded_deadline_info(&rt.policy, *rt.epoch.borrow())
     }
 
-    pub fn advance_deadline(&self, rt: &mut MockRuntime, mut cfg: CronConfig) -> DeadlineInfo {
+    pub fn advance_deadline(&self, rt: &MockRuntime, mut cfg: CronConfig) -> DeadlineInfo {
         let state = self.get_state(rt);
         let deadline = new_deadline_info_from_offset_and_epoch(
             &rt.policy,
@@ -1220,7 +1220,7 @@ impl ActorHarness {
         state.deadline_info(&rt.policy, *rt.epoch.borrow())
     }
 
-    pub fn on_deadline_cron(&self, rt: &mut MockRuntime, cfg: CronConfig) {
+    pub fn on_deadline_cron(&self, rt: &MockRuntime, cfg: CronConfig) {
         let state = self.get_state(rt);
         rt.expect_validate_caller_addr(vec![STORAGE_POWER_ACTOR_ADDR]);
 
@@ -1314,7 +1314,7 @@ impl ActorHarness {
 
     pub fn submit_window_post(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         deadline: &DeadlineInfo,
         partitions: Vec<PoStPartition>,
         infos: Vec<SectorOnChainInfo>,
@@ -1333,7 +1333,7 @@ impl ActorHarness {
 
     pub fn submit_window_post_raw(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         deadline: &DeadlineInfo,
         infos: Vec<SectorOnChainInfo>,
         params: SubmitWindowedPoStParams,
@@ -1458,7 +1458,7 @@ impl ActorHarness {
 
     pub fn dispute_window_post(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         deadline: &DeadlineInfo,
         proof_index: u64,
         infos: &[SectorOnChainInfo],
@@ -1611,7 +1611,7 @@ impl ActorHarness {
         caller_addrs
     }
 
-    pub fn apply_rewards(&self, rt: &mut MockRuntime, amt: TokenAmount, penalty: TokenAmount) {
+    pub fn apply_rewards(&self, rt: &MockRuntime, amt: TokenAmount, penalty: TokenAmount) {
         // This harness function does not handle the state where apply rewards is
         // on a miner with existing fee debt.  This state is not protocol reachable
         // because currently fee debt prevents election participation.
@@ -1656,7 +1656,7 @@ impl ActorHarness {
         state.locked_funds
     }
 
-    pub fn advance_and_submit_posts(&self, rt: &mut MockRuntime, sectors: &[SectorOnChainInfo]) {
+    pub fn advance_and_submit_posts(&self, rt: &MockRuntime, sectors: &[SectorOnChainInfo]) {
         // Advance between 0 and 48 deadlines submitting window posts where necessary to keep
         // sectors proven.  If sectors is empty this is a noop. If sectors is a singleton this
         // will advance to that sector's proving deadline running deadline crons up to and
@@ -1765,7 +1765,7 @@ impl ActorHarness {
 
     pub fn declare_faults(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         fault_sector_infos: &[SectorOnChainInfo],
     ) -> PowerPair {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
@@ -1802,7 +1802,7 @@ impl ActorHarness {
 
     pub fn declare_recoveries(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         dlidx: u64,
         pidx: u64,
         recovery_sectors: BitField,
@@ -1901,7 +1901,7 @@ impl ActorHarness {
 
     pub fn report_consensus_fault(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         from: Address,
         fault: Option<ConsensusFault>,
     ) -> Result<(), ActorError> {
@@ -1994,7 +1994,7 @@ impl ActorHarness {
 
     pub fn terminate_sectors(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         sectors: &BitField,
         expected_fee: TokenAmount,
     ) -> (PowerPair, TokenAmount) {
@@ -2100,7 +2100,7 @@ impl ActorHarness {
         (-sector_power, pledge_delta)
     }
 
-    pub fn change_peer_id(&self, rt: &mut MockRuntime, new_id: Vec<u8>) {
+    pub fn change_peer_id(&self, rt: &MockRuntime, new_id: Vec<u8>) {
         let params = ChangePeerIDParams { new_id: new_id.to_owned() };
 
         rt.expect_validate_caller_addr(self.caller_addrs());
@@ -2124,7 +2124,7 @@ impl ActorHarness {
 
     pub fn repay_debts(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         value: &TokenAmount,
         expected_repaid_from_vest: &TokenAmount,
         expected_repaid_from_balance: &TokenAmount,
@@ -2164,7 +2164,7 @@ impl ActorHarness {
 
     pub fn withdraw_funds(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         from_address: Address,
         amount_requested: &TokenAmount,
         expected_withdrawn: &TokenAmount,
@@ -2220,7 +2220,7 @@ impl ActorHarness {
 
     pub fn check_sector_proven(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         sector_number: SectorNumber,
     ) -> Result<(), ActorError> {
         let params = CheckSectorProvenParams { sector_number };
@@ -2235,7 +2235,7 @@ impl ActorHarness {
 
     pub fn change_worker_address(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         new_worker: Address,
         new_control_addresses: Vec<Address>,
     ) -> Result<Option<IpldBlock>, ActorError> {
@@ -2280,7 +2280,7 @@ impl ActorHarness {
         ret
     }
 
-    pub fn confirm_change_worker_address(&self, rt: &mut MockRuntime) -> Result<(), ActorError> {
+    pub fn confirm_change_worker_address(&self, rt: &MockRuntime) -> Result<(), ActorError> {
         rt.expect_validate_caller_addr(vec![self.owner]);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.owner);
         rt.call::<Actor>(Method::ConfirmChangeWorkerAddress as u64, None)?;
@@ -2291,7 +2291,7 @@ impl ActorHarness {
 
     pub fn propose_approve_initial_beneficiary(
         &mut self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         beneficiary_id_addr: Address,
         beneficiary_term: BeneficiaryTerm,
     ) -> Result<(), ActorError> {
@@ -2318,7 +2318,7 @@ impl ActorHarness {
 
     pub fn change_beneficiary(
         &mut self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         expect_caller: Address,
         beneficiary_change: &BeneficiaryChange,
         expect_beneficiary_addr: Option<Address>,
@@ -2352,7 +2352,7 @@ impl ActorHarness {
 
     pub fn get_beneficiary(
         &mut self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
     ) -> Result<GetBeneficiaryReturn, ActorError> {
         rt.expect_validate_caller_any();
         let ret = rt.call::<Actor>(Method::GetBeneficiary as u64, None)?;
@@ -2363,7 +2363,7 @@ impl ActorHarness {
     // extend sectors without verified deals using either legacy or updated sector extension
     pub fn extend_sectors_versioned(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         params: ExtendSectorExpirationParams,
         v2: bool,
     ) -> Result<Option<IpldBlock>, ActorError> {
@@ -2380,7 +2380,7 @@ impl ActorHarness {
 
     pub fn extend_sectors(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         mut params: ExtendSectorExpirationParams,
     ) -> Result<Option<IpldBlock>, ActorError> {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
@@ -2423,7 +2423,7 @@ impl ActorHarness {
 
     pub fn extend_sectors2(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         mut params: ExtendSectorExpiration2Params,
         expected_claims: HashMap<ClaimID, Result<FILPlusClaim, ActorError>>,
     ) -> Result<Option<IpldBlock>, ActorError> {
@@ -2525,7 +2525,7 @@ impl ActorHarness {
 
     pub fn compact_partitions(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         deadline: u64,
         partition: BitField,
     ) -> Result<(), ActorError> {
@@ -2549,7 +2549,7 @@ impl ActorHarness {
 
     pub fn change_owner_address(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         new_address: Address,
     ) -> Result<Option<IpldBlock>, ActorError> {
         let expected = if *rt.caller.borrow() == self.owner {
@@ -2575,7 +2575,7 @@ impl ActorHarness {
         ret
     }
 
-    pub fn get_available_balance(&self, rt: &mut MockRuntime) -> Result<TokenAmount, ActorError> {
+    pub fn get_available_balance(&self, rt: &MockRuntime) -> Result<TokenAmount, ActorError> {
         // set caller to non-builtin
         rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1234));
         rt.expect_validate_caller_any();
@@ -3160,7 +3160,7 @@ impl CronControl {
     pub fn pre_commit_to_start_cron(
         &mut self,
         h: &ActorHarness,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         pre_commit_epoch: ChainEpoch,
     ) -> ChainEpoch {
         rt.set_epoch(pre_commit_epoch);
@@ -3196,7 +3196,7 @@ impl CronControl {
     fn expire_pre_commit_stop_cron(
         &self,
         h: &ActorHarness,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         start_epoch: ChainEpoch,
         clean_up_epoch: ChainEpoch,
     ) -> ChainEpoch {
@@ -3232,7 +3232,7 @@ impl CronControl {
     pub fn pre_commit_start_cron_expire_stop_cron(
         &mut self,
         h: &ActorHarness,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         start_epoch: ChainEpoch,
     ) -> ChainEpoch {
         let clean_up_epoch = self.pre_commit_to_start_cron(h, rt, start_epoch);

--- a/actors/miner/tests/withdraw_balance.rs
+++ b/actors/miner/tests/withdraw_balance.rs
@@ -38,7 +38,7 @@ fn happy_path_withdraws_funds() {
 
 #[test]
 fn withdraw_funds_restricted_correctly() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
     rt.set_balance(BIG_BALANCE.clone());
     let amount_requested = ONE_PERCENT_BALANCE.clone();
 

--- a/actors/miner/tests/withdraw_balance.rs
+++ b/actors/miner/tests/withdraw_balance.rs
@@ -21,12 +21,12 @@ const PERIOD_OFFSET: ChainEpoch = 100;
 #[test]
 fn happy_path_withdraws_funds() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     h.withdraw_funds(
-        &mut rt,
+        &rt,
         h.owner,
         &ONE_PERCENT_BALANCE,
         &ONE_PERCENT_BALANCE,
@@ -86,10 +86,10 @@ fn withdraw_funds_restricted_correctly() {
 #[test]
 fn fails_if_miner_cant_repay_fee_debt() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
 
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let mut st = h.get_state(&rt);
     st.fee_debt = &*rt.balance.borrow() + TokenAmount::from_whole(1);
@@ -98,7 +98,7 @@ fn fails_if_miner_cant_repay_fee_debt() {
         ExitCode::USR_INSUFFICIENT_FUNDS,
         "unlocked balance can not repay fee debt",
         h.withdraw_funds(
-            &mut rt,
+            &rt,
             h.owner,
             &ONE_PERCENT_BALANCE,
             &ONE_PERCENT_BALANCE,
@@ -112,9 +112,9 @@ fn fails_if_miner_cant_repay_fee_debt() {
 #[test]
 fn withdraw_only_what_we_can_after_fee_debt() {
     let h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let mut st = h.get_state(&rt);
     let fee_debt = &*BIG_BALANCE - &*ONE_PERCENT_BALANCE;
@@ -123,49 +123,49 @@ fn withdraw_only_what_we_can_after_fee_debt() {
 
     let requested = rt.balance.borrow().to_owned();
     let expected_withdraw = &requested - &fee_debt;
-    h.withdraw_funds(&mut rt, h.owner, &requested, &expected_withdraw, &fee_debt).unwrap();
+    h.withdraw_funds(&rt, h.owner, &requested, &expected_withdraw, &fee_debt).unwrap();
     h.check_state(&rt);
 }
 
 #[test]
 fn successfully_withdraw() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let one = TokenAmount::from_atto(1);
-    h.withdraw_funds(&mut rt, h.owner, &one, &one, &TokenAmount::zero()).unwrap();
+    h.withdraw_funds(&rt, h.owner, &one, &one, &TokenAmount::zero()).unwrap();
 
     let first_beneficiary_id = Address::new_id(999);
     let quota = &*ONE_PERCENT_BALANCE;
     h.propose_approve_initial_beneficiary(
-        &mut rt,
+        &rt,
         first_beneficiary_id,
         BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), PERIOD_OFFSET + 100),
     )
     .unwrap();
-    h.withdraw_funds(&mut rt, h.owner, &one, &one, &TokenAmount::zero()).unwrap();
-    h.withdraw_funds(&mut rt, h.beneficiary, &one, &one, &TokenAmount::zero()).unwrap();
+    h.withdraw_funds(&rt, h.owner, &one, &one, &TokenAmount::zero()).unwrap();
+    h.withdraw_funds(&rt, h.beneficiary, &one, &one, &TokenAmount::zero()).unwrap();
     h.check_state(&rt);
 }
 
 #[test]
 fn successfully_withdraw_allow_zero() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let first_beneficiary_id = Address::new_id(999);
     h.propose_approve_initial_beneficiary(
-        &mut rt,
+        &rt,
         first_beneficiary_id,
         BeneficiaryTerm::new(TokenAmount::from_atto(1), TokenAmount::zero(), PERIOD_OFFSET + 100),
     )
     .unwrap();
     h.withdraw_funds(
-        &mut rt,
+        &rt,
         first_beneficiary_id,
         &TokenAmount::zero(),
         &TokenAmount::zero(),
@@ -178,36 +178,35 @@ fn successfully_withdraw_allow_zero() {
 #[test]
 fn successfully_withdraw_limited_to_quota() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let first_beneficiary_id = Address::new_id(999);
     let quota = &*ONE_PERCENT_BALANCE;
     h.propose_approve_initial_beneficiary(
-        &mut rt,
+        &rt,
         first_beneficiary_id,
         BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), PERIOD_OFFSET + 100),
     )
     .unwrap();
 
     let withdraw_amount = &*ONE_PERCENT_BALANCE * 2;
-    h.withdraw_funds(&mut rt, h.beneficiary, &withdraw_amount, quota, &TokenAmount::zero())
-        .unwrap();
+    h.withdraw_funds(&rt, h.beneficiary, &withdraw_amount, quota, &TokenAmount::zero()).unwrap();
     h.check_state(&rt);
 }
 
 #[test]
 fn withdraw_fail_when_beneficiary_expired() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let first_beneficiary_id = Address::new_id(999);
     let quota = &*ONE_PERCENT_BALANCE;
     h.propose_approve_initial_beneficiary(
-        &mut rt,
+        &rt,
         first_beneficiary_id,
         BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), PERIOD_OFFSET - 10),
     )
@@ -216,7 +215,7 @@ fn withdraw_fail_when_beneficiary_expired() {
     assert_eq!(PERIOD_OFFSET - 10, info.beneficiary_term.expiration);
     rt.set_epoch(100);
     let ret =
-        h.withdraw_funds(&mut rt, h.beneficiary, quota, &TokenAmount::zero(), &TokenAmount::zero());
+        h.withdraw_funds(&rt, h.beneficiary, quota, &TokenAmount::zero(), &TokenAmount::zero());
     expect_abort_contains_message(ExitCode::USR_FORBIDDEN, "beneficiary expiration of epoch", ret);
     h.check_state(&rt);
 }
@@ -224,9 +223,9 @@ fn withdraw_fail_when_beneficiary_expired() {
 #[test]
 fn fail_withdraw_from_non_beneficiary() {
     let mut h = ActorHarness::new(PERIOD_OFFSET);
-    let mut rt = h.new_runtime();
+    let rt = h.new_runtime();
     rt.set_balance(BIG_BALANCE.clone());
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
 
     let first_beneficiary_id = Address::new_id(999);
     let another_actor = Address::new_id(1000);
@@ -236,7 +235,7 @@ fn fail_withdraw_from_non_beneficiary() {
     expect_abort(
         ExitCode::USR_FORBIDDEN,
         h.withdraw_funds(
-            &mut rt,
+            &rt,
             first_beneficiary_id,
             &one,
             &TokenAmount::zero(),
@@ -245,7 +244,7 @@ fn fail_withdraw_from_non_beneficiary() {
     );
 
     h.propose_approve_initial_beneficiary(
-        &mut rt,
+        &rt,
         first_beneficiary_id,
         BeneficiaryTerm::new(quota.clone(), TokenAmount::zero(), PERIOD_OFFSET - 10),
     )
@@ -253,12 +252,12 @@ fn fail_withdraw_from_non_beneficiary() {
 
     expect_abort(
         ExitCode::USR_FORBIDDEN,
-        h.withdraw_funds(&mut rt, another_actor, &one, &TokenAmount::zero(), &TokenAmount::zero()),
+        h.withdraw_funds(&rt, another_actor, &one, &TokenAmount::zero(), &TokenAmount::zero()),
     );
 
     //allow owner withdraw
-    h.withdraw_funds(&mut rt, h.owner, &one, &one, &TokenAmount::zero()).unwrap();
+    h.withdraw_funds(&rt, h.owner, &one, &one, &TokenAmount::zero()).unwrap();
     //allow beneficiary withdraw
-    h.withdraw_funds(&mut rt, first_beneficiary_id, &one, &one, &TokenAmount::zero()).unwrap();
+    h.withdraw_funds(&rt, first_beneficiary_id, &one, &one, &TokenAmount::zero()).unwrap();
     h.check_state(&rt);
 }

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -52,7 +52,7 @@ pub struct Actor;
 
 impl Actor {
     /// Constructor for Multisig actor
-    pub fn constructor(rt: &mut impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
+    pub fn constructor(rt: &impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&INIT_ACTOR_ADDR))?;
 
         if params.signers.is_empty() {
@@ -121,10 +121,7 @@ impl Actor {
     }
 
     /// Multisig actor propose function
-    pub fn propose(
-        rt: &mut impl Runtime,
-        params: ProposeParams,
-    ) -> Result<ProposeReturn, ActorError> {
+    pub fn propose(rt: &impl Runtime, params: ProposeParams) -> Result<ProposeReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let proposer: Address = rt.message().caller();
 
@@ -174,10 +171,7 @@ impl Actor {
     }
 
     /// Multisig actor approve function
-    pub fn approve(
-        rt: &mut impl Runtime,
-        params: TxnIDParams,
-    ) -> Result<ApproveReturn, ActorError> {
+    pub fn approve(rt: &impl Runtime, params: TxnIDParams) -> Result<ApproveReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let approver: Address = rt.message().caller();
 
@@ -209,7 +203,7 @@ impl Actor {
     }
 
     /// Multisig actor cancel function
-    pub fn cancel(rt: &mut impl Runtime, params: TxnIDParams) -> Result<(), ActorError> {
+    pub fn cancel(rt: &impl Runtime, params: TxnIDParams) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let caller_addr: Address = rt.message().caller();
 
@@ -254,7 +248,7 @@ impl Actor {
     }
 
     /// Multisig actor function to add signers to multisig
-    pub fn add_signer(rt: &mut impl Runtime, params: AddSignerParams) -> Result<(), ActorError> {
+    pub fn add_signer(rt: &impl Runtime, params: AddSignerParams) -> Result<(), ActorError> {
         let receiver = rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let resolved_new_signer = resolve_to_actor_id(rt, &params.signer, true)?;
@@ -282,10 +276,7 @@ impl Actor {
     }
 
     /// Multisig actor function to remove signers to multisig
-    pub fn remove_signer(
-        rt: &mut impl Runtime,
-        params: RemoveSignerParams,
-    ) -> Result<(), ActorError> {
+    pub fn remove_signer(rt: &impl Runtime, params: RemoveSignerParams) -> Result<(), ActorError> {
         let receiver = rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let resolved_old_signer = resolve_to_actor_id(rt, &params.signer, false)?;
@@ -332,7 +323,7 @@ impl Actor {
     }
 
     /// Multisig actor function to swap signers to multisig
-    pub fn swap_signer(rt: &mut impl Runtime, params: SwapSignerParams) -> Result<(), ActorError> {
+    pub fn swap_signer(rt: &impl Runtime, params: SwapSignerParams) -> Result<(), ActorError> {
         let receiver = rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let from_resolved = resolve_to_actor_id(rt, &params.from, false)?;
@@ -362,7 +353,7 @@ impl Actor {
 
     /// Multisig actor function to change number of approvals needed
     pub fn change_num_approvals_threshold(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: ChangeNumApprovalsThresholdParams,
     ) -> Result<(), ActorError> {
         let receiver = rt.message().receiver();
@@ -383,10 +374,7 @@ impl Actor {
     }
 
     /// Multisig actor function to change number of approvals needed
-    pub fn lock_balance(
-        rt: &mut impl Runtime,
-        params: LockBalanceParams,
-    ) -> Result<(), ActorError> {
+    pub fn lock_balance(rt: &impl Runtime, params: LockBalanceParams) -> Result<(), ActorError> {
         let receiver = rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
 
@@ -410,7 +398,7 @@ impl Actor {
     }
 
     fn approve_transaction(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         tx_id: TxnID,
         mut txn: Transaction,
     ) -> Result<(bool, RawBytes, ExitCode), ActorError> {
@@ -451,7 +439,7 @@ impl Actor {
 
     // Always succeeds, accepting any transfers, so long as the params are valid `UniversalReceiverParams`.
     pub fn universal_receiver_hook(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         _params: UniversalReceiverParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -460,7 +448,7 @@ impl Actor {
 }
 
 fn execute_transaction_if_approved(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     st: &State,
     txn_id: TxnID,
     txn: &Transaction,

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -67,7 +67,7 @@ mod constructor_tests {
 
     #[test]
     fn test_simple_construction() {
-        let mut rt = construct_runtime(MSIG);
+        let rt = construct_runtime(MSIG);
         let h = util::ActorHarness::new();
         let params = ConstructorParams {
             signers: vec![ANNE, BOB, CHARLIE],
@@ -127,7 +127,7 @@ mod constructor_tests {
 
     #[test]
     fn test_construction_with_vesting() {
-        let mut rt = construct_runtime(MSIG);
+        let rt = construct_runtime(MSIG);
         let h = util::ActorHarness::new();
         rt.set_epoch(1234);
         let params = ConstructorParams {
@@ -322,18 +322,18 @@ mod vesting_tests {
 
     #[test]
     fn happy_path_full_vesting() {
-        let mut rt = construct_runtime(MSIG);
+        let rt = construct_runtime(MSIG);
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
         rt.set_received(MSIG_INITIAL_BALANCE.clone());
-        h.construct_and_verify(&mut rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
+        h.construct_and_verify(&rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
         rt.set_received(TokenAmount::zero());
 
         // anne proposes that darlene receive inital balance
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
         let proposal_hash = h.propose_ok(
-            &mut rt,
+            &rt,
             DARLENE,
             MSIG_INITIAL_BALANCE.clone(),
             METHOD_SEND,
@@ -342,7 +342,7 @@ mod vesting_tests {
 
         // bob approves anne's tx too soon
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, BOB);
-        expect_abort(ExitCode::USR_INSUFFICIENT_FUNDS, h.approve(&mut rt, TxnID(0), proposal_hash));
+        expect_abort(ExitCode::USR_INSUFFICIENT_FUNDS, h.approve(&rt, TxnID(0), proposal_hash));
         rt.reset();
 
         // advance the epoch s.t. all funds are unlocked
@@ -355,7 +355,7 @@ mod vesting_tests {
             None,
             ExitCode::OK,
         );
-        assert_eq!(RawBytes::default(), h.approve_ok(&mut rt, TxnID(0), proposal_hash));
+        assert_eq!(RawBytes::default(), h.approve_ok(&rt, TxnID(0), proposal_hash));
 
         check_state(&rt);
     }
@@ -363,17 +363,17 @@ mod vesting_tests {
     #[test]
     fn partial_vesting_propose_to_send_half_the_actor_balance_when_the_epoch_is_half_the_unlock_duration(
     ) {
-        let mut rt = construct_runtime(MSIG);
+        let rt = construct_runtime(MSIG);
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
         rt.set_received(MSIG_INITIAL_BALANCE.clone());
-        h.construct_and_verify(&mut rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
+        h.construct_and_verify(&rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
         rt.set_received(TokenAmount::zero());
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
         let proposal_hash = h.propose_ok(
-            &mut rt,
+            &rt,
             DARLENE,
             MSIG_INITIAL_BALANCE.div_floor(2),
             METHOD_SEND,
@@ -389,54 +389,48 @@ mod vesting_tests {
             None,
             ExitCode::OK,
         );
-        h.approve_ok(&mut rt, TxnID(0), proposal_hash);
+        h.approve_ok(&rt, TxnID(0), proposal_hash);
 
         check_state(&rt);
     }
 
     #[test]
     fn propose_and_autoapprove_tx_above_locked_amount_fails() {
-        let mut rt = construct_runtime(MSIG);
+        let rt = construct_runtime(MSIG);
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
         rt.set_received(MSIG_INITIAL_BALANCE.clone());
-        h.construct_and_verify(&mut rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
+        h.construct_and_verify(&rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
         rt.set_received(TokenAmount::zero());
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
         expect_abort(
             ExitCode::USR_INSUFFICIENT_FUNDS,
-            h.propose(
-                &mut rt,
-                DARLENE,
-                MSIG_INITIAL_BALANCE.clone(),
-                METHOD_SEND,
-                RawBytes::default(),
-            ),
+            h.propose(&rt, DARLENE, MSIG_INITIAL_BALANCE.clone(), METHOD_SEND, RawBytes::default()),
         );
         rt.reset();
         rt.set_epoch(START_EPOCH + UNLOCK_DURATION / 10);
         let amount_out = MSIG_INITIAL_BALANCE.div_floor(10);
         rt.expect_send_simple(DARLENE, METHOD_SEND, None, amount_out.clone(), None, ExitCode::OK);
-        h.propose_ok(&mut rt, DARLENE, amount_out, METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, DARLENE, amount_out, METHOD_SEND, RawBytes::default());
 
         check_state(&rt);
     }
 
     #[test]
     fn fail_to_vest_more_than_locked_amount() {
-        let mut rt = construct_runtime(MSIG);
+        let rt = construct_runtime(MSIG);
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
         rt.set_received(MSIG_INITIAL_BALANCE.clone());
-        h.construct_and_verify(&mut rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
+        h.construct_and_verify(&rt, 2, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
         rt.set_received(TokenAmount::zero());
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
         let proposal_hash = h.propose_ok(
-            &mut rt,
+            &rt,
             DARLENE,
             MSIG_INITIAL_BALANCE.div_floor(2),
             METHOD_SEND,
@@ -444,27 +438,27 @@ mod vesting_tests {
         );
         rt.set_epoch(START_EPOCH + UNLOCK_DURATION / 10);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, BOB);
-        expect_abort(ExitCode::USR_INSUFFICIENT_FUNDS, h.approve(&mut rt, TxnID(0), proposal_hash));
+        expect_abort(ExitCode::USR_INSUFFICIENT_FUNDS, h.approve(&rt, TxnID(0), proposal_hash));
         check_state(&rt);
     }
 
     #[test]
     fn avoid_truncating_division() {
-        let mut rt = construct_runtime(MSIG);
+        let rt = construct_runtime(MSIG);
         let h = util::ActorHarness::new();
 
         let locked_balance = TokenAmount::from_atto(UNLOCK_DURATION - 1); // balance < duration
         let one = TokenAmount::from_atto(1u8);
         rt.set_balance(locked_balance.clone());
         rt.set_received(locked_balance.clone());
-        h.construct_and_verify(&mut rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
+        h.construct_and_verify(&rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
         rt.set_received(TokenAmount::zero());
 
         // expect nothing vested yet
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
         expect_abort(
             ExitCode::USR_INSUFFICIENT_FUNDS,
-            h.propose(&mut rt, ANNE, one.clone(), METHOD_SEND, RawBytes::default()),
+            h.propose(&rt, ANNE, one.clone(), METHOD_SEND, RawBytes::default()),
         );
         rt.reset();
 
@@ -472,21 +466,21 @@ mod vesting_tests {
         rt.set_epoch(START_EPOCH + 1);
         expect_abort(
             ExitCode::USR_INSUFFICIENT_FUNDS,
-            h.propose(&mut rt, ANNE, one.clone(), METHOD_SEND, RawBytes::default()),
+            h.propose(&rt, ANNE, one.clone(), METHOD_SEND, RawBytes::default()),
         );
         rt.reset();
 
         // expect 1 unit available after 2 epochs
         rt.set_epoch(START_EPOCH + 2);
         rt.expect_send_simple(ANNE, METHOD_SEND, None, one.clone(), None, ExitCode::OK);
-        h.propose_ok(&mut rt, ANNE, one.clone(), METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, ANNE, one.clone(), METHOD_SEND, RawBytes::default());
         rt.set_balance(locked_balance.clone());
 
         // do not expect full vesting before full duration elapsed
         rt.set_epoch(START_EPOCH + UNLOCK_DURATION - 1);
         expect_abort(
             ExitCode::USR_INSUFFICIENT_FUNDS,
-            h.propose(&mut rt, ANNE, locked_balance.clone(), METHOD_SEND, RawBytes::default()),
+            h.propose(&rt, ANNE, locked_balance.clone(), METHOD_SEND, RawBytes::default()),
         );
         rt.reset();
 
@@ -499,57 +493,56 @@ mod vesting_tests {
             None,
             ExitCode::OK,
         );
-        h.propose_ok(&mut rt, ANNE, locked_balance.clone() - one, METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, ANNE, locked_balance.clone() - one, METHOD_SEND, RawBytes::default());
         rt.set_balance(locked_balance.clone());
 
         // expect everything after exactly lock duration
         rt.set_epoch(START_EPOCH + UNLOCK_DURATION);
         rt.expect_send_simple(ANNE, METHOD_SEND, None, locked_balance.clone(), None, ExitCode::OK);
-        h.propose_ok(&mut rt, ANNE, locked_balance, METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, ANNE, locked_balance, METHOD_SEND, RawBytes::default());
         check_state(&rt);
     }
 
     #[test]
     fn sending_zero_ok_when_nothing_vests() {
-        let mut rt = construct_runtime(MSIG);
+        let rt = construct_runtime(MSIG);
         let h = util::ActorHarness::new();
 
         rt.set_balance(MSIG_INITIAL_BALANCE.clone());
         rt.set_received(MSIG_INITIAL_BALANCE.clone());
-        h.construct_and_verify(&mut rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
+        h.construct_and_verify(&rt, 1, UNLOCK_DURATION, START_EPOCH, vec![ANNE, BOB, CHARLIE]);
         rt.set_received(TokenAmount::zero());
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
         rt.expect_send_simple(BOB, METHOD_SEND, None, TokenAmount::zero(), None, ExitCode::OK);
-        h.propose_ok(&mut rt, BOB, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, BOB, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
         check_state(&rt);
     }
 
     #[test]
     fn sending_zero_when_lockup_exceeds_balance() {
-        let mut rt = construct_runtime(MSIG);
+        let rt = construct_runtime(MSIG);
         let h = util::ActorHarness::new();
 
-        h.construct_and_verify(&mut rt, 1, 0, START_EPOCH, vec![ANNE]);
+        h.construct_and_verify(&rt, 1, 0, START_EPOCH, vec![ANNE]);
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, MSIG);
         rt.set_balance(TokenAmount::from_atto(10u8));
         rt.set_received(TokenAmount::from_atto(10u8));
 
         // lock up funds the actor doesn't have yet
-        h.lock_balance(&mut rt, START_EPOCH, UNLOCK_DURATION, TokenAmount::from_atto(10u8))
-            .unwrap();
+        h.lock_balance(&rt, START_EPOCH, UNLOCK_DURATION, TokenAmount::from_atto(10u8)).unwrap();
 
         // make a tx that transfers no value
         let send_amount = TokenAmount::zero();
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, ANNE);
         rt.expect_send_simple(BOB, METHOD_SEND, None, send_amount.clone(), None, ExitCode::OK);
-        h.propose_ok(&mut rt, BOB, send_amount, METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, BOB, send_amount, METHOD_SEND, RawBytes::default());
 
         // verify that sending any value is prevented
         let send_amount = TokenAmount::from_atto(1u8);
         expect_abort(
             ExitCode::USR_INSUFFICIENT_FUNDS,
-            h.propose(&mut rt, BOB, send_amount, METHOD_SEND, RawBytes::default()),
+            h.propose(&rt, BOB, send_amount, METHOD_SEND, RawBytes::default()),
         );
         check_state(&rt);
     }
@@ -560,7 +553,7 @@ mod vesting_tests {
 #[test]
 fn test_simple_propose() {
     let msig = Address::new_id(1000);
-    let mut rt = construct_runtime(msig);
+    let rt = construct_runtime(msig);
     let h = util::ActorHarness::new();
 
     let anne = Address::new_id(101);
@@ -571,9 +564,9 @@ fn test_simple_propose() {
     let signers = vec![anne, bob];
 
     let send_value = TokenAmount::from_atto(10u8);
-    h.construct_and_verify(&mut rt, 2, no_unlock_duration, start_epoch, signers);
+    h.construct_and_verify(&rt, 2, no_unlock_duration, start_epoch, signers);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-    h.propose_ok(&mut rt, chuck, send_value.clone(), METHOD_SEND, RawBytes::default());
+    h.propose_ok(&rt, chuck, send_value.clone(), METHOD_SEND, RawBytes::default());
     let txn0 = Transaction {
         to: chuck,
         value: send_value,
@@ -589,7 +582,7 @@ fn test_simple_propose() {
 #[test]
 fn test_propose_with_threshold_met() {
     let msig = Address::new_id(1000);
-    let mut rt = construct_runtime(msig);
+    let rt = construct_runtime(msig);
     let h = util::ActorHarness::new();
 
     let num_approvals = 1;
@@ -604,7 +597,7 @@ fn test_propose_with_threshold_met() {
     let signers = vec![anne, bob];
     rt.set_balance(TokenAmount::from_atto(10u8));
     rt.set_received(TokenAmount::zero());
-    h.construct_and_verify(&mut rt, num_approvals, no_unlock_duration, start_epoch, signers);
+    h.construct_and_verify(&rt, num_approvals, no_unlock_duration, start_epoch, signers);
 
     rt.expect_send_simple(
         chuck,
@@ -615,7 +608,7 @@ fn test_propose_with_threshold_met() {
         ExitCode::OK,
     );
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-    h.propose_ok(&mut rt, chuck, send_value, METHOD_SEND, fake_params);
+    h.propose_ok(&rt, chuck, send_value, METHOD_SEND, fake_params);
     h.assert_transactions(&rt, vec![]);
     check_state(&rt);
 }
@@ -623,7 +616,7 @@ fn test_propose_with_threshold_met() {
 #[test]
 fn test_propose_with_threshold_and_non_empty_return_value() {
     let msig = Address::new_id(1000);
-    let mut rt = construct_runtime(msig);
+    let rt = construct_runtime(msig);
     let h = util::ActorHarness::new();
 
     let num_approvals = 1;
@@ -638,7 +631,7 @@ fn test_propose_with_threshold_and_non_empty_return_value() {
 
     rt.set_balance(TokenAmount::from_atto(20u8));
     rt.set_received(TokenAmount::zero());
-    h.construct_and_verify(&mut rt, num_approvals, no_unlock_duration, start_epoch, signers);
+    h.construct_and_verify(&rt, num_approvals, no_unlock_duration, start_epoch, signers);
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
     struct FakeReturn {
@@ -664,7 +657,7 @@ fn test_propose_with_threshold_and_non_empty_return_value() {
     );
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
     let ret = h
-        .propose(&mut rt, chuck, send_value, fake_method, fake_params)
+        .propose(&rt, chuck, send_value, fake_method, fake_params)
         .unwrap()
         .unwrap()
         .deserialize::<ProposeReturn>()
@@ -679,7 +672,7 @@ fn test_propose_with_threshold_and_non_empty_return_value() {
 #[test]
 fn test_fail_propose_with_threshold_met_and_insufficient_balance() {
     let msig = Address::new_id(1000);
-    let mut rt = construct_runtime(msig);
+    let rt = construct_runtime(msig);
     let h = util::ActorHarness::new();
 
     let num_approvals = 1;
@@ -694,12 +687,12 @@ fn test_fail_propose_with_threshold_met_and_insufficient_balance() {
 
     rt.set_balance(TokenAmount::zero());
     rt.set_received(TokenAmount::zero());
-    h.construct_and_verify(&mut rt, num_approvals, no_unlock_duration, start_epoch, signers);
+    h.construct_and_verify(&rt, num_approvals, no_unlock_duration, start_epoch, signers);
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
     expect_abort(
         ExitCode::USR_INSUFFICIENT_FUNDS,
-        h.propose(&mut rt, chuck, send_value, METHOD_SEND, fake_params),
+        h.propose(&rt, chuck, send_value, METHOD_SEND, fake_params),
     );
     rt.reset();
     h.assert_transactions(&rt, vec![]);
@@ -709,7 +702,7 @@ fn test_fail_propose_with_threshold_met_and_insufficient_balance() {
 #[test]
 fn test_fail_propose_from_non_signer() {
     let msig = Address::new_id(1000);
-    let mut rt = construct_runtime(msig);
+    let rt = construct_runtime(msig);
     let h = util::ActorHarness::new();
 
     let num_approvals = 1;
@@ -724,14 +717,14 @@ fn test_fail_propose_from_non_signer() {
 
     rt.set_balance(TokenAmount::zero());
     rt.set_received(TokenAmount::zero());
-    h.construct_and_verify(&mut rt, num_approvals, no_unlock_duration, start_epoch, signers);
+    h.construct_and_verify(&rt, num_approvals, no_unlock_duration, start_epoch, signers);
 
     // non signer
     let richard = Address::new_id(105);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, richard);
     expect_abort(
         ExitCode::USR_FORBIDDEN,
-        h.propose(&mut rt, chuck, send_value, METHOD_SEND, fake_params),
+        h.propose(&rt, chuck, send_value, METHOD_SEND, fake_params),
     );
 
     rt.reset();
@@ -824,24 +817,24 @@ fn test_add_signer() {
     ];
 
     for tc in test_cases {
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
         for (src, target) in tc.id_addr_mapping {
             rt.id_addresses.borrow_mut().insert(src, target);
         }
 
-        h.construct_and_verify(&mut rt, tc.initial_approvals, 0, 0, tc.initial_signers);
+        h.construct_and_verify(&rt, tc.initial_approvals, 0, 0, tc.initial_signers);
 
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
         match tc.code {
             ExitCode::OK => {
-                let ret = h.add_signer(&mut rt, tc.add_signer, tc.increase).unwrap();
+                let ret = h.add_signer(&rt, tc.add_signer, tc.increase).unwrap();
                 assert!(ret.is_none());
                 let st: State = rt.get_state();
                 assert_eq!(tc.expect_signers, st.signers);
                 assert_eq!(tc.expect_approvals, st.num_approvals_threshold);
             }
-            _ => expect_abort(tc.code, h.add_signer(&mut rt, tc.add_signer, tc.increase)),
+            _ => expect_abort(tc.code, h.add_signer(&rt, tc.add_signer, tc.increase)),
         }
         check_state(&rt);
     }
@@ -967,13 +960,13 @@ fn test_remove_signer() {
     ];
 
     for tc in test_cases {
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         rt.id_addresses.borrow_mut().insert(anne_non_id, anne);
         let h = util::ActorHarness::new();
-        h.construct_and_verify(&mut rt, tc.initial_approvals, 0, 0, tc.initial_signers);
+        h.construct_and_verify(&rt, tc.initial_approvals, 0, 0, tc.initial_signers);
 
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-        let ret = h.remove_signer(&mut rt, tc.remove_signer, tc.decrease);
+        let ret = h.remove_signer(&rt, tc.remove_signer, tc.decrease);
 
         match tc.code {
             ExitCode::OK => {
@@ -1082,13 +1075,13 @@ fn test_signer_swap() {
     ];
 
     for tc in test_cases {
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         rt.id_addresses.borrow_mut().insert(bob_non_id, bob);
         let h = util::ActorHarness::new();
-        h.construct_and_verify(&mut rt, num_approvals, 0, 0, tc.initial_signers);
+        h.construct_and_verify(&rt, num_approvals, 0, 0, tc.initial_signers);
 
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-        let ret = h.swap_signers(&mut rt, tc.swap_from, tc.swap_to);
+        let ret = h.swap_signers(&rt, tc.swap_from, tc.swap_to);
         match tc.code {
             ExitCode::OK => {
                 assert!(ret.unwrap().is_none());
@@ -1113,30 +1106,30 @@ fn test_swap_signer_removes_approvals() {
     let darlene = Address::new_id(104);
     let num_approvals: u64 = 3;
 
-    let mut rt = construct_runtime(msig);
+    let rt = construct_runtime(msig);
     let h = util::ActorHarness::new();
-    h.construct_and_verify(&mut rt, num_approvals, 0, 0, vec![anne, bob, chuck]);
+    h.construct_and_verify(&rt, num_approvals, 0, 0, vec![anne, bob, chuck]);
 
     // anne proposes a tx
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
     let proposal_hash1 =
-        h.propose_ok(&mut rt, chuck, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, chuck, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
 
     // bob approves
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
-    h.approve_ok(&mut rt, TxnID(0), proposal_hash1);
+    h.approve_ok(&rt, TxnID(0), proposal_hash1);
 
     // bob proposes a tx
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
     let proposal_hash2 =
-        h.propose_ok(&mut rt, chuck, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, chuck, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
     // anne approves
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-    h.approve_ok(&mut rt, TxnID(1), proposal_hash2);
+    h.approve_ok(&rt, TxnID(1), proposal_hash2);
 
     // anne is removed, threshold dropped to 2 of 2
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-    h.swap_signers(&mut rt, anne, darlene).unwrap();
+    h.swap_signers(&rt, anne, darlene).unwrap();
 
     // Anne's approval is removed from each tx
     h.assert_transactions(
@@ -1176,17 +1169,17 @@ fn test_swap_signer_deletes_solo_proposals() {
     let darlene = Address::new_id(104);
     let num_approvals: u64 = 3;
 
-    let mut rt = construct_runtime(msig);
+    let rt = construct_runtime(msig);
     let h = util::ActorHarness::new();
-    h.construct_and_verify(&mut rt, num_approvals, 0, 0, vec![anne, bob, chuck]);
+    h.construct_and_verify(&rt, num_approvals, 0, 0, vec![anne, bob, chuck]);
 
     // anne proposes a tx
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-    h.propose_ok(&mut rt, chuck, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
+    h.propose_ok(&rt, chuck, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
 
     // anne is swapped
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-    h.swap_signers(&mut rt, anne, darlene).unwrap();
+    h.swap_signers(&rt, anne, darlene).unwrap();
     h.assert_transactions(&rt, vec![]);
     check_state(&rt);
 }
@@ -1199,30 +1192,30 @@ fn test_remove_signer_removes_approvals() {
     let chuck = Address::new_id(103);
     let num_approvals: u64 = 3;
 
-    let mut rt = construct_runtime(msig);
+    let rt = construct_runtime(msig);
     let h = util::ActorHarness::new();
-    h.construct_and_verify(&mut rt, num_approvals, 0, 0, vec![anne, bob, chuck]);
+    h.construct_and_verify(&rt, num_approvals, 0, 0, vec![anne, bob, chuck]);
 
     // anne proposes a tx
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
     let proposal_hash1 =
-        h.propose_ok(&mut rt, chuck, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, chuck, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
 
     // bob approves!
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
-    h.approve_ok(&mut rt, TxnID(0), proposal_hash1);
+    h.approve_ok(&rt, TxnID(0), proposal_hash1);
 
     // bob proposes a tx
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
     let proposal_hash2 =
-        h.propose_ok(&mut rt, chuck, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, chuck, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
     // anne approves
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-    h.approve_ok(&mut rt, TxnID(1), proposal_hash2);
+    h.approve_ok(&rt, TxnID(1), proposal_hash2);
 
     // anne is removed, threshold dropped to 2 of 2
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-    h.remove_signer(&mut rt, anne, true).unwrap();
+    h.remove_signer(&rt, anne, true).unwrap();
 
     // Anne's approval is removed from each tx
     h.assert_transactions(
@@ -1261,17 +1254,17 @@ fn remove_signer_deletes_solo_proposals() {
     let chuck = Address::new_id(103);
     let num_approvals: u64 = 2;
 
-    let mut rt = construct_runtime(msig);
+    let rt = construct_runtime(msig);
     let h = util::ActorHarness::new();
-    h.construct_and_verify(&mut rt, num_approvals, 0, 0, vec![anne, bob, chuck]);
+    h.construct_and_verify(&rt, num_approvals, 0, 0, vec![anne, bob, chuck]);
 
     // anne proposes a tx
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-    h.propose_ok(&mut rt, chuck, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
+    h.propose_ok(&rt, chuck, TokenAmount::zero(), METHOD_SEND, RawBytes::default());
 
     // anne is removed
     rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-    h.remove_signer(&mut rt, anne, false).unwrap();
+    h.remove_signer(&rt, anne, false).unwrap();
 
     // Tx is gone
     h.assert_transactions(&rt, vec![]);
@@ -1290,10 +1283,10 @@ mod approval_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
         let signers = vec![anne, bob];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
         // construct msig
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
@@ -1301,7 +1294,7 @@ mod approval_tests {
         let send_value = TokenAmount::from_atto(10u8);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, fake_params.clone());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, fake_params.clone());
 
         // assert txn
         let expect_txn = Transaction {
@@ -1324,7 +1317,7 @@ mod approval_tests {
             to_ipld_block(fake_ret),
             ExitCode::OK,
         );
-        h.approve_ok(&mut rt, TxnID(0), proposal_hash);
+        h.approve_ok(&rt, TxnID(0), proposal_hash);
         h.assert_transactions(&rt, vec![]);
         check_state(&rt);
     }
@@ -1336,19 +1329,19 @@ mod approval_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
         let signers = vec![anne, bob];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
         rt.set_received(TokenAmount::zero());
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
         let fake_ret = RawBytes::from(vec![4, 3, 2, 1]);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, fake_params.clone());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, fake_params.clone());
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
         rt.expect_send_simple(
@@ -1359,7 +1352,7 @@ mod approval_tests {
             to_ipld_block(fake_ret.clone()),
             ExitCode::OK,
         );
-        let ret = h.approve_ok(&mut rt, TxnID(0), proposal_hash);
+        let ret = h.approve_ok(&rt, TxnID(0), proposal_hash);
         assert_eq!(fake_ret, ret);
         h.assert_transactions(&rt, vec![]);
         check_state(&rt);
@@ -1372,20 +1365,20 @@ mod approval_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
         let signers = vec![anne, bob];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let send_value = TokenAmount::from_atto(20u8);
         let unlock_duration = 20;
         let start_epoch = 10;
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
         rt.set_received(send_value.clone());
-        h.construct_and_verify(&mut rt, 2, unlock_duration, start_epoch, signers);
+        h.construct_and_verify(&rt, 2, unlock_duration, start_epoch, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, fake_params.clone());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, fake_params.clone());
         h.assert_transactions(
             &rt,
             vec![(
@@ -1410,7 +1403,7 @@ mod approval_tests {
             ExitCode::OK,
         );
 
-        h.approve_ok(&mut rt, TxnID(0), proposal_hash);
+        h.approve_ok(&rt, TxnID(0), proposal_hash);
         check_state(&rt);
     }
 
@@ -1421,21 +1414,21 @@ mod approval_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
         let signers = vec![anne, bob];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone() - TokenAmount::from_atto(1));
         rt.set_received(TokenAmount::zero());
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, fake_params.clone());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, fake_params.clone());
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
-        expect_abort(ExitCode::USR_INSUFFICIENT_FUNDS, h.approve(&mut rt, TxnID(0), proposal_hash));
+        expect_abort(ExitCode::USR_INSUFFICIENT_FUNDS, h.approve(&rt, TxnID(0), proposal_hash));
         h.assert_transactions(
             &rt,
             vec![(
@@ -1459,20 +1452,20 @@ mod approval_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
         let signers = vec![anne, bob];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let send_value = TokenAmount::from_atto(20u8);
         let unlock_duration = 20;
         let start_epoch = 10;
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
         rt.set_received(send_value.clone());
-        h.construct_and_verify(&mut rt, 2, unlock_duration, start_epoch, signers);
+        h.construct_and_verify(&rt, 2, unlock_duration, start_epoch, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, fake_params.clone());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, fake_params.clone());
         h.assert_transactions(
             &rt,
             vec![(
@@ -1488,7 +1481,7 @@ mod approval_tests {
         );
         rt.set_epoch(start_epoch + unlock_duration / 2);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
-        expect_abort(ExitCode::USR_INSUFFICIENT_FUNDS, h.approve(&mut rt, TxnID(0), proposal_hash));
+        expect_abort(ExitCode::USR_INSUFFICIENT_FUNDS, h.approve(&rt, TxnID(0), proposal_hash));
         check_state(&rt);
     }
 
@@ -1499,17 +1492,17 @@ mod approval_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
         let signers = vec![anne, bob];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
         rt.set_received(TokenAmount::zero());
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-        h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, fake_params.clone());
+        h.propose_ok(&rt, chuck, send_value.clone(), fake_method, fake_params.clone());
         let bad_hash = compute_proposal_hash(
             &Transaction {
                 to: chuck,
@@ -1522,7 +1515,7 @@ mod approval_tests {
         )
         .unwrap();
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
-        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.approve(&mut rt, TxnID(0), bad_hash));
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.approve(&rt, TxnID(0), bad_hash));
         check_state(&rt);
     }
 
@@ -1533,17 +1526,17 @@ mod approval_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
         let signers = vec![anne, bob];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
         rt.set_received(TokenAmount::zero());
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-        h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, fake_params.clone());
+        h.propose_ok(&rt, chuck, send_value.clone(), fake_method, fake_params.clone());
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
         rt.expect_send_simple(
@@ -1572,21 +1565,21 @@ mod approval_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
         let signers = vec![anne, bob];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
         rt.set_received(TokenAmount::zero());
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, fake_params.clone());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, fake_params.clone());
 
         // anne tries to approve a tx she proposed and fails
-        expect_abort(ExitCode::USR_FORBIDDEN, h.approve(&mut rt, TxnID(0), proposal_hash));
+        expect_abort(ExitCode::USR_FORBIDDEN, h.approve(&rt, TxnID(0), proposal_hash));
         rt.reset();
         h.assert_transactions(
             &rt,
@@ -1611,12 +1604,12 @@ mod approval_tests {
         let anne = Address::new_id(101);
         let bob = Address::new_id(102);
         let signers = vec![anne, bob];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value);
         rt.set_received(TokenAmount::zero());
-        h.construct_and_verify(&mut rt, 1, 0, 0, signers);
+        h.construct_and_verify(&rt, 1, 0, 0, signers);
 
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
         rt.expect_validate_caller_any();
@@ -1637,22 +1630,22 @@ mod approval_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
         let signers = vec![anne, bob];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
         rt.set_received(TokenAmount::zero());
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, fake_params.clone());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, fake_params.clone());
 
         let richard = Address::new_id(105);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, richard);
-        expect_abort(ExitCode::USR_FORBIDDEN, h.approve(&mut rt, TxnID(0), proposal_hash));
+        expect_abort(ExitCode::USR_FORBIDDEN, h.approve(&rt, TxnID(0), proposal_hash));
         rt.reset();
         h.assert_transactions(
             &rt,
@@ -1677,23 +1670,23 @@ mod approval_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
         let signers = vec![anne, bob];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
         rt.set_received(TokenAmount::zero());
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, fake_params.clone());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, fake_params.clone());
 
         // reduce threshold so tx is already approved
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
         let new_threshold = 1;
-        h.change_num_approvals_threshold(&mut rt, new_threshold).unwrap();
+        h.change_num_approvals_threshold(&rt, new_threshold).unwrap();
 
         // self approval executes tx because the msig is across the threshold
         rt.expect_send_simple(
@@ -1705,7 +1698,7 @@ mod approval_tests {
             ExitCode::OK,
         );
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-        h.approve_ok(&mut rt, TxnID(0), proposal_hash);
+        h.approve_ok(&rt, TxnID(0), proposal_hash);
         h.assert_transactions(&rt, vec![]);
         check_state(&rt);
     }
@@ -1717,27 +1710,27 @@ mod approval_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
         let signers = vec![anne, bob, chuck];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
         rt.set_received(TokenAmount::zero());
-        h.construct_and_verify(&mut rt, 3, 0, 0, signers);
+        h.construct_and_verify(&rt, 3, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, fake_params.clone());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, fake_params.clone());
 
         // bob approves tx
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
-        h.approve_ok(&mut rt, TxnID(0), proposal_hash);
+        h.approve_ok(&rt, TxnID(0), proposal_hash);
 
         // reduce threshold so tx is already approved
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
         let new_threshold = 2;
-        h.change_num_approvals_threshold(&mut rt, new_threshold).unwrap();
+        h.change_num_approvals_threshold(&rt, new_threshold).unwrap();
 
         // duplicate approval executes tx because the msig is across the threshold
         rt.expect_send_simple(
@@ -1749,7 +1742,7 @@ mod approval_tests {
             ExitCode::OK,
         );
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
-        h.approve_ok(&mut rt, TxnID(0), proposal_hash);
+        h.approve_ok(&rt, TxnID(0), proposal_hash);
         h.assert_transactions(&rt, vec![]);
         check_state(&rt);
     }
@@ -1762,28 +1755,28 @@ mod approval_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
         let signers = vec![anne, bob];
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let send_value = TokenAmount::from_atto(10u8);
         let h = util::ActorHarness::new();
         rt.set_balance(send_value.clone());
         rt.set_received(TokenAmount::zero());
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, fake_params.clone());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, fake_params.clone());
 
         // reduce threshold so tx is already approved
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
         let new_threshold = 1;
-        h.change_num_approvals_threshold(&mut rt, new_threshold).unwrap();
+        h.change_num_approvals_threshold(&rt, new_threshold).unwrap();
 
         // non-signer alice cannot approve the tx
         let alice = Address::new_id(104);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, alice);
-        expect_abort(ExitCode::USR_FORBIDDEN, h.approve(&mut rt, TxnID(0), proposal_hash));
+        expect_abort(ExitCode::USR_FORBIDDEN, h.approve(&rt, TxnID(0), proposal_hash));
         rt.reset();
 
         // anne can self approve with lower threshold
@@ -1796,7 +1789,7 @@ mod approval_tests {
             None,
             ExitCode::OK,
         );
-        h.approve_ok(&mut rt, TxnID(0), proposal_hash);
+        h.approve_ok(&rt, TxnID(0), proposal_hash);
 
         h.assert_transactions(&rt, vec![]);
         check_state(&rt);
@@ -1814,21 +1807,21 @@ mod cancel_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
 
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
         let signers = vec![anne, bob];
 
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         let fake_params = RawBytes::from(vec![1, 2, 3, 4]);
         let fake_method = 42;
         let send_value = TokenAmount::from_atto(10u8);
         // anne proposes tx
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-        let proposal_hash = h.propose_ok(&mut rt, chuck, send_value, fake_method, fake_params);
+        let proposal_hash = h.propose_ok(&rt, chuck, send_value, fake_method, fake_params);
 
         // anne cancels the tx
-        let ret = h.cancel(&mut rt, TxnID(0), proposal_hash).unwrap();
+        let ret = h.cancel(&rt, TxnID(0), proposal_hash).unwrap();
         assert!(ret.is_none());
 
         // tx should be removed from actor state
@@ -1844,20 +1837,19 @@ mod cancel_tests {
         let chuck = Address::new_id(103);
         let send_value = TokenAmount::from_atto(10u8);
 
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
         let signers = vec![anne, bob];
 
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         // anne proposes a tx
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-        let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value, fake_method, RawBytes::default());
+        let proposal_hash = h.propose_ok(&rt, chuck, send_value, fake_method, RawBytes::default());
 
         // anne cancels their tx
-        h.cancel(&mut rt, TxnID(0), proposal_hash).unwrap();
+        h.cancel(&rt, TxnID(0), proposal_hash).unwrap();
 
         // tx should be removed from actor state after cancel
         h.assert_transactions(&rt, vec![]);
@@ -1872,21 +1864,21 @@ mod cancel_tests {
         let chuck = Address::new_id(103);
         let send_value = TokenAmount::from_atto(10u8);
 
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
         let signers = vec![anne, bob];
 
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         // anne proposes a tx
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, RawBytes::default());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, RawBytes::default());
 
         // bob (a signer) fails to cancel anne's tx because bob didn't create it, nice try bob
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
-        expect_abort(ExitCode::USR_FORBIDDEN, h.cancel(&mut rt, TxnID(0), proposal_hash));
+        expect_abort(ExitCode::USR_FORBIDDEN, h.cancel(&rt, TxnID(0), proposal_hash));
         rt.reset();
 
         // tx should remain after invalid cancel
@@ -1914,21 +1906,21 @@ mod cancel_tests {
         let chuck = Address::new_id(103);
         let send_value = TokenAmount::from_atto(10u8);
 
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
         let signers = vec![anne, bob];
 
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         // anne proposes a tx
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, RawBytes::default());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, RawBytes::default());
 
         let richard = Address::new_id(111); // not a signer
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, richard);
-        expect_abort(ExitCode::USR_FORBIDDEN, h.cancel(&mut rt, TxnID(0), proposal_hash));
+        expect_abort(ExitCode::USR_FORBIDDEN, h.cancel(&rt, TxnID(0), proposal_hash));
         rt.reset();
 
         h.assert_transactions(
@@ -1955,21 +1947,21 @@ mod cancel_tests {
         let chuck = Address::new_id(103);
         let send_value = TokenAmount::from_atto(10u8);
 
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
         let signers = vec![anne, bob];
 
-        h.construct_and_verify(&mut rt, 2, 0, 0, signers);
+        h.construct_and_verify(&rt, 2, 0, 0, signers);
 
         // anne proposes a tx with id TxnID(0)
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, RawBytes::default());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, RawBytes::default());
 
         // anne fails to cancel a tx that does not exist
         let dne_txn_id = TxnID(99);
-        expect_abort(ExitCode::USR_NOT_FOUND, h.cancel(&mut rt, dne_txn_id, proposal_hash));
+        expect_abort(ExitCode::USR_NOT_FOUND, h.cancel(&rt, dne_txn_id, proposal_hash));
         rt.reset();
 
         // txn remains after invalid cancel
@@ -1998,35 +1990,35 @@ mod cancel_tests {
         let send_value = TokenAmount::from_atto(10u8);
         let num_approvers = 3;
 
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
         let signers = vec![anne, bob, chuck];
 
-        h.construct_and_verify(&mut rt, num_approvers, 0, 0, signers);
+        h.construct_and_verify(&rt, num_approvers, 0, 0, signers);
 
         // anne propses a tx id 0
         let fake_method = 42;
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, RawBytes::default());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, RawBytes::default());
 
         // bob approves the tx, he is the second approver
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
-        h.approve_ok(&mut rt, TxnID(0), proposal_hash);
+        h.approve_ok(&rt, TxnID(0), proposal_hash);
 
         // remove anne as a signer, now bob is the proposer
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-        h.remove_signer(&mut rt, anne, true).unwrap();
+        h.remove_signer(&rt, anne, true).unwrap();
 
         // anne fails to cancel a tx -- she is not a signer
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-        expect_abort(ExitCode::USR_FORBIDDEN, h.cancel(&mut rt, TxnID(0), proposal_hash));
+        expect_abort(ExitCode::USR_FORBIDDEN, h.cancel(&rt, TxnID(0), proposal_hash));
 
         // even after anne is restored as a signer, she's not the proposer
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-        h.add_signer(&mut rt, anne, true).unwrap();
+        h.add_signer(&rt, anne, true).unwrap();
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-        expect_abort(ExitCode::USR_FORBIDDEN, h.cancel(&mut rt, TxnID(0), proposal_hash));
+        expect_abort(ExitCode::USR_FORBIDDEN, h.cancel(&rt, TxnID(0), proposal_hash));
 
         // tx should remain after invalid cancel
         let new_tx = Transaction {
@@ -2041,7 +2033,7 @@ mod cancel_tests {
 
         //bob can cancel the tx
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, bob);
-        h.cancel(&mut rt, TxnID(0), new_proposal_hash).unwrap();
+        h.cancel(&rt, TxnID(0), new_proposal_hash).unwrap();
         check_state(&rt);
     }
 }
@@ -2093,12 +2085,12 @@ mod change_threshold_tests {
         ];
 
         for tc in test_cases {
-            let mut rt = construct_runtime(msig);
+            let rt = construct_runtime(msig);
             let h = util::ActorHarness::new();
             let signers = vec![anne, bob, chuck];
-            h.construct_and_verify(&mut rt, tc.initial_threshold, 0, 0, signers);
+            h.construct_and_verify(&rt, tc.initial_threshold, 0, 0, signers);
             rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-            let ret = h.change_num_approvals_threshold(&mut rt, tc.set_threshold);
+            let ret = h.change_num_approvals_threshold(&rt, tc.set_threshold);
             match tc.code {
                 ExitCode::OK => {
                     assert!(ret.unwrap().is_none());
@@ -2125,29 +2117,29 @@ mod change_threshold_tests {
         let bob = Address::new_id(102);
         let chuck = Address::new_id(103);
 
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
         let signers = vec![anne, bob, chuck];
         let num_approvals = 2;
 
-        h.construct_and_verify(&mut rt, num_approvals, 0, 0, signers);
+        h.construct_and_verify(&rt, num_approvals, 0, 0, signers);
 
         // anne proposes tx id 0
         let fake_method = 42;
         let send_value = TokenAmount::from_atto(10u8);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
         let proposal_hash =
-            h.propose_ok(&mut rt, chuck, send_value.clone(), fake_method, RawBytes::default());
+            h.propose_ok(&rt, chuck, send_value.clone(), fake_method, RawBytes::default());
 
         // lower approval threshold, tx is technically approved, but will not be executed yet
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-        h.change_num_approvals_threshold(&mut rt, 1).unwrap();
+        h.change_num_approvals_threshold(&rt, 1).unwrap();
 
         // anne may re-approve causing tx to be exected
         rt.expect_send_simple(chuck, fake_method, None, send_value.clone(), None, ExitCode::OK);
         rt.set_balance(send_value);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, anne);
-        h.approve_ok(&mut rt, TxnID(0), proposal_hash);
+        h.approve_ok(&rt, TxnID(0), proposal_hash);
         h.assert_transactions(&rt, vec![]);
         check_state(&rt);
     }
@@ -2163,12 +2155,12 @@ mod lock_balance_tests {
         let anne = Address::new_id(101);
         let bob = Address::new_id(102);
 
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
 
         // create empty multisig
         rt.set_epoch(100);
-        h.construct_and_verify(&mut rt, 1, 0, 0, vec![anne]);
+        h.construct_and_verify(&rt, 1, 0, 0, vec![anne]);
 
         // some time later, initialize vesting
         rt.set_epoch(200);
@@ -2176,7 +2168,7 @@ mod lock_balance_tests {
         let lock_amount = TokenAmount::from_atto(100_000u32);
         let vest_duration = 1000;
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-        h.lock_balance(&mut rt, vest_start, vest_duration, lock_amount.clone()).unwrap();
+        h.lock_balance(&rt, vest_start, vest_duration, lock_amount.clone()).unwrap();
 
         rt.set_epoch(300);
         let vested = TokenAmount::from_atto(30_000);
@@ -2185,7 +2177,7 @@ mod lock_balance_tests {
         // Fail to spend balance the multisig doesn't have
         expect_abort(
             ExitCode::USR_INSUFFICIENT_FUNDS,
-            h.propose(&mut rt, bob, vested.clone(), METHOD_SEND, RawBytes::default()),
+            h.propose(&rt, bob, vested.clone(), METHOD_SEND, RawBytes::default()),
         );
         rt.reset();
 
@@ -2194,7 +2186,7 @@ mod lock_balance_tests {
         expect_abort(
             ExitCode::USR_INSUFFICIENT_FUNDS,
             h.propose(
-                &mut rt,
+                &rt,
                 bob,
                 vested.clone() + TokenAmount::from_atto(1),
                 METHOD_SEND,
@@ -2206,13 +2198,13 @@ mod lock_balance_tests {
         // can fully spend the vested amount
         rt.set_balance(lock_amount.clone());
         rt.expect_send_simple(bob, METHOD_SEND, None, vested.clone(), None, ExitCode::OK);
-        h.propose_ok(&mut rt, bob, vested.clone(), METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, bob, vested.clone(), METHOD_SEND, RawBytes::default());
 
         // can't spend more
         rt.set_balance(lock_amount - vested);
         expect_abort(
             ExitCode::USR_INSUFFICIENT_FUNDS,
-            h.propose(&mut rt, bob, TokenAmount::from_atto(1), METHOD_SEND, RawBytes::default()),
+            h.propose(&rt, bob, TokenAmount::from_atto(1), METHOD_SEND, RawBytes::default()),
         );
         rt.reset();
 
@@ -2220,7 +2212,7 @@ mod lock_balance_tests {
         rt.set_epoch(vest_start + vest_duration);
         let rested = TokenAmount::from_atto(70_000u32);
         rt.expect_send_simple(bob, METHOD_SEND, None, rested.clone(), None, ExitCode::OK);
-        h.propose_ok(&mut rt, bob, rested, METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, bob, rested, METHOD_SEND, RawBytes::default());
         check_state(&rt);
     }
 
@@ -2230,11 +2222,11 @@ mod lock_balance_tests {
         let anne = Address::new_id(101);
         let bob = Address::new_id(102);
 
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
         // create empty multisig
         rt.set_epoch(100);
-        h.construct_and_verify(&mut rt, 1, 0, 0, vec![anne]);
+        h.construct_and_verify(&rt, 1, 0, 0, vec![anne]);
 
         // some time later initialize vesting
         rt.set_epoch(200);
@@ -2242,7 +2234,7 @@ mod lock_balance_tests {
         let lock_amount = TokenAmount::from_atto(100_000);
         let vest_duration = 1000;
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-        h.lock_balance(&mut rt, vest_start, vest_duration, lock_amount.clone()).unwrap();
+        h.lock_balance(&rt, vest_start, vest_duration, lock_amount.clone()).unwrap();
 
         // oversupply the wallet allow spending the oversupply
         rt.set_epoch(300);
@@ -2256,13 +2248,13 @@ mod lock_balance_tests {
             None,
             ExitCode::OK,
         );
-        h.propose_ok(&mut rt, bob, TokenAmount::from_atto(1), METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, bob, TokenAmount::from_atto(1), METHOD_SEND, RawBytes::default());
 
         // fail to spend locked funds before vesting starts
         rt.set_balance(lock_amount.clone());
         expect_abort(
             ExitCode::USR_INSUFFICIENT_FUNDS,
-            h.propose(&mut rt, bob, TokenAmount::from_atto(1), METHOD_SEND, RawBytes::default()),
+            h.propose(&rt, bob, TokenAmount::from_atto(1), METHOD_SEND, RawBytes::default()),
         );
         rt.reset();
 
@@ -2270,20 +2262,20 @@ mod lock_balance_tests {
         rt.set_epoch(vest_start + 200);
         let expect_vested = TokenAmount::from_atto(20_000);
         rt.expect_send_simple(bob, METHOD_SEND, None, expect_vested.clone(), None, ExitCode::OK);
-        h.propose_ok(&mut rt, bob, expect_vested.clone(), METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, bob, expect_vested.clone(), METHOD_SEND, RawBytes::default());
 
         // can't spend more
         rt.set_balance(lock_amount - expect_vested);
         expect_abort(
             ExitCode::USR_INSUFFICIENT_FUNDS,
-            h.propose(&mut rt, bob, TokenAmount::from_atto(1), METHOD_SEND, RawBytes::default()),
+            h.propose(&rt, bob, TokenAmount::from_atto(1), METHOD_SEND, RawBytes::default()),
         );
 
         // later, can spend the rest
         rt.set_epoch(vest_start + vest_duration);
         let rested = TokenAmount::from_atto(80_000);
         rt.expect_send_simple(bob, METHOD_SEND, None, rested.clone(), None, ExitCode::OK);
-        h.propose_ok(&mut rt, bob, rested, METHOD_SEND, RawBytes::default());
+        h.propose_ok(&rt, bob, rested, METHOD_SEND, RawBytes::default());
         check_state(&rt);
     }
 
@@ -2292,41 +2284,36 @@ mod lock_balance_tests {
         let msig = Address::new_id(100);
         let anne = Address::new_id(101);
 
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
 
         // create empty multisig
         rt.set_epoch(100);
-        h.construct_and_verify(&mut rt, 1, 0, 0, vec![anne]);
+        h.construct_and_verify(&rt, 1, 0, 0, vec![anne]);
 
         // initialize vesting from zero
         let vest_start = 0;
         let lock_amount = TokenAmount::from_atto(100_000);
         let vest_duration = 1000;
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
-        h.lock_balance(&mut rt, vest_start, vest_duration, lock_amount.clone()).unwrap();
+        h.lock_balance(&rt, vest_start, vest_duration, lock_amount.clone()).unwrap();
 
         // can't change vest start
         expect_abort(
             ExitCode::USR_FORBIDDEN,
-            h.lock_balance(&mut rt, vest_start - 1, vest_duration, lock_amount.clone()),
+            h.lock_balance(&rt, vest_start - 1, vest_duration, lock_amount.clone()),
         );
 
         // can't change lock duration
         expect_abort(
             ExitCode::USR_FORBIDDEN,
-            h.lock_balance(&mut rt, vest_start, vest_duration - 1, lock_amount.clone()),
+            h.lock_balance(&rt, vest_start, vest_duration - 1, lock_amount.clone()),
         );
 
         // can't change locked amount
         expect_abort(
             ExitCode::USR_FORBIDDEN,
-            h.lock_balance(
-                &mut rt,
-                vest_start,
-                vest_duration,
-                lock_amount - TokenAmount::from_atto(1),
-            ),
+            h.lock_balance(&rt, vest_start, vest_duration, lock_amount - TokenAmount::from_atto(1)),
         );
         rt.reset();
         check_state(&rt);
@@ -2337,18 +2324,18 @@ mod lock_balance_tests {
         let msig = Address::new_id(100);
         let anne = Address::new_id(101);
 
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
 
         let start_epoch = 100;
         let unlock_duration = 1000;
-        h.construct_and_verify(&mut rt, 1, unlock_duration, start_epoch, vec![anne]);
+        h.construct_and_verify(&rt, 1, unlock_duration, start_epoch, vec![anne]);
 
         // can't change vest start
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
         expect_abort(
             ExitCode::USR_FORBIDDEN,
-            h.lock_balance(&mut rt, start_epoch - 1, unlock_duration, TokenAmount::zero()),
+            h.lock_balance(&rt, start_epoch - 1, unlock_duration, TokenAmount::zero()),
         );
         rt.reset();
         check_state(&rt);
@@ -2359,10 +2346,10 @@ mod lock_balance_tests {
         let msig = Address::new_id(100);
         let anne = Address::new_id(101);
 
-        let mut rt = construct_runtime(msig);
+        let rt = construct_runtime(msig);
         let h = util::ActorHarness::new();
 
-        h.construct_and_verify(&mut rt, 1, 0, 0, vec![anne]);
+        h.construct_and_verify(&rt, 1, 0, 0, vec![anne]);
 
         let vest_start = 0_i64;
         let lock_amount = TokenAmount::from_atto(100_000u32);
@@ -2372,13 +2359,13 @@ mod lock_balance_tests {
         rt.set_caller(*MULTISIG_ACTOR_CODE_ID, msig);
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.lock_balance(&mut rt, vest_start, -1_i64, lock_amount),
+            h.lock_balance(&rt, vest_start, -1_i64, lock_amount),
         );
 
         // Disallow negative amount
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.lock_balance(&mut rt, vest_start, vest_duration, TokenAmount::from_atto(-1i32)),
+            h.lock_balance(&rt, vest_start, vest_duration, TokenAmount::from_atto(-1i32)),
         );
         check_state(&rt);
     }
@@ -2390,9 +2377,9 @@ fn token_receiver() {
     let anne = Address::new_id(101);
     let bob = Address::new_id(102);
 
-    let mut rt = construct_runtime(msig);
+    let rt = construct_runtime(msig);
     let h = util::ActorHarness::new();
-    h.construct_and_verify(&mut rt, 2, 0, 0, vec![anne, bob]);
+    h.construct_and_verify(&rt, 2, 0, 0, vec![anne, bob]);
 
     rt.expect_validate_caller_any();
     let ret = rt

--- a/actors/multisig/tests/util.rs
+++ b/actors/multisig/tests/util.rs
@@ -27,7 +27,7 @@ impl ActorHarness {
 
     pub fn construct_and_verify(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         initial_approvals: u64,
         unlock_duration: ChainEpoch,
         start_epoch: ChainEpoch,
@@ -50,7 +50,7 @@ impl ActorHarness {
 
     pub fn add_signer(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         signer: Address,
         increase: bool,
     ) -> Result<Option<IpldBlock>, ActorError> {
@@ -64,7 +64,7 @@ impl ActorHarness {
 
     pub fn remove_signer(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         signer: Address,
         decrease: bool,
     ) -> Result<Option<IpldBlock>, ActorError> {
@@ -80,7 +80,7 @@ impl ActorHarness {
 
     pub fn swap_signers(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         old_signer: Address,
         new_signer: Address,
     ) -> Result<Option<IpldBlock>, ActorError> {
@@ -94,7 +94,7 @@ impl ActorHarness {
 
     pub fn propose_ok(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         to: Address,
         value: TokenAmount,
         method: MethodNum,
@@ -109,12 +109,7 @@ impl ActorHarness {
 
     // requires that the approval finishes the transaction and that the resulting invocation succeeds.
     // returns the (raw) output of the successful invocation.
-    pub fn approve_ok(
-        &self,
-        rt: &mut MockRuntime,
-        txn_id: TxnID,
-        proposal_hash: [u8; 32],
-    ) -> RawBytes {
+    pub fn approve_ok(&self, rt: &MockRuntime, txn_id: TxnID, proposal_hash: [u8; 32]) -> RawBytes {
         let ret = self.approve(rt, txn_id, proposal_hash).unwrap();
         let approve_ret = ret.unwrap().deserialize::<ApproveReturn>().unwrap();
         assert_eq!(ExitCode::OK, approve_ret.code);
@@ -123,7 +118,7 @@ impl ActorHarness {
 
     pub fn propose(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         to: Address,
         value: TokenAmount,
         method: MethodNum,
@@ -141,7 +136,7 @@ impl ActorHarness {
 
     pub fn approve(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         txn_id: TxnID,
         proposal_hash: [u8; 32],
     ) -> Result<Option<IpldBlock>, ActorError> {
@@ -158,7 +153,7 @@ impl ActorHarness {
 
     pub fn cancel(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         txn_id: TxnID,
         proposal_hash: [u8; 32],
     ) -> Result<Option<IpldBlock>, ActorError> {
@@ -175,7 +170,7 @@ impl ActorHarness {
 
     pub fn lock_balance(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         start: ChainEpoch,
         duration: ChainEpoch,
         amount: TokenAmount,
@@ -193,7 +188,7 @@ impl ActorHarness {
 
     pub fn change_num_approvals_threshold(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         new_threshold: u64,
     ) -> Result<Option<IpldBlock>, ActorError> {
         rt.expect_validate_caller_addr(vec![rt.receiver]);

--- a/actors/multisig/tests/util.rs
+++ b/actors/multisig/tests/util.rs
@@ -103,7 +103,7 @@ impl ActorHarness {
         let ret = self.propose(rt, to, value.clone(), method, params.clone());
         ret.unwrap().unwrap().deserialize::<ProposeReturn>().unwrap();
         // compute proposal hash
-        let txn = Transaction { to, value, method, params, approved: vec![rt.caller] };
+        let txn = Transaction { to, value, method, params, approved: vec![*rt.caller.borrow()] };
         compute_proposal_hash(&txn, rt).unwrap()
     }
 

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -49,7 +49,7 @@ pub struct Actor;
 
 impl Actor {
     /// Constructor for Payment channel actor
-    pub fn constructor(rt: &mut impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
+    pub fn constructor(rt: &impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
         // Only InitActor can create a payment channel actor. It creates the actor on
         // behalf of the payer/payee.
         rt.validate_immediate_caller_type(std::iter::once(&Type::Init))?;
@@ -70,7 +70,7 @@ impl Actor {
     }
 
     pub fn update_channel_state(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: UpdateChannelStateParams,
     ) -> Result<(), ActorError> {
         let st: State = rt.state()?;
@@ -264,7 +264,7 @@ impl Actor {
         })
     }
 
-    pub fn settle(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    pub fn settle(rt: &impl Runtime) -> Result<(), ActorError> {
         rt.transaction(|st: &mut State, rt| {
             rt.validate_immediate_caller_is([st.from, st.to].iter())?;
 
@@ -281,7 +281,7 @@ impl Actor {
         })
     }
 
-    pub fn collect(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    pub fn collect(rt: &impl Runtime) -> Result<(), ActorError> {
         let st: State = rt.state()?;
         rt.validate_immediate_caller_is(&[st.from, st.to])?;
 

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -78,7 +78,7 @@ pub struct Actor;
 
 impl Actor {
     /// Constructor for StoragePower actor
-    fn constructor(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    fn constructor(rt: &impl Runtime) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
         let st = State::new(rt.store()).map_err(|e| {
@@ -89,7 +89,7 @@ impl Actor {
     }
 
     fn create_miner(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: CreateMinerParams,
     ) -> Result<CreateMinerReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -160,7 +160,7 @@ impl Actor {
     /// Adds or removes claimed power for the calling actor.
     /// May only be invoked by a miner actor.
     fn update_claimed_power(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: UpdateClaimedPowerParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
@@ -197,7 +197,7 @@ impl Actor {
     }
 
     fn enroll_cron_event(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: EnrollCronEventParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
@@ -236,7 +236,7 @@ impl Actor {
         Ok(())
     }
 
-    fn on_epoch_tick_end(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    fn on_epoch_tick_end(rt: &impl Runtime) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&CRON_ACTOR_ADDR))?;
 
         let rewret: ThisEpochRewardReturn = deserialize_block(
@@ -252,7 +252,7 @@ impl Actor {
         if let Err(e) = Self::process_batch_proof_verifies(rt, &rewret) {
             error!("unexpected error processing batch proof verifies: {}. Skipping all verification for epoch {}", e, rt.curr_epoch());
         }
-        Self::process_deferred_cron_events(rt, rewret.clone())?;
+        Self::process_deferred_cron_events(rt, rewret)?;
 
         let this_epoch_raw_byte_power = rt.transaction(|st: &mut State, _| {
             let (raw_byte_power, qa_power) = st.current_total_power();
@@ -278,7 +278,7 @@ impl Actor {
     }
 
     fn update_pledge_total(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: UpdatePledgeTotalParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
@@ -297,7 +297,7 @@ impl Actor {
     }
 
     fn submit_porep_for_bulk_verify(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: SubmitPoRepForBulkVerifyParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
@@ -361,7 +361,7 @@ impl Actor {
     /// The returned values are frozen during the cron tick before this epoch
     /// so that this method returns consistent values while processing all messages
     /// of an epoch.
-    fn current_total_power(rt: &mut impl Runtime) -> Result<CurrentTotalPowerReturn, ActorError> {
+    fn current_total_power(rt: &impl Runtime) -> Result<CurrentTotalPowerReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let st: State = rt.state()?;
 
@@ -378,7 +378,7 @@ impl Actor {
     /// of all miners that have more than the consensus minimum amount of storage active.
     /// This value is static over an epoch, and does NOT get updated as messages are executed.
     /// It is recalculated after all messages at an epoch have been executed.
-    fn network_raw_power(rt: &mut impl Runtime) -> Result<NetworkRawPowerReturn, ActorError> {
+    fn network_raw_power(rt: &impl Runtime) -> Result<NetworkRawPowerReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let st: State = rt.state()?;
 
@@ -389,7 +389,7 @@ impl Actor {
     /// and whether the miner has more than the consensus minimum amount of storage active.
     /// The raw power is defined as the active (i.e. non-faulty) byte commitments of the miner.
     fn miner_raw_power(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: MinerRawPowerParams,
     ) -> Result<MinerRawPowerReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
@@ -403,7 +403,7 @@ impl Actor {
 
     /// Returns the total number of miners created, regardless of whether or not
     /// they have any pledged storage.
-    fn miner_count(rt: &mut impl Runtime) -> Result<MinerCountReturn, ActorError> {
+    fn miner_count(rt: &impl Runtime) -> Result<MinerCountReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let st: State = rt.state()?;
 
@@ -412,9 +412,7 @@ impl Actor {
 
     /// Returns the total number of miners that have more than the consensus minimum amount of storage active.
     /// Active means that the storage must not be faulty.
-    fn miner_consensus_count(
-        rt: &mut impl Runtime,
-    ) -> Result<MinerConsensusCountReturn, ActorError> {
+    fn miner_consensus_count(rt: &impl Runtime) -> Result<MinerConsensusCountReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let st: State = rt.state()?;
 
@@ -422,7 +420,7 @@ impl Actor {
     }
 
     fn process_batch_proof_verifies(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         rewret: &ThisEpochRewardReturn,
     ) -> Result<(), String> {
         let mut miners: Vec<(Address, usize)> = Vec::new();
@@ -559,7 +557,7 @@ impl Actor {
     }
 
     fn process_deferred_cron_events(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         rewret: ThisEpochRewardReturn,
     ) -> Result<(), ActorError> {
         let rt_epoch = rt.curr_epoch();

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -86,9 +86,9 @@ pub fn new_harness() -> Harness {
 }
 
 pub fn setup() -> (Harness, MockRuntime) {
-    let mut rt = new_runtime();
+    let rt = new_runtime();
     let h = new_harness();
-    h.construct(&mut rt);
+    h.construct(&rt);
     (h, rt)
 }
 
@@ -102,14 +102,14 @@ pub struct Harness {
 }
 
 impl Harness {
-    pub fn construct(&self, rt: &mut MockRuntime) {
+    pub fn construct(&self, rt: &MockRuntime) {
         rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
         rt.call::<PowerActor>(Method::Constructor as MethodNum, None).unwrap();
         rt.verify()
     }
 
-    pub fn construct_and_verify(&self, rt: &mut MockRuntime) {
+    pub fn construct_and_verify(&self, rt: &MockRuntime) {
         self.construct(rt);
         let st: State = rt.get_state();
         assert_eq!(StoragePower::zero(), st.total_raw_byte_power);
@@ -131,7 +131,7 @@ impl Harness {
     #[allow(clippy::too_many_arguments)]
     pub fn create_miner(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         owner: &Address,
         worker: &Address,
         miner: &Address,
@@ -183,7 +183,7 @@ impl Harness {
 
     pub fn create_miner_basic(
         &mut self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         owner: Address,
         worker: Address,
         miner: Address,
@@ -213,7 +213,7 @@ impl Harness {
         keys.iter().map(|k| Address::from_bytes(k).unwrap()).collect::<Vec<_>>()
     }
 
-    pub fn miner_count(&self, rt: &mut MockRuntime) -> i64 {
+    pub fn miner_count(&self, rt: &MockRuntime) -> i64 {
         rt.expect_validate_caller_any();
         let ret: MinerCountReturn = rt
             .call::<PowerActor>(Method::MinerCountExported as MethodNum, None)
@@ -234,7 +234,7 @@ impl Harness {
         st.get_claim(rt.store(), miner).unwrap()
     }
 
-    pub fn delete_claim(&mut self, rt: &mut MockRuntime, miner: &Address) {
+    pub fn delete_claim(&mut self, rt: &MockRuntime, miner: &Address) {
         let mut state: State = rt.get_state();
 
         let mut claims =
@@ -248,7 +248,7 @@ impl Harness {
 
     pub fn enroll_cron_event(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         epoch: ChainEpoch,
         miner_address: &Address,
         payload: &RawBytes,
@@ -291,7 +291,7 @@ impl Harness {
         acc.assert_empty();
     }
 
-    pub fn update_pledge_total(&self, rt: &mut MockRuntime, miner: Address, delta: &TokenAmount) {
+    pub fn update_pledge_total(&self, rt: &MockRuntime, miner: Address, delta: &TokenAmount) {
         let st: State = rt.get_state();
         let prev = st.total_pledge_collateral;
 
@@ -308,7 +308,7 @@ impl Harness {
         assert_eq!(prev + delta, st.total_pledge_collateral);
     }
 
-    pub fn current_power_total(&self, rt: &mut MockRuntime) -> CurrentTotalPowerReturn {
+    pub fn current_power_total(&self, rt: &MockRuntime) -> CurrentTotalPowerReturn {
         rt.expect_validate_caller_any();
         let ret: CurrentTotalPowerReturn = rt
             .call::<PowerActor>(Method::CurrentTotalPower as u64, None)
@@ -322,7 +322,7 @@ impl Harness {
 
     pub fn update_claimed_power(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         miner: Address,
         raw_delta: &StoragePower,
         qa_delta: &StoragePower,
@@ -360,7 +360,7 @@ impl Harness {
 
     pub fn expect_total_power_eager(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         expected_raw: &StoragePower,
         expected_qa: &StoragePower,
     ) {
@@ -371,12 +371,12 @@ impl Harness {
         assert_eq!(expected_qa, &quality_adj_power);
     }
 
-    pub fn expect_total_pledge_eager(&self, rt: &mut MockRuntime, expected_pledge: &TokenAmount) {
+    pub fn expect_total_pledge_eager(&self, rt: &MockRuntime, expected_pledge: &TokenAmount) {
         let st: State = rt.get_state();
         assert_eq!(expected_pledge, &st.total_pledge_collateral);
     }
 
-    pub fn expect_miners_above_min_power(&self, rt: &mut MockRuntime, count: i64) {
+    pub fn expect_miners_above_min_power(&self, rt: &MockRuntime, count: i64) {
         rt.expect_validate_caller_any();
         let ret: MinerConsensusCountReturn = rt
             .call::<PowerActor>(Method::MinerConsensusCountExported as MethodNum, None)
@@ -388,7 +388,7 @@ impl Harness {
         assert_eq!(count, ret.miner_consensus_count);
     }
 
-    pub fn expect_query_network_info(&self, rt: &mut MockRuntime) {
+    pub fn expect_query_network_info(&self, rt: &MockRuntime) {
         let current_reward = ThisEpochRewardReturn {
             this_epoch_baseline_power: self.this_epoch_baseline_power.clone(),
             this_epoch_reward_smoothed: self.this_epoch_reward_smoothed.clone(),
@@ -406,7 +406,7 @@ impl Harness {
 
     pub fn on_epoch_tick_end(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         current_epoch: ChainEpoch,
         expected_raw_power: &StoragePower,
         confirmed_sectors: Vec<ConfirmedSectorSend>,
@@ -460,7 +460,7 @@ impl Harness {
 
     pub fn submit_porep_for_bulk_verify(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         miner_address: Address,
         seal_info: SealVerifyInfo,
         expect_success: bool,

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use cid::Cid;
 use fil_actor_power::detail::GAS_ON_SUBMIT_VERIFY_SEAL;
 use fil_actor_power::ext::miner::ConfirmSectorProofsParams;
@@ -66,8 +68,8 @@ lazy_static! {
 pub fn new_runtime() -> MockRuntime {
     MockRuntime {
         receiver: STORAGE_POWER_ACTOR_ADDR,
-        caller: SYSTEM_ACTOR_ADDR,
-        caller_type: *SYSTEM_ACTOR_CODE_ID,
+        caller: RefCell::new(SYSTEM_ACTOR_ADDR),
+        caller_type: RefCell::new(*SYSTEM_ACTOR_CODE_ID),
         ..Default::default()
     }
 }
@@ -140,7 +142,7 @@ impl Harness {
         value: &TokenAmount,
     ) -> Result<(), ActorError> {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *owner);
-        rt.set_value(value.clone());
+        rt.set_received(value.clone());
         rt.set_balance(value.clone());
         rt.expect_validate_caller_any();
 

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -96,7 +96,7 @@ fn create_miner_given_send_to_init_actor_fails_should_fail() {
 
     // owner send CreateMiner to Actor
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *OWNER);
-    rt.value_received = TokenAmount::from_atto(10);
+    rt.value_received.replace(TokenAmount::from_atto(10));
     rt.set_balance(TokenAmount::from_atto(10));
     rt.expect_validate_caller_any();
 
@@ -135,7 +135,7 @@ fn create_miner_given_send_to_init_actor_fails_should_fail() {
 
 #[test]
 fn claimed_power_given_caller_is_not_storage_miner_should_fail() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let params = UpdateClaimedPowerParams {
         raw_byte_delta: StoragePower::from(100),
@@ -159,7 +159,7 @@ fn claimed_power_given_caller_is_not_storage_miner_should_fail() {
 
 #[test]
 fn claimed_power_given_claim_does_not_exist_should_fail() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let params = UpdateClaimedPowerParams {
         raw_byte_delta: StoragePower::from(100),
@@ -419,7 +419,7 @@ fn all_of_one_miners_power_disappears_when_that_miner_dips_below_min_power_thres
 
 #[test]
 fn enroll_cron_epoch_given_negative_epoch_should_fail() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     rt.set_caller(*MINER_ACTOR_CODE_ID, *MINER);
     rt.expect_validate_caller_type(vec![Type::Miner]);
@@ -1443,7 +1443,7 @@ mod submit_porep_for_bulk_verify_tests {
 
 #[test]
 fn create_miner_restricted_correctly() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let peer = "miner".as_bytes().to_vec();
     let multiaddrs = vec![BytesDe("multiaddr".as_bytes().to_vec())];

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -31,21 +31,21 @@ mod harness;
 
 #[test]
 fn construct() {
-    let mut rt = new_runtime();
+    let rt = new_runtime();
     let h = new_harness();
-    h.construct_and_verify(&mut rt);
+    h.construct_and_verify(&rt);
     h.check_state(&rt);
 }
 
 #[test]
 fn create_miner() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let peer = "miner".as_bytes().to_vec();
     let multiaddrs = vec![BytesDe("multiaddr".as_bytes().to_vec())];
 
     h.create_miner(
-        &mut rt,
+        &rt,
         &OWNER,
         &OWNER,
         &MINER,
@@ -81,7 +81,7 @@ fn create_miner() {
 
 #[test]
 fn create_miner_given_send_to_init_actor_fails_should_fail() {
-    let (h, mut rt) = setup();
+    let (h, rt) = setup();
 
     let peer = "miner".as_bytes().to_vec();
     let multiaddrs = vec![BytesDe("multiaddr".as_bytes().to_vec())];
@@ -195,25 +195,25 @@ fn power_and_pledge_accounted_below_threshold() {
     let small_power_unit_x2 = &(small_power_unit * 2);
     let small_power_unit_x3 = &(small_power_unit * 3);
 
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER1).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER2).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER1).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER2).unwrap();
 
-    let ret = h.current_power_total(&mut rt);
+    let ret = h.current_power_total(&rt);
     assert_eq!(StoragePower::zero(), ret.raw_byte_power);
     assert_eq!(StoragePower::zero(), ret.quality_adj_power);
     assert_eq!(TokenAmount::zero(), ret.pledge_collateral);
 
     // Add power for miner1
-    h.update_claimed_power(&mut rt, MINER1, small_power_unit, small_power_unit_x2);
-    h.expect_total_power_eager(&mut rt, small_power_unit, small_power_unit_x2);
+    h.update_claimed_power(&rt, MINER1, small_power_unit, small_power_unit_x2);
+    h.expect_total_power_eager(&rt, small_power_unit, small_power_unit_x2);
 
     // Add power and pledge for miner2
-    h.update_claimed_power(&mut rt, MINER2, small_power_unit, small_power_unit);
-    h.update_pledge_total(&mut rt, MINER1, &TokenAmount::from_atto(1_000_000));
-    h.expect_total_power_eager(&mut rt, small_power_unit_x2, small_power_unit_x3);
-    h.expect_total_pledge_eager(&mut rt, &TokenAmount::from_atto(1_000_000));
+    h.update_claimed_power(&rt, MINER2, small_power_unit, small_power_unit);
+    h.update_pledge_total(&rt, MINER1, &TokenAmount::from_atto(1_000_000));
+    h.expect_total_power_eager(&rt, small_power_unit_x2, small_power_unit_x3);
+    h.expect_total_pledge_eager(&rt, &TokenAmount::from_atto(1_000_000));
 
     rt.verify();
 
@@ -227,10 +227,10 @@ fn power_and_pledge_accounted_below_threshold() {
     assert_eq!(small_power_unit, &claim2.quality_adj_power);
 
     // Subtract power and some pledge for miner2
-    h.update_claimed_power(&mut rt, MINER2, &small_power_unit.neg(), &small_power_unit.neg());
-    h.update_pledge_total(&mut rt, MINER2, &TokenAmount::from_atto(100_000).neg());
-    h.expect_total_power_eager(&mut rt, small_power_unit, small_power_unit_x2);
-    h.expect_total_pledge_eager(&mut rt, &TokenAmount::from_atto(900_000));
+    h.update_claimed_power(&rt, MINER2, &small_power_unit.neg(), &small_power_unit.neg());
+    h.update_pledge_total(&rt, MINER2, &TokenAmount::from_atto(100_000).neg());
+    h.expect_total_power_eager(&rt, small_power_unit, small_power_unit_x2);
+    h.expect_total_pledge_eager(&rt, &TokenAmount::from_atto(900_000));
 
     let claim2 = h.get_claim(&rt, &MINER2).unwrap();
     assert!(claim2.raw_byte_power.is_zero());
@@ -240,16 +240,16 @@ fn power_and_pledge_accounted_below_threshold() {
 
 #[test]
 fn enroll_cron_epoch_multiple_events() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, *MINER).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, *MINER).unwrap();
     let miner2_address = Address::new_id(501);
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, miner2_address).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, miner2_address).unwrap();
 
-    let mut enroll_and_check_cron_event = |epoch, miner_address, payload| {
+    let enroll_and_check_cron_event = |epoch, miner_address, payload| {
         let pre_existing_event_count = h.get_enrolled_cron_ticks(&rt, epoch).len();
 
-        h.enroll_cron_event(&mut rt, epoch, miner_address, payload).unwrap();
+        h.enroll_cron_event(&rt, epoch, miner_address, payload).unwrap();
 
         let events = h.get_enrolled_cron_ticks(&rt, epoch);
         assert_eq!(events.len(), pre_existing_event_count + 1);
@@ -274,9 +274,9 @@ fn enroll_cron_epoch_multiple_events() {
 
 #[test]
 fn enroll_cron_epoch_before_current_epoch() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, *MINER).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, *MINER).unwrap();
 
     let current_epoch: ChainEpoch = 5;
     rt.set_epoch(current_epoch);
@@ -284,7 +284,7 @@ fn enroll_cron_epoch_before_current_epoch() {
     // enroll event with miner at epoch=2
     let miner_epoch = 2;
     let payload = RawBytes::serialize(b"Cthulhu").unwrap();
-    h.enroll_cron_event(&mut rt, miner_epoch, &MINER, &payload).unwrap();
+    h.enroll_cron_event(&rt, miner_epoch, &MINER, &payload).unwrap();
 
     let events = h.get_enrolled_cron_ticks(&rt, miner_epoch);
     assert_eq!(events.len(), 1);
@@ -297,7 +297,7 @@ fn enroll_cron_epoch_before_current_epoch() {
     // enroll event with miner at epoch=1
     let miner_epoch = 1;
     let payload = RawBytes::serialize(b"Azathoth").unwrap();
-    h.enroll_cron_event(&mut rt, miner_epoch, &MINER, &payload).unwrap();
+    h.enroll_cron_event(&rt, miner_epoch, &MINER, &payload).unwrap();
 
     let events = h.get_enrolled_cron_ticks(&rt, miner_epoch);
     assert_eq!(events.len(), 1);
@@ -324,11 +324,11 @@ fn new_miner_updates_miner_above_min_power_count() {
     ];
 
     for test in test_cases {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
         h.window_post_proof = test.proof;
-        h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER1).unwrap();
+        h.create_miner_basic(&rt, *OWNER, *OWNER, MINER1).unwrap();
 
-        h.expect_miners_above_min_power(&mut rt, test.expected_miners);
+        h.expect_miners_above_min_power(&rt, test.expected_miners);
         h.check_state(&rt);
     }
 }
@@ -347,37 +347,37 @@ fn power_accounting_crossing_threshold() {
 
     assert!(small_power_unit < power_unit);
 
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER1).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER2).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER3).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER4).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER5).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER1).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER2).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER3).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER4).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER5).unwrap();
 
     // Use qa power 10x raw power to show it's not being used for threshold calculations.
-    h.update_claimed_power(&mut rt, MINER1, small_power_unit, small_power_unit_x10);
-    h.update_claimed_power(&mut rt, MINER2, small_power_unit, small_power_unit_x10);
+    h.update_claimed_power(&rt, MINER1, small_power_unit, small_power_unit_x10);
+    h.update_claimed_power(&rt, MINER2, small_power_unit, small_power_unit_x10);
 
-    h.update_claimed_power(&mut rt, MINER3, power_unit, power_unit_x10);
-    h.update_claimed_power(&mut rt, MINER4, power_unit, power_unit_x10);
-    h.update_claimed_power(&mut rt, MINER5, power_unit, power_unit_x10);
+    h.update_claimed_power(&rt, MINER3, power_unit, power_unit_x10);
+    h.update_claimed_power(&rt, MINER4, power_unit, power_unit_x10);
+    h.update_claimed_power(&rt, MINER5, power_unit, power_unit_x10);
 
     // Below threshold small miner power is counted
     let expected_total_below = small_power_unit * 2 + power_unit * 3;
-    h.expect_total_power_eager(&mut rt, &expected_total_below, &(&expected_total_below * 10));
+    h.expect_total_power_eager(&rt, &expected_total_below, &(&expected_total_below * 10));
 
     // Above threshold (power.ConsensusMinerMinMiners = 4) small miner power is ignored
     let delta = &(power_unit - small_power_unit);
-    h.update_claimed_power(&mut rt, MINER2, delta, &(delta * 10));
+    h.update_claimed_power(&rt, MINER2, delta, &(delta * 10));
     let expected_total_above = &(power_unit * 4);
-    h.expect_total_power_eager(&mut rt, expected_total_above, &(expected_total_above * 10));
+    h.expect_total_power_eager(&rt, expected_total_above, &(expected_total_above * 10));
 
-    h.expect_miners_above_min_power(&mut rt, 4);
+    h.expect_miners_above_min_power(&rt, 4);
 
     // Less than 4 miners above threshold again small miner power is counted again
-    h.update_claimed_power(&mut rt, MINER4, &delta.neg(), &(delta.neg() * 10));
-    h.expect_total_power_eager(&mut rt, &expected_total_below, &(&expected_total_below * 10));
+    h.update_claimed_power(&rt, MINER4, &delta.neg(), &(delta.neg() * 10));
+    h.expect_total_power_eager(&rt, &expected_total_below, &(&expected_total_below * 10));
     h.check_state(&rt);
 }
 
@@ -392,28 +392,28 @@ fn all_of_one_miners_power_disappears_when_that_miner_dips_below_min_power_thres
 
     assert!(small_power_unit < power_unit);
 
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER1).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER2).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER3).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER4).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER5).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER1).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER2).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER3).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER4).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER5).unwrap();
 
-    h.update_claimed_power(&mut rt, MINER1, power_unit, power_unit);
-    h.update_claimed_power(&mut rt, MINER2, power_unit, power_unit);
-    h.update_claimed_power(&mut rt, MINER3, power_unit, power_unit);
-    h.update_claimed_power(&mut rt, MINER4, power_unit, power_unit);
-    h.update_claimed_power(&mut rt, MINER5, power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER1, power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER2, power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER3, power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER4, power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER5, power_unit, power_unit);
 
     let expected_total = &(power_unit * 5);
-    h.expect_total_power_eager(&mut rt, expected_total, expected_total);
+    h.expect_total_power_eager(&rt, expected_total, expected_total);
 
     // miner4 dips just below threshold
-    h.update_claimed_power(&mut rt, MINER4, &small_power_unit.neg(), &small_power_unit.neg());
+    h.update_claimed_power(&rt, MINER4, &small_power_unit.neg(), &small_power_unit.neg());
 
     let expected_total = &(power_unit * 4);
-    h.expect_total_power_eager(&mut rt, expected_total, expected_total);
+    h.expect_total_power_eager(&rt, expected_total, expected_total);
     h.check_state(&rt);
 }
 
@@ -449,42 +449,42 @@ fn power_gets_added_when_miner_crosses_min_power_but_not_before() {
     .unwrap();
 
     // Setup four miners above threshold
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
     // create 4 miners that meet minimum
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER1).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER2).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER3).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER4).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER1).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER2).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER3).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER4).unwrap();
 
-    h.update_claimed_power(&mut rt, MINER1, power_unit, power_unit);
-    h.update_claimed_power(&mut rt, MINER2, power_unit, power_unit);
-    h.update_claimed_power(&mut rt, MINER3, power_unit, power_unit);
-    h.update_claimed_power(&mut rt, MINER4, power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER1, power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER2, power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER3, power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER4, power_unit, power_unit);
 
-    h.expect_miners_above_min_power(&mut rt, 4);
+    h.expect_miners_above_min_power(&rt, 4);
     let expected_total = &(power_unit * 4);
-    h.expect_total_power_eager(&mut rt, expected_total, expected_total);
+    h.expect_total_power_eager(&rt, expected_total, expected_total);
 
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER5).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER5).unwrap();
     let below_limit_unit = power_unit / 2;
 
     // below limit actors power is not added
-    h.update_claimed_power(&mut rt, MINER5, &below_limit_unit, &below_limit_unit);
-    h.expect_miners_above_min_power(&mut rt, 4);
-    h.expect_total_power_eager(&mut rt, expected_total, expected_total);
+    h.update_claimed_power(&rt, MINER5, &below_limit_unit, &below_limit_unit);
+    h.expect_miners_above_min_power(&rt, 4);
+    h.expect_total_power_eager(&rt, expected_total, expected_total);
 
     // just below limit
     let delta = power_unit - below_limit_unit - 1;
-    h.update_claimed_power(&mut rt, MINER5, &delta, &delta);
-    h.expect_miners_above_min_power(&mut rt, 4);
-    h.expect_total_power_eager(&mut rt, expected_total, expected_total);
+    h.update_claimed_power(&rt, MINER5, &delta, &delta);
+    h.expect_miners_above_min_power(&rt, 4);
+    h.expect_total_power_eager(&rt, expected_total, expected_total);
 
     // at limit power is added
-    h.update_claimed_power(&mut rt, MINER5, &StoragePower::from(1), &StoragePower::from(1));
-    h.expect_miners_above_min_power(&mut rt, 5);
+    h.update_claimed_power(&rt, MINER5, &StoragePower::from(1), &StoragePower::from(1));
+    h.expect_miners_above_min_power(&rt, 5);
     let new_expected_total = expected_total + power_unit;
-    h.expect_total_power_eager(&mut rt, &new_expected_total, &new_expected_total);
+    h.expect_total_power_eager(&rt, &new_expected_total, &new_expected_total);
     h.check_state(&rt);
 }
 
@@ -497,22 +497,22 @@ fn threshold_only_depends_on_raw_power_not_qa_power() {
     .unwrap();
     let half_power_unit = &(power_unit / 2);
 
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER1).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER2).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER3).unwrap();
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER4).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER1).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER2).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER3).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER4).unwrap();
 
-    h.update_claimed_power(&mut rt, MINER1, half_power_unit, power_unit);
-    h.update_claimed_power(&mut rt, MINER2, half_power_unit, power_unit);
-    h.update_claimed_power(&mut rt, MINER3, half_power_unit, power_unit);
-    h.expect_miners_above_min_power(&mut rt, 0);
+    h.update_claimed_power(&rt, MINER1, half_power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER2, half_power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER3, half_power_unit, power_unit);
+    h.expect_miners_above_min_power(&rt, 0);
 
-    h.update_claimed_power(&mut rt, MINER1, half_power_unit, power_unit);
-    h.update_claimed_power(&mut rt, MINER2, half_power_unit, power_unit);
-    h.update_claimed_power(&mut rt, MINER3, half_power_unit, power_unit);
-    h.expect_miners_above_min_power(&mut rt, 3);
+    h.update_claimed_power(&rt, MINER1, half_power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER2, half_power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER3, half_power_unit, power_unit);
+    h.expect_miners_above_min_power(&rt, 3);
     h.check_state(&rt);
 }
 
@@ -526,17 +526,17 @@ fn qa_power_is_above_threshold_before_and_after_update() {
     let power_unit_x3 = &(power_unit * 3);
     let power_unit_x4 = &(power_unit * 4);
 
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
     // update claim so qa is above threshold
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER1).unwrap();
-    h.update_claimed_power(&mut rt, MINER1, power_unit_x3, power_unit_x3);
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER1).unwrap();
+    h.update_claimed_power(&rt, MINER1, power_unit_x3, power_unit_x3);
     let st: State = rt.get_state();
     assert_eq!(power_unit_x3, &st.total_quality_adj_power);
     assert_eq!(power_unit_x3, &st.total_raw_byte_power);
 
     // update such that it's above threshold again
-    h.update_claimed_power(&mut rt, MINER1, power_unit, power_unit);
+    h.update_claimed_power(&rt, MINER1, power_unit, power_unit);
     let st: State = rt.get_state();
     assert_eq!(power_unit_x4, &st.total_quality_adj_power);
     assert_eq!(power_unit_x4, &st.total_raw_byte_power);
@@ -551,10 +551,10 @@ fn claimed_power_is_externally_available() {
     )
     .unwrap();
 
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER1).unwrap();
-    h.update_claimed_power(&mut rt, MINER1, power_unit, power_unit);
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER1).unwrap();
+    h.update_claimed_power(&rt, MINER1, power_unit, power_unit);
 
     let claim = h.get_claim(&rt, &MINER1).unwrap();
 
@@ -571,10 +571,10 @@ fn get_network_and_miner_power() {
     )
     .unwrap();
 
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, MINER1).unwrap();
-    h.update_claimed_power(&mut rt, MINER1, power_unit, power_unit);
+    h.create_miner_basic(&rt, *OWNER, *OWNER, MINER1).unwrap();
+    h.update_claimed_power(&rt, MINER1, power_unit, power_unit);
 
     // manually update state in lieu of cron running
     let mut state: State = rt.get_state();
@@ -613,12 +613,12 @@ fn get_network_and_miner_power() {
 
 #[test]
 fn given_no_miner_claim_update_pledge_total_should_abort() {
-    let (mut h, mut rt) = setup();
+    let (mut h, rt) = setup();
 
-    h.create_miner_basic(&mut rt, *OWNER, *OWNER, *MINER).unwrap();
+    h.create_miner_basic(&rt, *OWNER, *OWNER, *MINER).unwrap();
 
     // explicitly delete miner claim
-    h.delete_claim(&mut rt, &MINER);
+    h.delete_claim(&rt, &MINER);
 
     rt.set_caller(*MINER_ACTOR_CODE_ID, *MINER);
     rt.expect_validate_caller_type(vec![Type::Miner]);
@@ -651,14 +651,14 @@ mod cron_tests {
 
     #[test]
     fn call_reward_actor() {
-        let (h, mut rt) = setup();
+        let (h, rt) = setup();
 
         let expected_power = BigInt::zero();
         rt.set_epoch(1);
 
         rt.expect_validate_caller_addr(vec![CRON_ACTOR_ADDR]);
 
-        h.expect_query_network_info(&mut rt);
+        h.expect_query_network_info(&rt);
         rt.expect_send_simple(
             REWARD_ACTOR_ADDR,
             RewardMethod::UpdateNetworkKPI as u64,
@@ -678,7 +678,7 @@ mod cron_tests {
 
     #[test]
     fn amount_sent_to_reward_actor_and_state_change() {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
         let power_unit = consensus_miner_min_power(
             &Policy::default(),
             RegisteredPoStProof::StackedDRGWindow2KiBV1,
@@ -690,21 +690,21 @@ mod cron_tests {
         let miner3 = Address::new_id(103);
         let miner4 = Address::new_id(104);
 
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner1).unwrap();
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner2).unwrap();
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner3).unwrap();
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner4).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner1).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner2).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner3).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner4).unwrap();
 
-        h.update_claimed_power(&mut rt, miner1, &power_unit, &power_unit);
-        h.update_claimed_power(&mut rt, miner2, &power_unit, &power_unit);
-        h.update_claimed_power(&mut rt, miner3, &power_unit, &power_unit);
-        h.update_claimed_power(&mut rt, miner4, &power_unit, &power_unit);
+        h.update_claimed_power(&rt, miner1, &power_unit, &power_unit);
+        h.update_claimed_power(&rt, miner2, &power_unit, &power_unit);
+        h.update_claimed_power(&rt, miner3, &power_unit, &power_unit);
+        h.update_claimed_power(&rt, miner4, &power_unit, &power_unit);
 
         let expected_power: BigInt = power_unit * 4u8;
 
         let delta = TokenAmount::from_atto(1u8);
-        h.update_pledge_total(&mut rt, miner1, &delta);
-        h.on_epoch_tick_end(&mut rt, 0, &expected_power, Vec::new(), Vec::new());
+        h.update_pledge_total(&rt, miner1, &delta);
+        h.on_epoch_tick_end(&rt, 0, &expected_power, Vec::new(), Vec::new());
 
         let state: State = rt.get_state();
 
@@ -718,13 +718,13 @@ mod cron_tests {
 
     #[test]
     fn event_scheduled_in_null_round_called_next_round() {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
 
         let miner1 = Address::new_id(101);
         let miner2 = Address::new_id(102);
 
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner1).unwrap();
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner2).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner1).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner2).unwrap();
 
         //  0 - genesis
         //  1 - block - registers events
@@ -733,13 +733,13 @@ mod cron_tests {
         //  4 - block - has event
 
         rt.set_epoch(1);
-        h.enroll_cron_event(&mut rt, 2, &miner1, &RawBytes::from(vec![0x01, 0x03])).unwrap();
-        h.enroll_cron_event(&mut rt, 4, &miner2, &RawBytes::from(vec![0x02, 0x03])).unwrap();
+        h.enroll_cron_event(&rt, 2, &miner1, &RawBytes::from(vec![0x01, 0x03])).unwrap();
+        h.enroll_cron_event(&rt, 4, &miner2, &RawBytes::from(vec![0x02, 0x03])).unwrap();
 
         let expected_raw_byte_power = BigInt::zero();
         rt.set_epoch(4);
         rt.expect_validate_caller_addr(vec![CRON_ACTOR_ADDR]);
-        h.expect_query_network_info(&mut rt);
+        h.expect_query_network_info(&rt);
         let state: State = rt.get_state();
 
         let params1 = DeferredCronEventParams {
@@ -788,16 +788,16 @@ mod cron_tests {
 
     #[test]
     fn event_scheduled_in_past_called_next_round() {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
 
         let miner_addr = Address::new_id(101);
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner_addr).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner_addr).unwrap();
 
         // run cron once to put it in a clean state at epoch 4
         let expected_raw_byte_power = BigInt::zero();
         rt.set_epoch(4);
         rt.expect_validate_caller_addr(vec![CRON_ACTOR_ADDR]);
-        h.expect_query_network_info(&mut rt);
+        h.expect_query_network_info(&rt);
         rt.expect_send_simple(
             REWARD_ACTOR_ADDR,
             UPDATE_NETWORK_KPI,
@@ -815,12 +815,12 @@ mod cron_tests {
 
         // enroll a cron task at epoch 2 (which is in the past)
         let payload = vec![0x01, 0x03];
-        h.enroll_cron_event(&mut rt, 2, &miner_addr, &RawBytes::from(payload.clone())).unwrap();
+        h.enroll_cron_event(&rt, 2, &miner_addr, &RawBytes::from(payload.clone())).unwrap();
 
         // run cron again in the future
         rt.set_epoch(6);
         rt.expect_validate_caller_addr(vec![CRON_ACTOR_ADDR]);
-        h.expect_query_network_info(&mut rt);
+        h.expect_query_network_info(&rt);
 
         let state: State = rt.get_state();
 
@@ -860,41 +860,41 @@ mod cron_tests {
 
     #[test]
     fn fails_to_enroll_if_epoch_negative() {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
         let miner_addr = Address::new_id(101);
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner_addr).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner_addr).unwrap();
 
         expect_abort_contains_message(
             ExitCode::USR_ILLEGAL_ARGUMENT,
             "epoch -2 cannot be less than zero",
-            h.enroll_cron_event(&mut rt, -2, &miner_addr, &RawBytes::from(vec![0x01, 0x03])),
+            h.enroll_cron_event(&rt, -2, &miner_addr, &RawBytes::from(vec![0x01, 0x03])),
         );
         h.check_state(&rt);
     }
 
     #[test]
     fn skips_invocation_if_miner_has_no_claim() {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
         rt.set_epoch(1);
 
         let miner1 = Address::new_id(101);
         let miner2 = Address::new_id(102);
 
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner1).unwrap();
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner2).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner1).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner2).unwrap();
 
-        h.enroll_cron_event(&mut rt, 2, &miner1, &RawBytes::default()).unwrap();
-        h.enroll_cron_event(&mut rt, 2, &miner2, &RawBytes::default()).unwrap();
+        h.enroll_cron_event(&rt, 2, &miner1, &RawBytes::default()).unwrap();
+        h.enroll_cron_event(&rt, 2, &miner2, &RawBytes::default()).unwrap();
 
         // explicitly delete miner 1's claim
-        h.delete_claim(&mut rt, &miner1);
+        h.delete_claim(&rt, &miner1);
 
         rt.set_epoch(2);
         rt.expect_validate_caller_addr(vec![CRON_ACTOR_ADDR]);
 
         // process batch verifies first
         rt.expect_batch_verify_seals(Vec::new(), Ok(Vec::new()));
-        h.expect_query_network_info(&mut rt);
+        h.expect_query_network_info(&rt);
 
         let state: State = rt.get_state();
         let input = DeferredCronEventParams {
@@ -931,17 +931,17 @@ mod cron_tests {
 
     #[test]
     fn handles_failed_call() {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
         rt.set_epoch(1);
 
         let miner1 = Address::new_id(101);
         let miner2 = Address::new_id(102);
 
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner1).unwrap();
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner2).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner1).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner2).unwrap();
 
-        h.enroll_cron_event(&mut rt, 2, &miner1, &RawBytes::default()).unwrap();
-        h.enroll_cron_event(&mut rt, 2, &miner2, &RawBytes::default()).unwrap();
+        h.enroll_cron_event(&rt, 2, &miner1, &RawBytes::default()).unwrap();
+        h.enroll_cron_event(&rt, 2, &miner2, &RawBytes::default()).unwrap();
 
         let raw_power = consensus_miner_min_power(
             &Policy::default(),
@@ -950,9 +950,9 @@ mod cron_tests {
         .unwrap();
 
         let qa_power = &raw_power;
-        h.update_claimed_power(&mut rt, miner1, &raw_power, qa_power);
-        h.expect_total_power_eager(&mut rt, &raw_power, qa_power);
-        h.expect_miners_above_min_power(&mut rt, 1);
+        h.update_claimed_power(&rt, miner1, &raw_power, qa_power);
+        h.expect_total_power_eager(&rt, &raw_power, qa_power);
+        h.expect_miners_above_min_power(&rt, 1);
 
         rt.set_epoch(2);
         rt.expect_validate_caller_addr(vec![CRON_ACTOR_ADDR]);
@@ -960,7 +960,7 @@ mod cron_tests {
         // process batch verifies first
         rt.expect_batch_verify_seals(Vec::new(), Ok(Vec::new()));
 
-        h.expect_query_network_info(&mut rt);
+        h.expect_query_network_info(&rt);
 
         let state: State = rt.get_state();
         let input = IpldBlock::serialize_cbor(&DeferredCronEventParams {
@@ -1003,20 +1003,20 @@ mod cron_tests {
         rt.verify();
 
         // expect power stats to be decremented due to claim deletion
-        h.expect_total_power_eager(&mut rt, &BigInt::zero(), &BigInt::zero());
-        h.expect_miners_above_min_power(&mut rt, 0);
+        h.expect_total_power_eager(&rt, &BigInt::zero(), &BigInt::zero());
+        h.expect_miners_above_min_power(&rt, 0);
 
         // miner's claim is removed
         assert!(h.get_claim(&rt, &miner1).is_none());
 
         // miner count has been reduced to 1
-        assert_eq!(h.miner_count(&mut rt), 1);
+        assert_eq!(h.miner_count(&rt), 1);
 
         // next epoch, only the reward actor is invoked
         rt.set_epoch(3);
         rt.expect_validate_caller_addr(vec![CRON_ACTOR_ADDR]);
 
-        h.expect_query_network_info(&mut rt);
+        h.expect_query_network_info(&rt);
 
         rt.expect_send_simple(
             REWARD_ACTOR_ADDR,
@@ -1069,16 +1069,16 @@ mod cron_batch_proof_verifies_tests {
 
     #[test]
     fn success_with_one_miner_and_one_confirmed_sector() {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
 
-        h.create_miner_basic(&mut rt, OWNER, OWNER, MINER_1).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, MINER_1).unwrap();
 
         let info = create_basic_seal_info(0);
-        h.submit_porep_for_bulk_verify(&mut rt, MINER_1, info.clone(), true).unwrap();
+        h.submit_porep_for_bulk_verify(&rt, MINER_1, info.clone(), true).unwrap();
 
         let confirmed_sectors =
             vec![ConfirmedSectorSend { miner: MINER_1, sector_nums: vec![info.sector_id.number] }];
-        h.on_epoch_tick_end(&mut rt, 0, &BigInt::zero(), confirmed_sectors, vec![info]);
+        h.on_epoch_tick_end(&rt, 0, &BigInt::zero(), confirmed_sectors, vec![info]);
 
         rt.verify();
         h.check_state(&rt);
@@ -1086,19 +1086,19 @@ mod cron_batch_proof_verifies_tests {
 
     #[test]
     fn success_with_one_miner_and_multiple_confirmed_sectors() {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
 
-        h.create_miner_basic(&mut rt, OWNER, OWNER, MINER_1).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, MINER_1).unwrap();
 
         let infos: Vec<_> = (1..=3).map(create_basic_seal_info).collect();
         infos.iter().for_each(|info| {
-            h.submit_porep_for_bulk_verify(&mut rt, MINER_1, info.clone(), true).unwrap()
+            h.submit_porep_for_bulk_verify(&rt, MINER_1, info.clone(), true).unwrap()
         });
 
         let sector_id_nums = infos.iter().map(|info| info.sector_id.number).collect();
         let confirmed_sectors =
             vec![ConfirmedSectorSend { miner: MINER_1, sector_nums: sector_id_nums }];
-        h.on_epoch_tick_end(&mut rt, 0, &BigInt::zero(), confirmed_sectors, infos);
+        h.on_epoch_tick_end(&rt, 0, &BigInt::zero(), confirmed_sectors, infos);
 
         rt.verify();
         h.check_state(&rt);
@@ -1106,23 +1106,23 @@ mod cron_batch_proof_verifies_tests {
 
     #[test]
     fn duplicate_sector_numbers_are_ignored_for_a_miner() {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
 
-        h.create_miner_basic(&mut rt, OWNER, OWNER, MINER_1).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, MINER_1).unwrap();
 
         // duplicates will be sent to the batch verify call
         let infos =
             vec![create_basic_seal_info(1), create_basic_seal_info(1), create_basic_seal_info(2)];
 
         infos.iter().for_each(|info| {
-            h.submit_porep_for_bulk_verify(&mut rt, MINER_1, info.clone(), true).unwrap()
+            h.submit_porep_for_bulk_verify(&rt, MINER_1, info.clone(), true).unwrap()
         });
 
         // however, duplicates will not be sent to the miner as confirmed
         let sector_id_nums = vec![infos[0].sector_id.number, infos[2].sector_id.number];
         let confirmed_sectors =
             vec![ConfirmedSectorSend { miner: MINER_1, sector_nums: sector_id_nums }];
-        h.on_epoch_tick_end(&mut rt, 0, &BigInt::zero(), confirmed_sectors, infos);
+        h.on_epoch_tick_end(&rt, 0, &BigInt::zero(), confirmed_sectors, infos);
 
         rt.verify();
         h.check_state(&rt);
@@ -1130,20 +1130,20 @@ mod cron_batch_proof_verifies_tests {
 
     #[test]
     fn skips_verify_if_miner_has_no_claim() {
-        let (mut h, mut rt) = setup();
-        h.create_miner_basic(&mut rt, OWNER, OWNER, MINER_1).unwrap();
+        let (mut h, rt) = setup();
+        h.create_miner_basic(&rt, OWNER, OWNER, MINER_1).unwrap();
 
         let info = create_basic_seal_info(1);
 
-        h.submit_porep_for_bulk_verify(&mut rt, MINER_1, info, true).unwrap();
+        h.submit_porep_for_bulk_verify(&rt, MINER_1, info, true).unwrap();
 
-        h.delete_claim(&mut rt, &MINER_1);
+        h.delete_claim(&rt, &MINER_1);
 
         let infos = vec![];
 
         let confirmed_sectors = vec![];
 
-        h.on_epoch_tick_end(&mut rt, 0, &BigInt::zero(), confirmed_sectors, infos);
+        h.on_epoch_tick_end(&rt, 0, &BigInt::zero(), confirmed_sectors, infos);
 
         h.check_state(&rt);
     }
@@ -1168,24 +1168,24 @@ mod cron_batch_proof_verifies_tests {
         let info7 = create_basic_seal_info(300);
         let info8 = create_basic_seal_info(301);
 
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
 
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner1).unwrap();
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner2).unwrap();
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner3).unwrap();
-        h.create_miner_basic(&mut rt, OWNER, OWNER, miner4).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner1).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner2).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner3).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, miner4).unwrap();
 
-        h.submit_porep_for_bulk_verify(&mut rt, miner1, info1.clone(), true).unwrap();
-        h.submit_porep_for_bulk_verify(&mut rt, miner1, info2.clone(), true).unwrap();
+        h.submit_porep_for_bulk_verify(&rt, miner1, info1.clone(), true).unwrap();
+        h.submit_porep_for_bulk_verify(&rt, miner1, info2.clone(), true).unwrap();
 
-        h.submit_porep_for_bulk_verify(&mut rt, miner2, info3.clone(), true).unwrap();
-        h.submit_porep_for_bulk_verify(&mut rt, miner2, info4.clone(), true).unwrap();
+        h.submit_porep_for_bulk_verify(&rt, miner2, info3.clone(), true).unwrap();
+        h.submit_porep_for_bulk_verify(&rt, miner2, info4.clone(), true).unwrap();
 
-        h.submit_porep_for_bulk_verify(&mut rt, miner3, info5.clone(), true).unwrap();
-        h.submit_porep_for_bulk_verify(&mut rt, miner3, info6.clone(), true).unwrap();
+        h.submit_porep_for_bulk_verify(&rt, miner3, info5.clone(), true).unwrap();
+        h.submit_porep_for_bulk_verify(&rt, miner3, info6.clone(), true).unwrap();
 
-        h.submit_porep_for_bulk_verify(&mut rt, miner4, info7.clone(), true).unwrap();
-        h.submit_porep_for_bulk_verify(&mut rt, miner4, info8.clone(), true).unwrap();
+        h.submit_porep_for_bulk_verify(&rt, miner4, info7.clone(), true).unwrap();
+        h.submit_porep_for_bulk_verify(&rt, miner4, info8.clone(), true).unwrap();
 
         // TODO Because read order of keys in a multi-map is not as per insertion order,
         // we have to move around the expected sends
@@ -1210,26 +1210,26 @@ mod cron_batch_proof_verifies_tests {
 
         let infos = vec![info1, info2, info5, info6, info7, info8, info3, info4];
 
-        h.on_epoch_tick_end(&mut rt, 0, &BigInt::zero(), confirmed_sectors, infos);
+        h.on_epoch_tick_end(&rt, 0, &BigInt::zero(), confirmed_sectors, infos);
         h.check_state(&rt);
     }
 
     #[test]
     fn success_when_no_confirmed_sector() {
-        let (h, mut rt) = setup();
-        h.on_epoch_tick_end(&mut rt, 0, &BigInt::zero(), vec![], vec![]);
+        let (h, rt) = setup();
+        h.on_epoch_tick_end(&rt, 0, &BigInt::zero(), vec![], vec![]);
 
         h.check_state(&rt);
     }
 
     #[test]
     fn verification_for_one_sector_fails_but_others_succeeds_for_a_miner() {
-        let (mut h, mut rt) = setup();
-        h.create_miner_basic(&mut rt, OWNER, OWNER, MINER_1).unwrap();
+        let (mut h, rt) = setup();
+        h.create_miner_basic(&rt, OWNER, OWNER, MINER_1).unwrap();
 
         let infos: Vec<_> = (1..=3).map(create_basic_seal_info).collect();
         infos.iter().for_each(|info| {
-            h.submit_porep_for_bulk_verify(&mut rt, MINER_1, info.clone(), true).unwrap()
+            h.submit_porep_for_bulk_verify(&rt, MINER_1, info.clone(), true).unwrap()
         });
 
         let res = Ok(vec![true, false, true]);
@@ -1240,7 +1240,7 @@ mod cron_batch_proof_verifies_tests {
             sector_nums: vec![infos[0].sector_id.number, infos[2].sector_id.number],
         };
 
-        h.expect_query_network_info(&mut rt);
+        h.expect_query_network_info(&rt);
 
         let state: State = rt.get_state();
 
@@ -1286,15 +1286,15 @@ mod cron_batch_proof_verifies_tests {
 
     #[test]
     fn cron_tick_does_not_fail_if_batch_verify_seals_fails() {
-        let (mut h, mut rt) = setup();
-        h.create_miner_basic(&mut rt, OWNER, OWNER, MINER_1).unwrap();
+        let (mut h, rt) = setup();
+        h.create_miner_basic(&rt, OWNER, OWNER, MINER_1).unwrap();
 
         let infos: Vec<_> = (1..=3).map(create_basic_seal_info).collect();
         infos.iter().for_each(|info| {
-            h.submit_porep_for_bulk_verify(&mut rt, MINER_1, info.clone(), true).unwrap()
+            h.submit_porep_for_bulk_verify(&rt, MINER_1, info.clone(), true).unwrap()
         });
 
-        h.expect_query_network_info(&mut rt);
+        h.expect_query_network_info(&rt);
 
         rt.expect_batch_verify_seals(infos, Err(anyhow::Error::msg("fail")));
         rt.expect_validate_caller_addr(vec![CRON_ACTOR_ADDR]);
@@ -1335,9 +1335,9 @@ mod submit_porep_for_bulk_verify_tests {
 
     #[test]
     fn registers_porep_and_charges_gas() {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
 
-        h.create_miner_basic(&mut rt, OWNER, OWNER, MINER).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, MINER).unwrap();
 
         let comm_r = make_sealed_cid("commR".as_bytes());
         let comm_d = make_piece_cid("commD".as_bytes());
@@ -1353,7 +1353,7 @@ mod submit_porep_for_bulk_verify_tests {
             sector_id: SectorID { number: 0, ..Default::default() },
         };
 
-        h.submit_porep_for_bulk_verify(&mut rt, MINER, info, true).unwrap();
+        h.submit_porep_for_bulk_verify(&rt, MINER, info, true).unwrap();
         let st: State = rt.get_state();
         let store = &rt.store;
         assert!(st.proof_validation_batch.is_some());
@@ -1374,9 +1374,9 @@ mod submit_porep_for_bulk_verify_tests {
 
     #[test]
     fn aborts_when_too_many_poreps() {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
 
-        h.create_miner_basic(&mut rt, OWNER, OWNER, MINER).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, MINER).unwrap();
 
         fn create_basic_seal_info(id: u64) -> SealVerifyInfo {
             SealVerifyInfo {
@@ -1393,14 +1393,13 @@ mod submit_porep_for_bulk_verify_tests {
 
         // Adding MAX_MINER_PROVE_COMMITS_PER_EPOCH works without error
         for i in 0..MAX_MINER_PROVE_COMMITS_PER_EPOCH {
-            h.submit_porep_for_bulk_verify(&mut rt, MINER, create_basic_seal_info(i), true)
-                .unwrap();
+            h.submit_porep_for_bulk_verify(&rt, MINER, create_basic_seal_info(i), true).unwrap();
         }
 
         expect_abort(
             ERR_TOO_MANY_PROVE_COMMITS,
             h.submit_porep_for_bulk_verify(
-                &mut rt,
+                &rt,
                 MINER,
                 create_basic_seal_info(MAX_MINER_PROVE_COMMITS_PER_EPOCH),
                 false,
@@ -1412,9 +1411,9 @@ mod submit_porep_for_bulk_verify_tests {
 
     #[test]
     fn aborts_when_miner_has_no_claim() {
-        let (mut h, mut rt) = setup();
+        let (mut h, rt) = setup();
 
-        h.create_miner_basic(&mut rt, OWNER, OWNER, MINER).unwrap();
+        h.create_miner_basic(&rt, OWNER, OWNER, MINER).unwrap();
 
         let comm_r = make_sealed_cid("commR".as_bytes());
         let comm_d = make_piece_cid("commD".as_bytes());
@@ -1431,11 +1430,11 @@ mod submit_porep_for_bulk_verify_tests {
         };
 
         // delete miner
-        h.delete_claim(&mut rt, &MINER);
+        h.delete_claim(&rt, &MINER);
 
         expect_abort(
             ExitCode::USR_FORBIDDEN,
-            h.submit_porep_for_bulk_verify(&mut rt, MINER, info, false),
+            h.submit_porep_for_bulk_verify(&rt, MINER, info, false),
         );
         h.check_state(&rt);
     }

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -51,7 +51,7 @@ pub struct Actor;
 
 impl Actor {
     /// Constructor for Reward actor
-    fn constructor(rt: &mut impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
+    fn constructor(rt: &impl Runtime, params: ConstructorParams) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
         if let Some(power) = params.power.map(|v| v.0) {
@@ -73,7 +73,7 @@ impl Actor {
     /// The reward is reduced before the residual is credited to the block producer, by:
     /// - a penalty amount, provided as a parameter, which is burnt,
     fn award_block_reward(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: AwardBlockRewardParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
@@ -176,7 +176,7 @@ impl Actor {
     /// The award value used for the current epoch, updated at the end of an epoch
     /// through cron tick.  In the case previous epochs were null blocks this
     /// is the reward value as calculated at the last non-null epoch.
-    fn this_epoch_reward(rt: &mut impl Runtime) -> Result<ThisEpochRewardReturn, ActorError> {
+    fn this_epoch_reward(rt: &impl Runtime) -> Result<ThisEpochRewardReturn, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let st: State = rt.state()?;
         Ok(ThisEpochRewardReturn {
@@ -189,7 +189,7 @@ impl Actor {
     /// This is only invoked for non-empty tipsets, but catches up any number of null
     /// epochs to compute the next epoch reward.
     fn update_network_kpi(
-        rt: &mut impl Runtime,
+        rt: &impl Runtime,
         params: UpdateNetworkKPIParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&STORAGE_POWER_ACTOR_ADDR))?;

--- a/actors/reward/tests/reward_actor_test.rs
+++ b/actors/reward/tests/reward_actor_test.rs
@@ -221,7 +221,7 @@ mod test_award_block_reward {
 
     #[test]
     fn total_mined_tracks_correctly() {
-        let mut rt = construct_and_verify(&StoragePower::from(1));
+        let rt = construct_and_verify(&StoragePower::from(1));
         let mut state: State = rt.get_state();
 
         assert_eq!(TokenAmount::zero(), state.total_storage_power_reward);
@@ -234,7 +234,7 @@ mod test_award_block_reward {
 
         for i in &[1000, 1000, 1000, 500] {
             assert!(award_block_reward(
-                &mut rt,
+                &rt,
                 *WINNER,
                 TokenAmount::zero(),
                 TokenAmount::zero(),
@@ -303,11 +303,11 @@ mod test_this_epoch_reward {
 
     #[test]
     fn successfully_fetch_reward_for_this_epoch() {
-        let mut rt = construct_and_verify(&StoragePower::from(1));
+        let rt = construct_and_verify(&StoragePower::from(1));
 
         let state: State = rt.get_state();
 
-        let resp: ThisEpochRewardReturn = this_epoch_reward(&mut rt);
+        let resp: ThisEpochRewardReturn = this_epoch_reward(&rt);
 
         assert_eq!(state.this_epoch_baseline_power, resp.this_epoch_baseline_power);
         assert_eq!(state.this_epoch_reward_smoothed, resp.this_epoch_reward_smoothed);
@@ -317,11 +317,11 @@ mod test_this_epoch_reward {
 #[test]
 fn test_successive_kpi_updates() {
     let power = StoragePower::from_i128(1 << 50).unwrap();
-    let mut rt = construct_and_verify(&power);
+    let rt = construct_and_verify(&power);
 
     for i in &[1, 2, 3] {
         rt.epoch.replace(ChainEpoch::from(*i));
-        update_network_kpi(&mut rt, &power);
+        update_network_kpi(&rt, &power);
     }
 }
 
@@ -347,7 +347,7 @@ fn construct_and_verify(curr_power: &StoragePower) -> MockRuntime {
 }
 
 fn award_block_reward(
-    rt: &mut MockRuntime,
+    rt: &MockRuntime,
     miner: Address,
     penalty: TokenAmount,
     gas_reward: TokenAmount,
@@ -394,7 +394,7 @@ fn award_block_reward(
     Ok(serialized_bytes)
 }
 
-fn this_epoch_reward(rt: &mut MockRuntime) -> ThisEpochRewardReturn {
+fn this_epoch_reward(rt: &MockRuntime) -> ThisEpochRewardReturn {
     rt.expect_validate_caller_any();
     let serialized_result = rt.call::<RewardActor>(Method::ThisEpochReward as u64, None).unwrap();
     let resp: ThisEpochRewardReturn = serialized_result.unwrap().deserialize().unwrap();
@@ -402,7 +402,7 @@ fn this_epoch_reward(rt: &mut MockRuntime) -> ThisEpochRewardReturn {
     resp
 }
 
-fn update_network_kpi(rt: &mut MockRuntime, curr_raw_power: &StoragePower) {
+fn update_network_kpi(rt: &MockRuntime, curr_raw_power: &StoragePower) {
     rt.set_caller(*POWER_ACTOR_CODE_ID, STORAGE_POWER_ACTOR_ADDR);
     rt.expect_validate_caller_addr(vec![STORAGE_POWER_ACTOR_ADDR]);
 

--- a/actors/system/src/lib.rs
+++ b/actors/system/src/lib.rs
@@ -55,7 +55,7 @@ pub struct Actor;
 
 impl Actor {
     /// System actor constructor.
-    pub fn constructor(rt: &mut impl Runtime) -> Result<(), ActorError> {
+    pub fn constructor(rt: &impl Runtime) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
         let state = State::new(rt.store()).context("failed to construct state")?;
@@ -73,6 +73,8 @@ impl ActorCode for Actor {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
     use fvm_shared::MethodNum;
 
     use fil_actors_runtime::test_utils::{MockRuntime, SYSTEM_ACTOR_CODE_ID};
@@ -83,15 +85,15 @@ mod tests {
     pub fn new_runtime() -> MockRuntime {
         MockRuntime {
             receiver: SYSTEM_ACTOR_ADDR,
-            caller: SYSTEM_ACTOR_ADDR,
-            caller_type: *SYSTEM_ACTOR_CODE_ID,
+            caller: RefCell::new(SYSTEM_ACTOR_ADDR),
+            caller_type: RefCell::new(*SYSTEM_ACTOR_CODE_ID),
             ..Default::default()
         }
     }
 
     #[test]
     fn construct_with_root_id() {
-        let mut rt = new_runtime();
+        let rt = new_runtime();
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
         rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
         rt.call::<Actor>(Method::Constructor as MethodNum, None).unwrap();

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -69,14 +69,14 @@ pub fn new_runtime() -> MockRuntime {
 }
 
 // Sets the miner code/type for an actor ID
-pub fn add_miner(rt: &mut MockRuntime, id: ActorID) {
+pub fn add_miner(rt: &MockRuntime, id: ActorID) {
     rt.set_address_actor_type(Address::new_id(id), *MINER_ACTOR_CODE_ID);
 }
 
 pub fn new_harness() -> (Harness, MockRuntime) {
-    let mut rt = new_runtime();
+    let rt = new_runtime();
     let h = Harness { root: ROOT_ADDR };
-    h.construct_and_verify(&mut rt, &h.root);
+    h.construct_and_verify(&rt, &h.root);
     (h, rt)
 }
 
@@ -85,7 +85,7 @@ pub struct Harness {
 }
 
 impl Harness {
-    pub fn construct_and_verify(&self, rt: &mut MockRuntime, root_param: &Address) {
+    pub fn construct_and_verify(&self, rt: &MockRuntime, root_param: &Address) {
         rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
         let ret = rt
@@ -106,7 +106,7 @@ impl Harness {
 
     pub fn add_verifier(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         verifier: &Address,
         allowance: &DataCap,
     ) -> Result<(), ActorError> {
@@ -115,7 +115,7 @@ impl Harness {
 
     pub fn add_verifier_with_existing_cap(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         verifier: &Address,
         allowance: &DataCap,
         cap: &DataCap, // Mocked data cap balance of the prospective verifier
@@ -145,11 +145,7 @@ impl Harness {
         Ok(())
     }
 
-    pub fn remove_verifier(
-        &self,
-        rt: &mut MockRuntime,
-        verifier: &Address,
-    ) -> Result<(), ActorError> {
+    pub fn remove_verifier(&self, rt: &MockRuntime, verifier: &Address) -> Result<(), ActorError> {
         rt.expect_validate_caller_addr(vec![self.root]);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.root);
         let ret = rt.call::<VerifregActor>(
@@ -187,7 +183,7 @@ impl Harness {
 
     pub fn add_client(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         verifier: &Address,
         client: &Address,
         allowance: &DataCap,
@@ -230,7 +226,7 @@ impl Harness {
     // TODO this should be implemented through a call to verifreg but for now it modifies state directly
     pub fn create_alloc(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         alloc: &Allocation,
     ) -> Result<AllocationID, ActorError> {
         let mut st: State = rt.get_state();
@@ -247,7 +243,7 @@ impl Harness {
 
     pub fn load_alloc(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         client: ActorID,
         id: AllocationID,
     ) -> Option<Allocation> {
@@ -259,7 +255,7 @@ impl Harness {
     // Invokes the ClaimAllocations actor method
     pub fn claim_allocations(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         provider: ActorID,
         claim_allocs: Vec<SectorAllocationClaim>,
         datacap_burnt: u64,
@@ -298,7 +294,7 @@ impl Harness {
     // Invokes the RemoveExpiredAllocations actor method.
     pub fn remove_expired_allocations(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         client: ActorID,
         allocation_ids: Vec<AllocationID>,
         expected_datacap: u64,
@@ -335,7 +331,7 @@ impl Harness {
     // Invokes the RemoveExpiredClaims actor method.
     pub fn remove_expired_claims(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         provider: ActorID,
         claim_ids: Vec<ClaimID>,
     ) -> Result<RemoveExpiredClaimsReturn, ActorError> {
@@ -354,12 +350,7 @@ impl Harness {
         Ok(ret)
     }
 
-    pub fn load_claim(
-        &self,
-        rt: &mut MockRuntime,
-        provider: ActorID,
-        id: ClaimID,
-    ) -> Option<Claim> {
+    pub fn load_claim(&self, rt: &MockRuntime, provider: ActorID, id: ClaimID) -> Option<Claim> {
         let st: State = rt.get_state();
         let mut claims = st.load_claims(rt.store()).unwrap();
         claims.get(provider, id).unwrap().cloned()
@@ -367,7 +358,7 @@ impl Harness {
 
     pub fn receive_tokens(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         payload: FRC46TokenReceived,
         expected_alloc_results: BatchReturn,
         expected_extension_results: BatchReturn,
@@ -412,7 +403,7 @@ impl Harness {
     }
 
     // Creates a claim directly in state.
-    pub fn create_claim(&self, rt: &mut MockRuntime, claim: &Claim) -> Result<ClaimID, ActorError> {
+    pub fn create_claim(&self, rt: &MockRuntime, claim: &Claim) -> Result<ClaimID, ActorError> {
         let mut st: State = rt.get_state();
         let mut claims = st.load_claims(rt.store()).unwrap();
         let id = st.next_allocation_id;
@@ -427,7 +418,7 @@ impl Harness {
 
     pub fn get_claims(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         provider: ActorID,
         claim_ids: Vec<ClaimID>,
     ) -> Result<GetClaimsReturn, ActorError> {
@@ -447,7 +438,7 @@ impl Harness {
 
     pub fn extend_claim_terms(
         &self,
-        rt: &mut MockRuntime,
+        rt: &MockRuntime,
         params: &ExtendClaimTermsParams,
     ) -> Result<ExtendClaimTermsReturn, ActorError> {
         rt.expect_validate_caller_any();

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -43,19 +43,19 @@ mod construction {
 
     #[test]
     fn construct_with_root_id() {
-        let mut rt = new_runtime();
+        let rt = new_runtime();
         let h = Harness { root: ROOT_ADDR };
-        h.construct_and_verify(&mut rt, &h.root);
+        h.construct_and_verify(&rt, &h.root);
         h.check_state(&rt);
     }
 
     #[test]
     fn construct_resolves_non_id() {
-        let mut rt = new_runtime();
+        let rt = new_runtime();
         let h = Harness { root: ROOT_ADDR };
         let root_pubkey = Address::new_bls(&[7u8; BLS_PUB_LEN]).unwrap();
         rt.id_addresses.borrow_mut().insert(root_pubkey, h.root);
-        h.construct_and_verify(&mut rt, &root_pubkey);
+        h.construct_and_verify(&rt, &root_pubkey);
         h.check_state(&rt);
     }
 
@@ -124,23 +124,20 @@ mod verifiers {
 
     #[test]
     fn add_verifier_rejects_root() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance = verifier_allowance(&rt);
-        expect_abort(
-            ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.add_verifier(&mut rt, &ROOT_ADDR, &allowance),
-        );
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.add_verifier(&rt, &ROOT_ADDR, &allowance));
         rt.reset();
         h.check_state(&rt);
     }
 
     #[test]
     fn add_verifier_rejects_client() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance = verifier_allowance(&rt);
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.add_verifier_with_existing_cap(&mut rt, &VERIFIER, &allowance, &DataCap::from(1)),
+            h.add_verifier_with_existing_cap(&rt, &VERIFIER, &allowance, &DataCap::from(1)),
         );
         h.check_state(&rt);
     }
@@ -173,27 +170,27 @@ mod verifiers {
 
     #[test]
     fn add_verifier_id_address() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance = verifier_allowance(&rt);
-        h.add_verifier(&mut rt, &VERIFIER, &allowance).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance).unwrap();
         h.check_state(&rt);
     }
 
     #[test]
     fn add_verifier_resolves_address() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance = verifier_allowance(&rt);
         let pubkey_addr = Address::new_secp256k1(&[0u8; 65]).unwrap();
         rt.id_addresses.borrow_mut().insert(pubkey_addr, *VERIFIER);
-        h.add_verifier(&mut rt, &pubkey_addr, &allowance).unwrap();
+        h.add_verifier(&rt, &pubkey_addr, &allowance).unwrap();
         h.check_state(&rt);
     }
 
     #[test]
     fn remove_requires_root() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance = verifier_allowance(&rt);
-        h.add_verifier(&mut rt, &VERIFIER, &allowance).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance).unwrap();
 
         let caller = Address::new_id(501);
         rt.expect_validate_caller_addr(vec![h.root]);
@@ -211,30 +208,30 @@ mod verifiers {
 
     #[test]
     fn remove_requires_verifier_exists() {
-        let (h, mut rt) = new_harness();
-        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.remove_verifier(&mut rt, &VERIFIER));
+        let (h, rt) = new_harness();
+        expect_abort(ExitCode::USR_ILLEGAL_ARGUMENT, h.remove_verifier(&rt, &VERIFIER));
         h.check_state(&rt);
     }
 
     #[test]
     fn remove_verifier() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance = verifier_allowance(&rt);
-        h.add_verifier(&mut rt, &VERIFIER, &allowance).unwrap();
-        h.remove_verifier(&mut rt, &VERIFIER).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance).unwrap();
+        h.remove_verifier(&rt, &VERIFIER).unwrap();
         h.check_state(&rt);
     }
 
     #[test]
     fn remove_verifier_id_address() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance = verifier_allowance(&rt);
         let verifier_pubkey = Address::new_bls(&[1u8; BLS_PUB_LEN]).unwrap();
         rt.id_addresses.borrow_mut().insert(verifier_pubkey, *VERIFIER);
         // Add using pubkey address.
-        h.add_verifier(&mut rt, &VERIFIER, &allowance).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance).unwrap();
         // Remove using ID address.
-        h.remove_verifier(&mut rt, &VERIFIER).unwrap();
+        h.remove_verifier(&rt, &VERIFIER).unwrap();
         h.check_state(&rt);
     }
 }
@@ -261,18 +258,18 @@ mod clients {
 
     #[test]
     fn many_verifiers_and_clients() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         // Each verifier has enough allowance for two clients.
         let allowance_client = client_allowance(&rt);
         let allowance_verifier = allowance_client.clone() + allowance_client.clone();
-        h.add_verifier(&mut rt, &VERIFIER, &allowance_verifier).unwrap();
-        h.add_verifier(&mut rt, &VERIFIER2, &allowance_verifier).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance_verifier).unwrap();
+        h.add_verifier(&rt, &VERIFIER2, &allowance_verifier).unwrap();
 
-        h.add_client(&mut rt, &VERIFIER, &CLIENT, &allowance_client).unwrap();
-        h.add_client(&mut rt, &VERIFIER, &CLIENT2, &allowance_client).unwrap();
+        h.add_client(&rt, &VERIFIER, &CLIENT, &allowance_client).unwrap();
+        h.add_client(&rt, &VERIFIER, &CLIENT2, &allowance_client).unwrap();
 
-        h.add_client(&mut rt, &VERIFIER2, &CLIENT3, &allowance_client).unwrap();
-        h.add_client(&mut rt, &VERIFIER2, &CLIENT4, &allowance_client).unwrap();
+        h.add_client(&rt, &VERIFIER2, &CLIENT3, &allowance_client).unwrap();
+        h.add_client(&rt, &VERIFIER2, &CLIENT4, &allowance_client).unwrap();
 
         // No more allowance left
         h.assert_verifier_allowance(&rt, &VERIFIER, &DataCap::from(0));
@@ -282,15 +279,15 @@ mod clients {
 
     #[test]
     fn verifier_allowance_exhausted() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance = client_allowance(&rt);
         // Verifier only has allowance for one client.
-        h.add_verifier(&mut rt, &VERIFIER, &allowance).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance).unwrap();
 
-        h.add_client(&mut rt, &VERIFIER, &CLIENT, &allowance).unwrap();
+        h.add_client(&rt, &VERIFIER, &CLIENT, &allowance).unwrap();
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.add_client(&mut rt, &VERIFIER, &CLIENT2, &allowance),
+            h.add_client(&rt, &VERIFIER, &CLIENT2, &allowance),
         );
         rt.reset();
         h.assert_verifier_allowance(&rt, &VERIFIER, &DataCap::zero());
@@ -299,40 +296,40 @@ mod clients {
 
     #[test]
     fn resolves_client_address() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance_verifier = verifier_allowance(&rt);
         let allowance_client = client_allowance(&rt);
 
         let client_pubkey = Address::new_bls(&[7u8; BLS_PUB_LEN]).unwrap();
         rt.id_addresses.borrow_mut().insert(client_pubkey, *CLIENT);
 
-        h.add_verifier(&mut rt, &VERIFIER, &allowance_verifier).unwrap();
-        h.add_client(&mut rt, &VERIFIER, &client_pubkey, &allowance_client).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance_verifier).unwrap();
+        h.add_client(&rt, &VERIFIER, &client_pubkey, &allowance_client).unwrap();
 
         // Adding another client with the same address increments
         // the data cap which has already been granted.
-        h.add_verifier(&mut rt, &VERIFIER, &allowance_verifier).unwrap();
-        h.add_client(&mut rt, &VERIFIER, &CLIENT, &allowance_client).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance_verifier).unwrap();
+        h.add_client(&rt, &VERIFIER, &CLIENT, &allowance_client).unwrap();
         h.check_state(&rt);
     }
 
     #[test]
     fn minimum_allowance_ok() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance_verifier = verifier_allowance(&rt);
-        h.add_verifier(&mut rt, &VERIFIER, &allowance_verifier).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance_verifier).unwrap();
 
         let allowance = rt.policy.minimum_verified_allocation_size.clone();
-        h.add_client(&mut rt, &VERIFIER, &CLIENT, &allowance).unwrap();
+        h.add_client(&rt, &VERIFIER, &CLIENT, &allowance).unwrap();
         h.check_state(&rt);
     }
 
     #[test]
     fn rejects_unresolved_address() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance_verifier = verifier_allowance(&rt);
         let allowance_client = client_allowance(&rt);
-        h.add_verifier(&mut rt, &VERIFIER, &allowance_verifier).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance_verifier).unwrap();
 
         let client = Address::new_bls(&[7u8; BLS_PUB_LEN]).unwrap();
         // Expect runtime to attempt to create the actor, but don't add it to the mock's
@@ -348,7 +345,7 @@ mod clients {
 
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.add_client(&mut rt, &VERIFIER, &client, &allowance_client),
+            h.add_client(&rt, &VERIFIER, &client, &allowance_client),
         );
         rt.reset();
         h.check_state(&rt);
@@ -356,14 +353,14 @@ mod clients {
 
     #[test]
     fn rejects_allowance_below_minimum() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance_verifier = verifier_allowance(&rt);
-        h.add_verifier(&mut rt, &VERIFIER, &allowance_verifier).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance_verifier).unwrap();
 
         let allowance = rt.policy.minimum_verified_allocation_size.clone() - 1;
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.add_client(&mut rt, &VERIFIER, &CLIENT, &allowance),
+            h.add_client(&rt, &VERIFIER, &CLIENT, &allowance),
         );
         rt.reset();
         h.check_state(&rt);
@@ -371,10 +368,10 @@ mod clients {
 
     #[test]
     fn rejects_non_verifier_caller() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance_verifier = verifier_allowance(&rt);
         let allowance_client = client_allowance(&rt);
-        h.add_verifier(&mut rt, &VERIFIER, &allowance_verifier).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance_verifier).unwrap();
 
         let caller = Address::new_id(209);
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, caller);
@@ -392,10 +389,10 @@ mod clients {
 
     #[test]
     fn add_verified_client_restricted_correctly() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance_verifier = verifier_allowance(&rt);
         let allowance_client = client_allowance(&rt);
-        h.add_verifier(&mut rt, &VERIFIER, &allowance_verifier).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance_verifier).unwrap();
 
         let params =
             AddVerifiedClientParams { address: *CLIENT, allowance: allowance_client.clone() };
@@ -445,14 +442,14 @@ mod clients {
 
     #[test]
     fn rejects_allowance_greater_than_verifier_cap() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance_verifier = verifier_allowance(&rt);
-        h.add_verifier(&mut rt, &VERIFIER, &allowance_verifier).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance_verifier).unwrap();
 
         let allowance = allowance_verifier.clone() + 1;
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.add_client(&mut rt, &VERIFIER, &h.root, &allowance),
+            h.add_client(&rt, &VERIFIER, &h.root, &allowance),
         );
         rt.reset();
         h.check_state(&rt);
@@ -460,13 +457,13 @@ mod clients {
 
     #[test]
     fn rejects_root_as_client() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance_verifier = verifier_allowance(&rt);
         let allowance_client = client_allowance(&rt);
-        h.add_verifier(&mut rt, &VERIFIER, &allowance_verifier).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance_verifier).unwrap();
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.add_client(&mut rt, &VERIFIER, &h.root, &allowance_client),
+            h.add_client(&rt, &VERIFIER, &h.root, &allowance_client),
         );
         rt.reset();
         h.check_state(&rt);
@@ -474,20 +471,20 @@ mod clients {
 
     #[test]
     fn rejects_verifier_as_client() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let allowance_verifier = verifier_allowance(&rt);
         let allowance_client = client_allowance(&rt);
-        h.add_verifier(&mut rt, &VERIFIER, &allowance_verifier).unwrap();
+        h.add_verifier(&rt, &VERIFIER, &allowance_verifier).unwrap();
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.add_client(&mut rt, &VERIFIER, &VERIFIER, &allowance_client),
+            h.add_client(&rt, &VERIFIER, &VERIFIER, &allowance_client),
         );
         rt.reset();
 
-        h.add_verifier(&mut rt, &VERIFIER2, &allowance_verifier).unwrap();
+        h.add_verifier(&rt, &VERIFIER2, &allowance_verifier).unwrap();
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            h.add_client(&mut rt, &VERIFIER, &VERIFIER2, &allowance_client),
+            h.add_client(&rt, &VERIFIER, &VERIFIER2, &allowance_client),
         );
         rt.reset();
         h.check_state(&rt);
@@ -529,7 +526,7 @@ mod allocs_claims {
 
     #[test]
     fn expire_allocs() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
 
         let mut alloc1 = make_alloc("1", CLIENT1, PROVIDER1, ALLOC_SIZE);
         alloc1.expiration = 100;
@@ -537,19 +534,19 @@ mod allocs_claims {
         alloc2.expiration = 200;
         let total_size = alloc1.size.0 + alloc2.size.0;
 
-        let id1 = h.create_alloc(&mut rt, &alloc1).unwrap();
-        let id2 = h.create_alloc(&mut rt, &alloc2).unwrap();
+        let id1 = h.create_alloc(&rt, &alloc1).unwrap();
+        let id2 = h.create_alloc(&rt, &alloc2).unwrap();
         let state_with_allocs: State = rt.get_state();
 
         // Can't remove allocations that aren't expired
-        let ret = h.remove_expired_allocations(&mut rt, CLIENT1, vec![id1, id2], 0).unwrap();
+        let ret = h.remove_expired_allocations(&rt, CLIENT1, vec![id1, id2], 0).unwrap();
         assert_eq!(vec![1, 2], ret.considered);
         assert_eq!(vec![ExitCode::USR_FORBIDDEN, ExitCode::USR_FORBIDDEN], ret.results.codes());
         assert_eq!(DataCap::zero(), ret.datacap_recovered);
 
         // Can't remove with wrong client ID
         rt.set_epoch(200);
-        let ret = h.remove_expired_allocations(&mut rt, CLIENT2, vec![id1, id2], 0).unwrap();
+        let ret = h.remove_expired_allocations(&rt, CLIENT2, vec![id1, id2], 0).unwrap();
         assert_eq!(vec![1, 2], ret.considered);
         assert_eq!(vec![ExitCode::USR_NOT_FOUND, ExitCode::USR_NOT_FOUND], ret.results.codes());
         assert_eq!(DataCap::zero(), ret.datacap_recovered);
@@ -557,7 +554,7 @@ mod allocs_claims {
         // Remove the first alloc, which expired.
         rt.set_epoch(100);
         let ret =
-            h.remove_expired_allocations(&mut rt, CLIENT1, vec![id1, id2], alloc1.size.0).unwrap();
+            h.remove_expired_allocations(&rt, CLIENT1, vec![id1, id2], alloc1.size.0).unwrap();
         assert_eq!(vec![1, 2], ret.considered);
         assert_eq!(vec![ExitCode::OK, ExitCode::USR_FORBIDDEN], ret.results.codes());
         assert_eq!(DataCap::from(alloc1.size.0), ret.datacap_recovered);
@@ -565,22 +562,21 @@ mod allocs_claims {
         // Remove the second alloc (the first is no longer found).
         rt.set_epoch(200);
         let ret =
-            h.remove_expired_allocations(&mut rt, CLIENT1, vec![id1, id2], alloc2.size.0).unwrap();
+            h.remove_expired_allocations(&rt, CLIENT1, vec![id1, id2], alloc2.size.0).unwrap();
         assert_eq!(vec![1, 2], ret.considered);
         assert_eq!(vec![ExitCode::USR_NOT_FOUND, ExitCode::OK], ret.results.codes());
         assert_eq!(DataCap::from(alloc2.size.0), ret.datacap_recovered);
 
         // Reset state and show we can remove two at once.
         rt.replace_state(&state_with_allocs);
-        let ret =
-            h.remove_expired_allocations(&mut rt, CLIENT1, vec![id1, id2], total_size).unwrap();
+        let ret = h.remove_expired_allocations(&rt, CLIENT1, vec![id1, id2], total_size).unwrap();
         assert_eq!(vec![1, 2], ret.considered);
         assert_eq!(vec![ExitCode::OK, ExitCode::OK], ret.results.codes());
         assert_eq!(DataCap::from(total_size), ret.datacap_recovered);
 
         // Reset state and show that only what was asked for is removed.
         rt.replace_state(&state_with_allocs);
-        let ret = h.remove_expired_allocations(&mut rt, CLIENT1, vec![id1], alloc1.size.0).unwrap();
+        let ret = h.remove_expired_allocations(&rt, CLIENT1, vec![id1], alloc1.size.0).unwrap();
         assert_eq!(vec![1], ret.considered);
         assert_eq!(vec![ExitCode::OK], ret.results.codes());
         assert_eq!(DataCap::from(alloc1.size.0), ret.datacap_recovered);
@@ -588,52 +584,52 @@ mod allocs_claims {
         // Reset state and show that specifying none removes only expired allocations
         rt.set_epoch(0);
         rt.replace_state(&state_with_allocs);
-        let ret = h.remove_expired_allocations(&mut rt, CLIENT1, vec![], 0).unwrap();
+        let ret = h.remove_expired_allocations(&rt, CLIENT1, vec![], 0).unwrap();
         assert_eq!(Vec::<AllocationID>::new(), ret.considered);
         assert_eq!(Vec::<ExitCode>::new(), ret.results.codes());
         assert_eq!(DataCap::zero(), ret.datacap_recovered);
-        assert!(h.load_alloc(&mut rt, CLIENT1, id1).is_some());
-        assert!(h.load_alloc(&mut rt, CLIENT1, id2).is_some());
+        assert!(h.load_alloc(&rt, CLIENT1, id1).is_some());
+        assert!(h.load_alloc(&rt, CLIENT1, id2).is_some());
 
         rt.set_epoch(100);
-        let ret = h.remove_expired_allocations(&mut rt, CLIENT1, vec![], alloc1.size.0).unwrap();
+        let ret = h.remove_expired_allocations(&rt, CLIENT1, vec![], alloc1.size.0).unwrap();
         assert_eq!(vec![1], ret.considered);
         assert_eq!(vec![ExitCode::OK], ret.results.codes());
         assert_eq!(DataCap::from(alloc1.size.0), ret.datacap_recovered);
-        assert!(h.load_alloc(&mut rt, CLIENT1, id1).is_none()); // removed
-        assert!(h.load_alloc(&mut rt, CLIENT1, id2).is_some());
+        assert!(h.load_alloc(&rt, CLIENT1, id1).is_none()); // removed
+        assert!(h.load_alloc(&rt, CLIENT1, id2).is_some());
 
         rt.set_epoch(200);
-        let ret = h.remove_expired_allocations(&mut rt, CLIENT1, vec![], alloc2.size.0).unwrap();
+        let ret = h.remove_expired_allocations(&rt, CLIENT1, vec![], alloc2.size.0).unwrap();
         assert_eq!(vec![2], ret.considered);
         assert_eq!(vec![ExitCode::OK], ret.results.codes());
         assert_eq!(DataCap::from(alloc2.size.0), ret.datacap_recovered);
-        assert!(h.load_alloc(&mut rt, CLIENT1, id1).is_none()); // removed
-        assert!(h.load_alloc(&mut rt, CLIENT1, id2).is_none()); // removed
+        assert!(h.load_alloc(&rt, CLIENT1, id1).is_none()); // removed
+        assert!(h.load_alloc(&rt, CLIENT1, id2).is_none()); // removed
 
         // Reset state and show that specifying none removes *all* expired allocations
         rt.replace_state(&state_with_allocs);
-        let ret = h.remove_expired_allocations(&mut rt, CLIENT1, vec![], total_size).unwrap();
+        let ret = h.remove_expired_allocations(&rt, CLIENT1, vec![], total_size).unwrap();
         assert_eq!(vec![1, 2], ret.considered);
         assert_eq!(vec![ExitCode::OK, ExitCode::OK], ret.results.codes());
         assert_eq!(DataCap::from(total_size), ret.datacap_recovered);
-        assert!(h.load_alloc(&mut rt, CLIENT1, id1).is_none()); // removed
-        assert!(h.load_alloc(&mut rt, CLIENT1, id2).is_none()); // removed
+        assert!(h.load_alloc(&rt, CLIENT1, id1).is_none()); // removed
+        assert!(h.load_alloc(&rt, CLIENT1, id2).is_none()); // removed
         h.check_state(&rt);
     }
 
     #[test]
     fn claim_allocs() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
 
         let size = MINIMUM_VERIFIED_ALLOCATION_SIZE as u64;
         let alloc1 = make_alloc("1", CLIENT1, PROVIDER1, size);
         let alloc2 = make_alloc("2", CLIENT2, PROVIDER1, size); // Distinct client
         let alloc3 = make_alloc("3", CLIENT1, PROVIDER2, size); // Distinct provider
 
-        h.create_alloc(&mut rt, &alloc1).unwrap();
-        h.create_alloc(&mut rt, &alloc2).unwrap();
-        h.create_alloc(&mut rt, &alloc3).unwrap();
+        h.create_alloc(&rt, &alloc1).unwrap();
+        h.create_alloc(&rt, &alloc2).unwrap();
+        h.create_alloc(&rt, &alloc3).unwrap();
         h.check_state(&rt);
 
         let sector = 1000;
@@ -646,7 +642,7 @@ mod allocs_claims {
                 make_claim_req(1, &alloc1, sector, expiry),
                 make_claim_req(2, &alloc2, sector, expiry),
             ];
-            let ret = h.claim_allocations(&mut rt, PROVIDER1, reqs, size * 2, false).unwrap();
+            let ret = h.claim_allocations(&rt, PROVIDER1, reqs, size * 2, false).unwrap();
 
             assert_eq!(ret.batch_info.codes(), vec![ExitCode::OK, ExitCode::OK]);
             assert_eq!(ret.claimed_space, BigInt::from(2 * size));
@@ -662,7 +658,7 @@ mod allocs_claims {
                 make_claim_req(2, &alloc2, sector, expiry),
             ];
             reqs[1].client = CLIENT1;
-            let ret = h.claim_allocations(&mut rt, PROVIDER1, reqs, size, false).unwrap();
+            let ret = h.claim_allocations(&rt, PROVIDER1, reqs, size, false).unwrap();
             assert_eq!(ret.batch_info.codes(), vec![ExitCode::OK, ExitCode::USR_NOT_FOUND]);
             assert_eq!(ret.claimed_space, BigInt::from(size));
             assert_alloc_claimed(&rt, CLIENT1, PROVIDER1, 1, &alloc1, 0, sector);
@@ -676,7 +672,7 @@ mod allocs_claims {
                 make_claim_req(2, &alloc2, sector, expiry),
                 make_claim_req(3, &alloc3, sector, expiry), // Different provider
             ];
-            let ret = h.claim_allocations(&mut rt, PROVIDER1, reqs, size, false).unwrap();
+            let ret = h.claim_allocations(&rt, PROVIDER1, reqs, size, false).unwrap();
             assert_eq!(ret.batch_info.codes(), vec![ExitCode::OK, ExitCode::USR_FORBIDDEN]);
             assert_eq!(ret.claimed_space, BigInt::from(size));
             assert_alloc_claimed(&rt, CLIENT1, PROVIDER1, 2, &alloc2, 0, sector);
@@ -694,7 +690,7 @@ mod allocs_claims {
                 Cid::from_str("bafyreibjo4xmgaevkgud7mbifn3dzp4v4lyaui4yvqp3f2bqwtxcjrdqg4")
                     .unwrap();
             reqs[1].size = PaddedPieceSize(size + 1);
-            let ret = h.claim_allocations(&mut rt, PROVIDER1, reqs, 0, false).unwrap();
+            let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
             assert_eq!(
                 ret.batch_info.codes(),
                 vec![ExitCode::USR_FORBIDDEN, ExitCode::USR_FORBIDDEN]
@@ -707,7 +703,7 @@ mod allocs_claims {
             rt.replace_state(&prior_state);
             let reqs = vec![make_claim_req(1, &alloc1, sector, expiry)];
             rt.set_epoch(alloc1.expiration + 1);
-            let ret = h.claim_allocations(&mut rt, PROVIDER1, reqs, 0, false).unwrap();
+            let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
             assert_eq!(ret.batch_info.codes(), vec![ExitCode::USR_FORBIDDEN]);
             assert_eq!(ret.claimed_space, BigInt::zero());
             h.check_state(&rt);
@@ -716,11 +712,11 @@ mod allocs_claims {
             // Sector expiration too soon
             rt.replace_state(&prior_state);
             let reqs = vec![make_claim_req(1, &alloc1, sector, alloc1.term_min - 1)];
-            let ret = h.claim_allocations(&mut rt, PROVIDER1, reqs, 0, false).unwrap();
+            let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
             assert_eq!(ret.batch_info.codes(), vec![ExitCode::USR_FORBIDDEN]);
             // Sector expiration too late
             let reqs = vec![make_claim_req(1, &alloc1, sector, alloc1.term_max + 1)];
-            let ret = h.claim_allocations(&mut rt, PROVIDER1, reqs, 0, false).unwrap();
+            let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
             assert_eq!(ret.batch_info.codes(), vec![ExitCode::USR_FORBIDDEN]);
             assert_eq!(ret.claimed_space, BigInt::zero());
             h.check_state(&rt);
@@ -729,7 +725,7 @@ mod allocs_claims {
 
     #[test]
     fn get_claims() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let size = MINIMUM_VERIFIED_ALLOCATION_SIZE as u64;
         let sector = 0;
         let start = 0;
@@ -739,25 +735,25 @@ mod allocs_claims {
         let claim1 = make_claim("1", CLIENT1, PROVIDER1, size, min_term, max_term, start, sector);
         let claim2 = make_claim("2", CLIENT1, PROVIDER1, size, min_term, max_term, start, sector);
         let claim3 = make_claim("3", CLIENT1, PROVIDER2, size, min_term, max_term, start, sector);
-        let id1 = h.create_claim(&mut rt, &claim1).unwrap();
-        let id2 = h.create_claim(&mut rt, &claim2).unwrap();
-        let id3 = h.create_claim(&mut rt, &claim3).unwrap();
+        let id1 = h.create_claim(&rt, &claim1).unwrap();
+        let id2 = h.create_claim(&rt, &claim2).unwrap();
+        let id3 = h.create_claim(&rt, &claim3).unwrap();
 
         {
             // Get multiple
-            let ret = h.get_claims(&mut rt, PROVIDER1, vec![id1, id2]).unwrap();
+            let ret = h.get_claims(&rt, PROVIDER1, vec![id1, id2]).unwrap();
             assert_eq!(2, ret.batch_info.success_count);
             assert_eq!(claim1, ret.claims[0]);
             assert_eq!(claim2, ret.claims[1]);
         }
         {
             // Wrong provider
-            let ret = h.get_claims(&mut rt, PROVIDER1, vec![id3]).unwrap();
+            let ret = h.get_claims(&rt, PROVIDER1, vec![id3]).unwrap();
             assert_eq!(0, ret.batch_info.success_count);
         }
         {
             // Mixed bag
-            let ret = h.get_claims(&mut rt, PROVIDER1, vec![id1, id3, id2]).unwrap();
+            let ret = h.get_claims(&rt, PROVIDER1, vec![id1, id3, id2]).unwrap();
             assert_eq!(2, ret.batch_info.success_count);
             assert_eq!(claim1, ret.claims[0]);
             assert_eq!(claim2, ret.claims[1]);
@@ -771,7 +767,7 @@ mod allocs_claims {
 
     #[test]
     fn extend_claims_basic() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let size = MINIMUM_VERIFIED_ALLOCATION_SIZE as u64;
         let sector = 0;
         let start = 0;
@@ -782,9 +778,9 @@ mod allocs_claims {
         let claim2 = make_claim("2", CLIENT1, PROVIDER1, size, min_term, max_term, start, sector);
         let claim3 = make_claim("3", CLIENT1, PROVIDER2, size, min_term, max_term, start, sector);
 
-        let id1 = h.create_claim(&mut rt, &claim1).unwrap();
-        let id2 = h.create_claim(&mut rt, &claim2).unwrap();
-        let id3 = h.create_claim(&mut rt, &claim3).unwrap();
+        let id1 = h.create_claim(&rt, &claim1).unwrap();
+        let id2 = h.create_claim(&rt, &claim2).unwrap();
+        let id3 = h.create_claim(&rt, &claim3).unwrap();
 
         // Extend claim terms and verify return value.
         let params = ExtendClaimTermsParams {
@@ -795,7 +791,7 @@ mod allocs_claims {
             ],
         };
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(CLIENT1));
-        let ret = h.extend_claim_terms(&mut rt, &params).unwrap();
+        let ret = h.extend_claim_terms(&rt, &params).unwrap();
         assert_eq!(ret.codes(), vec![ExitCode::OK, ExitCode::OK, ExitCode::OK]);
 
         // Verify state directly.
@@ -807,7 +803,7 @@ mod allocs_claims {
 
     #[test]
     fn extend_claims_edge_cases() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let size = MINIMUM_VERIFIED_ALLOCATION_SIZE as u64;
         let sector = 0;
         let start = 0;
@@ -818,40 +814,40 @@ mod allocs_claims {
 
         // Basic success case with no-op extension
         {
-            let claim_id = h.create_claim(&mut rt, &claim).unwrap();
+            let claim_id = h.create_claim(&rt, &claim).unwrap();
             let params = ExtendClaimTermsParams {
                 terms: vec![ClaimTerm { provider: PROVIDER1, claim_id, term_max: max_term }],
             };
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(CLIENT1));
-            let ret = h.extend_claim_terms(&mut rt, &params).unwrap();
+            let ret = h.extend_claim_terms(&rt, &params).unwrap();
             assert_eq!(ret.codes(), vec![ExitCode::OK]);
             rt.verify()
         }
         // Mismatched client is forbidden
         {
-            let claim_id = h.create_claim(&mut rt, &claim).unwrap();
+            let claim_id = h.create_claim(&rt, &claim).unwrap();
             let params = ExtendClaimTermsParams {
                 terms: vec![ClaimTerm { provider: PROVIDER1, claim_id, term_max: max_term }],
             };
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(CLIENT2));
-            let ret = h.extend_claim_terms(&mut rt, &params).unwrap();
+            let ret = h.extend_claim_terms(&rt, &params).unwrap();
             assert_eq!(ret.codes(), vec![ExitCode::USR_FORBIDDEN]);
             rt.verify()
         }
         // Mismatched provider is not found
         {
-            let claim_id = h.create_claim(&mut rt, &claim).unwrap();
+            let claim_id = h.create_claim(&rt, &claim).unwrap();
             let params = ExtendClaimTermsParams {
                 terms: vec![ClaimTerm { provider: PROVIDER2, claim_id, term_max: max_term }],
             };
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(CLIENT1));
-            let ret = h.extend_claim_terms(&mut rt, &params).unwrap();
+            let ret = h.extend_claim_terms(&rt, &params).unwrap();
             assert_eq!(ret.codes(), vec![ExitCode::USR_NOT_FOUND]);
             rt.verify()
         }
         // Term in excess of limit is denied
         {
-            let claim_id = h.create_claim(&mut rt, &claim).unwrap();
+            let claim_id = h.create_claim(&rt, &claim).unwrap();
             let params = ExtendClaimTermsParams {
                 terms: vec![ClaimTerm {
                     provider: PROVIDER1,
@@ -860,24 +856,24 @@ mod allocs_claims {
                 }],
             };
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(CLIENT1));
-            let ret = h.extend_claim_terms(&mut rt, &params).unwrap();
+            let ret = h.extend_claim_terms(&rt, &params).unwrap();
             assert_eq!(ret.codes(), vec![ExitCode::USR_ILLEGAL_ARGUMENT]);
             rt.verify()
         }
         // Reducing term is denied.
         {
-            let claim_id = h.create_claim(&mut rt, &claim).unwrap();
+            let claim_id = h.create_claim(&rt, &claim).unwrap();
             let params = ExtendClaimTermsParams {
                 terms: vec![ClaimTerm { provider: PROVIDER1, claim_id, term_max: max_term - 1 }],
             };
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(CLIENT1));
-            let ret = h.extend_claim_terms(&mut rt, &params).unwrap();
+            let ret = h.extend_claim_terms(&rt, &params).unwrap();
             assert_eq!(ret.codes(), vec![ExitCode::USR_ILLEGAL_ARGUMENT]);
             rt.verify()
         }
         // Extending an already-expired claim is ok
         {
-            let claim_id = h.create_claim(&mut rt, &claim).unwrap();
+            let claim_id = h.create_claim(&rt, &claim).unwrap();
             let params = ExtendClaimTermsParams {
                 terms: vec![ClaimTerm {
                     provider: PROVIDER1,
@@ -887,7 +883,7 @@ mod allocs_claims {
             };
             rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(CLIENT1));
             rt.set_epoch(max_term + 1);
-            let ret = h.extend_claim_terms(&mut rt, &params).unwrap();
+            let ret = h.extend_claim_terms(&rt, &params).unwrap();
             assert_eq!(ret.codes(), vec![ExitCode::OK]);
             rt.verify()
         }
@@ -896,7 +892,7 @@ mod allocs_claims {
 
     #[test]
     fn expire_claims() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let term_start = 0;
         let term_min = MINIMUM_VERIFIED_ALLOCATION_TERM;
         let sector = 0;
@@ -924,8 +920,8 @@ mod allocs_claims {
             sector,
         );
 
-        let id1 = h.create_claim(&mut rt, &claim1).unwrap();
-        let id2 = h.create_claim(&mut rt, &claim2).unwrap();
+        let id1 = h.create_claim(&rt, &claim1).unwrap();
+        let id2 = h.create_claim(&rt, &claim2).unwrap();
         let state_with_allocs: State = rt.get_state();
 
         // Removal of expired claims shares most of its implementation with removing expired allocations.
@@ -934,43 +930,43 @@ mod allocs_claims {
 
         // None expired yet
         rt.set_epoch(term_start + term_min + 99);
-        let ret = h.remove_expired_claims(&mut rt, PROVIDER1, vec![id1, id2]).unwrap();
+        let ret = h.remove_expired_claims(&rt, PROVIDER1, vec![id1, id2]).unwrap();
         assert_eq!(vec![1, 2], ret.considered);
         assert_eq!(vec![ExitCode::USR_FORBIDDEN, ExitCode::USR_FORBIDDEN], ret.results.codes());
 
         // One expired
         rt.set_epoch(term_start + term_min + 100);
-        let ret = h.remove_expired_claims(&mut rt, PROVIDER1, vec![id1, id2]).unwrap();
+        let ret = h.remove_expired_claims(&rt, PROVIDER1, vec![id1, id2]).unwrap();
         assert_eq!(vec![1, 2], ret.considered);
         assert_eq!(vec![ExitCode::OK, ExitCode::USR_FORBIDDEN], ret.results.codes());
 
         // Both now expired
         rt.set_epoch(term_start + term_min + 200);
-        let ret = h.remove_expired_claims(&mut rt, PROVIDER1, vec![id1, id2]).unwrap();
+        let ret = h.remove_expired_claims(&rt, PROVIDER1, vec![id1, id2]).unwrap();
         assert_eq!(vec![1, 2], ret.considered);
         assert_eq!(vec![ExitCode::USR_NOT_FOUND, ExitCode::OK], ret.results.codes());
 
         // Reset state, and show that specifying none removes only expired allocations
         rt.set_epoch(term_start + term_min);
         rt.replace_state(&state_with_allocs);
-        let ret = h.remove_expired_claims(&mut rt, PROVIDER1, vec![]).unwrap();
+        let ret = h.remove_expired_claims(&rt, PROVIDER1, vec![]).unwrap();
         assert_eq!(Vec::<AllocationID>::new(), ret.considered);
         assert_eq!(Vec::<ExitCode>::new(), ret.results.codes());
-        assert!(h.load_claim(&mut rt, PROVIDER1, id1).is_some());
-        assert!(h.load_claim(&mut rt, PROVIDER1, id2).is_some());
+        assert!(h.load_claim(&rt, PROVIDER1, id1).is_some());
+        assert!(h.load_claim(&rt, PROVIDER1, id2).is_some());
 
         rt.set_epoch(term_start + term_min + 200);
-        let ret = h.remove_expired_claims(&mut rt, PROVIDER1, vec![]).unwrap();
+        let ret = h.remove_expired_claims(&rt, PROVIDER1, vec![]).unwrap();
         assert_eq!(vec![1, 2], ret.considered);
         assert_eq!(vec![ExitCode::OK, ExitCode::OK], ret.results.codes());
-        assert!(h.load_claim(&mut rt, PROVIDER1, id1).is_none()); // removed
-        assert!(h.load_claim(&mut rt, PROVIDER1, id2).is_none()); // removed
+        assert!(h.load_claim(&rt, PROVIDER1, id1).is_none()); // removed
+        assert!(h.load_claim(&rt, PROVIDER1, id2).is_none()); // removed
         h.check_state(&rt);
     }
 
     #[test]
     fn claims_restricted_correctly() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let size = MINIMUM_VERIFIED_ALLOCATION_SIZE as u64;
         let sector = 0;
         let start = 0;
@@ -979,7 +975,7 @@ mod allocs_claims {
 
         let claim1 = make_claim("1", CLIENT1, PROVIDER1, size, min_term, max_term, start, sector);
 
-        let id1 = h.create_claim(&mut rt, &claim1).unwrap();
+        let id1 = h.create_claim(&rt, &claim1).unwrap();
 
         // First, let's extend some claims
 
@@ -994,7 +990,7 @@ mod allocs_claims {
         expect_abort_contains_message(
             ExitCode::USR_FORBIDDEN,
             "must be built-in",
-            h.extend_claim_terms(&mut rt, &params),
+            h.extend_claim_terms(&rt, &params),
         );
 
         // can call the exported method num
@@ -1083,9 +1079,9 @@ mod datacap {
 
     #[test]
     fn receive_tokens_make_allocs() {
-        let (h, mut rt) = new_harness();
-        add_miner(&mut rt, PROVIDER1);
-        add_miner(&mut rt, PROVIDER2);
+        let (h, rt) = new_harness();
+        add_miner(&rt, PROVIDER1);
+        add_miner(&rt, PROVIDER2);
 
         {
             let reqs = vec![
@@ -1093,8 +1089,7 @@ mod datacap {
                 make_alloc_req(&rt, PROVIDER2, SIZE * 2),
             ];
             let payload = make_receiver_hook_token_payload(CLIENT1, reqs.clone(), vec![], SIZE * 3);
-            h.receive_tokens(&mut rt, payload, BatchReturn::ok(2), BATCH_EMPTY, vec![1, 2], 0)
-                .unwrap();
+            h.receive_tokens(&rt, payload, BatchReturn::ok(2), BATCH_EMPTY, vec![1, 2], 0).unwrap();
 
             // Verify allocations in state.
             assert_allocation(&rt, CLIENT1, 1, &alloc_from_req(CLIENT1, &reqs[0]));
@@ -1106,8 +1101,7 @@ mod datacap {
             // Make another allocation from a different client
             let reqs = vec![make_alloc_req(&rt, PROVIDER1, SIZE)];
             let payload = make_receiver_hook_token_payload(CLIENT2, reqs.clone(), vec![], SIZE);
-            h.receive_tokens(&mut rt, payload, BatchReturn::ok(1), BATCH_EMPTY, vec![3], 0)
-                .unwrap();
+            h.receive_tokens(&rt, payload, BatchReturn::ok(1), BATCH_EMPTY, vec![3], 0).unwrap();
 
             // Verify allocations in state.
             assert_allocation(&rt, CLIENT2, 3, &alloc_from_req(CLIENT2, &reqs[0]));
@@ -1119,7 +1113,7 @@ mod datacap {
 
     #[test]
     fn receive_tokens_extend_claims() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
 
         let term_min = MINIMUM_VERIFIED_ALLOCATION_TERM;
         let term_max = term_min + 100;
@@ -1131,8 +1125,8 @@ mod datacap {
         let claim2 =
             make_claim("2", CLIENT2, PROVIDER2, SIZE * 2, term_min, term_max, term_start, sector);
 
-        let cid1 = h.create_claim(&mut rt, &claim1).unwrap();
-        let cid2 = h.create_claim(&mut rt, &claim2).unwrap();
+        let cid1 = h.create_claim(&rt, &claim1).unwrap();
+        let cid2 = h.create_claim(&rt, &claim2).unwrap();
 
         let reqs = vec![
             make_extension_req(PROVIDER1, cid1, term_max + 1000),
@@ -1140,8 +1134,7 @@ mod datacap {
         ];
         // Client1 extends both claims
         let payload = make_receiver_hook_token_payload(CLIENT1, vec![], reqs, SIZE * 3);
-        h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BatchReturn::ok(2), vec![], SIZE * 3)
-            .unwrap();
+        h.receive_tokens(&rt, payload, BATCH_EMPTY, BatchReturn::ok(2), vec![], SIZE * 3).unwrap();
 
         // Verify claims in state.
         assert_claim(&rt, PROVIDER1, cid1, &Claim { term_max: term_max + 1000, ..claim1 });
@@ -1151,9 +1144,9 @@ mod datacap {
 
     #[test]
     fn receive_tokens_make_alloc_and_extend_claims() {
-        let (h, mut rt) = new_harness();
-        add_miner(&mut rt, PROVIDER1);
-        add_miner(&mut rt, PROVIDER2);
+        let (h, rt) = new_harness();
+        add_miner(&rt, PROVIDER1);
+        add_miner(&rt, PROVIDER2);
 
         let alloc_reqs =
             vec![make_alloc_req(&rt, PROVIDER1, SIZE), make_alloc_req(&rt, PROVIDER2, SIZE * 2)];
@@ -1167,8 +1160,8 @@ mod datacap {
             make_claim("1", CLIENT1, PROVIDER1, SIZE, term_min, term_max, term_start, sector);
         let claim2 =
             make_claim("2", CLIENT2, PROVIDER2, SIZE * 2, term_min, term_max, term_start, sector);
-        let cid1 = h.create_claim(&mut rt, &claim1).unwrap();
-        let cid2 = h.create_claim(&mut rt, &claim2).unwrap();
+        let cid1 = h.create_claim(&rt, &claim1).unwrap();
+        let cid2 = h.create_claim(&rt, &claim2).unwrap();
 
         let ext_reqs = vec![
             make_extension_req(PROVIDER1, cid1, term_max + 1000),
@@ -1179,7 +1172,7 @@ mod datacap {
         let payload =
             make_receiver_hook_token_payload(CLIENT1, alloc_reqs.clone(), ext_reqs, SIZE * 6);
         h.receive_tokens(
-            &mut rt,
+            &rt,
             payload,
             BatchReturn::ok(2),
             BatchReturn::ok(2),
@@ -1201,8 +1194,8 @@ mod datacap {
 
     #[test]
     fn receive_requires_datacap_caller() {
-        let (h, mut rt) = new_harness();
-        add_miner(&mut rt, PROVIDER1);
+        let (h, rt) = new_harness();
+        add_miner(&rt, PROVIDER1);
 
         let params = UniversalReceiverParams {
             type_: FRC46_TOKEN_TYPE,
@@ -1234,8 +1227,8 @@ mod datacap {
 
     #[test]
     fn receive_requires_to_self() {
-        let (h, mut rt) = new_harness();
-        add_miner(&mut rt, PROVIDER1);
+        let (h, rt) = new_harness();
+        add_miner(&rt, PROVIDER1);
 
         let mut payload = make_receiver_hook_token_payload(
             CLIENT1,
@@ -1266,7 +1259,7 @@ mod datacap {
 
     #[test]
     fn receive_alloc_requires_miner_actor() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
         let provider1 = Address::new_id(PROVIDER1);
         rt.set_address_actor_type(provider1, *ACCOUNT_ACTOR_CODE_ID);
 
@@ -1276,16 +1269,16 @@ mod datacap {
             ExitCode::USR_ILLEGAL_ARGUMENT,
             format!("allocation provider {} must be a miner actor", provider1.id().unwrap())
                 .as_str(),
-            h.receive_tokens(&mut rt, payload, BatchReturn::ok(1), BATCH_EMPTY, vec![1], 0),
+            h.receive_tokens(&rt, payload, BatchReturn::ok(1), BATCH_EMPTY, vec![1], 0),
         );
         h.check_state(&rt);
     }
 
     #[test]
     fn receive_invalid_alloc_reqs() {
-        let (h, mut rt) = new_harness();
-        add_miner(&mut rt, PROVIDER1);
-        add_miner(&mut rt, PROVIDER2);
+        let (h, rt) = new_harness();
+        add_miner(&rt, PROVIDER1);
+        add_miner(&rt, PROVIDER2);
 
         // Alloc too small
         {
@@ -1294,7 +1287,7 @@ mod datacap {
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "allocation size 1048575 below minimum 1048576",
-                h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
+                h.receive_tokens(&rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
             );
         }
         // Min term too short
@@ -1305,7 +1298,7 @@ mod datacap {
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "allocation term min 518399 below limit 518400",
-                h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
+                h.receive_tokens(&rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
             );
         }
         // Max term too long
@@ -1316,7 +1309,7 @@ mod datacap {
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "allocation term max 5259486 above limit 5259485",
-                h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
+                h.receive_tokens(&rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
             );
         }
         // Term minimum greater than maximum
@@ -1328,7 +1321,7 @@ mod datacap {
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "allocation term min 2103795 exceeds term max 2103794",
-                h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
+                h.receive_tokens(&rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
             );
         }
         // Allocation expires too late
@@ -1339,7 +1332,7 @@ mod datacap {
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "allocation expiration 172801 exceeds maximum 172800",
-                h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
+                h.receive_tokens(&rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
             );
         }
         // Tokens received doesn't match sum of allocation sizes
@@ -1350,7 +1343,7 @@ mod datacap {
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "total allocation size 2097152 must match data cap amount received 2097153",
-                h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
+                h.receive_tokens(&rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
             );
         }
         // One bad request fails the lot
@@ -1364,7 +1357,7 @@ mod datacap {
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "allocation size 1048575 below minimum 1048576",
-                h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
+                h.receive_tokens(&rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
             );
         }
         h.check_state(&rt);
@@ -1372,7 +1365,7 @@ mod datacap {
 
     #[test]
     fn receive_invalid_extension_reqs() {
-        let (h, mut rt) = new_harness();
+        let (h, rt) = new_harness();
 
         let term_min = MINIMUM_VERIFIED_ALLOCATION_TERM;
         let term_max = term_min + 100;
@@ -1381,7 +1374,7 @@ mod datacap {
         let claim1 =
             make_claim("1", CLIENT1, PROVIDER1, SIZE, term_min, term_max, term_start, sector);
 
-        let cid1 = h.create_claim(&mut rt, &claim1).unwrap();
+        let cid1 = h.create_claim(&rt, &claim1).unwrap();
         let st: State = rt.get_state();
 
         // Extension too long
@@ -1395,13 +1388,12 @@ mod datacap {
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "term_max 5260486 for claim 1 exceeds maximum 5260485 at current epoch 1100",
-                h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
+                h.receive_tokens(&rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
             );
             // But just on the limit is allowed
             let reqs = vec![make_extension_req(PROVIDER1, cid1, max_allowed_term)];
             let payload = make_receiver_hook_token_payload(CLIENT1, vec![], reqs, SIZE);
-            h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BatchReturn::ok(1), vec![], SIZE)
-                .unwrap();
+            h.receive_tokens(&rt, payload, BATCH_EMPTY, BatchReturn::ok(1), vec![], SIZE).unwrap();
             h.check_state(&rt);
         }
         {
@@ -1415,7 +1407,7 @@ mod datacap {
             expect_abort_contains_message(
                 ExitCode::USR_FORBIDDEN,
                 "claim 1 expired at 518600, current epoch 518601",
-                h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
+                h.receive_tokens(&rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
             );
             // But just at expiration is allowed
             let epoch = term_start + term_max;
@@ -1423,8 +1415,7 @@ mod datacap {
             rt.set_epoch(epoch);
             let reqs = vec![make_extension_req(PROVIDER1, cid1, new_term)];
             let payload = make_receiver_hook_token_payload(CLIENT1, vec![], reqs, SIZE);
-            h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BatchReturn::ok(1), vec![], SIZE)
-                .unwrap();
+            h.receive_tokens(&rt, payload, BATCH_EMPTY, BatchReturn::ok(1), vec![], SIZE).unwrap();
             h.check_state(&rt);
         }
         {
@@ -1436,7 +1427,7 @@ mod datacap {
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "term_max 518500 for claim 1 is not larger than existing term max 518500",
-                h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
+                h.receive_tokens(&rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
             );
             // Extension is negative
             let reqs = vec![make_extension_req(PROVIDER1, cid1, term_max - 1)];
@@ -1444,13 +1435,12 @@ mod datacap {
             expect_abort_contains_message(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
                 "term_max 518499 for claim 1 is not larger than existing term max 518500",
-                h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
+                h.receive_tokens(&rt, payload, BATCH_EMPTY, BATCH_EMPTY, vec![], 0),
             );
             // But extension by just 1 epoch is allowed
             let reqs = vec![make_extension_req(PROVIDER1, cid1, term_max + 1)];
             let payload = make_receiver_hook_token_payload(CLIENT1, vec![], reqs, SIZE);
-            h.receive_tokens(&mut rt, payload, BATCH_EMPTY, BatchReturn::ok(1), vec![], SIZE)
-                .unwrap();
+            h.receive_tokens(&rt, payload, BATCH_EMPTY, BatchReturn::ok(1), vec![], SIZE).unwrap();
             h.check_state(&rt);
         }
     }

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -446,7 +446,7 @@ mod clients {
         let allowance_verifier = verifier_allowance(&rt);
         h.add_verifier(&rt, &VERIFIER, &allowance_verifier).unwrap();
 
-        let allowance = allowance_verifier.clone() + 1;
+        let allowance = allowance_verifier + 1;
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
             h.add_client(&rt, &VERIFIER, &h.root, &allowance),

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -19,7 +19,7 @@ pub const FIRST_ACTOR_SPECIFIC_EXIT_CODE: u32 = 32;
 /// If an actor ID for the given address doesn't exist yet, it tries to create one by sending
 /// a zero balance to the given address.
 pub fn resolve_to_actor_id(
-    rt: &mut impl Runtime,
+    rt: &impl Runtime,
     address: &Address,
     check_existence: bool,
 ) -> Result<ActorID, ActorError> {
@@ -61,7 +61,7 @@ pub const FIRST_EXPORTED_METHOD_NUMBER: MethodNum = 1 << 24;
 // All method numbers below the FRC-42 range are restricted to built-in actors
 // (including the account and multisig actors).
 // Methods may subsequently enforce tighter restrictions.
-pub fn restrict_internal_api<RT>(rt: &mut RT, method: MethodNum) -> Result<(), ActorError>
+pub fn restrict_internal_api<RT>(rt: &RT, method: MethodNum) -> Result<(), ActorError>
 where
     RT: Runtime,
 {

--- a/runtime/src/dispatch.rs
+++ b/runtime/src/dispatch.rs
@@ -133,12 +133,12 @@ where
 /// Like [`dispatch`], but pass the default value to if there are no parameters.
 #[doc(hidden)]
 pub fn dispatch_default<'de, F, A, R, RT>(
-    rt: &mut RT,
+    rt: &RT,
     func: F,
     arg: &'de Option<IpldBlock>,
 ) -> Result<Option<IpldBlock>, ActorError>
 where
-    F: FnOnce(&mut RT, A) -> Result<R, ActorError>,
+    F: FnOnce(&RT, A) -> Result<R, ActorError>,
     A: Deserialize<'de> + Default,
     R: Serialize,
 {

--- a/runtime/src/runtime/actor_code.rs
+++ b/runtime/src/runtime/actor_code.rs
@@ -13,7 +13,7 @@ pub trait ActorCode {
     /// Invokes method with runtime on the actor's code. Method number will match one
     /// defined by the Actor, and parameters will be serialized and used in execution
     fn invoke_method<RT>(
-        rt: &mut RT,
+        rt: &RT,
         method: MethodNum,
         params: Option<IpldBlock>,
     ) -> Result<Option<IpldBlock>, ActorError>

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -32,6 +32,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 #[cfg(feature = "fake-proofs")]
 use sha2::{Digest, Sha256};
+use std::cell::RefCell;
 
 use crate::runtime::actor_blockstore::ActorBlockstore;
 use crate::runtime::builtins::Type;
@@ -46,9 +47,9 @@ pub struct FvmRuntime<B = ActorBlockstore> {
     blockstore: B,
     /// Indicates whether we are in a state transaction. During such, sending
     /// messages is prohibited.
-    in_transaction: bool,
+    in_transaction: RefCell<bool>,
     /// Indicates that the caller has been validated.
-    caller_validated: bool,
+    caller_validated: RefCell<bool>,
     /// The runtime policy
     policy: Policy,
 }
@@ -57,16 +58,16 @@ impl Default for FvmRuntime {
     fn default() -> Self {
         FvmRuntime {
             blockstore: ActorBlockstore,
-            in_transaction: false,
-            caller_validated: false,
+            in_transaction: RefCell::new(false),
+            caller_validated: RefCell::new(false),
             policy: Policy::default(),
         }
     }
 }
 
 impl<B> FvmRuntime<B> {
-    fn assert_not_validated(&mut self) -> Result<(), ActorError> {
-        if self.caller_validated {
+    fn assert_not_validated(&self) -> Result<(), ActorError> {
+        if *self.caller_validated.borrow() {
             return Err(actor_error!(
                 assertion_failed,
                 "Method must validate caller identity exactly once"
@@ -132,20 +133,20 @@ where
         fvm::network::chain_id()
     }
 
-    fn validate_immediate_caller_accept_any(&mut self) -> Result<(), ActorError> {
+    fn validate_immediate_caller_accept_any(&self) -> Result<(), ActorError> {
         self.assert_not_validated()?;
-        self.caller_validated = true;
+        self.caller_validated.replace(true);
         Ok(())
     }
 
-    fn validate_immediate_caller_is<'a, I>(&mut self, addresses: I) -> Result<(), ActorError>
+    fn validate_immediate_caller_is<'a, I>(&self, addresses: I) -> Result<(), ActorError>
     where
         I: IntoIterator<Item = &'a Address>,
     {
         self.assert_not_validated()?;
         let caller_addr = self.message().caller();
         if addresses.into_iter().any(|a| *a == caller_addr) {
-            self.caller_validated = true;
+            self.caller_validated.replace(true);
             Ok(())
         } else {
             Err(actor_error!(forbidden;
@@ -154,7 +155,7 @@ where
         }
     }
 
-    fn validate_immediate_caller_namespace<I>(&mut self, addresses: I) -> Result<(), ActorError>
+    fn validate_immediate_caller_namespace<I>(&self, addresses: I) -> Result<(), ActorError>
     where
         I: IntoIterator<Item = u64>,
     {
@@ -166,7 +167,7 @@ where
             .into_iter()
             .any(|a| matches!(caller_f4, Some(Payload::Delegated(d)) if d.namespace() == a))
         {
-            self.caller_validated = true;
+            self.caller_validated.replace(true);
             Ok(())
         } else {
             Err(actor_error!(forbidden;
@@ -175,7 +176,7 @@ where
         }
     }
 
-    fn validate_immediate_caller_type<'a, I>(&mut self, types: I) -> Result<(), ActorError>
+    fn validate_immediate_caller_type<'a, I>(&self, types: I) -> Result<(), ActorError>
     where
         I: IntoIterator<Item = &'a Type>,
     {
@@ -188,7 +189,7 @@ where
 
         match self.resolve_builtin_actor_type(&caller_cid) {
             Some(typ) if types.into_iter().any(|t| *t == typ) => {
-                self.caller_validated = true;
+                self.caller_validated.replace(true);
                 Ok(())
             }
             _ => Err(actor_error!(forbidden;
@@ -260,14 +261,14 @@ where
         Ok(fvm::sself::root()?)
     }
 
-    fn set_state_root(&mut self, root: &Cid) -> Result<(), ActorError> {
+    fn set_state_root(&self, root: &Cid) -> Result<(), ActorError> {
         Ok(fvm::sself::set_root(root)?)
     }
 
-    fn transaction<S, RT, F>(&mut self, f: F) -> Result<RT, ActorError>
+    fn transaction<S, RT, F>(&self, f: F) -> Result<RT, ActorError>
     where
         S: Serialize + DeserializeOwned,
-        F: FnOnce(&mut S, &mut Self) -> Result<RT, ActorError>,
+        F: FnOnce(&mut S, &Self) -> Result<RT, ActorError>,
     {
         let state_cid = fvm::sself::root()
             .map_err(|_| actor_error!(illegal_argument; "failed to get actor root state CID"))?;
@@ -277,9 +278,9 @@ where
             .map_err(|_| actor_error!(illegal_argument; "failed to get actor state"))?
             .expect("State does not exist for actor state root");
 
-        self.in_transaction = true;
+        self.in_transaction.replace(true);
         let result = f(&mut state, self);
-        self.in_transaction = false;
+        self.in_transaction.replace(false);
 
         let ret = result?;
         let new_root = ActorBlockstore.put_cbor(&state, Code::Blake2b256)
@@ -301,7 +302,7 @@ where
         gas_limit: Option<u64>,
         flags: SendFlags,
     ) -> Result<Response, SendError> {
-        if self.in_transaction {
+        if *self.in_transaction.borrow() {
             // Note: It's slightly improper to call this ErrorNumber::IllegalOperation,
             // since the error arises before getting to the VM.
             return Err(SendError(ErrorNumber::IllegalOperation));
@@ -310,17 +311,17 @@ where
         fvm::send::send(to, method, params, value, gas_limit, flags).map_err(SendError)
     }
 
-    fn new_actor_address(&mut self) -> Result<Address, ActorError> {
+    fn new_actor_address(&self) -> Result<Address, ActorError> {
         Ok(fvm::actor::next_actor_address())
     }
 
     fn create_actor(
-        &mut self,
+        &self,
         code_id: Cid,
         actor_id: ActorID,
         predictable_address: Option<Address>,
     ) -> Result<(), ActorError> {
-        if self.in_transaction {
+        if *self.in_transaction.borrow() {
             return Err(
                 actor_error!(assertion_failed; "create_actor is not allowed during transaction"),
             );
@@ -334,8 +335,8 @@ where
         })
     }
 
-    fn delete_actor(&mut self, beneficiary: &Address) -> Result<(), ActorError> {
-        if self.in_transaction {
+    fn delete_actor(&self, beneficiary: &Address) -> Result<(), ActorError> {
+        if *self.in_transaction.borrow() {
             return Err(
                 actor_error!(assertion_failed; "delete_actor is not allowed during transaction"),
             );
@@ -347,7 +348,7 @@ where
         fvm::network::total_fil_circ_supply()
     }
 
-    fn charge_gas(&mut self, name: &'static str, compute: i64) {
+    fn charge_gas(&self, name: &'static str, compute: i64) {
         fvm::gas::charge(name, compute as u64)
     }
 
@@ -573,16 +574,16 @@ pub fn trampoline<C: ActorCode>(params: u32) -> u32 {
     let params = fvm::message::params_raw(params).expect("params block invalid");
 
     // Construct a new runtime.
-    let mut rt = FvmRuntime::default();
+    let rt = FvmRuntime::default();
     // Invoke the method, aborting if the actor returns an errored exit code.
-    let ret = C::invoke_method(&mut rt, method, params).unwrap_or_else(|mut err| {
+    let ret = C::invoke_method(&rt, method, params).unwrap_or_else(|mut err| {
         fvm::vm::exit(err.exit_code().value(), err.take_data(), Some(err.msg()))
     });
 
     // Abort with "assertion failed" if the actor failed to validate the caller somewhere.
     // We do this after handling the error, because the actor may have encountered an error before
     // it even could validate the caller.
-    if !rt.caller_validated {
+    if !*rt.caller_validated.borrow() {
         fvm::vm::abort(ExitCode::USR_ASSERTION_FAILED.value(), Some("failed to validate caller"))
     }
 

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -71,20 +71,20 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
 
     /// Validates the caller against some predicate.
     /// Exported actor methods must invoke at least one caller validation before returning.
-    fn validate_immediate_caller_accept_any(&mut self) -> Result<(), ActorError>;
-    fn validate_immediate_caller_is<'a, I>(&mut self, addresses: I) -> Result<(), ActorError>
+    fn validate_immediate_caller_accept_any(&self) -> Result<(), ActorError>;
+    fn validate_immediate_caller_is<'a, I>(&self, addresses: I) -> Result<(), ActorError>
     where
         I: IntoIterator<Item = &'a Address>;
     /// Validates that the caller has a delegated address that is a member of
     /// one of the provided namespaces.
     /// Addresses must be of Protocol ID.
     fn validate_immediate_caller_namespace<I>(
-        &mut self,
+        &self,
         namespace_manager_addresses: I,
     ) -> Result<(), ActorError>
     where
         I: IntoIterator<Item = u64>;
-    fn validate_immediate_caller_type<'a, I>(&mut self, types: I) -> Result<(), ActorError>
+    fn validate_immediate_caller_type<'a, I>(&self, types: I) -> Result<(), ActorError>
     where
         I: IntoIterator<Item = &'a Type>;
 
@@ -129,7 +129,7 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// Initializes the state object.
     /// This is only valid when the state has not yet been initialized.
     /// NOTE: we should also limit this to being invoked during the constructor method
-    fn create<T: Serialize>(&mut self, obj: &T) -> Result<(), ActorError> {
+    fn create<T: Serialize>(&self, obj: &T) -> Result<(), ActorError> {
         let root = self.get_state_root()?;
         if root != EMPTY_ARR_CID {
             return Err(
@@ -155,7 +155,7 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     fn get_state_root(&self) -> Result<Cid, ActorError>;
 
     /// Sets the state-root.
-    fn set_state_root(&mut self, root: &Cid) -> Result<(), ActorError>;
+    fn set_state_root(&self, root: &Cid) -> Result<(), ActorError>;
 
     /// Loads a mutable copy of the state of the receiver, passes it to `f`,
     /// and after `f` completes puts the state object back to the store and sets it as
@@ -164,10 +164,10 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// During the call to `f`, execution is protected from side-effects, (including message send).
     ///
     /// Returns the result of `f`.
-    fn transaction<S, RT, F>(&mut self, f: F) -> Result<RT, ActorError>
+    fn transaction<S, RT, F>(&self, f: F) -> Result<RT, ActorError>
     where
         S: Serialize + DeserializeOwned,
-        F: FnOnce(&mut S, &mut Self) -> Result<RT, ActorError>;
+        F: FnOnce(&mut S, &Self) -> Result<RT, ActorError>;
 
     /// Returns reference to blockstore
     fn store(&self) -> &Self::Blockstore;
@@ -200,12 +200,12 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// the actor even in the event of a chain re-org (whereas an ID-address might refer to a
     /// different actor after messages are re-ordered).
     /// Always an ActorExec address.
-    fn new_actor_address(&mut self) -> Result<Address, ActorError>;
+    fn new_actor_address(&self) -> Result<Address, ActorError>;
 
     /// Creates an actor with code `codeID`, an empty state, id `actor_id`, and an optional predictable address.
     /// May only be called by Init actor.
     fn create_actor(
-        &mut self,
+        &self,
         code_id: Cid,
         actor_id: ActorID,
         predictable_address: Option<Address>,
@@ -214,7 +214,7 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
     /// Deletes the executing actor from the state tree, transferring any balance to beneficiary.
     /// Aborts if the beneficiary does not exist.
     /// May only be called by the actor itself.
-    fn delete_actor(&mut self, beneficiary: &Address) -> Result<(), ActorError>;
+    fn delete_actor(&self, beneficiary: &Address) -> Result<(), ActorError>;
 
     /// Returns whether the specified CodeCID belongs to a built-in actor.
     fn resolve_builtin_actor_type(&self, code_id: &Cid) -> Option<Type>;
@@ -235,7 +235,7 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
 
     /// ChargeGas charges specified amount of `gas` for execution.
     /// `name` provides information about gas charging point
-    fn charge_gas(&mut self, name: &'static str, compute: i64);
+    fn charge_gas(&self, name: &'static str, compute: i64);
 
     /// Returns the gas base fee (cost per unit) for the current epoch.
     fn base_fee(&self) -> TokenAmount;

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -139,15 +139,15 @@ pub struct MockRuntime<BS = MemoryBlockstore> {
     pub miner: Address,
     pub base_fee: TokenAmount,
     pub chain_id: ChainID,
-    pub id_addresses: HashMap<Address, Address>,
-    pub delegated_addresses: HashMap<ActorID, Address>,
-    pub actor_code_cids: HashMap<Address, Cid>,
-    pub new_actor_addr: Option<Address>,
+    pub id_addresses: RefCell<HashMap<Address, Address>>,
+    pub delegated_addresses: RefCell<HashMap<ActorID, Address>>,
+    pub actor_code_cids: RefCell<HashMap<Address, Cid>>,
+    pub new_actor_addr: RefCell<Option<Address>>,
     pub receiver: Address,
-    pub caller: Address,
-    pub caller_type: Cid,
-    pub origin: Address,
-    pub value_received: TokenAmount,
+    pub caller: RefCell<Address>,
+    pub caller_type: RefCell<Cid>,
+    pub origin: RefCell<Address>,
+    pub value_received: RefCell<TokenAmount>,
     #[allow(clippy::type_complexity)]
     pub hash_func: Box<dyn Fn(SupportedHashes, &[u8]) -> ([u8; 64], usize)>,
     #[allow(clippy::type_complexity)]
@@ -160,13 +160,13 @@ pub struct MockRuntime<BS = MemoryBlockstore> {
     pub network_version: NetworkVersion,
 
     // Actor State
-    pub state: Option<Cid>,
+    pub state: RefCell<Option<Cid>>,
     pub balance: RefCell<TokenAmount>,
 
     // VM Impl
-    pub in_call: bool,
+    pub in_call: RefCell<bool>,
     pub store: Rc<BS>,
-    pub in_transaction: bool,
+    pub in_transaction: RefCell<bool>,
 
     // Expectations
     pub expectations: RefCell<Expectations>,
@@ -337,9 +337,9 @@ impl<BS> MockRuntime<BS> {
             actor_code_cids: Default::default(),
             new_actor_addr: Default::default(),
             receiver: Address::new_id(0),
-            caller: Address::new_id(0),
+            caller: RefCell::new(Address::new_id(0)),
             caller_type: Default::default(),
-            origin: Address::new_id(0),
+            origin: RefCell::new(Address::new_id(0)),
             value_received: Default::default(),
             hash_func: Box::new(hash),
             recover_secp_pubkey_fn: Box::new(recover_secp_public_key),
@@ -486,99 +486,99 @@ impl<BS: Blockstore> MockRuntime<BS> {
     ///// Runtime access for tests /////
 
     pub fn get_state<T: DeserializeOwned>(&self) -> T {
-        self.store_get(self.state.as_ref().unwrap())
+        self.store_get(self.state.borrow().as_ref().unwrap())
     }
 
-    pub fn replace_state<T: Serialize>(&mut self, obj: &T) {
-        self.state = Some(self.store_put(obj));
+    pub fn replace_state<T: Serialize>(&self, obj: &T) {
+        self.state.replace(Some(self.store_put(obj)));
     }
 
-    pub fn set_balance(&mut self, amount: TokenAmount) {
-        *self.balance.get_mut() = amount;
+    pub fn set_balance(&self, amount: TokenAmount) {
+        self.balance.replace(amount);
     }
 
     pub fn get_balance(&self) -> TokenAmount {
         self.balance.borrow().to_owned()
     }
 
-    pub fn add_balance(&mut self, amount: TokenAmount) {
-        *self.balance.get_mut() += amount;
+    pub fn add_balance(&self, amount: TokenAmount) {
+        self.balance.replace_with(|b| b.clone() + amount);
     }
 
-    pub fn set_value(&mut self, value: TokenAmount) {
-        self.value_received = value;
+    pub fn set_value(&self, value: TokenAmount) {
+        self.value_received.replace(value);
     }
 
-    pub fn set_caller(&mut self, code_id: Cid, address: Address) {
+    pub fn set_caller(&self, code_id: Cid, address: Address) {
         // fail if called with a non-ID address, since the caller() method must always return an ID
         address.id().unwrap();
-        self.caller = address;
-        self.caller_type = code_id;
-        self.actor_code_cids.insert(address, code_id);
+        self.caller.replace(address);
+        self.caller_type.replace(code_id);
+        self.actor_code_cids.borrow_mut().insert(address, code_id);
     }
 
-    pub fn set_origin(&mut self, address: Address) {
-        self.origin = address;
+    pub fn set_origin(&self, address: Address) {
+        self.origin.replace(address);
     }
 
-    pub fn set_address_actor_type(&mut self, address: Address, actor_type: Cid) {
-        self.actor_code_cids.insert(address, actor_type);
+    pub fn set_address_actor_type(&self, address: Address, actor_type: Cid) {
+        self.actor_code_cids.borrow_mut().insert(address, actor_type);
     }
 
     pub fn get_id_address(&self, address: &Address) -> Option<Address> {
         if address.protocol() == Protocol::ID {
             return Some(*address);
         }
-        self.id_addresses.get(address).cloned()
+        self.id_addresses.borrow().get(address).cloned()
     }
 
-    pub fn add_id_address(&mut self, source: Address, target: Address) {
+    pub fn add_id_address(&self, source: Address, target: Address) {
         assert_eq!(target.protocol(), Protocol::ID, "target must use ID address protocol");
-        self.id_addresses.insert(source, target);
+        self.id_addresses.borrow_mut().insert(source, target);
     }
 
-    pub fn set_delegated_address(&mut self, source: ActorID, target: Address) {
+    pub fn set_delegated_address(&self, source: ActorID, target: Address) {
         assert_eq!(
             target.protocol(),
             Protocol::Delegated,
             "target must use Delegated address protocol"
         );
-        self.delegated_addresses.insert(source, target);
-        self.id_addresses.insert(target, Address::new_id(source));
+        self.delegated_addresses.borrow_mut().insert(source, target);
+        self.id_addresses.borrow_mut().insert(target, Address::new_id(source));
     }
 
     pub fn call<A: ActorCode>(
-        &mut self,
+        &self,
         method_num: MethodNum,
         params: Option<IpldBlock>,
     ) -> Result<Option<IpldBlock>, ActorError> {
-        self.in_call = true;
-        let prev_state = self.state;
+        self.in_call.replace(true);
+        let prev_state = *self.state.borrow();
         let res = A::invoke_method(self, method_num, params);
 
         if res.is_err() {
-            self.state = prev_state;
+            self.state.replace(prev_state);
         }
-        self.in_call = false;
+        self.in_call.replace(false);
         res
     }
 
     /// Verifies that all mock expectations have been met (and resets the expectations).
-    pub fn verify(&mut self) {
+    pub fn verify(&self) {
         self.expectations.borrow_mut().verify()
     }
 
     /// Clears all mock expectations.
-    pub fn reset(&mut self) {
+    pub fn reset(&self) {
         self.expectations.borrow_mut().reset();
     }
 
     ///// Mock expectations /////
 
     #[allow(dead_code)]
-    pub fn expect_validate_caller_addr(&mut self, addr: Vec<Address>) {
+    pub fn expect_validate_caller_addr(&self, addr: Vec<Address>) {
         assert!(!addr.is_empty(), "addrs must be non-empty");
-        self.expectations.get_mut().expect_validate_caller_addr = Some(addr);
+        self.expectations.borrow_mut().expect_validate_caller_addr = Some(addr);
     }
 
     #[allow(dead_code)]
@@ -619,7 +619,7 @@ impl<BS: Blockstore> MockRuntime<BS> {
     }
 
     #[allow(dead_code)]
-    pub fn expect_validate_caller_type(&mut self, types: Vec<Type>) {
+    pub fn expect_validate_caller_type(&self, types: Vec<Type>) {
         assert!(!types.is_empty(), "addrs must be non-empty");
         self.expectations.borrow_mut().expect_validate_caller_type = Some(types);
     }
@@ -636,13 +636,13 @@ impl<BS: Blockstore> MockRuntime<BS> {
     }
 
     #[allow(dead_code)]
-    pub fn expect_delete_actor(&mut self, beneficiary: Address) {
+    pub fn expect_delete_actor(&self, beneficiary: Address) {
         self.expectations.borrow_mut().expect_delete_actor = Some(beneficiary);
     }
 
     #[allow(dead_code)]
     pub fn expect_send_simple(
-        &mut self,
+        &self,
         to: Address,
         method: MethodNum,
         params: Option<IpldBlock>,
@@ -666,7 +666,7 @@ impl<BS: Blockstore> MockRuntime<BS> {
     #[allow(dead_code)]
     #[allow(clippy::too_many_arguments)]
     pub fn expect_send(
-        &mut self,
+        &self,
         to: Address,
         method: MethodNum,
         params: Option<IpldBlock>,
@@ -692,7 +692,7 @@ impl<BS: Blockstore> MockRuntime<BS> {
 
     #[allow(dead_code)]
     pub fn expect_create_actor(
-        &mut self,
+        &self,
         code_id: Cid,
         actor_id: ActorID,
         predictable_address: Option<Address>,
@@ -702,20 +702,20 @@ impl<BS: Blockstore> MockRuntime<BS> {
     }
 
     #[allow(dead_code)]
-    pub fn expect_verify_seal(&mut self, seal: SealVerifyInfo, exit_code: ExitCode) {
+    pub fn expect_verify_seal(&self, seal: SealVerifyInfo, exit_code: ExitCode) {
         let a = ExpectVerifySeal { seal, exit_code };
         self.expectations.borrow_mut().expect_verify_seal = Some(a);
     }
 
     #[allow(dead_code)]
-    pub fn expect_verify_post(&mut self, post: WindowPoStVerifyInfo, exit_code: ExitCode) {
+    pub fn expect_verify_post(&self, post: WindowPoStVerifyInfo, exit_code: ExitCode) {
         let a = ExpectVerifyPoSt { post, exit_code };
         self.expectations.borrow_mut().expect_verify_post = Some(a);
     }
 
     #[allow(dead_code)]
-    pub fn set_received(&mut self, amount: TokenAmount) {
-        self.value_received = amount;
+    pub fn set_received(&self, amount: TokenAmount) {
+        self.value_received.replace(amount);
     }
 
     #[allow(dead_code)]
@@ -734,7 +734,7 @@ impl<BS: Blockstore> MockRuntime<BS> {
     }
 
     pub fn expect_get_randomness_from_tickets(
-        &mut self,
+        &self,
         tag: DomainSeparationTag,
         epoch: ChainEpoch,
         entropy: Vec<u8>,
@@ -746,7 +746,7 @@ impl<BS: Blockstore> MockRuntime<BS> {
 
     #[allow(dead_code)]
     pub fn expect_get_randomness_from_beacon(
-        &mut self,
+        &self,
         tag: DomainSeparationTag,
         epoch: ChainEpoch,
         entropy: Vec<u8>,
@@ -758,7 +758,7 @@ impl<BS: Blockstore> MockRuntime<BS> {
 
     #[allow(dead_code)]
     pub fn expect_batch_verify_seals(
-        &mut self,
+        &self,
         input: Vec<SealVerifyInfo>,
         result: anyhow::Result<Vec<bool>>,
     ) {
@@ -768,7 +768,7 @@ impl<BS: Blockstore> MockRuntime<BS> {
 
     #[allow(dead_code)]
     pub fn expect_aggregate_verify_seals(
-        &mut self,
+        &self,
         in_svis: Vec<AggregateSealVerifyInfo>,
         in_proof: Vec<u8>,
         result: anyhow::Result<()>,
@@ -778,30 +778,30 @@ impl<BS: Blockstore> MockRuntime<BS> {
     }
 
     #[allow(dead_code)]
-    pub fn expect_replica_verify(&mut self, input: ReplicaUpdateInfo, result: anyhow::Result<()>) {
+    pub fn expect_replica_verify(&self, input: ReplicaUpdateInfo, result: anyhow::Result<()>) {
         let a = ExpectReplicaVerify { input, result };
         self.expectations.borrow_mut().expect_replica_verify = Some(a);
     }
 
     #[allow(dead_code)]
-    pub fn expect_gas_charge(&mut self, value: i64) {
+    pub fn expect_gas_charge(&self, value: i64) {
         self.expectations.borrow_mut().expect_gas_charge.push_back(value);
     }
 
     #[allow(dead_code)]
-    pub fn expect_gas_available(&mut self, value: u64) {
+    pub fn expect_gas_available(&self, value: u64) {
         self.expectations.borrow_mut().expect_gas_available.push_back(value);
     }
 
     #[allow(dead_code)]
-    pub fn expect_emitted_event(&mut self, event: ActorEvent) {
+    pub fn expect_emitted_event(&self, event: ActorEvent) {
         self.expectations.borrow_mut().expect_emitted_events.push_back(event)
     }
 
     ///// Private helpers /////
 
     fn require_in_call(&self) {
-        assert!(self.in_call, "invalid runtime invocation outside of method call")
+        assert!(*self.in_call.borrow(), "invalid runtime invocation outside of method call")
     }
 
     fn store_put<T: Serialize>(&self, o: &T) -> Cid {
@@ -819,16 +819,16 @@ impl<BS> MessageInfo for MockRuntime<BS> {
     }
 
     fn caller(&self) -> Address {
-        self.caller
+        *self.caller.borrow()
     }
     fn origin(&self) -> Address {
-        self.origin
+        *self.origin.borrow()
     }
     fn receiver(&self) -> Address {
         self.receiver
     }
     fn value_received(&self) -> TokenAmount {
-        self.value_received.clone()
+        self.value_received.borrow().clone()
     }
     fn gas_premium(&self) -> TokenAmount {
         self.gas_premium.clone()
@@ -852,7 +852,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         self.epoch
     }
 
-    fn validate_immediate_caller_accept_any(&mut self) -> Result<(), ActorError> {
+    fn validate_immediate_caller_accept_any(&self) -> Result<(), ActorError> {
         self.require_in_call();
         assert!(
             self.expectations.borrow_mut().expect_validate_caller_any,
@@ -862,7 +862,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         Ok(())
     }
 
-    fn validate_immediate_caller_is<'a, I>(&mut self, addresses: I) -> Result<(), ActorError>
+    fn validate_immediate_caller_is<'a, I>(&self, addresses: I) -> Result<(), ActorError>
     where
         I: IntoIterator<Item = &'a Address>,
     {
@@ -896,7 +896,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         ))
     }
 
-    fn validate_immediate_caller_namespace<I>(&mut self, namespaces: I) -> Result<(), ActorError>
+    fn validate_immediate_caller_namespace<I>(&self, namespaces: I) -> Result<(), ActorError>
     where
         I: IntoIterator<Item = u64>,
     {
@@ -942,7 +942,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         ))
     }
 
-    fn validate_immediate_caller_type<'a, I>(&mut self, types: I) -> Result<(), ActorError>
+    fn validate_immediate_caller_type<'a, I>(&self, types: I) -> Result<(), ActorError>
     where
         I: IntoIterator<Item = &'a Type>,
     {
@@ -961,7 +961,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
             types, expected_caller_type,
         );
 
-        if let Some(call_type) = self.resolve_builtin_actor_type(&self.caller_type) {
+        if let Some(call_type) = self.resolve_builtin_actor_type(&*self.caller_type.borrow()) {
             for expected in &types {
                 if &call_type == expected {
                     self.expectations.borrow_mut().expect_validate_caller_type = None;
@@ -1004,12 +1004,12 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
 
     fn lookup_delegated_address(&self, id: ActorID) -> Option<Address> {
         self.require_in_call();
-        self.delegated_addresses.get(&id).copied()
+        self.delegated_addresses.borrow().get(&id).copied()
     }
 
     fn get_actor_code_cid(&self, id: &ActorID) -> Option<Cid> {
         self.require_in_call();
-        self.actor_code_cids.get(&Address::new_id(*id)).cloned()
+        self.actor_code_cids.borrow().get(&Address::new_id(*id)).cloned()
     }
 
     fn get_randomness_from_tickets(
@@ -1078,42 +1078,42 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         Ok(expected.out)
     }
 
-    fn create<T: Serialize>(&mut self, obj: &T) -> Result<(), ActorError> {
-        if self.state.is_some() {
+    fn create<T: Serialize>(&self, obj: &T) -> Result<(), ActorError> {
+        if self.state.borrow().is_some() {
             return Err(actor_error!(illegal_state; "state already constructed"));
         }
-        self.state = Some(self.store_put(obj));
+        self.state.replace(Some(self.store_put(obj)));
         Ok(())
     }
 
     fn state<T: DeserializeOwned>(&self) -> Result<T, ActorError> {
-        Ok(self.store_get(self.state.as_ref().unwrap()))
+        Ok(self.store_get(self.state.borrow().as_ref().unwrap()))
     }
 
     fn get_state_root(&self) -> Result<Cid, ActorError> {
-        Ok(self.state.unwrap_or(EMPTY_ARR_CID))
+        Ok(self.state.borrow().unwrap_or(EMPTY_ARR_CID))
     }
 
-    fn set_state_root(&mut self, root: &Cid) -> Result<(), ActorError> {
-        self.state = Some(*root);
+    fn set_state_root(&self, root: &Cid) -> Result<(), ActorError> {
+        self.state.replace(Some(*root));
         Ok(())
     }
 
-    fn transaction<S, RT, F>(&mut self, f: F) -> Result<RT, ActorError>
+    fn transaction<S, RT, F>(&self, f: F) -> Result<RT, ActorError>
     where
         S: Serialize + DeserializeOwned,
-        F: FnOnce(&mut S, &mut Self) -> Result<RT, ActorError>,
+        F: FnOnce(&mut S, &Self) -> Result<RT, ActorError>,
     {
-        if self.in_transaction {
+        if *self.in_transaction.borrow() {
             return Err(actor_error!(assertion_failed; "nested transaction"));
         }
         let mut read_only = self.state()?;
-        self.in_transaction = true;
+        self.in_transaction.replace(true);
         let ret = f(&mut read_only, self);
         if ret.is_ok() {
-            self.state = Some(self.store_put(&read_only));
+            self.state.replace(Some(self.store_put(&read_only)));
         }
-        self.in_transaction = false;
+        self.in_transaction.replace(false);
         ret
     }
 
@@ -1131,7 +1131,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         send_flags: SendFlags,
     ) -> Result<Response, SendError> {
         self.require_in_call();
-        if self.in_transaction {
+        if *self.in_transaction.borrow() {
             return Ok(Response { exit_code: ExitCode::USR_ASSERTION_FAILED, return_data: None });
         }
 
@@ -1168,21 +1168,22 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         Ok(Response { exit_code: expected_msg.exit_code, return_data: expected_msg.send_return })
     }
 
-    fn new_actor_address(&mut self) -> Result<Address, ActorError> {
+    fn new_actor_address(&self) -> Result<Address, ActorError> {
         self.require_in_call();
-        let ret = *self.new_actor_addr.as_ref().expect("unexpected call to new actor address");
-        self.new_actor_addr = None;
+        let ret =
+            *self.new_actor_addr.borrow().as_ref().expect("unexpected call to new actor address");
+        self.new_actor_addr.replace(None);
         Ok(ret)
     }
 
     fn create_actor(
-        &mut self,
+        &self,
         code_id: Cid,
         actor_id: ActorID,
         predictable_address: Option<Address>,
     ) -> Result<(), ActorError> {
         self.require_in_call();
-        if self.in_transaction {
+        if *self.in_transaction.borrow() {
             return Err(actor_error!(assertion_failed; "side-effect within transaction"));
         }
         let expect_create_actor = self
@@ -1201,9 +1202,9 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         Ok(())
     }
 
-    fn delete_actor(&mut self, addr: &Address) -> Result<(), ActorError> {
+    fn delete_actor(&self, addr: &Address) -> Result<(), ActorError> {
         self.require_in_call();
-        if self.in_transaction {
+        if *self.in_transaction.borrow() {
             return Err(actor_error!(assertion_failed; "side-effect within transaction"));
         }
         let exp_act = self.expectations.borrow_mut().expect_delete_actor.take();
@@ -1234,7 +1235,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         self.circulating_supply.clone()
     }
 
-    fn charge_gas(&mut self, _: &'static str, value: i64) {
+    fn charge_gas(&self, _: &'static str, value: i64) {
         let mut exs = self.expectations.borrow_mut();
         assert!(!exs.expect_gas_charge.is_empty(), "unexpected gas charge {:?}", value);
         let expected = exs.expect_gas_charge.pop_front().unwrap();


### PR DESCRIPTION
Closes https://github.com/filecoin-project/builtin-actors/issues/1248

When updating to latest versions of the `fvm_actor_utils` library, it becomes tricky to correctly implement the `Syscalls` trait which expects methods to be implemented non &mut. E.g. see https://github.com/filecoin-project/builtin-actors/pull/1244/files/ebc9207605141d33495aa4d23b684b5be24bdd72#r1138115658

This refactors the builtin-actors runtime to be useful immutably and uses interior mutability for providing mock functionality during tests.