### PR TITLE
WIP: Abstract VM Trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,7 +2306,24 @@ name = "fil_actor_account"
 version = "10.0.0"
 dependencies = [
  "anyhow",
- "fil_actors_runtime",
+ "fil_actors_runtime 10.0.0",
+ "frc42_dispatch",
+ "fvm_actor_utils",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "fil_actor_account"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "anyhow",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
@@ -2340,7 +2357,22 @@ dependencies = [
 name = "fil_actor_cron"
 version = "10.0.0"
 dependencies = [
- "fil_actors_runtime",
+ "fil_actors_runtime 10.0.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "log",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "fil_actor_cron"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared",
@@ -2355,7 +2387,28 @@ name = "fil_actor_datacap"
 version = "10.0.0"
 dependencies = [
  "cid",
- "fil_actors_runtime",
+ "fil_actors_runtime 10.0.0",
+ "frc42_dispatch",
+ "frc46_token",
+ "fvm_actor_utils",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_shared",
+ "lazy_static",
+ "log",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "fil_actor_datacap"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "cid",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
  "frc42_dispatch",
  "frc46_token",
  "fvm_actor_utils",
@@ -2376,9 +2429,31 @@ version = "10.0.0"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actor_evm",
- "fil_actors_evm_shared",
- "fil_actors_runtime",
+ "fil_actor_evm 10.0.0",
+ "fil_actors_evm_shared 10.0.0",
+ "fil_actors_runtime 10.0.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "hex-literal",
+ "log",
+ "multihash",
+ "num-derive",
+ "num-traits",
+ "rlp",
+ "serde",
+ "serde_tuple",
+]
+
+[[package]]
+name = "fil_actor_eam"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_evm_shared 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared",
@@ -2396,7 +2471,23 @@ dependencies = [
 name = "fil_actor_ethaccount"
 version = "10.0.0"
 dependencies = [
- "fil_actors_runtime",
+ "fil_actors_runtime 10.0.0",
+ "frc42_dispatch",
+ "fvm_actor_utils",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "hex-literal",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "fil_actor_ethaccount"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_encoding",
@@ -2415,8 +2506,8 @@ dependencies = [
  "cid",
  "ethers 1.0.2",
  "etk-asm",
- "fil_actors_evm_shared",
- "fil_actors_runtime",
+ "fil_actors_evm_shared 10.0.0",
+ "fil_actors_runtime 10.0.0",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
@@ -2438,12 +2529,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actor_evm"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_evm_shared 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "frc42_dispatch",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_kamt",
+ "fvm_shared",
+ "hex",
+ "hex-literal",
+ "log",
+ "multihash",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "serde_tuple",
+ "substrate-bn",
+]
+
+[[package]]
 name = "fil_actor_init"
 version = "10.0.0"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime",
+ "fil_actors_runtime 10.0.0",
+ "frc42_dispatch",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_shared",
+ "log",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "fil_actor_init"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
@@ -2461,10 +2596,10 @@ version = "10.0.0"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actor_power",
- "fil_actor_reward",
- "fil_actor_verifreg",
- "fil_actors_runtime",
+ "fil_actor_power 10.0.0",
+ "fil_actor_reward 10.0.0",
+ "fil_actor_verifreg 10.0.0",
+ "fil_actors_runtime 10.0.0",
  "frc42_dispatch",
  "frc46_token",
  "fvm_ipld_amt",
@@ -2486,17 +2621,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actor_market"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "frc42_dispatch",
+ "frc46_token",
+ "fvm_ipld_bitfield",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_shared",
+ "integer-encoding",
+ "libipld-core 0.13.1",
+ "log",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "fil_actor_miner"
 version = "10.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
  "cid",
- "fil_actor_account",
- "fil_actor_market",
- "fil_actor_power",
- "fil_actor_reward",
- "fil_actors_runtime",
+ "fil_actor_account 10.0.0",
+ "fil_actor_market 10.0.0",
+ "fil_actor_power 10.0.0",
+ "fil_actor_reward 10.0.0",
+ "fil_actors_runtime 10.0.0",
  "frc42_dispatch",
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
@@ -2516,12 +2674,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actor_miner"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "cid",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "frc42_dispatch",
+ "fvm_ipld_amt",
+ "fvm_ipld_bitfield",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_shared",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multihash",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "fil_actor_multisig"
 version = "10.0.0"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime",
+ "fil_actors_runtime 10.0.0",
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
@@ -2537,13 +2720,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actor_multisig"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "frc42_dispatch",
+ "fvm_actor_utils",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_shared",
+ "indexmap",
+ "integer-encoding",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "fil_actor_paych"
 version = "10.0.0"
 dependencies = [
  "anyhow",
  "cid",
  "derive_builder 0.10.2",
- "fil_actors_runtime",
+ "fil_actors_runtime 10.0.0",
  "frc42_dispatch",
  "fvm_ipld_amt",
  "fvm_ipld_blockstore",
@@ -2556,8 +2760,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actor_paych"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "frc42_dispatch",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "fil_actor_placeholder"
 version = "10.0.0"
+
+[[package]]
+name = "fil_actor_placeholder"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
 
 [[package]]
 name = "fil_actor_power"
@@ -2565,8 +2791,30 @@ version = "10.0.0"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actor_reward",
- "fil_actors_runtime",
+ "fil_actor_reward 10.0.0",
+ "fil_actors_runtime 10.0.0",
+ "frc42_dispatch",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_shared",
+ "indexmap",
+ "integer-encoding",
+ "lazy_static",
+ "log",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "fil_actor_power"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
@@ -2585,7 +2833,7 @@ dependencies = [
 name = "fil_actor_reward"
 version = "10.0.0"
 dependencies = [
- "fil_actors_runtime",
+ "fil_actors_runtime 10.0.0",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared",
@@ -2598,12 +2846,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actor_reward"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "lazy_static",
+ "log",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "fil_actor_system"
 version = "10.0.0"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime",
+ "fil_actors_runtime 10.0.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "fil_actor_system"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared",
@@ -2618,7 +2898,29 @@ version = "10.0.0"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime",
+ "fil_actors_runtime 10.0.0",
+ "frc42_dispatch",
+ "frc46_token",
+ "fvm_actor_utils",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_shared",
+ "lazy_static",
+ "log",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "fil_actor_verifreg"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
  "frc42_dispatch",
  "frc46_token",
  "fvm_actor_utils",
@@ -2637,7 +2939,20 @@ dependencies = [
 name = "fil_actors_evm_shared"
 version = "10.0.0"
 dependencies = [
- "fil_actors_runtime",
+ "fil_actors_runtime 10.0.0",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "hex",
+ "serde",
+ "uint",
+]
+
+[[package]]
+name = "fil_actors_evm_shared"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
  "fvm_ipld_encoding",
  "fvm_shared",
  "hex",
@@ -2683,29 +2998,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actors_runtime"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "castaway",
+ "cid",
+ "fvm_ipld_amt",
+ "fvm_ipld_bitfield",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_sdk",
+ "fvm_shared",
+ "itertools 0.10.5",
+ "log",
+ "multihash",
+ "num",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "regex",
+ "serde",
+ "serde_repr",
+ "sha2 0.10.6",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "fil_builtin_actors_bundle"
 version = "10.0.0"
 dependencies = [
  "cid",
  "clap",
- "fil_actor_account",
+ "fil_actor_account 10.0.0",
  "fil_actor_bundler",
- "fil_actor_cron",
- "fil_actor_datacap",
- "fil_actor_eam",
- "fil_actor_ethaccount",
- "fil_actor_evm",
- "fil_actor_init",
- "fil_actor_market",
- "fil_actor_miner",
- "fil_actor_multisig",
- "fil_actor_paych",
- "fil_actor_placeholder",
- "fil_actor_power",
- "fil_actor_reward",
- "fil_actor_system",
- "fil_actor_verifreg",
- "fil_actors_runtime",
+ "fil_actor_cron 10.0.0",
+ "fil_actor_datacap 10.0.0",
+ "fil_actor_eam 10.0.0",
+ "fil_actor_ethaccount 10.0.0",
+ "fil_actor_evm 10.0.0",
+ "fil_actor_init 10.0.0",
+ "fil_actor_market 10.0.0",
+ "fil_actor_miner 10.0.0",
+ "fil_actor_multisig 10.0.0",
+ "fil_actor_paych 10.0.0",
+ "fil_actor_placeholder 10.0.0",
+ "fil_actor_power 10.0.0",
+ "fil_actor_reward 10.0.0",
+ "fil_actor_system 10.0.0",
+ "fil_actor_verifreg 10.0.0",
+ "fil_actors_runtime 10.0.0",
+ "num-traits",
+]
+
+[[package]]
+name = "fil_builtin_actors_bundle"
+version = "10.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps#331102ce67c47b7ad33acf9ff32bde3f78e98d12"
+dependencies = [
+ "cid",
+ "clap",
+ "fil_actor_account 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_bundler",
+ "fil_actor_cron 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_datacap 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_eam 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_ethaccount 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_evm 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_init 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_market 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_miner 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_multisig 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_paych 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_placeholder 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_power 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_reward 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_system 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_verifreg 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
  "num-traits",
 ]
 
@@ -2716,19 +3090,19 @@ dependencies = [
  "anyhow",
  "bimap",
  "cid",
- "fil_actor_account",
- "fil_actor_cron",
- "fil_actor_datacap",
- "fil_actor_init",
- "fil_actor_market",
- "fil_actor_miner",
- "fil_actor_multisig",
- "fil_actor_paych",
- "fil_actor_power",
- "fil_actor_reward",
- "fil_actor_system",
- "fil_actor_verifreg",
- "fil_actors_runtime",
+ "fil_actor_account 10.0.0",
+ "fil_actor_cron 10.0.0",
+ "fil_actor_datacap 10.0.0",
+ "fil_actor_init 10.0.0",
+ "fil_actor_market 10.0.0",
+ "fil_actor_miner 10.0.0",
+ "fil_actor_multisig 10.0.0",
+ "fil_actor_paych 10.0.0",
+ "fil_actor_power 10.0.0",
+ "fil_actor_reward 10.0.0",
+ "fil_actor_system 10.0.0",
+ "fil_actor_verifreg 10.0.0",
+ "fil_actors_runtime 10.0.0",
  "frc46_token",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
@@ -3160,6 +3534,45 @@ dependencies = [
  "fvm_shared",
  "itertools 0.10.5",
  "num-format",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm-workbench-builtin-actors"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "blake2b_simd",
+ "bls-signatures",
+ "cid",
+ "fil_actor_account 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_cron 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_datacap 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_init 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_market 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_miner 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_multisig 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_paych 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_power 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_reward 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_system 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actor_verifreg 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_actors_runtime 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "fil_builtin_actors_bundle 10.0.0 (git+https://github.com/filecoin-project/builtin-actors?branch=alex/update-deps)",
+ "frc46_token",
+ "fvm",
+ "fvm-workbench-api",
+ "fvm-workbench-vm",
+ "fvm_ipld_amt",
+ "fvm_ipld_bitfield",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_car",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_shared",
+ "libsecp256k1",
+ "multihash",
+ "rand_chacha",
  "thiserror",
 ]
 
@@ -5815,26 +6228,28 @@ dependencies = [
  "blake2b_simd",
  "cid",
  "ethers 0.17.0",
- "fil_actor_account",
- "fil_actor_cron",
- "fil_actor_datacap",
- "fil_actor_eam",
- "fil_actor_ethaccount",
- "fil_actor_evm",
- "fil_actor_init",
- "fil_actor_market",
- "fil_actor_miner",
- "fil_actor_multisig",
- "fil_actor_paych",
- "fil_actor_power",
- "fil_actor_reward",
- "fil_actor_system",
- "fil_actor_verifreg",
- "fil_actors_evm_shared",
- "fil_actors_runtime",
+ "fil_actor_account 10.0.0",
+ "fil_actor_cron 10.0.0",
+ "fil_actor_datacap 10.0.0",
+ "fil_actor_eam 10.0.0",
+ "fil_actor_ethaccount 10.0.0",
+ "fil_actor_evm 10.0.0",
+ "fil_actor_init 10.0.0",
+ "fil_actor_market 10.0.0",
+ "fil_actor_miner 10.0.0",
+ "fil_actor_multisig 10.0.0",
+ "fil_actor_paych 10.0.0",
+ "fil_actor_power 10.0.0",
+ "fil_actor_reward 10.0.0",
+ "fil_actor_system 10.0.0",
+ "fil_actor_verifreg 10.0.0",
+ "fil_actors_evm_shared 10.0.0",
+ "fil_actors_runtime 10.0.0",
+ "fil_builtin_actors_bundle 10.0.0",
  "fil_builtin_actors_state",
  "frc46_token",
  "fvm-workbench-api",
+ "fvm-workbench-builtin-actors",
  "fvm-workbench-vm",
  "fvm_actor_utils",
  "fvm_ipld_bitfield",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
- "cipher 0.4.3",
+ "cipher 0.4.4",
  "cpufeatures",
 ]
 
@@ -47,6 +47,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,15 +68,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "arrayref"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
@@ -130,17 +141,16 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "async-lock"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
  "event-listener",
- "futures-lite",
 ]
 
 [[package]]
@@ -177,13 +187,13 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -223,7 +233,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -235,7 +245,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -304,9 +314,9 @@ checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
 
 [[package]]
 name = "bimap"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bincode"
@@ -412,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.6",
 ]
@@ -444,47 +454,47 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.9.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
+checksum = "40f9ca3698b2e4cb7c15571db0abc5551dca417a21ae8140460b50309bb2cc62"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.11.2",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.9.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
+checksum = "598b3eacc6db9c3ee57b22707ad8f6a8d2f6d442bfe24ffeb8cbb70ca59e6a35"
 dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.9.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
+checksum = "186b734fa1c9f6743e90c95d7233c9faab6360d1a96d4ffa19d9cfd1e9350f8a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.9.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
+checksum = "99b7ff1008316626f485991b960ade129253d4034014616b94f309a15366cc49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -513,23 +523,24 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
+checksum = "13fe11640a23eb24562225322cd3e452b93a3d4091d62fab69c70542fcd17d1f"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
+ "simdutf8",
 ]
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
+checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -540,18 +551,18 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "camino"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
 ]
@@ -567,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
+checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -611,9 +622,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -644,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
@@ -679,7 +690,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -759,15 +770,15 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
+checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "convert_case"
@@ -804,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -865,7 +876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -883,7 +894,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.3",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -907,7 +918,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -918,7 +929,7 @@ checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -944,7 +955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -975,7 +986,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -985,7 +996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -996,7 +1007,7 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1023,7 +1034,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -1080,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
@@ -1346,7 +1357,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn",
+ "syn 1.0.109",
  "url",
  "walkdir",
 ]
@@ -1370,7 +1381,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn",
+ "syn 1.0.109",
  "toml",
  "url",
  "walkdir",
@@ -1388,7 +1399,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1403,7 +1414,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1432,7 +1443,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn",
+ "syn 1.0.109",
  "thiserror",
  "tiny-keccak",
  "unicode-xid",
@@ -1463,7 +1474,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn",
+ "syn 1.0.109",
  "thiserror",
  "tiny-keccak",
  "unicode-xid",
@@ -1699,9 +1710,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -1721,14 +1732,14 @@ dependencies = [
 
 [[package]]
 name = "fastrlp-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e454d03710df0cd95ce075d7731ce3fa35fb3779c15270cd491bc5f2ef9355"
+checksum = "a0f9d074ab623d1b388c12544bfeed759c7df36dc5c300cda053df9ba1232075"
 dependencies = [
  "bytes",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2229,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "frc42_dispatch"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc80f65be319b625b0a09e86ba0793e3da8e4ab9030a801f0cdd00bbcb8e24"
+checksum = "a4dc594c941eba1d5a9474f595c6d0f9d752fa333b672755bbe7c23d30f64282"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
@@ -2243,9 +2254,9 @@ dependencies = [
 
 [[package]]
 name = "frc42_hasher"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab91345ff52851dfa6e3a253f08462e703a04c5c6458cecddbec9596519b9026"
+checksum = "d6caf7fa3028536d11b1ff94a63bd1d60926ff7366b25b2a94d07bd23190f459"
 dependencies = [
  "fvm_sdk",
  "fvm_shared",
@@ -2254,22 +2265,22 @@ dependencies = [
 
 [[package]]
 name = "frc42_macros"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e5a8b295ad4267907612c931b60f25ab7a74e540de41668cee96ce6af0ed3b"
+checksum = "c57201a8c3c26b41c4234a0f68b123ec2c33c958d31d09a3a780c345256e7928"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "frc46_token"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef4c6ab802df24f9d29fe4f0c6b463b46a27954ea722d29a80ab3c93800c0a0"
+checksum = "c0a7c3f316549c34350c5713ee6885fcaece30a83399c54681016dfc6faa671e"
 dependencies = [
  "anyhow",
  "cid",
@@ -2296,9 +2307,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2311,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2321,15 +2332,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2338,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-lite"
@@ -2370,26 +2381,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-timer"
@@ -2399,9 +2410,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2417,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_actor_utils"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37f347ddbb46adeba750a8bbc499d5b7f83610d977615b4bcd83b84081b8721"
+checksum = "2ca7d35816608fb36ecc01448938d7827820051390459abb573fdad2aff626b1"
 dependencies = [
  "anyhow",
  "cid",
@@ -2561,9 +2572,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99c06aa865e34198d9ca0da54e53e2fca14ae9ce5402f51b7c8e78175205861"
+checksum = "45742ae0f445a80121a97e9ee36fd0112f56e19daa5865fe458452ec6ff358f2"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2654,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -2673,20 +2684,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -2700,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -2769,9 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -2812,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2907,7 +2918,7 @@ checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2975,15 +2986,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3030,9 +3041,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libipld-core"
@@ -3140,20 +3151,20 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3197,7 +3208,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "synstructure",
 ]
 
@@ -3245,7 +3256,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3341,20 +3352,20 @@ dependencies = [
  "bytes",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.2.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ab01d0f889e957861bc65888d5ccbe82c158d0270136ba46820d43837cdf72"
+checksum = "637935964ff85a605d114591d4d2c13c5d1ba2806dae97cea6bf180238a749ac"
 dependencies = [
  "arrayvec",
  "bitvec 1.0.1",
@@ -3373,7 +3384,7 @@ dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3431,9 +3442,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pbkdf2"
@@ -3464,9 +3475,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.3"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
+checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3474,9 +3485,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.3"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
+checksum = "a81186863f3d0a27340815be8f2078dd8050b14cd71913db9fbda795e5f707d7"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3484,22 +3495,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.3"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
+checksum = "75a1ef20bf3193c15ac345acb32e26b3dc3223aff4d77ae4fc5359567683796b"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.5.3"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
+checksum = "5e3b284b1f13a20dc5ebc90aff59a51b8d7137c221131b52a7260c08cbc1cc80"
 dependencies = [
  "once_cell",
  "pest",
@@ -3533,7 +3544,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3560,16 +3571,18 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.5.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
+checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
 dependencies = [
  "autocfg",
+ "bitflags",
  "cfg-if",
+ "concurrent-queue",
  "libc",
  "log",
- "wepoll-ffi",
- "windows-sys",
+ "pin-project-lite",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3643,7 +3656,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -3660,9 +3673,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -3684,7 +3697,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3695,9 +3708,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3772,18 +3785,18 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rend"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
 dependencies = [
  "bytecheck",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "0ba30cc2c0cd02af1222ed216ba659cdb2f879dfe3181852fe7c50b1d0005949"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -3855,9 +3868,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.39"
+version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
+checksum = "c30f1d45d9aa61cbc8cd1eb87705470892289bb2d01943e7803b873a57404dc3"
 dependencies = [
  "bytecheck",
  "hashbrown 0.12.3",
@@ -3869,13 +3882,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.39"
+version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
+checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3896,14 +3909,14 @@ checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "rust_decimal"
-version = "1.27.0"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c321ee4e17d2b7abe12b5d20c1231db708dd36185c8a21e9de5fed6da4dbe9"
+checksum = "2b1b21b8760b0ef8ae5b43d40913ff711a2053cb7ff892a34facff7a6365375a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -3955,15 +3968,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "salsa20"
@@ -3980,7 +3993,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher 0.4.3",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -4013,7 +4026,7 @@ dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4079,24 +4092,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "send_wrapper"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
 ]
@@ -4141,13 +4154,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -4164,9 +4177,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -4175,13 +4188,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -4202,7 +4215,7 @@ checksum = "4076151d1a2b688e25aaf236997933c66e18b870d0369f8b248b8ab2be630d7e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4274,6 +4287,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4307,14 +4326,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -4367,7 +4386,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4401,6 +4420,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c622ae390c9302e214c31013517c2061ecb2699935882c60a9b37f82f8625ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4408,7 +4438,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "unicode-xid",
 ]
 
@@ -4446,7 +4476,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4509,22 +4539,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -4547,15 +4577,15 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4565,7 +4595,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4581,9 +4611,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4628,7 +4658,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4682,15 +4712,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -4703,9 +4733,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-xid"
@@ -4770,12 +4800,11 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -4797,9 +4826,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4807,24 +4836,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4834,9 +4863,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4844,22 +4873,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-timer"
@@ -4878,9 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4903,15 +4932,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -4961,46 +4981,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"
@@ -5013,13 +5057,14 @@ dependencies = [
 
 [[package]]
 name = "ws_stream_wasm"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ca1ab42f5afed7fc332b22b6e932ca5414b209465412c8cdf0ad23bc0de645"
+checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
 dependencies = [
  "async_io_stream",
  "futures",
  "js-sys",
+ "log",
  "pharos",
  "rustc_version",
  "send_wrapper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6226,6 +6226,7 @@ dependencies = [
  "anyhow",
  "bimap",
  "blake2b_simd",
+ "bls-signatures",
  "cid",
  "ethers 0.17.0",
  "fil_actor_account 10.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli 0.26.2",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli 0.27.2",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,12 +95,21 @@ name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -126,22 +159,22 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
  "async-lock",
  "autocfg",
+ "cfg-if",
  "concurrent-queue",
  "futures-lite",
- "libc",
  "log",
  "parking",
  "polling",
+ "rustix 0.37.3",
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -193,7 +226,7 @@ checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.4",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -255,6 +288,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line 0.19.0",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.30.3",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +359,34 @@ name = "bech32"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
+
+[[package]]
+name = "bellperson"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a8623f815c0b1fd89efd9b5f4afbb937f91f51c1ebe3f6dda399c69fa938f3"
+dependencies = [
+ "bincode",
+ "blake2s_simd 1.0.1",
+ "blstrs",
+ "byteorder",
+ "crossbeam-channel",
+ "digest 0.10.6",
+ "ec-gpu",
+ "ec-gpu-gen",
+ "ff",
+ "group",
+ "log",
+ "memmap2",
+ "pairing",
+ "rand",
+ "rand_core",
+ "rayon",
+ "rustversion",
+ "serde",
+ "sha2 0.10.6",
+ "thiserror",
+]
 
 [[package]]
 name = "bimap"
@@ -371,8 +447,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
- "arrayvec",
- "constant_time_eq",
+ "arrayvec 0.7.2",
+ "constant_time_eq 0.2.5",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "constant_time_eq 0.1.5",
 ]
 
 [[package]]
@@ -382,8 +469,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
- "arrayvec",
- "constant_time_eq",
+ "arrayvec 0.7.2",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -393,10 +480,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.7.2",
  "cc",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -405,7 +492,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
@@ -439,6 +526,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
+dependencies = [
+ "generic-array 0.14.6",
+]
+
+[[package]]
 name = "blocking"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,10 +549,56 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "0.10.2"
+name = "bls-signatures"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f9ca3698b2e4cb7c15571db0abc5551dca417a21ae8140460b50309bb2cc62"
+checksum = "9fcead733e20b9afbf3784a3f33cc6d728e0f11a593a35bd6c5c4503db19e06e"
+dependencies = [
+ "blst",
+ "blstrs",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a30d0edd9dd1c60ddb42b80341c7852f6f985279a5c1a83659dcb65899dec99"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "which",
+ "zeroize",
+]
+
+[[package]]
+name = "blstrs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ecb6f3a9429706971633edf4b84f922aba9d2e3a7d71bfb450337e64ccb7df0"
+dependencies = [
+ "blst",
+ "byte-slice-cast",
+ "ec-gpu",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "serde",
+ "subtle",
+]
+
+[[package]]
+name = "borsh"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive",
  "hashbrown 0.13.2",
@@ -464,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598b3eacc6db9c3ee57b22707ad8f6a8d2f6d442bfe24ffeb8cbb70ca59e6a35"
+checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
 dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
@@ -477,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186b734fa1c9f6743e90c95d7233c9faab6360d1a96d4ffa19d9cfd1e9350f8a"
+checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -488,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b7ff1008316626f485991b960ade129253d4034014616b94f309a15366cc49"
+checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -597,6 +739,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -769,6 +920,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ad70579325f1a38ea4c13412b82241c5900700a69785d73e2736bd65a33f86"
+dependencies = [
+ "async-trait",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,9 +941,21 @@ checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "constant_time_eq"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -805,12 +982,186 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpp_demangle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "593b398dd0c5b1e2e3a9c3dae8584e287894ea84e361949ad506376e99196265"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc0d8faabd099ea15ab33d49d150e5572c04cfeb95d675fd41286739b754629"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.26.2",
+ "log",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac1669e42579476f001571d6ba4b825fac686282c97b88b18f8e34242066a81"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a1b1eef9640ab72c1e7b583ac678083855a509da34b4b4378bd99954127c20"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea4e17c3791fd8134640b26242a9ddbd7c67db78f0bad98cb778bf563ef81a0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca1474b5302348799656d43a40eacd716a3b46169405a3af812832c9edf77b4"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77aa537f020ea43483100153278e7215d41695bdcef9eea6642d122675f64249"
+
+[[package]]
+name = "cranelift-native"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bdc6b65241a95b7d8eafbf4e114c082e49b80162a2dcd9c6bcc5989c3310c9e"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-wasm"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb6359f606a1c80ccaa04fae9dbbb504615ec7a49b6c212b341080fff7a65dd"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "itertools 0.10.5",
+ "log",
+ "smallvec",
+ "wasmparser 0.92.0",
+ "wasmtime-types",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset 0.8.0",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -903,8 +1254,18 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.12.4",
+ "darling_macro 0.12.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
 ]
 
 [[package]]
@@ -922,12 +1283,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
- "darling_core",
+ "darling_core 0.12.4",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
 ]
@@ -969,12 +1355,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-getters"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.10.2",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro 0.12.0",
 ]
 
 [[package]]
@@ -983,7 +1389,19 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
 dependencies = [
- "darling",
+ "darling 0.12.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -995,7 +1413,17 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.10.2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core 0.12.0",
  "syn 1.0.109",
 ]
 
@@ -1005,10 +1433,18 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1050,6 +1486,34 @@ name = "dunce"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
+
+[[package]]
+name = "ec-gpu"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd63582de2b59ea1aa48d7c1941b5d87618d95484397521b3acdfa0e1e9f5e45"
+
+[[package]]
+name = "ec-gpu-gen"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd09bf9d5313ad60379f70250590bccc10f7a04e2773062ac13255a37022584e"
+dependencies = [
+ "bitvec 1.0.1",
+ "crossbeam-channel",
+ "ec-gpu",
+ "execute",
+ "ff",
+ "group",
+ "hex",
+ "log",
+ "num_cpus",
+ "once_cell",
+ "rayon",
+ "sha2 0.10.6",
+ "thiserror",
+ "yastl",
+]
 
 [[package]]
 name = "ecdsa"
@@ -1109,6 +1573,38 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1423,7 +1919,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ebdd63c828f58aa067f40f9adcbea5e114fb1f90144b3a1e2858e0c9b1ff4e8"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "bytes",
  "cargo_metadata",
  "chrono",
@@ -1455,7 +1951,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade3e9c97727343984e1ceada4fdab11142d2ee3472d2c67027d56b1251d4f15"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "bytes",
  "cargo_metadata",
  "chrono",
@@ -1693,6 +2189,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "execute"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313431b1c5e3a6ec9b864333defee57d2ddb50de77abab419e4baedb6cdff292"
+dependencies = [
+ "execute-command-macro",
+ "execute-command-tokens",
+ "generic-array 0.14.6",
+]
+
+[[package]]
+name = "execute-command-macro"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5fbc65a0cf735106743f4c38c9a3671c1e734b5c2c20d21a3c93c696daa3157"
+dependencies = [
+ "execute-command-macro-impl",
+]
+
+[[package]]
+name = "execute-command-macro-impl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5109f6bc9cd57feda665da326f3f6c57e0498c8fe9f7d12d7b8abc96719ca91b"
+dependencies = [
+ "execute-command-tokens",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "execute-command-tokens"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba569491c70ec8471e34aa7e9c0b9e82bb5d2464c0398442d17d3c4af814e5a"
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +2242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,7 +2262,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "089263294bb1c38ac73649a6ad563dd9a5142c8dc0482be15b8b9acb22a1611e"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "auto_impl 1.0.1",
  "bytes",
  "ethereum-types 0.13.1",
@@ -1743,11 +2282,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdlimit"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4c9e43643f5a3be4ca5b67d26b98031ff9db6806c3440ae32e02e3ceac3f1b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
+ "bitvec 1.0.1",
  "rand_core",
  "subtle",
 ]
@@ -1925,7 +2474,7 @@ dependencies = [
  "fvm_ipld_hamt",
  "fvm_shared",
  "integer-encoding",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "libipld-core 0.13.1",
  "log",
@@ -1955,7 +2504,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multihash",
@@ -1993,7 +2542,7 @@ version = "10.0.0"
 dependencies = [
  "anyhow",
  "cid",
- "derive_builder",
+ "derive_builder 0.10.2",
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_amt",
@@ -2105,7 +2654,7 @@ dependencies = [
  "byteorder",
  "castaway",
  "cid",
- "derive_builder",
+ "derive_builder 0.10.2",
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
@@ -2114,7 +2663,7 @@ dependencies = [
  "fvm_sdk",
  "fvm_shared",
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "libsecp256k1",
  "log",
@@ -2190,6 +2739,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_pasta_curves"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3303ea3c462ab949ab95b49f6e6d255d8d9396ebd4f1626ccb34c7037615aa8f"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "filecoin-hashers"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ac783ebbc0fa47fa3f4491a83ee46e7a5909384b5786dfd5319722b173a50f"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "blstrs",
+ "ff",
+ "generic-array 0.14.6",
+ "hex",
+ "lazy_static",
+ "merkletree",
+ "neptune",
+ "rand",
+ "serde",
+ "sha2 0.10.6",
+]
+
+[[package]]
+name = "filecoin-proofs"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bfd144962260633b7b5151f1cf38a93c26a53238f52dae8baf414e0b329a00"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "bincode",
+ "blake2b_simd",
+ "blstrs",
+ "filecoin-hashers",
+ "fr32",
+ "generic-array 0.14.6",
+ "hex",
+ "lazy_static",
+ "log",
+ "memmap2",
+ "merkletree",
+ "once_cell",
+ "rand",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha2 0.10.6",
+ "storage-proofs-core",
+ "storage-proofs-porep",
+ "storage-proofs-post",
+ "storage-proofs-update",
+ "typenum",
+]
+
+[[package]]
+name = "filecoin-proofs-api"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5b3d55a6acea686b5c7c908de9388a4d1812fa993f2060fd969b609225bdd7"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "bincode",
+ "blstrs",
+ "filecoin-hashers",
+ "filecoin-proofs",
+ "fr32",
+ "lazy_static",
+ "serde",
+ "storage-proofs-core",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,6 +2845,15 @@ dependencies = [
  "rand",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "spin 0.9.6",
 ]
 
 [[package]]
@@ -2236,6 +2879,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fr32"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54886e6035e8df26591853a500ad8024709aaec78948f080496fbd8477618690"
+dependencies = [
+ "anyhow",
+ "blstrs",
+ "byte-slice-cast",
+ "byteorder",
+ "ff",
+ "thiserror",
 ]
 
 [[package]]
@@ -2297,6 +2954,16 @@ dependencies = [
  "serde",
  "serde_tuple",
  "thiserror",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2427,6 +3094,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "fvm"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3760dd47434b4f53bc8944dfd800994fff61ece4ef7159975167c0adfa7363e4"
+dependencies = [
+ "anyhow",
+ "blake2b_simd",
+ "byteorder",
+ "cid",
+ "derive-getters",
+ "derive_builder 0.12.0",
+ "derive_more",
+ "filecoin-proofs-api",
+ "fvm-wasm-instrument",
+ "fvm_ipld_amt",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_shared",
+ "lazy_static",
+ "log",
+ "minstant",
+ "multihash",
+ "num-derive",
+ "num-traits",
+ "num_cpus",
+ "once_cell",
+ "rand",
+ "rayon",
+ "replace_with",
+ "serde",
+ "serde_repr",
+ "serde_tuple",
+ "thiserror",
+ "wasmtime",
+ "wasmtime-environ",
+ "wasmtime-runtime",
+ "yastl",
+]
+
+[[package]]
+name = "fvm-wasm-instrument"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd62c1cbb59244314d761b57cb5d2bcc35e8b7bc8f3082d56980f69145c1be8"
+dependencies = [
+ "anyhow",
+ "wasm-encoder",
+ "wasmparser 0.95.0",
+ "wasmprinter",
+]
+
+[[package]]
+name = "fvm-workbench-api"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fvm_ipld_amt",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_car",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_shared",
+ "itertools 0.10.5",
+ "num-format",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm-workbench-vm"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cid",
+ "futures",
+ "fvm",
+ "fvm-workbench-api",
+ "fvm_ipld_amt",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_car",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_shared",
+ "multihash",
+ "thiserror",
+]
+
+[[package]]
 name = "fvm_actor_utils"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2455,7 +3211,7 @@ dependencies = [
  "cid",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "itertools",
+ "itertools 0.10.5",
  "once_cell",
  "serde",
  "thiserror",
@@ -2579,13 +3335,16 @@ dependencies = [
  "anyhow",
  "bitflags",
  "blake2b_simd",
+ "bls-signatures",
  "byteorder",
  "cid",
  "data-encoding",
  "data-encoding-macro",
+ "filecoin-proofs-api",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "lazy_static",
+ "libsecp256k1",
  "log",
  "multihash",
  "num-bigint",
@@ -2636,9 +3395,32 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-timers"
@@ -2659,7 +3441,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
+ "rand",
  "rand_core",
+ "rand_xorshift",
  "subtle",
 ]
 
@@ -2732,6 +3516,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -2944,6 +3734,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
+ "block-padding 0.3.2",
  "generic-array 0.14.6",
 ]
 
@@ -2970,10 +3761,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3036,8 +3853,14 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -3124,6 +3947,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3144,16 +3985,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memfd"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
+dependencies = [
+ "rustix 0.36.11",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "merkletree"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d348b5b0d1707be1c8a727b7078daa08e2a3051d63b35715a19c35a324d2aaac"
+dependencies = [
+ "anyhow",
+ "arrayref",
+ "log",
+ "memmap2",
+ "positioned-io",
+ "rayon",
+ "serde",
+ "tempfile",
+ "typenum",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "minstant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5dcfca9a0725105ac948b84cfeb69c3942814c696326743797215413f854b9"
+dependencies = [
+ "ctor",
+ "libc",
+ "wasi 0.7.0",
+]
 
 [[package]]
 name = "mio"
@@ -3163,7 +4092,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
 ]
 
@@ -3185,7 +4114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
  "blake2b_simd",
- "blake2s_simd",
+ "blake2s_simd 1.0.1",
  "blake3",
  "core2",
  "digest 0.10.6",
@@ -3210,6 +4139,35 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "synstructure",
+]
+
+[[package]]
+name = "neptune"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dedb261f1b35ddfd867295eacbc25eb78b4b5b63b08b1c0dc4c1b5ef0e5b2c2"
+dependencies = [
+ "bellperson",
+ "blake2s_simd 0.5.11",
+ "blstrs",
+ "byteorder",
+ "ff",
+ "fil_pasta_curves",
+ "generic-array 0.14.6",
+ "itertools 0.8.2",
+ "lazy_static",
+ "log",
+ "trait-set",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3257,6 +4215,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec 0.7.2",
+ "itoa",
 ]
 
 [[package]]
@@ -3313,6 +4281,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.12.3",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3336,7 +4325,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "auto_impl 1.0.1",
  "bytes",
  "ethereum-types 0.14.1",
@@ -3362,12 +4351,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "pairing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+dependencies = [
+ "group",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "637935964ff85a605d114591d4d2c13c5d1ba2806dae97cea6bf180238a749ac"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "bitvec 1.0.1",
  "byte-slice-cast",
  "impl-trait-for-tuples",
@@ -3445,6 +4452,12 @@ name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"
@@ -3586,10 +4599,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "positioned-io"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b9485cf7f528baf34edd811ec8283a168864912e11d0b7d3e0510738761114"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
+]
 
 [[package]]
 name = "pretty_env_logger"
@@ -3673,11 +4709,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3758,6 +4803,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3767,10 +4843,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.7.1"
+name = "regalloc2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "91b2eab54204ea0117fe9a060537e0b07a4e72f7c7d182361ecc346cab2240e5"
+dependencies = [
+ "fxhash",
+ "log",
+ "slice-group-by",
+ "smallvec",
+]
+
+[[package]]
+name = "regex"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3779,9 +4867,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rend"
@@ -3791,6 +4879,12 @@ checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
 dependencies = [
  "bytecheck",
 ]
+
+[[package]]
+name = "replace_with"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
 
 [[package]]
 name = "reqwest"
@@ -3851,7 +4945,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -3918,7 +5012,7 @@ version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b1b21b8760b0ef8ae5b43d40913ff711a2053cb7ff892a34facff7a6365375a"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "borsh",
  "bytecheck",
  "byteorder",
@@ -3929,6 +5023,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hex"
@@ -3943,6 +5043,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.35.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+dependencies = [
+ "bitflags",
+ "errno 0.2.8",
+ "io-lifetimes 0.7.5",
+ "libc",
+ "linux-raw-sys 0.0.46",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+dependencies = [
+ "bitflags",
+ "errno 0.2.8",
+ "io-lifetimes 1.0.9",
+ "libc",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
+dependencies = [
+ "bitflags",
+ "errno 0.3.0",
+ "io-lifetimes 1.0.9",
+ "libc",
+ "linux-raw-sys 0.3.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4160,7 +5302,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.4",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -4194,7 +5336,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.4",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -4264,6 +5406,31 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.6",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf27176fb5d15398e3a479c652c20459d9dac830dedd1fa55b42a77dbcdbfcea"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "sha2raw"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b391e41e31b302788683ab67b5e2ec4f25040dc52f24e625fdd9cd3809f41cc3"
+dependencies = [
+ "byteorder",
+ "cpufeatures",
+ "digest 0.10.6",
+ "fake-simd",
+ "lazy_static",
+ "opaque-debug 0.3.0",
+ "sha2-asm",
 ]
 
 [[package]]
@@ -4300,6 +5467,12 @@ checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "slice-group-by"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 
 [[package]]
 name = "smallvec"
@@ -4346,6 +5519,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,10 +5538,136 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "storage-proofs-core"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7bf5cd6d0a2f85914de385c09b9939b7ac894f1c3b628f216f8c13b7d22f04"
+dependencies = [
+ "aes 0.8.2",
+ "anyhow",
+ "bellperson",
+ "blake2b_simd",
+ "blstrs",
+ "byteorder",
+ "cbc",
+ "config",
+ "ff",
+ "filecoin-hashers",
+ "fr32",
+ "fs2",
+ "generic-array 0.14.6",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "memmap2",
+ "merkletree",
+ "num_cpus",
+ "rand",
+ "rand_chacha",
+ "rayon",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "storage-proofs-porep"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ac4c7b0628871b76588ff15bde6f1e61e380e844cb2dac4d5882aae284d2d7"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "bincode",
+ "blstrs",
+ "byte-slice-cast",
+ "byteorder",
+ "crossbeam",
+ "fdlimit",
+ "ff",
+ "filecoin-hashers",
+ "fr32",
+ "generic-array 0.14.6",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmap2",
+ "merkletree",
+ "neptune",
+ "num-bigint",
+ "num-traits",
+ "num_cpus",
+ "pretty_assertions",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha2 0.10.6",
+ "sha2raw",
+ "storage-proofs-core",
+ "yastl",
+]
+
+[[package]]
+name = "storage-proofs-post"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207fd9dbdf2791a46c5fba617b39c623e7081a8b6608ad42b26d9d982073c104"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "blake2b_simd",
+ "blstrs",
+ "byteorder",
+ "ff",
+ "filecoin-hashers",
+ "fr32",
+ "generic-array 0.14.6",
+ "hex",
+ "log",
+ "rayon",
+ "serde",
+ "sha2 0.10.6",
+ "storage-proofs-core",
+]
+
+[[package]]
+name = "storage-proofs-update"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e31b37ab1ff191ea20ede4141dfb9b87cc861a36888a20c5ddeeb68b47cfd04"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "blstrs",
+ "ff",
+ "filecoin-hashers",
+ "fr32",
+ "generic-array 0.14.6",
+ "lazy_static",
+ "log",
+ "memmap2",
+ "merkletree",
+ "neptune",
+ "rayon",
+ "serde",
+ "storage-proofs-core",
+ "storage-proofs-porep",
+]
 
 [[package]]
 name = "strsim"
@@ -4421,9 +5729,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.4"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c622ae390c9302e214c31013517c2061ecb2699935882c60a9b37f82f8625ae"
+checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4447,6 +5755,25 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+
+[[package]]
+name = "tempfile"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix 0.36.11",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "termcolor"
@@ -4507,6 +5834,8 @@ dependencies = [
  "fil_actors_runtime",
  "fil_builtin_actors_state",
  "frc46_token",
+ "fvm-workbench-api",
+ "fvm-workbench-vm",
  "fvm_actor_utils",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
@@ -4554,7 +5883,16 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.4",
+ "syn 2.0.8",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -4678,6 +6016,17 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "trait-set"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79e2e9c9ab44c6d7c20d5976961b47e8f49ac199154daa514b77cd1ab536625"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4820,6 +6169,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -4891,6 +6246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05632e0a66a6ed8cca593c24223aabd6262f256c3693ad9822c315285f010614"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasm-timer"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4903,6 +6267,191 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.92.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da34cec2a8c23db906cdf8b26e988d7a7f0d549eb5d51299129647af61a1b37"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
+dependencies = [
+ "indexmap",
+ "url",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b"
+dependencies = [
+ "indexmap",
+ "url",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc17ae63836d010a2bf001c26a5fedbb9a05e5f71117fb63e0ab878bfbe1ca3"
+dependencies = [
+ "anyhow",
+ "wasmparser 0.102.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743d37c265fa134a76de653c7e66be22590eaccd03da13cee99f3ac7a59cb826"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "indexmap",
+ "libc",
+ "log",
+ "object 0.29.0",
+ "once_cell",
+ "paste",
+ "psm",
+ "rayon",
+ "serde",
+ "target-lexicon",
+ "wasmparser 0.92.0",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-jit",
+ "wasmtime-runtime",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de327cf46d5218315957138131ed904621e6f99018aa2da508c0dcf0c65f1bf2"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "017c3605ccce867b3ba7f71d95e5652acc22b9dc2971ad6a6f9df4a8d7af2648"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "cranelift-wasm",
+ "gimli 0.26.2",
+ "log",
+ "object 0.29.0",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.92.0",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aec5c1f81aab9bb35997113c171b6bb9093afc90e3757c55e0c08dc9ac612e4"
+dependencies = [
+ "anyhow",
+ "cranelift-entity",
+ "gimli 0.26.2",
+ "indexmap",
+ "log",
+ "object 0.29.0",
+ "serde",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.92.0",
+ "wasmtime-types",
+]
+
+[[package]]
+name = "wasmtime-jit"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c683893dbba3986aa71582a5332b87157fb95d34098de2e5f077c7f078726d"
+dependencies = [
+ "addr2line 0.17.0",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "cpp_demangle",
+ "gimli 0.26.2",
+ "log",
+ "object 0.29.0",
+ "rustc-demangle",
+ "rustix 0.35.13",
+ "serde",
+ "target-lexicon",
+ "thiserror",
+ "wasmtime-environ",
+ "wasmtime-runtime",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "wasmtime-jit-debug"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f8f15a81292eec468c79a4f887a37a3d02eb0c610f34ddbec607d3e9022f18"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "wasmtime-runtime"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09af6238c962e8220424c815a7b1a9a6d0ba0694f0ab0ae12a6cda1923935a0d"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "indexmap",
+ "libc",
+ "log",
+ "mach",
+ "memfd",
+ "memoffset 0.6.5",
+ "paste",
+ "rand",
+ "rustix 0.35.13",
+ "thiserror",
+ "wasmtime-asm-macros",
+ "wasmtime-environ",
+ "wasmtime-jit-debug",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "wasmtime-types"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc3dd9521815984b35d6362f79e6b9c72475027cd1c71c44eb8df8fbf33a9fb"
+dependencies = [
+ "cranelift-entity",
+ "serde",
+ "thiserror",
+ "wasmparser 0.92.0",
 ]
 
 [[package]]
@@ -4932,6 +6481,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -4967,17 +6527,30 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4996,12 +6569,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5012,9 +6585,21 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5024,9 +6609,21 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5039,6 +6636,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5084,7 +6687,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yastl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca6c5a4d66c1a9ea261811cf4773c27343de7e5033e1b75ea3f297dc7db3c1a"
+dependencies = [
+ "flume",
+ "scopeguard",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3523,6 +3523,7 @@ dependencies = [
 [[package]]
 name = "fvm-workbench-api"
 version = "0.1.0"
+source = "git+http://github.com/helix-onchain/fvm-workbench?branch=alex/test-vm#30d66dd0beae1d9ce3424545c6f1bdfffde91180"
 dependencies = [
  "anyhow",
  "cid",
@@ -3540,6 +3541,7 @@ dependencies = [
 [[package]]
 name = "fvm-workbench-builtin-actors"
 version = "0.1.0"
+source = "git+http://github.com/helix-onchain/fvm-workbench?branch=alex/test-vm#30d66dd0beae1d9ce3424545c6f1bdfffde91180"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -3579,6 +3581,7 @@ dependencies = [
 [[package]]
 name = "fvm-workbench-vm"
 version = "0.1.0"
+source = "git+http://github.com/helix-onchain/fvm-workbench?branch=alex/test-vm#30d66dd0beae1d9ce3424545c6f1bdfffde91180"
 dependencies = [
  "anyhow",
  "cid",
@@ -5439,9 +5442,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
 
 [[package]]
 name = "rustc-hex"
@@ -5562,9 +5565,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001cf62ece89779fd16105b5f515ad0e5cedcd5440d3dd806bb067978e7c3608"
+checksum = "61471dff9096de1d8b2319efed7162081e96793f5ebb147e50db10d50d648a4d"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -5574,9 +5577,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303959cf613a6f6efd19ed4b4ad5bf79966a13352716299ad532cfb115f4205c"
+checksum = "219580e803a66b3f05761fd06f1f879a872444e49ce23f73694d26e5a954c7e6"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ members = [
 [patch."http://github.com/helix-onchain/fvm-workbench"]
 fvm-workbench-vm = { path = "../../helix-onchain/fvm-workbench/vm" }
 fvm-workbench-api = { path = "../../helix-onchain/fvm-workbench/api" }
+fvm-workbench-builtin-actors = { path = "../../helix-onchain/fvm-workbench/builtin" }
 
 [profile.wasm]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,11 @@ members = [
 #frc42_dispatch = { path = "../../filecoin/frc42_dispatch"}
 #frc46_token = { path = "../../filecoin/frc46_token"}
 
+
+[patch."http://github.com/helix-onchain/fvm-workbench"]
+fvm-workbench-vm = { path = "../../helix-onchain/fvm-workbench/vm" }
+fvm-workbench-api = { path = "../../helix-onchain/fvm-workbench/api" }
+
 [profile.wasm]
 inherits = "release"
 # This needs to be unwind, not abort, so that we can handle panics within our panic hook.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,10 +97,10 @@ members = [
 #frc46_token = { path = "../../filecoin/frc46_token"}
 
 
-[patch."http://github.com/helix-onchain/fvm-workbench"]
-fvm-workbench-vm = { path = "../../helix-onchain/fvm-workbench/vm" }
-fvm-workbench-api = { path = "../../helix-onchain/fvm-workbench/api" }
-fvm-workbench-builtin-actors = { path = "../../helix-onchain/fvm-workbench/builtin" }
+# [patch."http://github.com/helix-onchain/fvm-workbench"]
+# fvm-workbench-vm = { path = "../../helix-onchain/fvm-workbench/vm" }
+# fvm-workbench-api = { path = "../../helix-onchain/fvm-workbench/api" }
+# fvm-workbench-builtin-actors = { path = "../../helix-onchain/fvm-workbench/builtin" }
 
 [profile.wasm]
 inherits = "release"

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-frc42_dispatch = "3.0.2"
-fvm_actor_utils = "4.0.2"
+frc42_dispatch = "3.1.0"
+fvm_actor_utils = "5.0.0"
 fvm_shared = { version = "3.0.0", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 num-traits = "0.2.14"

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -17,9 +17,9 @@ crate-type = ["cdylib", "lib"]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime"}
 
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.0.2"
-frc46_token = "4.0.2"
-fvm_actor_utils = "4.0.2"
+frc42_dispatch = "3.1.0"
+frc46_token = "5.0.0"
+fvm_actor_utils = "5.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"

--- a/actors/datacap/tests/datacap_actor_test.rs
+++ b/actors/datacap/tests/datacap_actor_test.rs
@@ -83,13 +83,13 @@ mod mint {
         assert_eq!(amt, ret.supply);
         assert_eq!(amt, ret.balance);
         assert_eq!(amt, h.get_supply(&rt));
-        assert_eq!(amt, h.get_balance(&rt, &*ALICE));
+        assert_eq!(amt, h.get_balance(&rt, &ALICE));
 
         let ret = h.mint(&rt, &BOB, &amt, vec![]).unwrap();
         assert_eq!(&amt * 2, ret.supply);
         assert_eq!(amt, ret.balance);
         assert_eq!(&amt * 2, h.get_supply(&rt));
-        assert_eq!(amt, h.get_balance(&rt, &*BOB));
+        assert_eq!(amt, h.get_balance(&rt, &BOB));
 
         h.check_state(&rt);
     }

--- a/actors/ethaccount/Cargo.toml
+++ b/actors/ethaccount/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-frc42_dispatch = "3.0.2"
-fvm_actor_utils = "4.0.2"
+frc42_dispatch = "3.1.0"
+fvm_actor_utils = "5.0.0"
 serde = { version = "1.0.136", features = ["derive"] }
 fvm_ipld_encoding = "0.3.3"
 fvm_shared = { version = "3.0.0", default-features = false }

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -31,7 +31,7 @@ multihash = { version = "0.16.1", default-features = false }
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.3.4"
 substrate-bn = { version = "0.6.0", default-features = false }
-frc42_dispatch = "3.0.2"
+frc42_dispatch = "3.1.0"
 fil_actors_evm_shared = { version = "10.0.0", path = "shared" }
 
 [dev-dependencies]

--- a/actors/evm/src/interpreter/memory.rs
+++ b/actors/evm/src/interpreter/memory.rs
@@ -10,13 +10,13 @@ impl Deref for Memory {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
-        &*self.0
+        &self.0
     }
 }
 
 impl DerefMut for Memory {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut *self.0
+        &mut self.0
     }
 }
 

--- a/actors/evm/tests/ext_opcodes.rs
+++ b/actors/evm/tests/ext_opcodes.rs
@@ -288,7 +288,7 @@ account:
         U256::from_big_endian(&result).to_bytes(),
         empty_hash.as_slice(),
         "expected empty hash: {}, got {}",
-        hex::encode(&empty_hash),
+        hex::encode(empty_hash),
         hex::encode(&result)
     );
     rt.reset();

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-frc42_dispatch = "3.0.2"
+frc42_dispatch = "3.1.0"
 fvm_shared = { version = "3.0.0", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -18,8 +18,8 @@ fil_actors_runtime = { version = "10.0.0", path = "../../runtime"}
 
 anyhow = "1.0.65"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.0.2"
-frc46_token = "4.0.2"
+frc42_dispatch = "3.1.0"
+frc46_token = "5.0.0"
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-frc42_dispatch = "3.0.2"
+frc42_dispatch = "3.1.0"
 fvm_shared = { version = "3.0.0", default-features = false }
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -18,8 +18,8 @@ fil_actors_runtime = { version = "10.0.0", path = "../../runtime"}
 
 anyhow = "1.0.65"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.0.2"
-fvm_actor_utils = "4.0.2"
+frc42_dispatch = "3.1.0"
+fvm_actor_utils = "5.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-frc42_dispatch = "3.0.2"
+frc42_dispatch = "3.1.0"
 fvm_shared = { version = "3.0.0", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "10.0.0", path = "../../runtime" }
-frc42_dispatch = "3.0.2"
+frc42_dispatch = "3.1.0"
 fvm_shared = { version = "3.0.0", default-features = false }
 fvm_ipld_hamt = "0.6.1"
 num-traits = "0.2.14"

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -18,9 +18,9 @@ fil_actors_runtime = { version = "10.0.0", path = "../../runtime"}
 
 anyhow = "1.0.65"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.0.2"
-frc46_token = "4.0.2"
-fvm_actor_utils = "4.0.2"
+frc42_dispatch = "3.1.0"
+frc46_token = "5.0.0"
+fvm_actor_utils = "5.0.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_hamt = "0.6.1"

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -957,7 +957,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
             types, expected_caller_type,
         );
 
-        if let Some(call_type) = self.resolve_builtin_actor_type(&*self.caller_type.borrow()) {
+        if let Some(call_type) = self.resolve_builtin_actor_type(&self.caller_type.borrow()) {
             for expected in &types {
                 if &call_type == expected {
                     self.expectations.borrow_mut().expect_validate_caller_type = None;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.64.0"
+channel = "nightly-2022-10-03"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -27,7 +27,7 @@ fil_actor_reward = { version = "10.0.0", path = "../actors/reward"}
 fil_actor_system = { version = "10.0.0", path = "../actors/system"}
 fil_actor_init = { version = "10.0.0", path = "../actors/init"}
 fil_actors_runtime = { version = "10.0.0", path = "../runtime"}
-frc46_token = "4.0.2"
+frc46_token = "5.0.0"
 fvm_shared = { version = "3.0.0", default-features = false }
 fvm_ipld_encoding = "0.3.3"
 fvm_ipld_blockstore = "0.1.1"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -54,6 +54,9 @@ thiserror = "1.0.30"
 libsecp256k1 = { version = "0.7.1"}
 fil_actors_evm_shared = { version = "10.0.0", path = "../actors/evm/shared" }
 
+fvm-workbench-vm = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "main"}
+fvm-workbench-api = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "main"}
+
 [dev-dependencies]
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.16.1", default-features = false }

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -54,6 +54,7 @@ thiserror = "1.0.30"
 libsecp256k1 = { version = "0.7.1"}
 fil_actors_evm_shared = { version = "10.0.0", path = "../actors/evm/shared" }
 
+bls-signatures = { version = "0.13", default-features = false }
 actors-v10 = { package = "fil_builtin_actors_bundle", version = "10.0.0", path = ".." } 
 fvm-workbench-vm = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "main"}
 fvm-workbench-api = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "main"}

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -61,3 +61,6 @@ test-case = "2.2.1"
 ethers = { version = "0.17.0", features = ["abigen"] }
 hex = "0.4.3"
 hex-literal = "0.3.4"
+
+[features]
+benchmark = []

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -54,8 +54,10 @@ thiserror = "1.0.30"
 libsecp256k1 = { version = "0.7.1"}
 fil_actors_evm_shared = { version = "10.0.0", path = "../actors/evm/shared" }
 
+actors-v10 = { package = "fil_builtin_actors_bundle", version = "10.0.0", path = ".." } 
 fvm-workbench-vm = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "main"}
 fvm-workbench-api = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "main"}
+fvm-workbench-builtin-actors = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "main"}
 
 [dev-dependencies]
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -56,9 +56,9 @@ fil_actors_evm_shared = { version = "10.0.0", path = "../actors/evm/shared" }
 
 bls-signatures = { version = "0.13", default-features = false }
 actors-v10 = { package = "fil_builtin_actors_bundle", version = "10.0.0", path = ".." } 
-fvm-workbench-vm = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "main"}
-fvm-workbench-api = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "main"}
-fvm-workbench-builtin-actors = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "main"}
+fvm-workbench-vm = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "alex/test-vm"}
+fvm-workbench-api = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "alex/test-vm"}
+fvm-workbench-builtin-actors = { version = "0.1.0", git = "http://github.com/helix-onchain/fvm-workbench", branch = "alex/test-vm"}
 
 [dev-dependencies]
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -33,8 +33,8 @@ anyhow = "1.0.65"
 bimap = { version = "0.6.2" }
 blake2b_simd = "1.0"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-frc46_token = "4.0.2"
-fvm_actor_utils = "4.0.2"
+frc46_token = "5.0.0"
+fvm_actor_utils = "5.0.0"
 fvm_ipld_bitfield = "0.5.4"
 fvm_ipld_blockstore = { version = "0.1.1", default-features = false }
 fvm_ipld_encoding = { version = "0.3.3", default-features = false }

--- a/test_vm/src/bench.rs
+++ b/test_vm/src/bench.rs
@@ -1,0 +1,26 @@
+use fvm_ipld_encoding::RawBytes;
+use fvm_workbench_api::wrangler::ExecutionWrangler;
+use fvm_workbench_api::Message;
+
+use crate::VM;
+
+impl<'a> VM for ExecutionWrangler<'a> {
+    fn send_message(
+        &self,
+        from: fvm_shared::address::Address,
+        to: fvm_shared::address::Address,
+        value: fvm_shared::econ::TokenAmount,
+        method: fvm_shared::MethodNum,
+        params: Option<fvm_ipld_encoding::ipld_block::IpldBlock>,
+    ) -> Result<crate::MessageResult, crate::TestVMError> {
+        let params = params.map_or(RawBytes::default(), |b| RawBytes::from(b.data));
+        let res = self.execute(from, to, method, params, value);
+    }
+
+    fn resolve_address(
+        &self,
+        addr: &fvm_shared::address::Address,
+    ) -> Option<fvm_shared::address::Address> {
+        todo!();
+    }
+}

--- a/test_vm/src/bench.rs
+++ b/test_vm/src/bench.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 
 use fvm_ipld_encoding::{ipld_block::IpldBlock, RawBytes, DAG_CBOR};
-use fvm_shared::{address::Address, crypto::signature::SignatureType, ActorID, METHOD_SEND};
+use fvm_shared::{address::Address, crypto::signature::SignatureType, METHOD_SEND};
 use fvm_workbench_api::{wrangler::ExecutionWrangler, ExecutionResult};
 use fvm_workbench_builtin_actors::genesis::GenesisResult;
 use fvm_workbench_builtin_actors::util::*;
@@ -51,7 +51,7 @@ impl<'a> VM for Benchmarker<'a> {
 
     fn resolve_address(&self, addr: &Address) -> Option<Address> {
         let res = self.wrangler.borrow().resolve_address(addr).map_or(None, |a| a);
-        res.map(|id| Address::new_id(id))
+        res.map(Address::new_id)
     }
 
     fn create_accounts_seeded(

--- a/test_vm/src/bench.rs
+++ b/test_vm/src/bench.rs
@@ -1,26 +1,49 @@
-use fvm_ipld_encoding::RawBytes;
-use fvm_workbench_api::wrangler::ExecutionWrangler;
-use fvm_workbench_api::Message;
+use std::cell::RefCell;
 
-use crate::VM;
+use fvm_ipld_encoding::{ipld_block::IpldBlock, RawBytes, DAG_CBOR};
+use fvm_shared::address::Address;
+use fvm_workbench_api::{wrangler::ExecutionWrangler, ExecutionResult};
 
-impl<'a> VM for ExecutionWrangler<'a> {
+use crate::{MessageResult, TestVMError, VM};
+
+pub struct Benchmarker<'a> {
+    pub wrangler: RefCell<ExecutionWrangler<'a>>,
+    pub execution_results: RefCell<Vec<ExecutionResult>>,
+}
+
+impl<'a> Benchmarker<'a> {
+    pub fn new(wrangler: ExecutionWrangler<'a>) -> Self {
+        Self { wrangler: RefCell::new(wrangler), execution_results: RefCell::new(Vec::new()) }
+    }
+}
+
+impl<'a> VM for Benchmarker<'a> {
     fn send_message(
         &self,
-        from: fvm_shared::address::Address,
-        to: fvm_shared::address::Address,
+        from: Address,
+        to: Address,
         value: fvm_shared::econ::TokenAmount,
         method: fvm_shared::MethodNum,
         params: Option<fvm_ipld_encoding::ipld_block::IpldBlock>,
-    ) -> Result<crate::MessageResult, crate::TestVMError> {
+    ) -> Result<MessageResult, TestVMError> {
         let params = params.map_or(RawBytes::default(), |b| RawBytes::from(b.data));
-        let res = self.execute(from, to, method, params, value);
+        let res = self
+            .wrangler
+            .borrow_mut()
+            .execute(from, to, method, params, value)
+            .map_err(|e| TestVMError { msg: e.to_string() })?;
+
+        self.execution_results.borrow_mut().push(res.clone());
+
+        Ok(MessageResult {
+            code: res.receipt.exit_code,
+            message: res.message,
+            ret: Some(IpldBlock { codec: DAG_CBOR, data: res.receipt.return_data.into() }),
+        })
     }
 
-    fn resolve_address(
-        &self,
-        addr: &fvm_shared::address::Address,
-    ) -> Option<fvm_shared::address::Address> {
-        todo!();
+    fn resolve_address(&self, addr: &Address) -> Option<Address> {
+        let res = self.wrangler.borrow().resolve_address(addr).map_or(None, |a| a);
+        res.map(|id| Address::new_id(id))
     }
 }

--- a/test_vm/src/bench.rs
+++ b/test_vm/src/bench.rs
@@ -1,19 +1,26 @@
 use std::cell::RefCell;
 
 use fvm_ipld_encoding::{ipld_block::IpldBlock, RawBytes, DAG_CBOR};
-use fvm_shared::address::Address;
+use fvm_shared::{address::Address, crypto::signature::SignatureType, ActorID, METHOD_SEND};
 use fvm_workbench_api::{wrangler::ExecutionWrangler, ExecutionResult};
+use fvm_workbench_builtin_actors::genesis::GenesisResult;
+use fvm_workbench_builtin_actors::util::*;
 
-use crate::{MessageResult, TestVMError, VM};
+use crate::{util::apply_ok_, MessageResult, TestVMError, VM};
 
 pub struct Benchmarker<'a> {
     pub wrangler: RefCell<ExecutionWrangler<'a>>,
     pub execution_results: RefCell<Vec<ExecutionResult>>,
+    genesis: GenesisResult,
 }
 
 impl<'a> Benchmarker<'a> {
-    pub fn new(wrangler: ExecutionWrangler<'a>) -> Self {
-        Self { wrangler: RefCell::new(wrangler), execution_results: RefCell::new(Vec::new()) }
+    pub fn new(wrangler: ExecutionWrangler<'a>, genesis: GenesisResult) -> Self {
+        Self {
+            wrangler: RefCell::new(wrangler),
+            execution_results: RefCell::new(Vec::new()),
+            genesis,
+        }
     }
 }
 
@@ -45,5 +52,36 @@ impl<'a> VM for Benchmarker<'a> {
     fn resolve_address(&self, addr: &Address) -> Option<Address> {
         let res = self.wrangler.borrow().resolve_address(addr).map_or(None, |a| a);
         res.map(|id| Address::new_id(id))
+    }
+
+    fn create_accounts_seeded(
+        &self,
+        count: u64,
+        balance: fvm_shared::econ::TokenAmount,
+        typ: fvm_shared::crypto::signature::SignatureType,
+        seed: u64,
+    ) -> Result<Vec<Address>, TestVMError> {
+        let keys = match typ {
+            SignatureType::Secp256k1 => make_secp_keys(seed, count),
+            SignatureType::BLS => make_bls_keys(seed, count),
+        };
+
+        // Send funds from faucet to pk address, creating account actor
+        for key in keys.iter() {
+            apply_ok_(
+                self,
+                Address::new_id(self.genesis.faucet_id),
+                key.addr,
+                balance.clone(),
+                METHOD_SEND,
+                None::<RawBytes>,
+            );
+        }
+        // Resolve pk address to return ID of account actor
+        let addresses: Vec<Address> =
+            keys.into_iter().map(|key| self.resolve_address(&key.addr).unwrap()).collect();
+        // let accounts =
+        //     keys.into_iter().enumerate().map(|(i, key)| Account { id: ids[i], key }).collect();
+        Ok(addresses)
     }
 }

--- a/test_vm/src/executor.rs
+++ b/test_vm/src/executor.rs
@@ -1,0 +1,1 @@
+pub trait Executor {}

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -75,7 +75,7 @@ use std::ops::Add;
 pub mod executor;
 pub mod util;
 
-pub struct VM<'bs> {
+pub struct TestVM<'bs> {
     pub store: &'bs MemoryBlockstore,
     pub state_root: RefCell<Cid>,
     total_fil: TokenAmount,
@@ -122,10 +122,10 @@ pub const TEST_FAUCET_ADDR: Address = Address::new_id(FIRST_NON_SINGLETON_ADDR +
 pub const FIRST_TEST_USER_ADDR: ActorID = FIRST_NON_SINGLETON_ADDR + 3;
 
 // accounts for verifreg root signer and msig
-impl<'bs> VM<'bs> {
-    pub fn new(store: &'bs MemoryBlockstore) -> VM<'bs> {
+impl<'bs> TestVM<'bs> {
+    pub fn new(store: &'bs MemoryBlockstore) -> TestVM<'bs> {
         let mut actors = Hamt::<&'bs MemoryBlockstore, Actor, BytesKey, Sha256>::new(store);
-        VM {
+        TestVM {
             store,
             state_root: RefCell::new(actors.flush().unwrap()),
             total_fil: TokenAmount::zero(),
@@ -141,11 +141,11 @@ impl<'bs> VM<'bs> {
         Self { total_fil, ..self }
     }
 
-    pub fn new_with_singletons(store: &'bs MemoryBlockstore) -> VM<'bs> {
+    pub fn new_with_singletons(store: &'bs MemoryBlockstore) -> TestVM<'bs> {
         let reward_total = TokenAmount::from_whole(1_100_000_000i64);
         let faucet_total = TokenAmount::from_whole(1_000_000_000i64);
 
-        let v = VM::new(store).with_total_fil(&reward_total + &faucet_total);
+        let v = TestVM::new(store).with_total_fil(&reward_total + &faucet_total);
 
         // system
         let sys_st = SystemState::new(store).unwrap();
@@ -284,9 +284,9 @@ impl<'bs> VM<'bs> {
         v
     }
 
-    pub fn with_epoch(self, epoch: ChainEpoch) -> VM<'bs> {
+    pub fn with_epoch(self, epoch: ChainEpoch) -> TestVM<'bs> {
         self.checkpoint();
-        VM {
+        TestVM {
             store: self.store,
             state_root: self.state_root.clone(),
             total_fil: self.total_fil,
@@ -600,7 +600,7 @@ pub const TEST_VM_RAND_ARRAY: [u8; 32] = [
 pub const TEST_VM_INVALID_POST: &str = "i_am_invalid_post";
 
 pub struct InvocationCtx<'invocation, 'bs> {
-    v: &'invocation VM<'bs>,
+    v: &'invocation TestVM<'bs>,
     top: TopCtx,
     msg: InternalMessage,
     allow_side_effects: RefCell<bool>,
@@ -1124,7 +1124,7 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
     }
 }
 
-impl Primitives for VM<'_> {
+impl Primitives for TestVM<'_> {
     // A "valid" signature has its bytes equal to the plaintext.
     // Anything else is considered invalid.
     fn verify_signature(

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -171,7 +171,7 @@ impl<'bs> VM for TestVM<'bs> {
         &self,
         count: u64,
         balance: TokenAmount,
-        typ: SignatureType,
+        _typ: SignatureType,
         seed: u64,
     ) -> Result<Vec<Address>, TestVMError> {
         let pk_addrs = pk_addrs_from(seed, count);
@@ -516,9 +516,7 @@ impl<'bs> TestVM<'bs> {
 
     pub fn get_state<T: DeserializeOwned>(&self, addr: Address) -> Option<T> {
         let a_opt = self.get_actor(addr);
-        if a_opt == None {
-            return None;
-        };
+        a_opt.as_ref()?;
         let a = a_opt.unwrap();
         self.store.get_cbor::<T>(&a.head).unwrap()
     }

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -72,6 +72,7 @@ use std::error::Error;
 use std::fmt;
 use std::ops::Add;
 
+pub mod executor;
 pub mod util;
 
 pub struct VM<'bs> {

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -72,6 +72,7 @@ use std::error::Error;
 use std::fmt;
 use std::ops::Add;
 
+pub mod bench;
 pub mod executor;
 pub mod util;
 

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -77,8 +77,13 @@ pub fn create_accounts(v: &TestVM, count: u64, balance: TokenAmount) -> Vec<Addr
     create_accounts_seeded(v, count, balance, ACCOUNT_SEED)
 }
 
-pub fn create_accounts_(v: &dyn VM, count: u64, balance: TokenAmount) -> Vec<Address> {
-    create_accounts_seeded_(v, count, balance, ACCOUNT_SEED)
+pub fn create_accounts_(
+    v: &dyn VM,
+    count: u64,
+    balance: TokenAmount,
+    typ: SignatureType,
+) -> Vec<Address> {
+    v.create_accounts_seeded(count, balance, typ, ACCOUNT_SEED).unwrap()
 }
 
 pub fn create_accounts_seeded(
@@ -94,21 +99,6 @@ pub fn create_accounts_seeded(
     }
     // Normalize pk address to return id address of account actor
     pk_addrs.iter().map(|&pk_addr| v.normalize_address(&pk_addr).unwrap()).collect()
-}
-
-fn create_accounts_seeded_(
-    v: &dyn VM,
-    count: u64,
-    balance: TokenAmount,
-    seed: u64,
-) -> Vec<Address> {
-    let pk_addrs = pk_addrs_from(seed, count);
-    // Send funds from faucet to pk address, creating account actor
-    for pk_addr in pk_addrs.clone() {
-        apply_ok_(v, TEST_FAUCET_ADDR, pk_addr, balance.clone(), METHOD_SEND, None::<RawBytes>);
-    }
-    // Normalize pk address to return id address of account actor
-    pk_addrs.iter().map(|&pk_addr| v.resolve_address(&pk_addr).unwrap()).collect()
 }
 
 pub fn apply_ok<S: Serialize>(

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -73,11 +73,16 @@ fn new_bls_from_rng(rng: &mut ChaCha8Rng) -> Address {
 
 const ACCOUNT_SEED: u64 = 93837778;
 
-pub fn create_accounts(v: &VM, count: u64, balance: TokenAmount) -> Vec<Address> {
+pub fn create_accounts(v: &TestVM, count: u64, balance: TokenAmount) -> Vec<Address> {
     create_accounts_seeded(v, count, balance, ACCOUNT_SEED)
 }
 
-pub fn create_accounts_seeded(v: &VM, count: u64, balance: TokenAmount, seed: u64) -> Vec<Address> {
+pub fn create_accounts_seeded(
+    v: &TestVM,
+    count: u64,
+    balance: TokenAmount,
+    seed: u64,
+) -> Vec<Address> {
     let pk_addrs = pk_addrs_from(seed, count);
     // Send funds from faucet to pk address, creating account actor
     for pk_addr in pk_addrs.clone() {
@@ -88,7 +93,7 @@ pub fn create_accounts_seeded(v: &VM, count: u64, balance: TokenAmount, seed: u6
 }
 
 pub fn apply_ok<S: Serialize>(
-    v: &VM,
+    v: &TestVM,
     from: Address,
     to: Address,
     value: TokenAmount,
@@ -99,7 +104,7 @@ pub fn apply_ok<S: Serialize>(
 }
 
 pub fn apply_code<S: Serialize>(
-    v: &VM,
+    v: &TestVM,
     from: Address,
     to: Address,
     value: TokenAmount,
@@ -112,7 +117,7 @@ pub fn apply_code<S: Serialize>(
     res.ret.map_or(RawBytes::default(), |b| RawBytes::new(b.data))
 }
 
-pub fn cron_tick(v: &VM) {
+pub fn cron_tick(v: &TestVM) {
     apply_ok(
         v,
         SYSTEM_ACTOR_ADDR,
@@ -124,7 +129,7 @@ pub fn cron_tick(v: &VM) {
 }
 
 pub fn create_miner(
-    v: &mut VM,
+    v: &mut TestVM,
     owner: Address,
     worker: Address,
     post_proof_type: RegisteredPoStProof,
@@ -157,7 +162,7 @@ pub fn create_miner(
 }
 
 pub fn miner_precommit_sector(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     miner_id: Address,
     seal_proof: RegisteredSealProof,
@@ -193,7 +198,12 @@ pub fn miner_precommit_sector(
     state.get_precommitted_sector(v.store, sector_number).unwrap().unwrap()
 }
 
-pub fn miner_prove_sector(v: &VM, worker: Address, miner_id: Address, sector_number: SectorNumber) {
+pub fn miner_prove_sector(
+    v: &TestVM,
+    worker: Address,
+    miner_id: Address,
+    sector_number: SectorNumber,
+) {
     let prove_commit_params = ProveCommitSectorParams { sector_number, proof: vec![] };
     apply_ok(
         v,
@@ -220,7 +230,7 @@ pub fn miner_prove_sector(v: &VM, worker: Address, miner_id: Address, sector_num
 
 #[allow(clippy::too_many_arguments)]
 pub fn precommit_sectors_v2(
-    v: &mut VM,
+    v: &mut TestVM,
     count: u64,
     batch_size: i64,
     worker: Address,
@@ -381,7 +391,7 @@ pub fn precommit_sectors_v2(
 
 #[allow(clippy::too_many_arguments)]
 pub fn precommit_sectors(
-    v: &mut VM,
+    v: &mut TestVM,
     count: u64,
     batch_size: i64,
     worker: Address,
@@ -406,7 +416,7 @@ pub fn precommit_sectors(
 }
 
 pub fn prove_commit_sectors(
-    v: &mut VM,
+    v: &mut TestVM,
     worker: Address,
     maddr: Address,
     precommits: Vec<SectorPreCommitOnChainInfo>,
@@ -470,7 +480,7 @@ pub fn prove_commit_sectors(
 
 #[allow(clippy::too_many_arguments)]
 pub fn miner_extend_sector_expiration2(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     miner_id: Address,
     deadline: u64,
@@ -546,24 +556,28 @@ pub fn miner_extend_sector_expiration2(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn advance_by_deadline_to_epoch(v: VM, maddr: Address, e: ChainEpoch) -> (VM, DeadlineInfo) {
+pub fn advance_by_deadline_to_epoch(
+    v: TestVM,
+    maddr: Address,
+    e: ChainEpoch,
+) -> (TestVM, DeadlineInfo) {
     // keep advancing until the epoch of interest is within the deadline
     // if e is dline.last() == dline.close -1 cron is not run
     let (v, dline_info) = advance_by_deadline(v, maddr, |dline_info| dline_info.close < e);
     (v.with_epoch(e), dline_info)
 }
 
-pub fn advance_by_deadline_to_index(v: VM, maddr: Address, i: u64) -> (VM, DeadlineInfo) {
+pub fn advance_by_deadline_to_index(v: TestVM, maddr: Address, i: u64) -> (TestVM, DeadlineInfo) {
     advance_by_deadline(v, maddr, |dline_info| dline_info.index != i)
 }
 
 pub fn advance_by_deadline_to_epoch_while_proving(
-    mut v: VM,
+    mut v: TestVM,
     maddr: Address,
     worker: Address,
     s: SectorNumber,
     e: ChainEpoch,
-) -> VM {
+) -> TestVM {
     let mut dline_info;
     let (d, p_idx) = sector_deadline(&v, maddr, s);
     loop {
@@ -586,17 +600,17 @@ pub fn advance_by_deadline_to_epoch_while_proving(
 }
 
 pub fn advance_to_proving_deadline(
-    v: VM,
+    v: TestVM,
     maddr: Address,
     s: SectorNumber,
-) -> (DeadlineInfo, u64, VM) {
+) -> (DeadlineInfo, u64, TestVM) {
     let (d, p) = sector_deadline(&v, maddr, s);
     let (v, dline_info) = advance_by_deadline_to_index(v, maddr, d);
     let v = v.with_epoch(dline_info.open);
     (dline_info, p, v)
 }
 
-fn advance_by_deadline<F>(mut v: VM, maddr: Address, more: F) -> (VM, DeadlineInfo)
+fn advance_by_deadline<F>(mut v: TestVM, maddr: Address, more: F) -> (TestVM, DeadlineInfo)
 where
     F: Fn(DeadlineInfo) -> bool,
 {
@@ -613,7 +627,7 @@ where
     }
 }
 
-pub fn miner_dline_info(v: &VM, m: Address) -> DeadlineInfo {
+pub fn miner_dline_info(v: &TestVM, m: Address) -> DeadlineInfo {
     let st = v.get_state::<MinerState>(m).unwrap();
     new_deadline_info_from_offset_and_epoch(
         &Policy::default(),
@@ -622,18 +636,24 @@ pub fn miner_dline_info(v: &VM, m: Address) -> DeadlineInfo {
     )
 }
 
-pub fn sector_deadline(v: &VM, m: Address, s: SectorNumber) -> (u64, u64) {
+pub fn sector_deadline(v: &TestVM, m: Address, s: SectorNumber) -> (u64, u64) {
     let st = v.get_state::<MinerState>(m).unwrap();
     st.find_sector(&Policy::default(), v.store, s).unwrap()
 }
 
-pub fn check_sector_active(v: &VM, m: Address, s: SectorNumber) -> bool {
+pub fn check_sector_active(v: &TestVM, m: Address, s: SectorNumber) -> bool {
     let (d_idx, p_idx) = sector_deadline(v, m, s);
     let st = v.get_state::<MinerState>(m).unwrap();
     st.check_sector_active(&Policy::default(), v.store, d_idx, p_idx, s, true).unwrap()
 }
 
-pub fn check_sector_faulty(v: &VM, m: Address, d_idx: u64, p_idx: u64, s: SectorNumber) -> bool {
+pub fn check_sector_faulty(
+    v: &TestVM,
+    m: Address,
+    d_idx: u64,
+    p_idx: u64,
+    s: SectorNumber,
+) -> bool {
     let st = v.get_state::<MinerState>(m).unwrap();
     let deadlines = st.load_deadlines(v.store).unwrap();
     let deadline = deadlines.load_deadline(&Policy::default(), v.store, d_idx).unwrap();
@@ -641,25 +661,25 @@ pub fn check_sector_faulty(v: &VM, m: Address, d_idx: u64, p_idx: u64, s: Sector
     partition.faults.get(s)
 }
 
-pub fn deadline_state(v: &VM, m: Address, d_idx: u64) -> Deadline {
+pub fn deadline_state(v: &TestVM, m: Address, d_idx: u64) -> Deadline {
     let st = v.get_state::<MinerState>(m).unwrap();
     let deadlines = st.load_deadlines(v.store).unwrap();
     deadlines.load_deadline(&Policy::default(), v.store, d_idx).unwrap()
 }
 
-pub fn sector_info(v: &VM, m: Address, s: SectorNumber) -> SectorOnChainInfo {
+pub fn sector_info(v: &TestVM, m: Address, s: SectorNumber) -> SectorOnChainInfo {
     let st = v.get_state::<MinerState>(m).unwrap();
     st.get_sector(v.store, s).unwrap().unwrap()
 }
 
-pub fn miner_power(v: &VM, m: Address) -> PowerPair {
+pub fn miner_power(v: &TestVM, m: Address) -> PowerPair {
     let st = v.get_state::<PowerState>(STORAGE_POWER_ACTOR_ADDR).unwrap();
     let claim = st.get_claim(v.store, &m).unwrap().unwrap();
     PowerPair::new(claim.raw_byte_power, claim.quality_adj_power)
 }
 
 pub fn declare_recovery(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     maddr: Address,
     deadline: u64,
@@ -685,7 +705,7 @@ pub fn declare_recovery(
 }
 
 pub fn submit_windowed_post(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     maddr: Address,
     dline_info: DeadlineInfo,
@@ -739,7 +759,7 @@ pub fn submit_windowed_post(
 }
 
 pub fn change_beneficiary(
-    v: &VM,
+    v: &TestVM,
     from: Address,
     maddr: Address,
     beneficiary_change_proposal: &ChangeBeneficiaryParams,
@@ -754,7 +774,7 @@ pub fn change_beneficiary(
     );
 }
 
-pub fn get_beneficiary(v: &VM, from: Address, m_addr: Address) -> GetBeneficiaryReturn {
+pub fn get_beneficiary(v: &TestVM, from: Address, m_addr: Address) -> GetBeneficiaryReturn {
     apply_ok(
         v,
         from,
@@ -767,7 +787,7 @@ pub fn get_beneficiary(v: &VM, from: Address, m_addr: Address) -> GetBeneficiary
     .unwrap()
 }
 
-pub fn change_owner_address(v: &VM, from: Address, m_addr: Address, new_miner_addr: Address) {
+pub fn change_owner_address(v: &TestVM, from: Address, m_addr: Address, new_miner_addr: Address) {
     apply_ok(
         v,
         from,
@@ -779,7 +799,7 @@ pub fn change_owner_address(v: &VM, from: Address, m_addr: Address, new_miner_ad
 }
 
 pub fn withdraw_balance(
-    v: &VM,
+    v: &TestVM,
     from: Address,
     m_addr: Address,
     to_withdraw_amount: TokenAmount,
@@ -818,7 +838,7 @@ pub fn withdraw_balance(
 }
 
 pub fn submit_invalid_post(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     maddr: Address,
     dline_info: DeadlineInfo,
@@ -844,7 +864,7 @@ pub fn submit_invalid_post(
     );
 }
 
-pub fn verifreg_add_verifier(v: &VM, verifier: Address, data_cap: StoragePower) {
+pub fn verifreg_add_verifier(v: &TestVM, verifier: Address, data_cap: StoragePower) {
     let add_verifier_params = VerifierParams { address: verifier, allowance: data_cap };
     // root address is msig, send proposal from root key
     let proposal = ProposeParams {
@@ -883,7 +903,12 @@ pub fn verifreg_add_verifier(v: &VM, verifier: Address, data_cap: StoragePower) 
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn verifreg_add_client(v: &VM, verifier: Address, client: Address, allowance: StoragePower) {
+pub fn verifreg_add_client(
+    v: &TestVM,
+    verifier: Address,
+    client: Address,
+    allowance: StoragePower,
+) {
     let add_client_params =
         AddVerifiedClientParams { address: client, allowance: allowance.clone() };
     apply_ok(
@@ -918,7 +943,7 @@ pub fn verifreg_add_client(v: &VM, verifier: Address, client: Address, allowance
 }
 
 pub fn verifreg_extend_claim_terms(
-    v: &VM,
+    v: &TestVM,
     client: Address,
     provider: Address,
     claim: ClaimID,
@@ -942,7 +967,7 @@ pub fn verifreg_extend_claim_terms(
 }
 
 pub fn verifreg_remove_expired_allocations(
-    v: &VM,
+    v: &TestVM,
     caller: Address,
     client: Address,
     ids: Vec<AllocationID>,
@@ -980,7 +1005,7 @@ pub fn verifreg_remove_expired_allocations(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn datacap_get_balance(v: &VM, address: Address) -> TokenAmount {
+pub fn datacap_get_balance(v: &TestVM, address: Address) -> TokenAmount {
     let ret = apply_ok(
         v,
         address,
@@ -993,7 +1018,7 @@ pub fn datacap_get_balance(v: &VM, address: Address) -> TokenAmount {
 }
 
 pub fn datacap_extend_claim(
-    v: &VM,
+    v: &TestVM,
     client: Address,
     provider: Address,
     claim: ClaimID,
@@ -1066,7 +1091,7 @@ pub fn datacap_extend_claim(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn market_add_balance(v: &VM, sender: Address, beneficiary: Address, amount: TokenAmount) {
+pub fn market_add_balance(v: &TestVM, sender: Address, beneficiary: Address, amount: TokenAmount) {
     apply_ok(
         v,
         sender,
@@ -1079,7 +1104,7 @@ pub fn market_add_balance(v: &VM, sender: Address, beneficiary: Address, amount:
 
 #[allow(clippy::too_many_arguments)]
 pub fn market_publish_deal(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     deal_client: Address,
     miner_id: Address,

--- a/test_vm/tests/authenticate_message_test.rs
+++ b/test_vm/tests/authenticate_message_test.rs
@@ -7,7 +7,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 
 use test_vm::util::{apply_code, apply_ok, create_accounts, generate_deal_proposal};
-use test_vm::VM;
+use test_vm::TestVM;
 
 // Using a deal proposal as a serialized message, we confirm that:
 // - calls to Account::authenticate_message with valid signatures succeed
@@ -15,7 +15,7 @@ use test_vm::VM;
 #[test]
 fn account_authenticate_message() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addr = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
 
     let proposal =

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -17,7 +17,7 @@ use test_vm::util::{
     advance_to_proving_deadline, apply_ok, create_accounts, create_miner,
     invariant_failure_patterns, precommit_sectors_v2, prove_commit_sectors, submit_windowed_post,
 };
-use test_vm::VM;
+use test_vm::TestVM;
 
 struct Onboarding {
     epoch_delay: i64,                 // epochs to advance since the prior action
@@ -49,7 +49,7 @@ impl Onboarding {
 #[test_case(true; "v2")]
 fn batch_onboarding(v2: bool) {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);

--- a/test_vm/tests/change_beneficiary_test.rs
+++ b/test_vm/tests/change_beneficiary_test.rs
@@ -10,12 +10,12 @@ use test_vm::util::{
     apply_code, change_beneficiary, create_accounts, create_miner, get_beneficiary,
     withdraw_balance,
 };
-use test_vm::VM;
+use test_vm::TestVM;
 
 #[test]
 fn change_beneficiary_success() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, another_beneficiary, query_addr) =
@@ -73,7 +73,7 @@ fn change_beneficiary_success() {
 #[test]
 fn change_beneficiary_back_owner_success() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, query_addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -126,7 +126,7 @@ fn change_beneficiary_back_owner_success() {
 #[test]
 fn change_beneficiary_fail() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/change_owner_test.rs
+++ b/test_vm/tests/change_owner_test.rs
@@ -5,22 +5,33 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::RegisteredSealProof;
 use test_vm::util::{
-    apply_code, change_beneficiary, change_owner_address, create_accounts, create_miner,
+    apply_code, change_beneficiary, change_beneficiary_, change_owner_address,
+    change_owner_address_, create_accounts, create_accounts_, create_miner, create_miner_,
     get_beneficiary,
 };
 use test_vm::TestVM;
 
-#[test]
-fn change_owner_success() {
-    let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
+enum ConcreteVM<'vm, 'bs> {
+    TestVM(&'vm TestVM<'bs>),
+    _BenchmarkVM(()),
+}
+
+/// Sample test that can be injected with either a TestVM (rust execution, stack traceable etc) or a
+/// _BenchmarkVM (wasm execution, gas metering etc)
+fn change_owner_test(concrete_vm: ConcreteVM) {
+    let vm = match concrete_vm {
+        ConcreteVM::TestVM(tvm) => tvm.vm(),
+        ConcreteVM::_BenchmarkVM(_) => todo!(),
+    };
+
+    // when the tests cases are merged, remove the match and use the concrete_vm directly
+    let addrs = create_accounts_(vm, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
 
     // create miner
-    let miner_id = create_miner(
-        &mut v,
+    let miner_id = create_miner_(
+        vm,
         owner,
         worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -28,136 +39,208 @@ fn change_owner_success() {
     )
     .0;
 
-    change_beneficiary(
-        &v,
+    change_beneficiary_(
+        vm,
         owner,
         miner_id,
         &ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(100), 100),
     );
-    change_owner_address(&v, owner, miner_id, new_owner);
-    let miner_info = v.get_miner_info(miner_id);
-    assert_eq!(new_owner, miner_info.pending_owner_address.unwrap());
+    change_owner_address_(vm, owner, miner_id, new_owner);
+    match concrete_vm {
+        ConcreteVM::TestVM(tvm) => {
+            let miner_info = tvm.get_miner_info(miner_id);
+            assert_eq!(new_owner, miner_info.pending_owner_address.unwrap());
+        }
+        #[cfg(feature = "benchmark")]
+        ConcreteVM::_BenchmarkVM(_) => {
+            // this block shouldn't compile unless the feature is enabled
+            compilation_error;
+        }
+        _ => {
+            unimplemented!("Only TestVM and BenchmarkVM are supported")
+        }
+    }
 
-    change_owner_address(&v, new_owner, miner_id, new_owner);
-    let miner_info = v.get_miner_info(miner_id);
-    assert!(miner_info.pending_owner_address.is_none());
-    assert_eq!(new_owner, miner_info.owner);
-    assert_eq!(new_owner, miner_info.beneficiary);
+    change_owner_address_(vm, new_owner, miner_id, new_owner);
 
-    v.assert_state_invariants();
+    match concrete_vm {
+        ConcreteVM::TestVM(tvm) => {
+            let miner_info = tvm.get_miner_info(miner_id);
+            assert!(miner_info.pending_owner_address.is_none());
+            assert_eq!(new_owner, miner_info.owner);
+            assert_eq!(new_owner, miner_info.beneficiary);
+        }
+        ConcreteVM::_BenchmarkVM(_) => todo!(),
+    }
 }
 
+#[cfg(feature = "benchmark")]
 #[test]
-fn keep_beneficiary_when_owner_changed() {
+fn benchmark_change_owner_success() {
+    println!("Running benchmark test");
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
-    let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
-    let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
-
-    // create miner
-    let miner_id = create_miner(
-        &mut v,
-        owner,
-        worker,
-        seal_proof.registered_window_post_proof().unwrap(),
-        TokenAmount::from_whole(1_000),
-    )
-    .0;
-
-    change_beneficiary(
-        &v,
-        owner,
-        miner_id,
-        &ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(100), 100),
-    );
-    change_beneficiary(
-        &v,
-        beneficiary,
-        miner_id,
-        &ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(100), 100),
-    );
-    assert_eq!(beneficiary, get_beneficiary(&v, worker, miner_id).active.beneficiary);
-
-    change_owner_address(&v, owner, miner_id, new_owner);
-    change_owner_address(&v, new_owner, miner_id, new_owner);
-    let miner_info = v.get_miner_info(miner_id);
-    assert!(miner_info.pending_owner_address.is_none());
-    assert_eq!(new_owner, miner_info.owner);
-    assert_eq!(beneficiary, miner_info.beneficiary);
-
+    let v = TestVM::new_with_singletons(&store);
+    change_owner_test(ConcreteVM::TestVM(&v));
     v.assert_state_invariants();
 }
 
+#[cfg(not(feature = "benchmark"))]
 #[test]
-fn change_owner_fail() {
+fn test_change_owner_success() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
-    let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
-    let (owner, worker, new_owner, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);
-
-    // create miner
-    let miner_id = create_miner(
-        &mut v,
-        owner,
-        worker,
-        seal_proof.registered_window_post_proof().unwrap(),
-        TokenAmount::from_whole(1_000),
-    )
-    .0;
-
-    // only owner can proposal
-    apply_code(
-        &v,
-        addr,
-        miner_id,
-        TokenAmount::zero(),
-        MinerMethod::ChangeOwnerAddress as u64,
-        Some(new_owner),
-        ExitCode::USR_FORBIDDEN,
-    );
-
-    change_owner_address(&v, owner, miner_id, new_owner);
-    // proposal must be the same
-    apply_code(
-        &v,
-        new_owner,
-        miner_id,
-        TokenAmount::zero(),
-        MinerMethod::ChangeOwnerAddress as u64,
-        Some(addr),
-        ExitCode::USR_ILLEGAL_ARGUMENT,
-    );
-    // only pending can confirm
-    apply_code(
-        &v,
-        addr,
-        miner_id,
-        TokenAmount::zero(),
-        MinerMethod::ChangeOwnerAddress as u64,
-        Some(new_owner),
-        ExitCode::USR_FORBIDDEN,
-    );
-    //only miner can change proposal
-    apply_code(
-        &v,
-        addr,
-        miner_id,
-        TokenAmount::zero(),
-        MinerMethod::ChangeOwnerAddress as u64,
-        Some(addr),
-        ExitCode::USR_FORBIDDEN,
-    );
-
-    //miner change proposal
-    change_owner_address(&v, owner, miner_id, addr);
-    //confirm owner proposal
-    change_owner_address(&v, addr, miner_id, addr);
-    let miner_info = v.get_miner_info(miner_id);
-    assert!(miner_info.pending_owner_address.is_none());
-    assert_eq!(addr, miner_info.owner);
-    assert_eq!(addr, miner_info.beneficiary);
-
+    let v = TestVM::new_with_singletons(&store);
+    change_owner_test(ConcreteVM::TestVM(&v));
     v.assert_state_invariants();
 }
+
+// #[test]
+// fn change_owner_success() {
+//     let store = MemoryBlockstore::new();
+//     let mut v = TestVM::new_with_singletons(&store);
+//     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
+//     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
+//     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
+
+//     // create miner
+//     let miner_id = create_miner(
+//         &mut v,
+//         owner,
+//         worker,
+//         seal_proof.registered_window_post_proof().unwrap(),
+//         TokenAmount::from_whole(1_000),
+//     )
+//     .0;
+
+//     change_beneficiary(
+//         &v,
+//         owner,
+//         miner_id,
+//         &ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(100), 100),
+//     );
+//     change_owner_address(&v, owner, miner_id, new_owner);
+//     let miner_info = v.get_miner_info(miner_id);
+//     assert_eq!(new_owner, miner_info.pending_owner_address.unwrap());
+
+//     change_owner_address(&v, new_owner, miner_id, new_owner);
+//     let miner_info = v.get_miner_info(miner_id);
+//     assert!(miner_info.pending_owner_address.is_none());
+//     assert_eq!(new_owner, miner_info.owner);
+//     assert_eq!(new_owner, miner_info.beneficiary);
+
+//     v.assert_state_invariants();
+// }
+
+// #[test]
+// fn keep_beneficiary_when_owner_changed() {
+//     let store = MemoryBlockstore::new();
+//     let mut v = TestVM::new_with_singletons(&store);
+//     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
+//     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
+//     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
+
+//     // create miner
+//     let miner_id = create_miner(
+//         &mut v,
+//         owner,
+//         worker,
+//         seal_proof.registered_window_post_proof().unwrap(),
+//         TokenAmount::from_whole(1_000),
+//     )
+//     .0;
+
+//     change_beneficiary(
+//         &v,
+//         owner,
+//         miner_id,
+//         &ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(100), 100),
+//     );
+//     change_beneficiary(
+//         &v,
+//         beneficiary,
+//         miner_id,
+//         &ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(100), 100),
+//     );
+//     assert_eq!(beneficiary, get_beneficiary(&v, worker, miner_id).active.beneficiary);
+
+//     change_owner_address(&v, owner, miner_id, new_owner);
+//     change_owner_address(&v, new_owner, miner_id, new_owner);
+//     let miner_info = v.get_miner_info(miner_id);
+//     assert!(miner_info.pending_owner_address.is_none());
+//     assert_eq!(new_owner, miner_info.owner);
+//     assert_eq!(beneficiary, miner_info.beneficiary);
+
+//     v.assert_state_invariants();
+// }
+
+// #[test]
+// fn change_owner_fail() {
+//     let store = MemoryBlockstore::new();
+//     let mut v = TestVM::new_with_singletons(&store);
+//     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
+//     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
+//     let (owner, worker, new_owner, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);
+
+//     // create miner
+//     let miner_id = create_miner(
+//         &mut v,
+//         owner,
+//         worker,
+//         seal_proof.registered_window_post_proof().unwrap(),
+//         TokenAmount::from_whole(1_000),
+//     )
+//     .0;
+
+//     // only owner can proposal
+//     apply_code(
+//         &v,
+//         addr,
+//         miner_id,
+//         TokenAmount::zero(),
+//         MinerMethod::ChangeOwnerAddress as u64,
+//         Some(new_owner),
+//         ExitCode::USR_FORBIDDEN,
+//     );
+
+//     change_owner_address(&v, owner, miner_id, new_owner);
+//     // proposal must be the same
+//     apply_code(
+//         &v,
+//         new_owner,
+//         miner_id,
+//         TokenAmount::zero(),
+//         MinerMethod::ChangeOwnerAddress as u64,
+//         Some(addr),
+//         ExitCode::USR_ILLEGAL_ARGUMENT,
+//     );
+//     // only pending can confirm
+//     apply_code(
+//         &v,
+//         addr,
+//         miner_id,
+//         TokenAmount::zero(),
+//         MinerMethod::ChangeOwnerAddress as u64,
+//         Some(new_owner),
+//         ExitCode::USR_FORBIDDEN,
+//     );
+//     //only miner can change proposal
+//     apply_code(
+//         &v,
+//         addr,
+//         miner_id,
+//         TokenAmount::zero(),
+//         MinerMethod::ChangeOwnerAddress as u64,
+//         Some(addr),
+//         ExitCode::USR_FORBIDDEN,
+//     );
+
+//     //miner change proposal
+//     change_owner_address(&v, owner, miner_id, addr);
+//     //confirm owner proposal
+//     change_owner_address(&v, addr, miner_id, addr);
+//     let miner_info = v.get_miner_info(miner_id);
+//     assert!(miner_info.pending_owner_address.is_none());
+//     assert_eq!(addr, miner_info.owner);
+//     assert_eq!(addr, miner_info.beneficiary);
+
+//     v.assert_state_invariants();
+// }

--- a/test_vm/tests/change_owner_test.rs
+++ b/test_vm/tests/change_owner_test.rs
@@ -8,12 +8,12 @@ use test_vm::util::{
     apply_code, change_beneficiary, change_owner_address, create_accounts, create_miner,
     get_beneficiary,
 };
-use test_vm::VM;
+use test_vm::TestVM;
 
 #[test]
 fn change_owner_success() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -50,7 +50,7 @@ fn change_owner_success() {
 #[test]
 fn keep_beneficiary_when_owner_changed() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -92,7 +92,7 @@ fn keep_beneficiary_when_owner_changed() {
 #[test]
 fn change_owner_fail() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/change_owner_test.rs
+++ b/test_vm/tests/change_owner_test.rs
@@ -1,6 +1,5 @@
-use actors_v10;
-use fil_actor_miner::{ChangeBeneficiaryParams, Method as MinerMethod};
-use fil_actors_runtime::runtime::Policy;
+
+use fil_actor_miner::ChangeBeneficiaryParams;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::crypto::signature::SignatureType;
 use fvm_shared::econ::TokenAmount;
@@ -13,11 +12,7 @@ use fvm_workbench_builtin_actors::genesis::{create_genesis_actors, GenesisSpec};
 use fvm_workbench_vm::builder::FvmBenchBuilder;
 use fvm_workbench_vm::externs::FakeExterns;
 use test_vm::bench::Benchmarker;
-use test_vm::util::{
-    apply_code, change_beneficiary, change_beneficiary_, change_owner_address,
-    change_owner_address_, create_accounts, create_accounts_, create_miner, create_miner_,
-    get_beneficiary,
-};
+use test_vm::util::{change_beneficiary_, change_owner_address_, create_accounts_, create_miner_};
 use test_vm::TestVM;
 
 enum ConcreteVM<'vm, 'bs> {
@@ -87,6 +82,7 @@ fn change_owner_test(concrete_vm: ConcreteVM) {
 }
 
 // TODO: this would be gated by #[cfg(feature = "benchmark")] to prevent it running/compiling normally
+// #[cfg(feature = "benchmark")]
 #[test]
 fn benchmark_change_owner_success() {
     println!("Running benchmark test");
@@ -96,7 +92,7 @@ fn benchmark_change_owner_success() {
         FakeExterns::new(),
         NetworkVersion::V18,
         StateTreeVersion::V5,
-        &actors_v10::BUNDLE_CAR,
+        actors_v10::BUNDLE_CAR,
     )
     .unwrap();
     let spec = GenesisSpec::default(manifest_data_cid);

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -28,7 +28,7 @@ use test_vm::util::{
     create_accounts, create_miner, invariant_failure_patterns, precommit_sectors,
     submit_windowed_post,
 };
-use test_vm::{ExpectInvocation, TEST_VM_RAND_ARRAY, VM};
+use test_vm::{ExpectInvocation, TestVM, TEST_VM_RAND_ARRAY};
 
 struct SectorInfo {
     number: SectorNumber,
@@ -44,8 +44,8 @@ struct MinerInfo {
     _miner_robust: Address,
 }
 
-fn setup(store: &'_ MemoryBlockstore) -> (VM<'_>, MinerInfo, SectorInfo) {
-    let mut v = VM::new_with_singletons(store);
+fn setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, MinerInfo, SectorInfo) {
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -308,7 +308,7 @@ fn missed_first_post_deadline() {
 fn overdue_precommit() {
     let store = MemoryBlockstore::new();
     let policy = &Policy::default();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -422,7 +422,7 @@ fn overdue_precommit() {
 #[test]
 fn aggregate_bad_sector_number() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -503,7 +503,7 @@ fn aggregate_bad_sector_number() {
 fn aggregate_size_limits() {
     let oversized_batch = 820;
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -636,7 +636,7 @@ fn aggregate_size_limits() {
 #[test]
 fn aggregate_bad_sender() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 2, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -712,7 +712,7 @@ fn aggregate_bad_sender() {
 #[test]
 fn aggregate_one_precommit_expires() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);

--- a/test_vm/tests/datacap_tests.rs
+++ b/test_vm/tests/datacap_tests.rs
@@ -12,7 +12,7 @@ use fil_actors_runtime::test_utils::make_piece_cid;
 use fil_actors_runtime::{DATACAP_TOKEN_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR};
 use fvm_shared::error::ExitCode;
 use test_vm::util::{apply_code, apply_ok, create_accounts, create_miner};
-use test_vm::VM;
+use test_vm::TestVM;
 
 use fil_actor_datacap::{Method as DataCapMethod, MintParams};
 use frc46_token::token::types::{GetAllowanceParams, TransferFromParams};
@@ -23,7 +23,7 @@ use fvm_ipld_encoding::RawBytes;
 fn datacap_transfer_scenario() {
     let policy = Policy::default();
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let (client, operator, owner) = (addrs[0], addrs[1], addrs[2]);
 
@@ -203,7 +203,7 @@ fn datacap_transfer_scenario() {
 #[test]
 fn call_name_symbol() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let sender = addrs[0];
 

--- a/test_vm/tests/evm_test.rs
+++ b/test_vm/tests/evm_test.rs
@@ -16,7 +16,7 @@ use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use test_vm::{
     util::{apply_ok, create_accounts},
-    TEST_FAUCET_ADDR, VM,
+    TestVM, TEST_FAUCET_ADDR,
 };
 
 // Generate a statically typed interface for the contracts.
@@ -38,7 +38,7 @@ struct ContractParams(#[serde(with = "strict_bytes")] pub Vec<u8>);
 #[test]
 fn test_evm_call() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
 
@@ -90,7 +90,7 @@ fn test_evm_call() {
 #[test]
 fn test_evm_create() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
 
@@ -233,7 +233,7 @@ fn test_evm_create() {
 #[test]
 fn test_evm_eth_create_external() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     // create the EthAccount
     let eth_bits = hex_literal::hex!("FEEDFACECAFEBEEF000000000000000000000000");
@@ -289,7 +289,7 @@ fn test_evm_eth_create_external() {
 #[test]
 fn test_evm_empty_initcode() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
     let create_result = v
@@ -321,7 +321,7 @@ fn test_evm_staticcall() {
     // A -> staticcall -> B -> call -> C (write) FAIL
 
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let accounts = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
@@ -475,7 +475,7 @@ fn test_evm_delegatecall() {
     // A -> staticcall -> B -> delegatecall -> C (write) FAIL
 
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let accounts = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
@@ -613,7 +613,7 @@ fn test_evm_staticcall_delegatecall() {
     // A -> staticcall -> B -> delegatecall -> C (write) FAIL
 
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let accounts = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
@@ -710,7 +710,7 @@ fn test_evm_staticcall_delegatecall() {
 #[test]
 fn test_evm_init_revert_data() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
     let create_result = v

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -22,7 +22,7 @@ use test_vm::util::{
     miner_precommit_sector, miner_prove_sector, submit_windowed_post, verifreg_add_client,
     verifreg_add_verifier,
 };
-use test_vm::{ExpectInvocation, VM};
+use test_vm::{ExpectInvocation, TestVM};
 
 #[test]
 fn extend_legacy_sector_with_deals() {
@@ -36,7 +36,7 @@ fn extend2_legacy_sector_with_deals() {
 
 #[allow(clippy::too_many_arguments)]
 fn extend(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     maddr: Address,
     deadline_index: u64,
@@ -107,7 +107,7 @@ fn extend(
 
 fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/init_test.rs
+++ b/test_vm/tests/init_test.rs
@@ -9,9 +9,9 @@ use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, METHOD_SEND};
 use num_traits::Zero;
-use test_vm::{actor, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
+use test_vm::{actor, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
 
-fn assert_placeholder_actor(exp_bal: TokenAmount, v: &VM, addr: Address) {
+fn assert_placeholder_actor(exp_bal: TokenAmount, v: &TestVM, addr: Address) {
     let act = v.get_actor(addr).unwrap();
     assert_eq!(EMPTY_ARR_CID, act.head);
     assert_eq!(*PLACEHOLDER_ACTOR_CODE_ID, act.code);
@@ -21,7 +21,7 @@ fn assert_placeholder_actor(exp_bal: TokenAmount, v: &VM, addr: Address) {
 #[test]
 fn placeholder_deploy() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     // Create a "fake" eam.
     v.set_actor(

--- a/test_vm/tests/market_miner_withdrawal_test.rs
+++ b/test_vm/tests/market_miner_withdrawal_test.rs
@@ -15,7 +15,7 @@ use fvm_shared::sector::RegisteredPoStProof;
 use fvm_shared::METHOD_SEND;
 use test_vm::util::{apply_code, apply_ok, create_accounts, create_miner};
 use test_vm::Actor;
-use test_vm::VM;
+use test_vm::TestVM;
 
 #[cfg(test)]
 mod market_tests {
@@ -143,7 +143,7 @@ mod miner_tests {
 // 2. Send a withdraw message attempting to remove `requested` funds
 // 3. Assert correct return value and actor balance transfer
 fn assert_add_collateral_and_withdraw(
-    v: &VM,
+    v: &TestVM,
     collateral: TokenAmount,
     expected_withdrawn: TokenAmount,
     requested: TokenAmount,
@@ -219,20 +219,20 @@ fn assert_add_collateral_and_withdraw(
     assert_eq!(caller_initial_balance, c.balance);
 }
 
-fn require_actor(v: &VM, addr: Address) -> Actor {
+fn require_actor(v: &TestVM, addr: Address) -> Actor {
     v.get_actor(addr).unwrap()
 }
 
-fn market_setup(store: &'_ MemoryBlockstore) -> (VM<'_>, Address) {
-    let v = VM::new_with_singletons(store);
+fn market_setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, Address) {
+    let v = TestVM::new_with_singletons(store);
     let initial_balance = TokenAmount::from_whole(6);
     let addrs = create_accounts(&v, 1, initial_balance);
     let caller = addrs[0];
     (v, caller)
 }
 
-fn miner_setup(store: &'_ MemoryBlockstore) -> (VM<'_>, Address, Address, Address) {
-    let mut v = VM::new_with_singletons(store);
+fn miner_setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, Address, Address, Address) {
+    let mut v = TestVM::new_with_singletons(store);
     let initial_balance = TokenAmount::from_whole(10_000);
     let addrs = create_accounts(&v, 2, initial_balance);
     let (worker, owner) = (addrs[0], addrs[1]);

--- a/test_vm/tests/multisig_test.rs
+++ b/test_vm/tests/multisig_test.rs
@@ -17,12 +17,12 @@ use integer_encoding::VarInt;
 use std::collections::HashSet;
 use std::iter::FromIterator;
 use test_vm::util::{apply_code, apply_ok, create_accounts};
-use test_vm::{ExpectInvocation, VM};
+use test_vm::{ExpectInvocation, TestVM};
 
 #[test]
 fn test_proposal_hash() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let alice = addrs[0];
     let bob = addrs[1];
@@ -102,7 +102,7 @@ fn test_proposal_hash() {
 fn test_delete_self() {
     let test = |threshold: usize, signers: u64, remove_idx: usize| {
         let store = MemoryBlockstore::new();
-        let v = VM::new_with_singletons(&store);
+        let v = TestVM::new_with_singletons(&store);
         let addrs = create_accounts(&v, signers, TokenAmount::from_whole(10_000));
 
         let msig_addr = create_msig(&v, addrs.clone(), threshold as u64);
@@ -174,7 +174,7 @@ fn test_delete_self() {
 #[test]
 fn swap_self_1_of_2() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
     let (alice, bob, chuck) = (addrs[0], addrs[1], addrs[2]);
@@ -203,7 +203,7 @@ fn swap_self_1_of_2() {
 #[test]
 fn swap_self_2_of_3() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let (alice, bob, chuck, dinesh) = (addrs[0], addrs[1], addrs[2], addrs[3]);
 
@@ -273,7 +273,7 @@ fn swap_self_2_of_3() {
     v.assert_state_invariants();
 }
 
-fn create_msig(v: &VM, signers: Vec<Address>, threshold: u64) -> Address {
+fn create_msig(v: &TestVM, signers: Vec<Address>, threshold: u64) -> Address {
     assert!(!signers.is_empty());
     let msig_ctor_params = serialize(
         &fil_actor_multisig::ConstructorParams {
@@ -301,7 +301,7 @@ fn create_msig(v: &VM, signers: Vec<Address>, threshold: u64) -> Address {
     msig_ctor_ret.id_address
 }
 
-fn check_txs(v: &VM, msig_addr: Address, mut expect_txns: Vec<(TxnID, Transaction)>) {
+fn check_txs(v: &TestVM, msig_addr: Address, mut expect_txns: Vec<(TxnID, Transaction)>) {
     let st = v.get_state::<MsigState>(msig_addr).unwrap();
     let ptx = make_map_with_root::<_, Transaction>(&st.pending_txs, v.store).unwrap();
     let mut actual_txns = Vec::new();

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -23,12 +23,12 @@ use num_traits::Zero;
 use test_vm::util::{
     apply_ok, create_accounts, create_miner, invariant_failure_patterns, miner_dline_info,
 };
-use test_vm::{ExpectInvocation, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
+use test_vm::{ExpectInvocation, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
 
 #[test]
 fn create_miner_test() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let owner = Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();
     v.apply_message(
@@ -99,7 +99,7 @@ fn create_miner_test() {
 #[test]
 fn test_cron_tick() {
     let store = MemoryBlockstore::new();
-    let mut vm = VM::new_with_singletons(&store);
+    let mut vm = TestVM::new_with_singletons(&store);
 
     let addrs = create_accounts(&vm, 1, TokenAmount::from_whole(10_000));
 

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -31,7 +31,7 @@ use fvm_shared::sector::{RegisteredSealProof, StoragePower};
 use test_vm::util::{
     apply_ok, bf_all, create_accounts, create_accounts_seeded, create_miner, verifreg_add_verifier,
 };
-use test_vm::{ExpectInvocation, VM};
+use test_vm::{ExpectInvocation, TestVM};
 
 struct Addrs {
     worker: Address,
@@ -53,8 +53,8 @@ fn token_defaults() -> (TokenAmount, TokenAmount, TokenAmount) {
 }
 
 // create miner and client and add collateral
-fn setup(store: &'_ MemoryBlockstore) -> (VM<'_>, Addrs, ChainEpoch) {
-    let mut v = VM::new_with_singletons(store);
+fn setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, Addrs, ChainEpoch) {
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 7, TokenAmount::from_whole(10_000));
     let (worker, client1, client2, not_miner, cheap_client, verifier, verified_client) =
         (addrs[0], addrs[1], addrs[2], addrs[3], addrs[4], addrs[5], addrs[6]);
@@ -607,7 +607,7 @@ struct DealOptions {
 
 struct DealBatcher<'bs> {
     deals: Vec<DealProposal>,
-    v: &'bs VM<'bs>,
+    v: &'bs TestVM<'bs>,
     default_provider: Address,
     default_piece_size: PaddedPieceSize,
     default_verified: bool,
@@ -620,7 +620,7 @@ struct DealBatcher<'bs> {
 
 impl<'bs> DealBatcher<'bs> {
     fn new(
-        v: &'bs VM<'bs>,
+        v: &'bs TestVM<'bs>,
         default_provider: Address,
         default_piece_size: PaddedPieceSize,
         default_verified: bool,

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -41,7 +41,7 @@ use test_vm::util::{
     market_publish_deal, miner_power, precommit_sectors, prove_commit_sectors, sector_info,
     submit_invalid_post, submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
 };
-use test_vm::VM;
+use test_vm::TestVM;
 // ---- Success cases ----
 
 // Tests that an active CC sector can be correctly upgraded, and the expected state changes occur
@@ -174,7 +174,7 @@ fn upgrade_and_miss_post(v2: bool) {
 fn prove_replica_update_multi_dline() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(1_000_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -313,7 +313,7 @@ fn prove_replica_update_multi_dline() {
 #[test]
 fn immutable_deadline_failure() {
     let store = &MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -364,7 +364,7 @@ fn immutable_deadline_failure() {
 fn unhealthy_sector_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -419,7 +419,7 @@ fn unhealthy_sector_failure() {
 #[test]
 fn terminated_sector_failure() {
     let store = &MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -485,7 +485,7 @@ fn terminated_sector_failure() {
 fn bad_batch_size_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -587,7 +587,7 @@ fn upgrade_bad_post_dispute() {
 fn bad_post_upgrade_dispute() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -750,7 +750,7 @@ fn extend_after_upgrade() {
 fn wrong_deadline_index_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -807,7 +807,7 @@ fn wrong_deadline_index_failure() {
 fn wrong_partition_index_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -864,7 +864,7 @@ fn wrong_partition_index_failure() {
 fn deal_included_in_multiple_sectors_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -992,7 +992,7 @@ fn deal_included_in_multiple_sectors_failure() {
 #[test]
 fn replica_update_verified_deal() {
     let store = &MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(100_000));
     let (worker, owner, client, verifier) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1116,7 +1116,7 @@ fn replica_update_verified_deal() {
 #[test]
 fn replica_update_verified_deal_max_term_violated() {
     let store = &MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(100_000));
     let (worker, owner, client, verifier) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1178,8 +1178,8 @@ fn replica_update_verified_deal_max_term_violated() {
 fn create_miner_and_upgrade_sector(
     store: &MemoryBlockstore,
     v2: bool,
-) -> (VM, SectorOnChainInfo, Address, Address, u64, u64, SectorSize) {
-    let mut v = VM::new_with_singletons(store);
+) -> (TestVM, SectorOnChainInfo, Address, Address, u64, u64, SectorSize) {
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1261,12 +1261,12 @@ fn create_miner_and_upgrade_sector(
 // - fastforwarding out of the proving period into a new deadline
 // This method assumes that this is a miners first and only sector
 fn create_sector(
-    mut v: VM,
+    mut v: TestVM,
     worker: Address,
     maddr: Address,
     sector_number: SectorNumber,
     seal_proof: RegisteredSealProof,
-) -> (VM, u64, u64) {
+) -> (TestVM, u64, u64) {
     // precommit
     let exp = v.get_epoch() + Policy::default().max_sector_expiration_extension;
     let precommits =
@@ -1329,7 +1329,7 @@ fn create_sector(
 }
 fn create_deals(
     num_deals: u32,
-    v: &VM,
+    v: &TestVM,
     client: Address,
     worker: Address,
     maddr: Address,
@@ -1339,7 +1339,7 @@ fn create_deals(
 
 fn create_verified_deals(
     num_deals: u32,
-    v: &VM,
+    v: &TestVM,
     client: Address,
     worker: Address,
     maddr: Address,
@@ -1351,7 +1351,7 @@ fn create_verified_deals(
 #[allow(clippy::too_many_arguments)]
 fn create_deals_frac(
     num_deals: u32,
-    v: &VM,
+    v: &TestVM,
     client: Address,
     worker: Address,
     maddr: Address,

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -31,12 +31,12 @@ use test_vm::util::{
     invariant_failure_patterns, make_bitfield, market_publish_deal, submit_windowed_post,
     verifreg_add_verifier,
 };
-use test_vm::{ExpectInvocation, VM};
+use test_vm::{ExpectInvocation, TestVM};
 
 #[test]
 fn terminate_sectors() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let (owner, verifier, unverified_client, verified_client) =
         (addrs[0], addrs[1], addrs[2], addrs[3]);

--- a/test_vm/tests/test_vm_test.rs
+++ b/test_vm/tests/test_vm_test.rs
@@ -10,12 +10,12 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::METHOD_SEND;
 use num_traits::Zero;
 use test_vm::util::pk_addrs_from;
-use test_vm::{actor, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
+use test_vm::{actor, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
 
 #[test]
 fn state_control() {
     let store = MemoryBlockstore::new();
-    let v = VM::new(&store);
+    let v = TestVM::new(&store);
     let addr1 = Address::new_id(1000);
     let addr2 = Address::new_id(2222);
 
@@ -57,7 +57,7 @@ fn assert_account_actor(
     exp_call_seq: u64,
     exp_bal: TokenAmount,
     exp_pk_addr: Address,
-    v: &VM,
+    v: &TestVM,
     addr: Address,
 ) {
     let act = v.get_actor(addr).unwrap();
@@ -71,7 +71,7 @@ fn assert_account_actor(
 #[test]
 fn test_sent() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     // send to uninitialized account actor
     let addr1 = Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();

--- a/test_vm/tests/verified_claim_test.rs
+++ b/test_vm/tests/verified_claim_test.rs
@@ -35,7 +35,7 @@ use test_vm::util::{
     verifreg_add_client, verifreg_add_verifier, verifreg_extend_claim_terms,
     verifreg_remove_expired_allocations,
 };
-use test_vm::VM;
+use test_vm::TestVM;
 
 // Tests a scenario involving a verified deal from the built-in market, with associated
 // allocation and claim.
@@ -43,7 +43,7 @@ use test_vm::VM;
 #[test]
 fn verified_claim_scenario() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client, verified_client2) =
@@ -339,7 +339,7 @@ fn verified_claim_scenario() {
 #[test]
 fn expired_allocations() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -28,12 +28,12 @@ use fil_actors_runtime::{
 };
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use test_vm::util::{apply_code, apply_ok, create_accounts, verifreg_add_verifier};
-use test_vm::{ExpectInvocation, TEST_VERIFREG_ROOT_ADDR, VM};
+use test_vm::{ExpectInvocation, TestVM, TEST_VERIFREG_ROOT_ADDR};
 
 #[test]
 fn remove_datacap_simple_successful_path() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let (verifier1, verifier2, verified_client) = (addrs[0], addrs[1], addrs[2]);
 
@@ -283,7 +283,7 @@ fn remove_datacap_simple_successful_path() {
 #[test]
 fn remove_datacap_fails_on_verifreg() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 2, TokenAmount::from_whole(10_000));
     let (verifier1, verifier2) = (addrs[0], addrs[1]);
 

--- a/test_vm/tests/withdraw_balance_test.rs
+++ b/test_vm/tests/withdraw_balance_test.rs
@@ -7,12 +7,12 @@ use fvm_shared::sector::RegisteredSealProof;
 use test_vm::util::{
     apply_code, change_beneficiary, create_accounts, create_miner, withdraw_balance,
 };
-use test_vm::VM;
+use test_vm::TestVM;
 
 #[test]
 fn withdraw_balance_success() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 2, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary) = (addrs[0], addrs[0], addrs[1]);
@@ -54,7 +54,7 @@ fn withdraw_balance_success() {
 #[test]
 fn withdraw_balance_fail() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);


### PR DESCRIPTION
Still WIP https://github.com/filecoin-project/builtin-actors/issues/1236

This allows integration tests to be injected with either the existing TestVM (rust execution, stack traces etc.) or the BenchmarkVM (wasm execution,  gas accounting, fvm traces). 

There's still a tonne of duplicate code and the `fvm_workbench_builtin_actors` package should probably move into this repo but putting this up for 👀  to get opinions on if this is optically ok from the POV of writing the tests.

