### PR TITLE
replace concrete blockstore in TestVM with a generic trait

### DIFF
--- a/actors/market/src/testing.rs
+++ b/actors/market/src/testing.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     convert::TryFrom,
-    fmt::Debug,
 };
 
 use cid::Cid;
@@ -61,7 +60,7 @@ pub struct StateSummary {
 }
 
 /// Checks internal invariants of market state
-pub fn check_state_invariants<BS: Blockstore + Debug>(
+pub fn check_state_invariants<BS: Blockstore>(
     state: &State,
     store: &BS,
     balance: &TokenAmount,
@@ -229,7 +228,10 @@ pub fn check_state_invariants<BS: Blockstore + Debug>(
             let ret = pending_proposals.for_each(|key, _| {
                 let proposal_cid = Cid::try_from(key.0.to_owned())?;
 
-                acc.require(proposal_cids.contains(&proposal_cid), format!("pending proposal with cid {proposal_cid} not found within proposals {pending_proposals:?}"));
+                acc.require(
+                    proposal_cids.contains(&proposal_cid),
+                    format!("pending proposal with cid {proposal_cid} not found within proposals"),
+                );
 
                 pending_proposal_count += 1;
                 Ok(())

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -1355,7 +1355,7 @@ fn fail_when_deal_is_activated_but_proposal_is_not_found() {
         &rt,
         &[
             Regex::new("no deal proposal for deal state \\d+").unwrap(),
-            Regex::new("pending proposal with cid \\w+ not found within proposals .*").unwrap(),
+            Regex::new("pending proposal with cid \\w+ not found within proposals").unwrap(),
             Regex::new("deal op found for deal id \\d+ with missing proposal at epoch \\d+")
                 .unwrap(),
         ],

--- a/actors/miner/tests/sectors.rs
+++ b/actors/miner/tests/sectors.rs
@@ -17,7 +17,7 @@ fn make_sector(i: u64) -> SectorOnChainInfo {
     }
 }
 
-fn setup_sectors(store: &'_ MemoryBlockstore) -> Sectors<'_, MemoryBlockstore> {
+fn setup_sectors(store: &'_ MemoryBlockstore) -> Sectors<MemoryBlockstore> {
     sectors_arr_mbs(store, vec![make_sector(0), make_sector(1), make_sector(5)])
 }
 

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2967,7 +2967,7 @@ pub fn test_sector(
 pub fn sectors_arr_mbs(
     store: &'_ MemoryBlockstore,
     sectors_info: Vec<SectorOnChainInfo>,
-) -> Sectors<'_, MemoryBlockstore> {
+) -> Sectors<MemoryBlockstore> {
     let empty_array =
         Amt::<(), _>::new_with_bit_width(store, SECTORS_AMT_BITWIDTH).flush().unwrap();
     let mut sectors = Sectors::load(store, &empty_array).unwrap();
@@ -3294,7 +3294,7 @@ pub fn select_sectors(sectors: &[SectorOnChainInfo], field: &BitField) -> Vec<Se
 #[allow(dead_code)]
 pub fn require_no_expiration_groups_before(
     epoch: ChainEpoch,
-    queue: &mut ExpirationQueue<'_, MemoryBlockstore>,
+    queue: &mut ExpirationQueue<MemoryBlockstore>,
 ) {
     queue.amt.flush().unwrap();
 

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -113,7 +113,7 @@ macro_rules! get_state {
 // to match the Manifest implementation in the FVM.
 // It could be replaced with a custom mapping trait (while Rust doesn't support
 // abstract collection traits).
-pub fn check_state_invariants<'a, BS: Blockstore + Debug>(
+pub fn check_state_invariants<'a, BS: Blockstore>(
     manifest: &BiBTreeMap<Cid, Type>,
     policy: &Policy,
     tree: Tree<'a, BS>,

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -34,6 +34,7 @@ use fil_actors_runtime::{
 use fil_actors_runtime::{MessageAccumulator, DATACAP_TOKEN_ACTOR_ADDR};
 use fil_builtin_actors_state::check::check_state_invariants;
 use fil_builtin_actors_state::check::Tree;
+use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::tuple::*;
@@ -74,8 +75,11 @@ use std::ops::Add;
 
 pub mod util;
 
-pub struct TestVM<'bs> {
-    pub store: &'bs MemoryBlockstore,
+pub struct TestVM<'bs, BS>
+where
+    BS: Blockstore,
+{
+    pub store: &'bs BS,
     pub state_root: RefCell<Cid>,
     total_fil: TokenAmount,
     actors_dirty: RefCell<bool>,
@@ -121,8 +125,11 @@ pub const TEST_FAUCET_ADDR: Address = Address::new_id(FIRST_NON_SINGLETON_ADDR +
 pub const FIRST_TEST_USER_ADDR: ActorID = FIRST_NON_SINGLETON_ADDR + 3;
 
 // accounts for verifreg root signer and msig
-impl<'bs> TestVM<'bs> {
-    pub fn new(store: &'bs MemoryBlockstore) -> TestVM<'bs> {
+impl<'bs, BS> TestVM<'bs, BS>
+where
+    BS: Blockstore,
+{
+    pub fn new(store: &'bs MemoryBlockstore) -> TestVM<'bs, MemoryBlockstore> {
         let mut actors = Hamt::<&'bs MemoryBlockstore, Actor, BytesKey, Sha256>::new(store);
         TestVM {
             store,
@@ -140,11 +147,12 @@ impl<'bs> TestVM<'bs> {
         Self { total_fil, ..self }
     }
 
-    pub fn new_with_singletons(store: &'bs MemoryBlockstore) -> TestVM<'bs> {
+    pub fn new_with_singletons(store: &'bs MemoryBlockstore) -> TestVM<'bs, MemoryBlockstore> {
         let reward_total = TokenAmount::from_whole(1_100_000_000i64);
         let faucet_total = TokenAmount::from_whole(1_000_000_000i64);
 
-        let v = TestVM::new(store).with_total_fil(&reward_total + &faucet_total);
+        let v = TestVM::<'_, MemoryBlockstore>::new(store)
+            .with_total_fil(&reward_total + &faucet_total);
 
         // system
         let sys_st = SystemState::new(store).unwrap();
@@ -283,7 +291,7 @@ impl<'bs> TestVM<'bs> {
         v
     }
 
-    pub fn with_epoch(self, epoch: ChainEpoch) -> TestVM<'bs> {
+    pub fn with_epoch(self, epoch: ChainEpoch) -> TestVM<'bs, BS> {
         self.checkpoint();
         TestVM {
             store: self.store,
@@ -352,11 +360,9 @@ impl<'bs> TestVM<'bs> {
             return Some(act.clone());
         }
         // go to persisted map
-        let actors = Hamt::<&'bs MemoryBlockstore, Actor, BytesKey, Sha256>::load(
-            &self.state_root.borrow(),
-            self.store,
-        )
-        .unwrap();
+        let actors =
+            Hamt::<&'bs BS, Actor, BytesKey, Sha256>::load(&self.state_root.borrow(), self.store)
+                .unwrap();
         let actor = actors.get(&addr.to_bytes()).unwrap().cloned();
         actor.iter().for_each(|a| {
             self.actors_cache.borrow_mut().insert(addr, a.clone());
@@ -372,11 +378,9 @@ impl<'bs> TestVM<'bs> {
 
     pub fn checkpoint(&self) -> Cid {
         // persist cache on top of latest checkpoint and clear
-        let mut actors = Hamt::<&'bs MemoryBlockstore, Actor, BytesKey, Sha256>::load(
-            &self.state_root.borrow(),
-            self.store,
-        )
-        .unwrap();
+        let mut actors =
+            Hamt::<&'bs BS, Actor, BytesKey, Sha256>::load(&self.state_root.borrow(), self.store)
+                .unwrap();
         for (addr, act) in self.actors_cache.borrow().iter() {
             actors.set(addr.to_bytes().into(), act.clone()).unwrap();
         }
@@ -394,7 +398,7 @@ impl<'bs> TestVM<'bs> {
 
     pub fn normalize_address(&self, addr: &Address) -> Option<Address> {
         let st = self.get_state::<InitState>(INIT_ACTOR_ADDR).unwrap();
-        st.resolve_address::<MemoryBlockstore>(self.store, addr).unwrap()
+        st.resolve_address::<BS>(self.store, addr).unwrap()
     }
 
     pub fn get_state<T: DeserializeOwned>(&self, addr: Address) -> Option<T> {
@@ -497,11 +501,9 @@ impl<'bs> TestVM<'bs> {
     /// Checks the state invariants and returns broken invariants.
     pub fn check_state_invariants(&self) -> anyhow::Result<MessageAccumulator> {
         self.checkpoint();
-        let actors = Hamt::<&'bs MemoryBlockstore, Actor, BytesKey, Sha256>::load(
-            &self.state_root.borrow(),
-            self.store,
-        )
-        .unwrap();
+        let actors =
+            Hamt::<&'bs BS, Actor, BytesKey, Sha256>::load(&self.state_root.borrow(), self.store)
+                .unwrap();
 
         let mut manifest = BiBTreeMap::new();
         actors
@@ -571,7 +573,10 @@ impl InternalMessage {
     }
 }
 
-impl MessageInfo for InvocationCtx<'_, '_> {
+impl<BS> MessageInfo for InvocationCtx<'_, '_, BS>
+where
+    BS: Blockstore,
+{
     fn nonce(&self) -> u64 {
         self.top.originator_call_seq
     }
@@ -598,8 +603,11 @@ pub const TEST_VM_RAND_ARRAY: [u8; 32] = [
 ];
 pub const TEST_VM_INVALID_POST: &str = "i_am_invalid_post";
 
-pub struct InvocationCtx<'invocation, 'bs> {
-    v: &'invocation TestVM<'bs>,
+pub struct InvocationCtx<'invocation, 'bs, BS>
+where
+    BS: Blockstore,
+{
+    v: &'invocation TestVM<'bs, BS>,
     top: TopCtx,
     msg: InternalMessage,
     allow_side_effects: RefCell<bool>,
@@ -609,7 +617,10 @@ pub struct InvocationCtx<'invocation, 'bs> {
     subinvocations: RefCell<Vec<InvocationTrace>>,
 }
 
-impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
+impl<'invocation, 'bs, BS> InvocationCtx<'invocation, 'bs, BS>
+where
+    BS: Blockstore,
+{
     fn resolve_target(&'invocation self, target: &Address) -> Result<(Actor, Address), ActorError> {
         if let Some(a) = self.v.normalize_address(target) {
             if let Some(act) = self.v.get_actor(a) {
@@ -779,8 +790,11 @@ impl<'invocation, 'bs> InvocationCtx<'invocation, 'bs> {
     }
 }
 
-impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
-    type Blockstore = &'bs MemoryBlockstore;
+impl<'invocation, 'bs, BS> Runtime for InvocationCtx<'invocation, 'bs, BS>
+where
+    BS: Blockstore,
+{
+    type Blockstore = &'bs BS;
 
     fn create_actor(
         &self,
@@ -822,7 +836,7 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
         Ok(())
     }
 
-    fn store(&self) -> &&'bs MemoryBlockstore {
+    fn store(&self) -> &&'bs BS {
         &self.v.store
     }
 
@@ -1123,7 +1137,10 @@ impl<'invocation, 'bs> Runtime for InvocationCtx<'invocation, 'bs> {
     }
 }
 
-impl Primitives for TestVM<'_> {
+impl<BS> Primitives for TestVM<'_, BS>
+where
+    BS: Blockstore,
+{
     // A "valid" signature has its bytes equal to the plaintext.
     // Anything else is considered invalid.
     fn verify_signature(
@@ -1179,7 +1196,10 @@ impl Primitives for TestVM<'_> {
     }
 }
 
-impl Primitives for InvocationCtx<'_, '_> {
+impl<BS> Primitives for InvocationCtx<'_, '_, BS>
+where
+    BS: Blockstore,
+{
     fn verify_signature(
         &self,
         signature: &Signature,
@@ -1218,7 +1238,10 @@ impl Primitives for InvocationCtx<'_, '_> {
     }
 }
 
-impl Verifier for InvocationCtx<'_, '_> {
+impl<BS> Verifier for InvocationCtx<'_, '_, BS>
+where
+    BS: Blockstore,
+{
     fn verify_seal(&self, _vi: &SealVerifyInfo) -> Result<(), anyhow::Error> {
         Ok(())
     }
@@ -1258,7 +1281,10 @@ impl Verifier for InvocationCtx<'_, '_> {
     }
 }
 
-impl RuntimePolicy for InvocationCtx<'_, '_> {
+impl<BS> RuntimePolicy for InvocationCtx<'_, '_, BS>
+where
+    BS: Blockstore,
+{
     fn policy(&self) -> &Policy {
         self.policy
     }

--- a/test_vm/tests/authenticate_message_test.rs
+++ b/test_vm/tests/authenticate_message_test.rs
@@ -15,7 +15,7 @@ use test_vm::TestVM;
 #[test]
 fn account_authenticate_message() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addr = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
 
     let proposal =

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -49,7 +49,7 @@ impl Onboarding {
 #[test_case(true; "v2")]
 fn batch_onboarding(v2: bool) {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);

--- a/test_vm/tests/change_beneficiary_test.rs
+++ b/test_vm/tests/change_beneficiary_test.rs
@@ -15,7 +15,7 @@ use test_vm::TestVM;
 #[test]
 fn change_beneficiary_success() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, another_beneficiary, query_addr) =
@@ -73,7 +73,7 @@ fn change_beneficiary_success() {
 #[test]
 fn change_beneficiary_back_owner_success() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, query_addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -126,7 +126,7 @@ fn change_beneficiary_back_owner_success() {
 #[test]
 fn change_beneficiary_fail() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/change_owner_test.rs
+++ b/test_vm/tests/change_owner_test.rs
@@ -13,7 +13,7 @@ use test_vm::TestVM;
 #[test]
 fn change_owner_success() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -50,7 +50,7 @@ fn change_owner_success() {
 #[test]
 fn keep_beneficiary_when_owner_changed() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -92,7 +92,7 @@ fn keep_beneficiary_when_owner_changed() {
 #[test]
 fn change_owner_fail() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -44,8 +44,8 @@ struct MinerInfo {
     _miner_robust: Address,
 }
 
-fn setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, MinerInfo, SectorInfo) {
-    let mut v = TestVM::new_with_singletons(store);
+fn setup(store: &'_ MemoryBlockstore) -> (TestVM<MemoryBlockstore>, MinerInfo, SectorInfo) {
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -308,7 +308,7 @@ fn missed_first_post_deadline() {
 fn overdue_precommit() {
     let store = MemoryBlockstore::new();
     let policy = &Policy::default();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -422,7 +422,7 @@ fn overdue_precommit() {
 #[test]
 fn aggregate_bad_sector_number() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -503,7 +503,7 @@ fn aggregate_bad_sector_number() {
 fn aggregate_size_limits() {
     let oversized_batch = 820;
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -636,7 +636,7 @@ fn aggregate_size_limits() {
 #[test]
 fn aggregate_bad_sender() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 2, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -712,7 +712,7 @@ fn aggregate_bad_sender() {
 #[test]
 fn aggregate_one_precommit_expires() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);

--- a/test_vm/tests/datacap_tests.rs
+++ b/test_vm/tests/datacap_tests.rs
@@ -23,7 +23,7 @@ use fvm_ipld_encoding::RawBytes;
 fn datacap_transfer_scenario() {
     let policy = Policy::default();
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let (client, operator, owner) = (addrs[0], addrs[1], addrs[2]);
 
@@ -203,7 +203,7 @@ fn datacap_transfer_scenario() {
 #[test]
 fn call_name_symbol() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let sender = addrs[0];
 

--- a/test_vm/tests/evm_test.rs
+++ b/test_vm/tests/evm_test.rs
@@ -38,7 +38,7 @@ struct ContractParams(#[serde(with = "strict_bytes")] pub Vec<u8>);
 #[test]
 fn test_evm_call() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
 
@@ -90,7 +90,7 @@ fn test_evm_call() {
 #[test]
 fn test_evm_create() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
 
@@ -233,7 +233,7 @@ fn test_evm_create() {
 #[test]
 fn test_evm_eth_create_external() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     // create the EthAccount
     let eth_bits = hex_literal::hex!("FEEDFACECAFEBEEF000000000000000000000000");
@@ -289,7 +289,7 @@ fn test_evm_eth_create_external() {
 #[test]
 fn test_evm_empty_initcode() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
     let create_result = v
@@ -321,7 +321,7 @@ fn test_evm_staticcall() {
     // A -> staticcall -> B -> call -> C (write) FAIL
 
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     let accounts = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
@@ -475,7 +475,7 @@ fn test_evm_delegatecall() {
     // A -> staticcall -> B -> delegatecall -> C (write) FAIL
 
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     let accounts = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
@@ -613,7 +613,7 @@ fn test_evm_staticcall_delegatecall() {
     // A -> staticcall -> B -> delegatecall -> C (write) FAIL
 
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     let accounts = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
@@ -710,7 +710,7 @@ fn test_evm_staticcall_delegatecall() {
 #[test]
 fn test_evm_init_revert_data() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
     let create_result = v

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -7,7 +7,7 @@ use fil_actor_power::{Method as PowerMethod, UpdateClaimedPowerParams};
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{DealWeight, EPOCHS_IN_DAY, STORAGE_POWER_ACTOR_ADDR};
 use fvm_ipld_bitfield::BitField;
-use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
@@ -35,8 +35,8 @@ fn extend2_legacy_sector_with_deals() {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn extend(
-    v: &TestVM,
+fn extend<BS: Blockstore>(
+    v: &TestVM<BS>,
     worker: Address,
     maddr: Address,
     deadline_index: u64,
@@ -107,7 +107,7 @@ fn extend(
 
 fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/init_test.rs
+++ b/test_vm/tests/init_test.rs
@@ -5,13 +5,13 @@ use fil_actors_runtime::{
     test_utils::{EAM_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID, PLACEHOLDER_ACTOR_CODE_ID},
     EAM_ACTOR_ADDR, EAM_ACTOR_ID, INIT_ACTOR_ADDR,
 };
-use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, METHOD_SEND};
 use num_traits::Zero;
 use test_vm::{actor, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
 
-fn assert_placeholder_actor(exp_bal: TokenAmount, v: &TestVM, addr: Address) {
+fn assert_placeholder_actor<BS: Blockstore>(exp_bal: TokenAmount, v: &TestVM<BS>, addr: Address) {
     let act = v.get_actor(addr).unwrap();
     assert_eq!(EMPTY_ARR_CID, act.head);
     assert_eq!(*PLACEHOLDER_ACTOR_CODE_ID, act.code);
@@ -21,7 +21,7 @@ fn assert_placeholder_actor(exp_bal: TokenAmount, v: &TestVM, addr: Address) {
 #[test]
 fn placeholder_deploy() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     // Create a "fake" eam.
     v.set_actor(

--- a/test_vm/tests/market_miner_withdrawal_test.rs
+++ b/test_vm/tests/market_miner_withdrawal_test.rs
@@ -4,6 +4,7 @@ use fil_actor_miner::Method as MinerMethod;
 use fil_actor_miner::WithdrawBalanceParams as MinerWithdrawBalanceParams;
 use fil_actors_runtime::test_utils::{MARKET_ACTOR_CODE_ID, MINER_ACTOR_CODE_ID};
 use fil_actors_runtime::STORAGE_MARKET_ACTOR_ADDR;
+use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
@@ -142,8 +143,8 @@ mod miner_tests {
 // 1. Add collateral to escrow address
 // 2. Send a withdraw message attempting to remove `requested` funds
 // 3. Assert correct return value and actor balance transfer
-fn assert_add_collateral_and_withdraw(
-    v: &TestVM,
+fn assert_add_collateral_and_withdraw<BS: Blockstore>(
+    v: &TestVM<BS>,
     collateral: TokenAmount,
     expected_withdrawn: TokenAmount,
     requested: TokenAmount,
@@ -219,20 +220,22 @@ fn assert_add_collateral_and_withdraw(
     assert_eq!(caller_initial_balance, c.balance);
 }
 
-fn require_actor(v: &TestVM, addr: Address) -> Actor {
+fn require_actor<BS: Blockstore>(v: &TestVM<BS>, addr: Address) -> Actor {
     v.get_actor(addr).unwrap()
 }
 
-fn market_setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, Address) {
-    let v = TestVM::new_with_singletons(store);
+fn market_setup(store: &'_ MemoryBlockstore) -> (TestVM<MemoryBlockstore>, Address) {
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let initial_balance = TokenAmount::from_whole(6);
     let addrs = create_accounts(&v, 1, initial_balance);
     let caller = addrs[0];
     (v, caller)
 }
 
-fn miner_setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, Address, Address, Address) {
-    let mut v = TestVM::new_with_singletons(store);
+fn miner_setup(
+    store: &'_ MemoryBlockstore,
+) -> (TestVM<MemoryBlockstore>, Address, Address, Address) {
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let initial_balance = TokenAmount::from_whole(10_000);
     let addrs = create_accounts(&v, 2, initial_balance);
     let (worker, owner) = (addrs[0], addrs[1]);

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -28,7 +28,7 @@ use test_vm::{ExpectInvocation, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
 #[test]
 fn create_miner_test() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     let owner = Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();
     v.apply_message(
@@ -99,7 +99,7 @@ fn create_miner_test() {
 #[test]
 fn test_cron_tick() {
     let store = MemoryBlockstore::new();
-    let mut vm = TestVM::new_with_singletons(&store);
+    let mut vm = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     let addrs = create_accounts(&vm, 1, TokenAmount::from_whole(10_000));
 

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -2,6 +2,7 @@ use fil_actor_market::{
     ClientDealProposal, DealProposal, Label, Method as MarketMethod, PublishStorageDealsParams,
     PublishStorageDealsReturn,
 };
+use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::crypto::signature::{Signature, SignatureType};
 
 use fil_actor_account::types::AuthenticateMessageParams;
@@ -53,8 +54,8 @@ fn token_defaults() -> (TokenAmount, TokenAmount, TokenAmount) {
 }
 
 // create miner and client and add collateral
-fn setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, Addrs, ChainEpoch) {
-    let mut v = TestVM::new_with_singletons(store);
+fn setup(store: &MemoryBlockstore) -> (TestVM<MemoryBlockstore>, Addrs, ChainEpoch) {
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 7, TokenAmount::from_whole(10_000));
     let (worker, client1, client2, not_miner, cheap_client, verifier, verified_client) =
         (addrs[0], addrs[1], addrs[2], addrs[3], addrs[4], addrs[5], addrs[6]);
@@ -605,9 +606,12 @@ struct DealOptions {
     client_collateral: Option<TokenAmount>,
 }
 
-struct DealBatcher<'bs> {
+struct DealBatcher<'bs, BS>
+where
+    BS: Blockstore,
+{
     deals: Vec<DealProposal>,
-    v: &'bs TestVM<'bs>,
+    v: &'bs TestVM<'bs, BS>,
     default_provider: Address,
     default_piece_size: PaddedPieceSize,
     default_verified: bool,
@@ -618,9 +622,12 @@ struct DealBatcher<'bs> {
     default_client_collateral: TokenAmount,
 }
 
-impl<'bs> DealBatcher<'bs> {
+impl<'bs, BS> DealBatcher<'bs, BS>
+where
+    BS: Blockstore,
+{
     fn new(
-        v: &'bs TestVM<'bs>,
+        v: &'bs TestVM<'bs, BS>,
         default_provider: Address,
         default_piece_size: PaddedPieceSize,
         default_verified: bool,

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -21,7 +21,7 @@ use fil_actors_runtime::{
     SYSTEM_ACTOR_ADDR,
 };
 use fvm_ipld_bitfield::BitField;
-use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
@@ -174,7 +174,7 @@ fn upgrade_and_miss_post(v2: bool) {
 fn prove_replica_update_multi_dline() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::new_with_singletons(store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(1_000_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -313,7 +313,7 @@ fn prove_replica_update_multi_dline() {
 #[test]
 fn immutable_deadline_failure() {
     let store = &MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -364,7 +364,7 @@ fn immutable_deadline_failure() {
 fn unhealthy_sector_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::new_with_singletons(store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -419,7 +419,7 @@ fn unhealthy_sector_failure() {
 #[test]
 fn terminated_sector_failure() {
     let store = &MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -485,7 +485,7 @@ fn terminated_sector_failure() {
 fn bad_batch_size_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::new_with_singletons(store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -587,7 +587,7 @@ fn upgrade_bad_post_dispute() {
 fn bad_post_upgrade_dispute() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::new_with_singletons(store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -750,7 +750,7 @@ fn extend_after_upgrade() {
 fn wrong_deadline_index_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::new_with_singletons(store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -807,7 +807,7 @@ fn wrong_deadline_index_failure() {
 fn wrong_partition_index_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::new_with_singletons(store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -864,7 +864,7 @@ fn wrong_partition_index_failure() {
 fn deal_included_in_multiple_sectors_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::new_with_singletons(store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -992,7 +992,7 @@ fn deal_included_in_multiple_sectors_failure() {
 #[test]
 fn replica_update_verified_deal() {
     let store = &MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(100_000));
     let (worker, owner, client, verifier) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1116,7 +1116,7 @@ fn replica_update_verified_deal() {
 #[test]
 fn replica_update_verified_deal_max_term_violated() {
     let store = &MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(100_000));
     let (worker, owner, client, verifier) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1178,8 +1178,8 @@ fn replica_update_verified_deal_max_term_violated() {
 fn create_miner_and_upgrade_sector(
     store: &MemoryBlockstore,
     v2: bool,
-) -> (TestVM, SectorOnChainInfo, Address, Address, u64, u64, SectorSize) {
-    let mut v = TestVM::new_with_singletons(store);
+) -> (TestVM<MemoryBlockstore>, SectorOnChainInfo, Address, Address, u64, u64, SectorSize) {
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1260,13 +1260,13 @@ fn create_miner_and_upgrade_sector(
 // - fastforwarding to its Proving period and PoSting it
 // - fastforwarding out of the proving period into a new deadline
 // This method assumes that this is a miners first and only sector
-fn create_sector(
-    mut v: TestVM,
+fn create_sector<BS: Blockstore>(
+    mut v: TestVM<BS>,
     worker: Address,
     maddr: Address,
     sector_number: SectorNumber,
     seal_proof: RegisteredSealProof,
-) -> (TestVM, u64, u64) {
+) -> (TestVM<BS>, u64, u64) {
     // precommit
     let exp = v.get_epoch() + Policy::default().max_sector_expiration_extension;
     let precommits =
@@ -1327,9 +1327,9 @@ fn create_sector(
 
     (v, d_idx, p_idx)
 }
-fn create_deals(
+fn create_deals<BS: Blockstore>(
     num_deals: u32,
-    v: &TestVM,
+    v: &TestVM<BS>,
     client: Address,
     worker: Address,
     maddr: Address,
@@ -1337,9 +1337,9 @@ fn create_deals(
     create_deals_frac(num_deals, v, client, worker, maddr, 1, false, 180 * EPOCHS_IN_DAY)
 }
 
-fn create_verified_deals(
+fn create_verified_deals<BS: Blockstore>(
     num_deals: u32,
-    v: &TestVM,
+    v: &TestVM<BS>,
     client: Address,
     worker: Address,
     maddr: Address,
@@ -1349,9 +1349,9 @@ fn create_verified_deals(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn create_deals_frac(
+fn create_deals_frac<BS: Blockstore>(
     num_deals: u32,
-    v: &TestVM,
+    v: &TestVM<BS>,
     client: Address,
     worker: Address,
     maddr: Address,

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -36,7 +36,7 @@ use test_vm::{ExpectInvocation, TestVM};
 #[test]
 fn terminate_sectors() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let (owner, verifier, unverified_client, verified_client) =
         (addrs[0], addrs[1], addrs[2], addrs[3]);

--- a/test_vm/tests/test_vm_test.rs
+++ b/test_vm/tests/test_vm_test.rs
@@ -2,7 +2,7 @@ use fil_actor_account::State as AccountState;
 use fil_actors_runtime::test_utils::{
     make_identity_cid, ACCOUNT_ACTOR_CODE_ID, PAYCH_ACTOR_CODE_ID,
 };
-use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
@@ -15,7 +15,7 @@ use test_vm::{actor, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
 #[test]
 fn state_control() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new(&store);
+    let v = TestVM::<MemoryBlockstore>::new(&store);
     let addr1 = Address::new_id(1000);
     let addr2 = Address::new_id(2222);
 
@@ -53,11 +53,11 @@ fn state_control() {
     assert!(invariants_check.unwrap_err().to_string().contains("AccountState is empty"));
 }
 
-fn assert_account_actor(
+fn assert_account_actor<BS: Blockstore>(
     exp_call_seq: u64,
     exp_bal: TokenAmount,
     exp_pk_addr: Address,
-    v: &TestVM,
+    v: &TestVM<BS>,
     addr: Address,
 ) {
     let act = v.get_actor(addr).unwrap();
@@ -71,7 +71,7 @@ fn assert_account_actor(
 #[test]
 fn test_sent() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     // send to uninitialized account actor
     let addr1 = Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();

--- a/test_vm/tests/verified_claim_test.rs
+++ b/test_vm/tests/verified_claim_test.rs
@@ -43,7 +43,7 @@ use test_vm::TestVM;
 #[test]
 fn verified_claim_scenario() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client, verified_client2) =
@@ -339,7 +339,7 @@ fn verified_claim_scenario() {
 #[test]
 fn expired_allocations() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -33,7 +33,7 @@ use test_vm::{ExpectInvocation, TestVM, TEST_VERIFREG_ROOT_ADDR};
 #[test]
 fn remove_datacap_simple_successful_path() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let (verifier1, verifier2, verified_client) = (addrs[0], addrs[1], addrs[2]);
 
@@ -283,7 +283,7 @@ fn remove_datacap_simple_successful_path() {
 #[test]
 fn remove_datacap_fails_on_verifreg() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::new_with_singletons(&store);
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 2, TokenAmount::from_whole(10_000));
     let (verifier1, verifier2) = (addrs[0], addrs[1]);
 

--- a/test_vm/tests/withdraw_balance_test.rs
+++ b/test_vm/tests/withdraw_balance_test.rs
@@ -12,7 +12,7 @@ use test_vm::TestVM;
 #[test]
 fn withdraw_balance_success() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 2, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary) = (addrs[0], addrs[0], addrs[1]);
@@ -54,7 +54,7 @@ fn withdraw_balance_success() {
 #[test]
 fn withdraw_balance_fail() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::new_with_singletons(&store);
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);


### PR DESCRIPTION
Further groundwork for an abstract VM trait. Especially in the context of benchmarking it may be useful to inject TrackingBlockstores etc. in future. 

The current TestVM could not implement a method that returns a BS: Blockstore which would be required by a generic VM<BS: Blockstore> trait.