### PR TITLE
rename test_vm::VM to test_vm::TestVM

### DIFF
--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -74,7 +74,7 @@ use std::ops::Add;
 
 pub mod util;
 
-pub struct VM<'bs> {
+pub struct TestVM<'bs> {
     pub store: &'bs MemoryBlockstore,
     pub state_root: RefCell<Cid>,
     total_fil: TokenAmount,
@@ -121,10 +121,10 @@ pub const TEST_FAUCET_ADDR: Address = Address::new_id(FIRST_NON_SINGLETON_ADDR +
 pub const FIRST_TEST_USER_ADDR: ActorID = FIRST_NON_SINGLETON_ADDR + 3;
 
 // accounts for verifreg root signer and msig
-impl<'bs> VM<'bs> {
-    pub fn new(store: &'bs MemoryBlockstore) -> VM<'bs> {
+impl<'bs> TestVM<'bs> {
+    pub fn new(store: &'bs MemoryBlockstore) -> TestVM<'bs> {
         let mut actors = Hamt::<&'bs MemoryBlockstore, Actor, BytesKey, Sha256>::new(store);
-        VM {
+        TestVM {
             store,
             state_root: RefCell::new(actors.flush().unwrap()),
             total_fil: TokenAmount::zero(),
@@ -140,11 +140,11 @@ impl<'bs> VM<'bs> {
         Self { total_fil, ..self }
     }
 
-    pub fn new_with_singletons(store: &'bs MemoryBlockstore) -> VM<'bs> {
+    pub fn new_with_singletons(store: &'bs MemoryBlockstore) -> TestVM<'bs> {
         let reward_total = TokenAmount::from_whole(1_100_000_000i64);
         let faucet_total = TokenAmount::from_whole(1_000_000_000i64);
 
-        let v = VM::new(store).with_total_fil(&reward_total + &faucet_total);
+        let v = TestVM::new(store).with_total_fil(&reward_total + &faucet_total);
 
         // system
         let sys_st = SystemState::new(store).unwrap();
@@ -283,9 +283,9 @@ impl<'bs> VM<'bs> {
         v
     }
 
-    pub fn with_epoch(self, epoch: ChainEpoch) -> VM<'bs> {
+    pub fn with_epoch(self, epoch: ChainEpoch) -> TestVM<'bs> {
         self.checkpoint();
-        VM {
+        TestVM {
             store: self.store,
             state_root: self.state_root.clone(),
             total_fil: self.total_fil,
@@ -599,7 +599,7 @@ pub const TEST_VM_RAND_ARRAY: [u8; 32] = [
 pub const TEST_VM_INVALID_POST: &str = "i_am_invalid_post";
 
 pub struct InvocationCtx<'invocation, 'bs> {
-    v: &'invocation VM<'bs>,
+    v: &'invocation TestVM<'bs>,
     top: TopCtx,
     msg: InternalMessage,
     allow_side_effects: RefCell<bool>,
@@ -1123,7 +1123,7 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
     }
 }
 
-impl Primitives for VM<'_> {
+impl Primitives for TestVM<'_> {
     // A "valid" signature has its bytes equal to the plaintext.
     // Anything else is considered invalid.
     fn verify_signature(

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -73,11 +73,11 @@ fn new_bls_from_rng(rng: &mut ChaCha8Rng) -> Address {
 
 const ACCOUNT_SEED: u64 = 93837778;
 
-pub fn create_accounts(v: &VM, count: u64, balance: TokenAmount) -> Vec<Address> {
+pub fn create_accounts(v: &TestVM, count: u64, balance: TokenAmount) -> Vec<Address> {
     create_accounts_seeded(v, count, balance, ACCOUNT_SEED)
 }
 
-pub fn create_accounts_seeded(v: &VM, count: u64, balance: TokenAmount, seed: u64) -> Vec<Address> {
+pub fn create_accounts_seeded(v: &TestVM, count: u64, balance: TokenAmount, seed: u64) -> Vec<Address> {
     let pk_addrs = pk_addrs_from(seed, count);
     // Send funds from faucet to pk address, creating account actor
     for pk_addr in pk_addrs.clone() {
@@ -88,7 +88,7 @@ pub fn create_accounts_seeded(v: &VM, count: u64, balance: TokenAmount, seed: u6
 }
 
 pub fn apply_ok<S: Serialize>(
-    v: &VM,
+    v: &TestVM,
     from: Address,
     to: Address,
     value: TokenAmount,
@@ -99,7 +99,7 @@ pub fn apply_ok<S: Serialize>(
 }
 
 pub fn apply_code<S: Serialize>(
-    v: &VM,
+    v: &TestVM,
     from: Address,
     to: Address,
     value: TokenAmount,
@@ -112,7 +112,7 @@ pub fn apply_code<S: Serialize>(
     res.ret.map_or(RawBytes::default(), |b| RawBytes::new(b.data))
 }
 
-pub fn cron_tick(v: &VM) {
+pub fn cron_tick(v: &TestVM) {
     apply_ok(
         v,
         SYSTEM_ACTOR_ADDR,
@@ -124,7 +124,7 @@ pub fn cron_tick(v: &VM) {
 }
 
 pub fn create_miner(
-    v: &mut VM,
+    v: &mut TestVM,
     owner: Address,
     worker: Address,
     post_proof_type: RegisteredPoStProof,
@@ -157,7 +157,7 @@ pub fn create_miner(
 }
 
 pub fn miner_precommit_sector(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     miner_id: Address,
     seal_proof: RegisteredSealProof,
@@ -193,7 +193,7 @@ pub fn miner_precommit_sector(
     state.get_precommitted_sector(v.store, sector_number).unwrap().unwrap()
 }
 
-pub fn miner_prove_sector(v: &VM, worker: Address, miner_id: Address, sector_number: SectorNumber) {
+pub fn miner_prove_sector(v: &TestVM, worker: Address, miner_id: Address, sector_number: SectorNumber) {
     let prove_commit_params = ProveCommitSectorParams { sector_number, proof: vec![] };
     apply_ok(
         v,
@@ -220,7 +220,7 @@ pub fn miner_prove_sector(v: &VM, worker: Address, miner_id: Address, sector_num
 
 #[allow(clippy::too_many_arguments)]
 pub fn precommit_sectors_v2(
-    v: &mut VM,
+    v: &mut TestVM,
     count: u64,
     batch_size: i64,
     worker: Address,
@@ -381,7 +381,7 @@ pub fn precommit_sectors_v2(
 
 #[allow(clippy::too_many_arguments)]
 pub fn precommit_sectors(
-    v: &mut VM,
+    v: &mut TestVM,
     count: u64,
     batch_size: i64,
     worker: Address,
@@ -406,7 +406,7 @@ pub fn precommit_sectors(
 }
 
 pub fn prove_commit_sectors(
-    v: &mut VM,
+    v: &mut TestVM,
     worker: Address,
     maddr: Address,
     precommits: Vec<SectorPreCommitOnChainInfo>,
@@ -470,7 +470,7 @@ pub fn prove_commit_sectors(
 
 #[allow(clippy::too_many_arguments)]
 pub fn miner_extend_sector_expiration2(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     miner_id: Address,
     deadline: u64,
@@ -546,24 +546,24 @@ pub fn miner_extend_sector_expiration2(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn advance_by_deadline_to_epoch(v: VM, maddr: Address, e: ChainEpoch) -> (VM, DeadlineInfo) {
+pub fn advance_by_deadline_to_epoch(v: TestVM, maddr: Address, e: ChainEpoch) -> (TestVM, DeadlineInfo) {
     // keep advancing until the epoch of interest is within the deadline
     // if e is dline.last() == dline.close -1 cron is not run
     let (v, dline_info) = advance_by_deadline(v, maddr, |dline_info| dline_info.close < e);
     (v.with_epoch(e), dline_info)
 }
 
-pub fn advance_by_deadline_to_index(v: VM, maddr: Address, i: u64) -> (VM, DeadlineInfo) {
+pub fn advance_by_deadline_to_index(v: TestVM, maddr: Address, i: u64) -> (TestVM, DeadlineInfo) {
     advance_by_deadline(v, maddr, |dline_info| dline_info.index != i)
 }
 
 pub fn advance_by_deadline_to_epoch_while_proving(
-    mut v: VM,
+    mut v: TestVM,
     maddr: Address,
     worker: Address,
     s: SectorNumber,
     e: ChainEpoch,
-) -> VM {
+) -> TestVM {
     let mut dline_info;
     let (d, p_idx) = sector_deadline(&v, maddr, s);
     loop {
@@ -586,17 +586,17 @@ pub fn advance_by_deadline_to_epoch_while_proving(
 }
 
 pub fn advance_to_proving_deadline(
-    v: VM,
+    v: TestVM,
     maddr: Address,
     s: SectorNumber,
-) -> (DeadlineInfo, u64, VM) {
+) -> (DeadlineInfo, u64, TestVM) {
     let (d, p) = sector_deadline(&v, maddr, s);
     let (v, dline_info) = advance_by_deadline_to_index(v, maddr, d);
     let v = v.with_epoch(dline_info.open);
     (dline_info, p, v)
 }
 
-fn advance_by_deadline<F>(mut v: VM, maddr: Address, more: F) -> (VM, DeadlineInfo)
+fn advance_by_deadline<F>(mut v: TestVM, maddr: Address, more: F) -> (TestVM, DeadlineInfo)
 where
     F: Fn(DeadlineInfo) -> bool,
 {
@@ -613,7 +613,7 @@ where
     }
 }
 
-pub fn miner_dline_info(v: &VM, m: Address) -> DeadlineInfo {
+pub fn miner_dline_info(v: &TestVM, m: Address) -> DeadlineInfo {
     let st = v.get_state::<MinerState>(m).unwrap();
     new_deadline_info_from_offset_and_epoch(
         &Policy::default(),
@@ -622,18 +622,18 @@ pub fn miner_dline_info(v: &VM, m: Address) -> DeadlineInfo {
     )
 }
 
-pub fn sector_deadline(v: &VM, m: Address, s: SectorNumber) -> (u64, u64) {
+pub fn sector_deadline(v: &TestVM, m: Address, s: SectorNumber) -> (u64, u64) {
     let st = v.get_state::<MinerState>(m).unwrap();
     st.find_sector(&Policy::default(), v.store, s).unwrap()
 }
 
-pub fn check_sector_active(v: &VM, m: Address, s: SectorNumber) -> bool {
+pub fn check_sector_active(v: &TestVM, m: Address, s: SectorNumber) -> bool {
     let (d_idx, p_idx) = sector_deadline(v, m, s);
     let st = v.get_state::<MinerState>(m).unwrap();
     st.check_sector_active(&Policy::default(), v.store, d_idx, p_idx, s, true).unwrap()
 }
 
-pub fn check_sector_faulty(v: &VM, m: Address, d_idx: u64, p_idx: u64, s: SectorNumber) -> bool {
+pub fn check_sector_faulty(v: &TestVM, m: Address, d_idx: u64, p_idx: u64, s: SectorNumber) -> bool {
     let st = v.get_state::<MinerState>(m).unwrap();
     let deadlines = st.load_deadlines(v.store).unwrap();
     let deadline = deadlines.load_deadline(&Policy::default(), v.store, d_idx).unwrap();
@@ -641,25 +641,25 @@ pub fn check_sector_faulty(v: &VM, m: Address, d_idx: u64, p_idx: u64, s: Sector
     partition.faults.get(s)
 }
 
-pub fn deadline_state(v: &VM, m: Address, d_idx: u64) -> Deadline {
+pub fn deadline_state(v: &TestVM, m: Address, d_idx: u64) -> Deadline {
     let st = v.get_state::<MinerState>(m).unwrap();
     let deadlines = st.load_deadlines(v.store).unwrap();
     deadlines.load_deadline(&Policy::default(), v.store, d_idx).unwrap()
 }
 
-pub fn sector_info(v: &VM, m: Address, s: SectorNumber) -> SectorOnChainInfo {
+pub fn sector_info(v: &TestVM, m: Address, s: SectorNumber) -> SectorOnChainInfo {
     let st = v.get_state::<MinerState>(m).unwrap();
     st.get_sector(v.store, s).unwrap().unwrap()
 }
 
-pub fn miner_power(v: &VM, m: Address) -> PowerPair {
+pub fn miner_power(v: &TestVM, m: Address) -> PowerPair {
     let st = v.get_state::<PowerState>(STORAGE_POWER_ACTOR_ADDR).unwrap();
     let claim = st.get_claim(v.store, &m).unwrap().unwrap();
     PowerPair::new(claim.raw_byte_power, claim.quality_adj_power)
 }
 
 pub fn declare_recovery(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     maddr: Address,
     deadline: u64,
@@ -685,7 +685,7 @@ pub fn declare_recovery(
 }
 
 pub fn submit_windowed_post(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     maddr: Address,
     dline_info: DeadlineInfo,
@@ -739,7 +739,7 @@ pub fn submit_windowed_post(
 }
 
 pub fn change_beneficiary(
-    v: &VM,
+    v: &TestVM,
     from: Address,
     maddr: Address,
     beneficiary_change_proposal: &ChangeBeneficiaryParams,
@@ -754,7 +754,7 @@ pub fn change_beneficiary(
     );
 }
 
-pub fn get_beneficiary(v: &VM, from: Address, m_addr: Address) -> GetBeneficiaryReturn {
+pub fn get_beneficiary(v: &TestVM, from: Address, m_addr: Address) -> GetBeneficiaryReturn {
     apply_ok(
         v,
         from,
@@ -767,7 +767,7 @@ pub fn get_beneficiary(v: &VM, from: Address, m_addr: Address) -> GetBeneficiary
     .unwrap()
 }
 
-pub fn change_owner_address(v: &VM, from: Address, m_addr: Address, new_miner_addr: Address) {
+pub fn change_owner_address(v: &TestVM, from: Address, m_addr: Address, new_miner_addr: Address) {
     apply_ok(
         v,
         from,
@@ -779,7 +779,7 @@ pub fn change_owner_address(v: &VM, from: Address, m_addr: Address, new_miner_ad
 }
 
 pub fn withdraw_balance(
-    v: &VM,
+    v: &TestVM,
     from: Address,
     m_addr: Address,
     to_withdraw_amount: TokenAmount,
@@ -818,7 +818,7 @@ pub fn withdraw_balance(
 }
 
 pub fn submit_invalid_post(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     maddr: Address,
     dline_info: DeadlineInfo,
@@ -844,7 +844,7 @@ pub fn submit_invalid_post(
     );
 }
 
-pub fn verifreg_add_verifier(v: &VM, verifier: Address, data_cap: StoragePower) {
+pub fn verifreg_add_verifier(v: &TestVM, verifier: Address, data_cap: StoragePower) {
     let add_verifier_params = VerifierParams { address: verifier, allowance: data_cap };
     // root address is msig, send proposal from root key
     let proposal = ProposeParams {
@@ -883,7 +883,7 @@ pub fn verifreg_add_verifier(v: &VM, verifier: Address, data_cap: StoragePower) 
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn verifreg_add_client(v: &VM, verifier: Address, client: Address, allowance: StoragePower) {
+pub fn verifreg_add_client(v: &TestVM, verifier: Address, client: Address, allowance: StoragePower) {
     let add_client_params =
         AddVerifiedClientParams { address: client, allowance: allowance.clone() };
     apply_ok(
@@ -918,7 +918,7 @@ pub fn verifreg_add_client(v: &VM, verifier: Address, client: Address, allowance
 }
 
 pub fn verifreg_extend_claim_terms(
-    v: &VM,
+    v: &TestVM,
     client: Address,
     provider: Address,
     claim: ClaimID,
@@ -942,7 +942,7 @@ pub fn verifreg_extend_claim_terms(
 }
 
 pub fn verifreg_remove_expired_allocations(
-    v: &VM,
+    v: &TestVM,
     caller: Address,
     client: Address,
     ids: Vec<AllocationID>,
@@ -980,7 +980,7 @@ pub fn verifreg_remove_expired_allocations(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn datacap_get_balance(v: &VM, address: Address) -> TokenAmount {
+pub fn datacap_get_balance(v: &TestVM, address: Address) -> TokenAmount {
     let ret = apply_ok(
         v,
         address,
@@ -993,7 +993,7 @@ pub fn datacap_get_balance(v: &VM, address: Address) -> TokenAmount {
 }
 
 pub fn datacap_extend_claim(
-    v: &VM,
+    v: &TestVM,
     client: Address,
     provider: Address,
     claim: ClaimID,
@@ -1066,7 +1066,7 @@ pub fn datacap_extend_claim(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn market_add_balance(v: &VM, sender: Address, beneficiary: Address, amount: TokenAmount) {
+pub fn market_add_balance(v: &TestVM, sender: Address, beneficiary: Address, amount: TokenAmount) {
     apply_ok(
         v,
         sender,
@@ -1079,7 +1079,7 @@ pub fn market_add_balance(v: &VM, sender: Address, beneficiary: Address, amount:
 
 #[allow(clippy::too_many_arguments)]
 pub fn market_publish_deal(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     deal_client: Address,
     miner_id: Address,

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -77,7 +77,12 @@ pub fn create_accounts(v: &TestVM, count: u64, balance: TokenAmount) -> Vec<Addr
     create_accounts_seeded(v, count, balance, ACCOUNT_SEED)
 }
 
-pub fn create_accounts_seeded(v: &TestVM, count: u64, balance: TokenAmount, seed: u64) -> Vec<Address> {
+pub fn create_accounts_seeded(
+    v: &TestVM,
+    count: u64,
+    balance: TokenAmount,
+    seed: u64,
+) -> Vec<Address> {
     let pk_addrs = pk_addrs_from(seed, count);
     // Send funds from faucet to pk address, creating account actor
     for pk_addr in pk_addrs.clone() {
@@ -193,7 +198,12 @@ pub fn miner_precommit_sector(
     state.get_precommitted_sector(v.store, sector_number).unwrap().unwrap()
 }
 
-pub fn miner_prove_sector(v: &TestVM, worker: Address, miner_id: Address, sector_number: SectorNumber) {
+pub fn miner_prove_sector(
+    v: &TestVM,
+    worker: Address,
+    miner_id: Address,
+    sector_number: SectorNumber,
+) {
     let prove_commit_params = ProveCommitSectorParams { sector_number, proof: vec![] };
     apply_ok(
         v,
@@ -546,7 +556,11 @@ pub fn miner_extend_sector_expiration2(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn advance_by_deadline_to_epoch(v: TestVM, maddr: Address, e: ChainEpoch) -> (TestVM, DeadlineInfo) {
+pub fn advance_by_deadline_to_epoch(
+    v: TestVM,
+    maddr: Address,
+    e: ChainEpoch,
+) -> (TestVM, DeadlineInfo) {
     // keep advancing until the epoch of interest is within the deadline
     // if e is dline.last() == dline.close -1 cron is not run
     let (v, dline_info) = advance_by_deadline(v, maddr, |dline_info| dline_info.close < e);
@@ -633,7 +647,13 @@ pub fn check_sector_active(v: &TestVM, m: Address, s: SectorNumber) -> bool {
     st.check_sector_active(&Policy::default(), v.store, d_idx, p_idx, s, true).unwrap()
 }
 
-pub fn check_sector_faulty(v: &TestVM, m: Address, d_idx: u64, p_idx: u64, s: SectorNumber) -> bool {
+pub fn check_sector_faulty(
+    v: &TestVM,
+    m: Address,
+    d_idx: u64,
+    p_idx: u64,
+    s: SectorNumber,
+) -> bool {
     let st = v.get_state::<MinerState>(m).unwrap();
     let deadlines = st.load_deadlines(v.store).unwrap();
     let deadline = deadlines.load_deadline(&Policy::default(), v.store, d_idx).unwrap();
@@ -883,7 +903,12 @@ pub fn verifreg_add_verifier(v: &TestVM, verifier: Address, data_cap: StoragePow
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn verifreg_add_client(v: &TestVM, verifier: Address, client: Address, allowance: StoragePower) {
+pub fn verifreg_add_client(
+    v: &TestVM,
+    verifier: Address,
+    client: Address,
+    allowance: StoragePower,
+) {
     let add_client_params =
         AddVerifiedClientParams { address: client, allowance: allowance.clone() };
     apply_ok(

--- a/test_vm/tests/authenticate_message_test.rs
+++ b/test_vm/tests/authenticate_message_test.rs
@@ -7,7 +7,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 
 use test_vm::util::{apply_code, apply_ok, create_accounts, generate_deal_proposal};
-use test_vm::VM;
+use test_vm::TestVM;
 
 // Using a deal proposal as a serialized message, we confirm that:
 // - calls to Account::authenticate_message with valid signatures succeed
@@ -15,7 +15,7 @@ use test_vm::VM;
 #[test]
 fn account_authenticate_message() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addr = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
 
     let proposal =

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -17,7 +17,7 @@ use test_vm::util::{
     advance_to_proving_deadline, apply_ok, create_accounts, create_miner,
     invariant_failure_patterns, precommit_sectors_v2, prove_commit_sectors, submit_windowed_post,
 };
-use test_vm::VM;
+use test_vm::TestVM;
 
 struct Onboarding {
     epoch_delay: i64,                 // epochs to advance since the prior action
@@ -49,7 +49,7 @@ impl Onboarding {
 #[test_case(true; "v2")]
 fn batch_onboarding(v2: bool) {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);

--- a/test_vm/tests/change_beneficiary_test.rs
+++ b/test_vm/tests/change_beneficiary_test.rs
@@ -10,12 +10,12 @@ use test_vm::util::{
     apply_code, change_beneficiary, create_accounts, create_miner, get_beneficiary,
     withdraw_balance,
 };
-use test_vm::VM;
+use test_vm::TestVM;
 
 #[test]
 fn change_beneficiary_success() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, another_beneficiary, query_addr) =
@@ -73,7 +73,7 @@ fn change_beneficiary_success() {
 #[test]
 fn change_beneficiary_back_owner_success() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, query_addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -126,7 +126,7 @@ fn change_beneficiary_back_owner_success() {
 #[test]
 fn change_beneficiary_fail() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/change_owner_test.rs
+++ b/test_vm/tests/change_owner_test.rs
@@ -8,12 +8,12 @@ use test_vm::util::{
     apply_code, change_beneficiary, change_owner_address, create_accounts, create_miner,
     get_beneficiary,
 };
-use test_vm::VM;
+use test_vm::TestVM;
 
 #[test]
 fn change_owner_success() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -50,7 +50,7 @@ fn change_owner_success() {
 #[test]
 fn keep_beneficiary_when_owner_changed() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -92,7 +92,7 @@ fn keep_beneficiary_when_owner_changed() {
 #[test]
 fn change_owner_fail() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -28,7 +28,7 @@ use test_vm::util::{
     create_accounts, create_miner, invariant_failure_patterns, precommit_sectors,
     submit_windowed_post,
 };
-use test_vm::{ExpectInvocation, TEST_VM_RAND_ARRAY, VM};
+use test_vm::{ExpectInvocation, TEST_VM_RAND_ARRAY, TestVM};
 
 struct SectorInfo {
     number: SectorNumber,
@@ -44,8 +44,8 @@ struct MinerInfo {
     _miner_robust: Address,
 }
 
-fn setup(store: &'_ MemoryBlockstore) -> (VM<'_>, MinerInfo, SectorInfo) {
-    let mut v = VM::new_with_singletons(store);
+fn setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, MinerInfo, SectorInfo) {
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -308,7 +308,7 @@ fn missed_first_post_deadline() {
 fn overdue_precommit() {
     let store = MemoryBlockstore::new();
     let policy = &Policy::default();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -422,7 +422,7 @@ fn overdue_precommit() {
 #[test]
 fn aggregate_bad_sector_number() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -503,7 +503,7 @@ fn aggregate_bad_sector_number() {
 fn aggregate_size_limits() {
     let oversized_batch = 820;
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -636,7 +636,7 @@ fn aggregate_size_limits() {
 #[test]
 fn aggregate_bad_sender() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 2, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -712,7 +712,7 @@ fn aggregate_bad_sender() {
 #[test]
 fn aggregate_one_precommit_expires() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -28,7 +28,7 @@ use test_vm::util::{
     create_accounts, create_miner, invariant_failure_patterns, precommit_sectors,
     submit_windowed_post,
 };
-use test_vm::{ExpectInvocation, TEST_VM_RAND_ARRAY, TestVM};
+use test_vm::{ExpectInvocation, TestVM, TEST_VM_RAND_ARRAY};
 
 struct SectorInfo {
     number: SectorNumber,

--- a/test_vm/tests/datacap_tests.rs
+++ b/test_vm/tests/datacap_tests.rs
@@ -12,7 +12,7 @@ use fil_actors_runtime::test_utils::make_piece_cid;
 use fil_actors_runtime::{DATACAP_TOKEN_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR};
 use fvm_shared::error::ExitCode;
 use test_vm::util::{apply_code, apply_ok, create_accounts, create_miner};
-use test_vm::VM;
+use test_vm::TestVM;
 
 use fil_actor_datacap::{Method as DataCapMethod, MintParams};
 use frc46_token::token::types::{GetAllowanceParams, TransferFromParams};
@@ -23,7 +23,7 @@ use fvm_ipld_encoding::RawBytes;
 fn datacap_transfer_scenario() {
     let policy = Policy::default();
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let (client, operator, owner) = (addrs[0], addrs[1], addrs[2]);
 
@@ -203,7 +203,7 @@ fn datacap_transfer_scenario() {
 #[test]
 fn call_name_symbol() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let sender = addrs[0];
 

--- a/test_vm/tests/evm_test.rs
+++ b/test_vm/tests/evm_test.rs
@@ -16,7 +16,7 @@ use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use test_vm::{
     util::{apply_ok, create_accounts},
-    TEST_FAUCET_ADDR, VM,
+    TEST_FAUCET_ADDR, TestVM,
 };
 
 // Generate a statically typed interface for the contracts.
@@ -38,7 +38,7 @@ struct ContractParams(#[serde(with = "strict_bytes")] pub Vec<u8>);
 #[test]
 fn test_evm_call() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
 
@@ -90,7 +90,7 @@ fn test_evm_call() {
 #[test]
 fn test_evm_create() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
 
@@ -233,7 +233,7 @@ fn test_evm_create() {
 #[test]
 fn test_evm_eth_create_external() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     // create the EthAccount
     let eth_bits = hex_literal::hex!("FEEDFACECAFEBEEF000000000000000000000000");
@@ -289,7 +289,7 @@ fn test_evm_eth_create_external() {
 #[test]
 fn test_evm_empty_initcode() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
     let create_result = v
@@ -321,7 +321,7 @@ fn test_evm_staticcall() {
     // A -> staticcall -> B -> call -> C (write) FAIL
 
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let accounts = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
@@ -475,7 +475,7 @@ fn test_evm_delegatecall() {
     // A -> staticcall -> B -> delegatecall -> C (write) FAIL
 
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let accounts = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
@@ -613,7 +613,7 @@ fn test_evm_staticcall_delegatecall() {
     // A -> staticcall -> B -> delegatecall -> C (write) FAIL
 
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let accounts = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
@@ -710,7 +710,7 @@ fn test_evm_staticcall_delegatecall() {
 #[test]
 fn test_evm_init_revert_data() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
     let create_result = v

--- a/test_vm/tests/evm_test.rs
+++ b/test_vm/tests/evm_test.rs
@@ -16,7 +16,7 @@ use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use test_vm::{
     util::{apply_ok, create_accounts},
-    TEST_FAUCET_ADDR, TestVM,
+    TestVM, TEST_FAUCET_ADDR,
 };
 
 // Generate a statically typed interface for the contracts.

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -22,7 +22,7 @@ use test_vm::util::{
     miner_precommit_sector, miner_prove_sector, submit_windowed_post, verifreg_add_client,
     verifreg_add_verifier,
 };
-use test_vm::{ExpectInvocation, VM};
+use test_vm::{ExpectInvocation, TestVM};
 
 #[test]
 fn extend_legacy_sector_with_deals() {
@@ -36,7 +36,7 @@ fn extend2_legacy_sector_with_deals() {
 
 #[allow(clippy::too_many_arguments)]
 fn extend(
-    v: &VM,
+    v: &TestVM,
     worker: Address,
     maddr: Address,
     deadline_index: u64,
@@ -107,7 +107,7 @@ fn extend(
 
 fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/init_test.rs
+++ b/test_vm/tests/init_test.rs
@@ -9,7 +9,7 @@ use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, METHOD_SEND};
 use num_traits::Zero;
-use test_vm::{actor, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, TestVM};
+use test_vm::{actor, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
 
 fn assert_placeholder_actor(exp_bal: TokenAmount, v: &TestVM, addr: Address) {
     let act = v.get_actor(addr).unwrap();

--- a/test_vm/tests/init_test.rs
+++ b/test_vm/tests/init_test.rs
@@ -9,9 +9,9 @@ use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, METHOD_SEND};
 use num_traits::Zero;
-use test_vm::{actor, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
+use test_vm::{actor, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, TestVM};
 
-fn assert_placeholder_actor(exp_bal: TokenAmount, v: &VM, addr: Address) {
+fn assert_placeholder_actor(exp_bal: TokenAmount, v: &TestVM, addr: Address) {
     let act = v.get_actor(addr).unwrap();
     assert_eq!(EMPTY_ARR_CID, act.head);
     assert_eq!(*PLACEHOLDER_ACTOR_CODE_ID, act.code);
@@ -21,7 +21,7 @@ fn assert_placeholder_actor(exp_bal: TokenAmount, v: &VM, addr: Address) {
 #[test]
 fn placeholder_deploy() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     // Create a "fake" eam.
     v.set_actor(

--- a/test_vm/tests/market_miner_withdrawal_test.rs
+++ b/test_vm/tests/market_miner_withdrawal_test.rs
@@ -15,7 +15,7 @@ use fvm_shared::sector::RegisteredPoStProof;
 use fvm_shared::METHOD_SEND;
 use test_vm::util::{apply_code, apply_ok, create_accounts, create_miner};
 use test_vm::Actor;
-use test_vm::VM;
+use test_vm::TestVM;
 
 #[cfg(test)]
 mod market_tests {
@@ -143,7 +143,7 @@ mod miner_tests {
 // 2. Send a withdraw message attempting to remove `requested` funds
 // 3. Assert correct return value and actor balance transfer
 fn assert_add_collateral_and_withdraw(
-    v: &VM,
+    v: &TestVM,
     collateral: TokenAmount,
     expected_withdrawn: TokenAmount,
     requested: TokenAmount,
@@ -219,20 +219,20 @@ fn assert_add_collateral_and_withdraw(
     assert_eq!(caller_initial_balance, c.balance);
 }
 
-fn require_actor(v: &VM, addr: Address) -> Actor {
+fn require_actor(v: &TestVM, addr: Address) -> Actor {
     v.get_actor(addr).unwrap()
 }
 
-fn market_setup(store: &'_ MemoryBlockstore) -> (VM<'_>, Address) {
-    let v = VM::new_with_singletons(store);
+fn market_setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, Address) {
+    let v = TestVM::new_with_singletons(store);
     let initial_balance = TokenAmount::from_whole(6);
     let addrs = create_accounts(&v, 1, initial_balance);
     let caller = addrs[0];
     (v, caller)
 }
 
-fn miner_setup(store: &'_ MemoryBlockstore) -> (VM<'_>, Address, Address, Address) {
-    let mut v = VM::new_with_singletons(store);
+fn miner_setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, Address, Address, Address) {
+    let mut v = TestVM::new_with_singletons(store);
     let initial_balance = TokenAmount::from_whole(10_000);
     let addrs = create_accounts(&v, 2, initial_balance);
     let (worker, owner) = (addrs[0], addrs[1]);

--- a/test_vm/tests/multisig_test.rs
+++ b/test_vm/tests/multisig_test.rs
@@ -17,12 +17,12 @@ use integer_encoding::VarInt;
 use std::collections::HashSet;
 use std::iter::FromIterator;
 use test_vm::util::{apply_code, apply_ok, create_accounts};
-use test_vm::{ExpectInvocation, VM};
+use test_vm::{ExpectInvocation, TestVM};
 
 #[test]
 fn test_proposal_hash() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let alice = addrs[0];
     let bob = addrs[1];
@@ -102,7 +102,7 @@ fn test_proposal_hash() {
 fn test_delete_self() {
     let test = |threshold: usize, signers: u64, remove_idx: usize| {
         let store = MemoryBlockstore::new();
-        let v = VM::new_with_singletons(&store);
+        let v = TestVM::new_with_singletons(&store);
         let addrs = create_accounts(&v, signers, TokenAmount::from_whole(10_000));
 
         let msig_addr = create_msig(&v, addrs.clone(), threshold as u64);
@@ -174,7 +174,7 @@ fn test_delete_self() {
 #[test]
 fn swap_self_1_of_2() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
     let (alice, bob, chuck) = (addrs[0], addrs[1], addrs[2]);
@@ -203,7 +203,7 @@ fn swap_self_1_of_2() {
 #[test]
 fn swap_self_2_of_3() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let (alice, bob, chuck, dinesh) = (addrs[0], addrs[1], addrs[2], addrs[3]);
 
@@ -273,7 +273,7 @@ fn swap_self_2_of_3() {
     v.assert_state_invariants();
 }
 
-fn create_msig(v: &VM, signers: Vec<Address>, threshold: u64) -> Address {
+fn create_msig(v: &TestVM, signers: Vec<Address>, threshold: u64) -> Address {
     assert!(!signers.is_empty());
     let msig_ctor_params = serialize(
         &fil_actor_multisig::ConstructorParams {
@@ -301,7 +301,7 @@ fn create_msig(v: &VM, signers: Vec<Address>, threshold: u64) -> Address {
     msig_ctor_ret.id_address
 }
 
-fn check_txs(v: &VM, msig_addr: Address, mut expect_txns: Vec<(TxnID, Transaction)>) {
+fn check_txs(v: &TestVM, msig_addr: Address, mut expect_txns: Vec<(TxnID, Transaction)>) {
     let st = v.get_state::<MsigState>(msig_addr).unwrap();
     let ptx = make_map_with_root::<_, Transaction>(&st.pending_txs, v.store).unwrap();
     let mut actual_txns = Vec::new();

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -23,12 +23,12 @@ use num_traits::Zero;
 use test_vm::util::{
     apply_ok, create_accounts, create_miner, invariant_failure_patterns, miner_dline_info,
 };
-use test_vm::{ExpectInvocation, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
+use test_vm::{ExpectInvocation, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, TestVM};
 
 #[test]
 fn create_miner_test() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let owner = Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();
     v.apply_message(
@@ -99,7 +99,7 @@ fn create_miner_test() {
 #[test]
 fn test_cron_tick() {
     let store = MemoryBlockstore::new();
-    let mut vm = VM::new_with_singletons(&store);
+    let mut vm = TestVM::new_with_singletons(&store);
 
     let addrs = create_accounts(&vm, 1, TokenAmount::from_whole(10_000));
 

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -23,7 +23,7 @@ use num_traits::Zero;
 use test_vm::util::{
     apply_ok, create_accounts, create_miner, invariant_failure_patterns, miner_dline_info,
 };
-use test_vm::{ExpectInvocation, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, TestVM};
+use test_vm::{ExpectInvocation, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
 
 #[test]
 fn create_miner_test() {

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -31,7 +31,7 @@ use fvm_shared::sector::{RegisteredSealProof, StoragePower};
 use test_vm::util::{
     apply_ok, bf_all, create_accounts, create_accounts_seeded, create_miner, verifreg_add_verifier,
 };
-use test_vm::{ExpectInvocation, VM};
+use test_vm::{ExpectInvocation, TestVM};
 
 struct Addrs {
     worker: Address,
@@ -53,8 +53,8 @@ fn token_defaults() -> (TokenAmount, TokenAmount, TokenAmount) {
 }
 
 // create miner and client and add collateral
-fn setup(store: &'_ MemoryBlockstore) -> (VM<'_>, Addrs, ChainEpoch) {
-    let mut v = VM::new_with_singletons(store);
+fn setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, Addrs, ChainEpoch) {
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 7, TokenAmount::from_whole(10_000));
     let (worker, client1, client2, not_miner, cheap_client, verifier, verified_client) =
         (addrs[0], addrs[1], addrs[2], addrs[3], addrs[4], addrs[5], addrs[6]);
@@ -607,7 +607,7 @@ struct DealOptions {
 
 struct DealBatcher<'bs> {
     deals: Vec<DealProposal>,
-    v: &'bs VM<'bs>,
+    v: &'bs TestVM<'bs>,
     default_provider: Address,
     default_piece_size: PaddedPieceSize,
     default_verified: bool,
@@ -620,7 +620,7 @@ struct DealBatcher<'bs> {
 
 impl<'bs> DealBatcher<'bs> {
     fn new(
-        v: &'bs VM<'bs>,
+        v: &'bs TestVM<'bs>,
         default_provider: Address,
         default_piece_size: PaddedPieceSize,
         default_verified: bool,

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -41,7 +41,7 @@ use test_vm::util::{
     market_publish_deal, miner_power, precommit_sectors, prove_commit_sectors, sector_info,
     submit_invalid_post, submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
 };
-use test_vm::VM;
+use test_vm::TestVM;
 // ---- Success cases ----
 
 // Tests that an active CC sector can be correctly upgraded, and the expected state changes occur
@@ -174,7 +174,7 @@ fn upgrade_and_miss_post(v2: bool) {
 fn prove_replica_update_multi_dline() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(1_000_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -313,7 +313,7 @@ fn prove_replica_update_multi_dline() {
 #[test]
 fn immutable_deadline_failure() {
     let store = &MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -364,7 +364,7 @@ fn immutable_deadline_failure() {
 fn unhealthy_sector_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -419,7 +419,7 @@ fn unhealthy_sector_failure() {
 #[test]
 fn terminated_sector_failure() {
     let store = &MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -485,7 +485,7 @@ fn terminated_sector_failure() {
 fn bad_batch_size_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -587,7 +587,7 @@ fn upgrade_bad_post_dispute() {
 fn bad_post_upgrade_dispute() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -750,7 +750,7 @@ fn extend_after_upgrade() {
 fn wrong_deadline_index_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -807,7 +807,7 @@ fn wrong_deadline_index_failure() {
 fn wrong_partition_index_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -864,7 +864,7 @@ fn wrong_partition_index_failure() {
 fn deal_included_in_multiple_sectors_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -992,7 +992,7 @@ fn deal_included_in_multiple_sectors_failure() {
 #[test]
 fn replica_update_verified_deal() {
     let store = &MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(100_000));
     let (worker, owner, client, verifier) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1116,7 +1116,7 @@ fn replica_update_verified_deal() {
 #[test]
 fn replica_update_verified_deal_max_term_violated() {
     let store = &MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(100_000));
     let (worker, owner, client, verifier) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1178,8 +1178,8 @@ fn replica_update_verified_deal_max_term_violated() {
 fn create_miner_and_upgrade_sector(
     store: &MemoryBlockstore,
     v2: bool,
-) -> (VM, SectorOnChainInfo, Address, Address, u64, u64, SectorSize) {
-    let mut v = VM::new_with_singletons(store);
+) -> (TestVM, SectorOnChainInfo, Address, Address, u64, u64, SectorSize) {
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1261,12 +1261,12 @@ fn create_miner_and_upgrade_sector(
 // - fastforwarding out of the proving period into a new deadline
 // This method assumes that this is a miners first and only sector
 fn create_sector(
-    mut v: VM,
+    mut v: TestVM,
     worker: Address,
     maddr: Address,
     sector_number: SectorNumber,
     seal_proof: RegisteredSealProof,
-) -> (VM, u64, u64) {
+) -> (TestVM, u64, u64) {
     // precommit
     let exp = v.get_epoch() + Policy::default().max_sector_expiration_extension;
     let precommits =
@@ -1329,7 +1329,7 @@ fn create_sector(
 }
 fn create_deals(
     num_deals: u32,
-    v: &VM,
+    v: &TestVM,
     client: Address,
     worker: Address,
     maddr: Address,
@@ -1339,7 +1339,7 @@ fn create_deals(
 
 fn create_verified_deals(
     num_deals: u32,
-    v: &VM,
+    v: &TestVM,
     client: Address,
     worker: Address,
     maddr: Address,
@@ -1351,7 +1351,7 @@ fn create_verified_deals(
 #[allow(clippy::too_many_arguments)]
 fn create_deals_frac(
     num_deals: u32,
-    v: &VM,
+    v: &TestVM,
     client: Address,
     worker: Address,
     maddr: Address,

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -31,12 +31,12 @@ use test_vm::util::{
     invariant_failure_patterns, make_bitfield, market_publish_deal, submit_windowed_post,
     verifreg_add_verifier,
 };
-use test_vm::{ExpectInvocation, VM};
+use test_vm::{ExpectInvocation, TestVM};
 
 #[test]
 fn terminate_sectors() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let (owner, verifier, unverified_client, verified_client) =
         (addrs[0], addrs[1], addrs[2], addrs[3]);

--- a/test_vm/tests/test_vm_test.rs
+++ b/test_vm/tests/test_vm_test.rs
@@ -10,7 +10,7 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::METHOD_SEND;
 use num_traits::Zero;
 use test_vm::util::pk_addrs_from;
-use test_vm::{actor, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, TestVM};
+use test_vm::{actor, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
 
 #[test]
 fn state_control() {

--- a/test_vm/tests/test_vm_test.rs
+++ b/test_vm/tests/test_vm_test.rs
@@ -10,12 +10,12 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::METHOD_SEND;
 use num_traits::Zero;
 use test_vm::util::pk_addrs_from;
-use test_vm::{actor, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
+use test_vm::{actor, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, TestVM};
 
 #[test]
 fn state_control() {
     let store = MemoryBlockstore::new();
-    let v = VM::new(&store);
+    let v = TestVM::new(&store);
     let addr1 = Address::new_id(1000);
     let addr2 = Address::new_id(2222);
 
@@ -57,7 +57,7 @@ fn assert_account_actor(
     exp_call_seq: u64,
     exp_bal: TokenAmount,
     exp_pk_addr: Address,
-    v: &VM,
+    v: &TestVM,
     addr: Address,
 ) {
     let act = v.get_actor(addr).unwrap();
@@ -71,7 +71,7 @@ fn assert_account_actor(
 #[test]
 fn test_sent() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     // send to uninitialized account actor
     let addr1 = Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();

--- a/test_vm/tests/verified_claim_test.rs
+++ b/test_vm/tests/verified_claim_test.rs
@@ -35,7 +35,7 @@ use test_vm::util::{
     verifreg_add_client, verifreg_add_verifier, verifreg_extend_claim_terms,
     verifreg_remove_expired_allocations,
 };
-use test_vm::VM;
+use test_vm::TestVM;
 
 // Tests a scenario involving a verified deal from the built-in market, with associated
 // allocation and claim.
@@ -43,7 +43,7 @@ use test_vm::VM;
 #[test]
 fn verified_claim_scenario() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client, verified_client2) =
@@ -339,7 +339,7 @@ fn verified_claim_scenario() {
 #[test]
 fn expired_allocations() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -28,12 +28,12 @@ use fil_actors_runtime::{
 };
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use test_vm::util::{apply_code, apply_ok, create_accounts, verifreg_add_verifier};
-use test_vm::{ExpectInvocation, TEST_VERIFREG_ROOT_ADDR, VM};
+use test_vm::{ExpectInvocation, TEST_VERIFREG_ROOT_ADDR, TestVM};
 
 #[test]
 fn remove_datacap_simple_successful_path() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let (verifier1, verifier2, verified_client) = (addrs[0], addrs[1], addrs[2]);
 
@@ -283,7 +283,7 @@ fn remove_datacap_simple_successful_path() {
 #[test]
 fn remove_datacap_fails_on_verifreg() {
     let store = MemoryBlockstore::new();
-    let v = VM::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 2, TokenAmount::from_whole(10_000));
     let (verifier1, verifier2) = (addrs[0], addrs[1]);
 

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -28,7 +28,7 @@ use fil_actors_runtime::{
 };
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use test_vm::util::{apply_code, apply_ok, create_accounts, verifreg_add_verifier};
-use test_vm::{ExpectInvocation, TEST_VERIFREG_ROOT_ADDR, TestVM};
+use test_vm::{ExpectInvocation, TestVM, TEST_VERIFREG_ROOT_ADDR};
 
 #[test]
 fn remove_datacap_simple_successful_path() {

--- a/test_vm/tests/withdraw_balance_test.rs
+++ b/test_vm/tests/withdraw_balance_test.rs
@@ -7,12 +7,12 @@ use fvm_shared::sector::RegisteredSealProof;
 use test_vm::util::{
     apply_code, change_beneficiary, create_accounts, create_miner, withdraw_balance,
 };
-use test_vm::VM;
+use test_vm::TestVM;
 
 #[test]
 fn withdraw_balance_success() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 2, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary) = (addrs[0], addrs[0], addrs[1]);
@@ -54,7 +54,7 @@ fn withdraw_balance_success() {
 #[test]
 fn withdraw_balance_fail() {
     let store = MemoryBlockstore::new();
-    let mut v = VM::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);


### PR DESCRIPTION
This rename frees up `VM` to be the name of the abstract trait that the tests will be injected with.

Step 0 for https://github.com/filecoin-project/builtin-actors/issues/1236
