### PR TITLE
SDM

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -28,7 +28,7 @@ use itertools::Itertools;
 use log::{error, info, warn};
 use multihash::Code::Blake2b256;
 use num_derive::FromPrimitive;
-use num_traits::Zero;
+use num_traits::{Signed, Zero};
 
 pub use beneficiary::*;
 pub use bitfield_queue::*;
@@ -3795,7 +3795,7 @@ fn extend_simple_qap_sector(
     new_sector.expiration = new_expiration;
     new_sector.power_base_epoch = curr_epoch;
     let old_duration = sector.expiration - sector.power_base_epoch;
-    let new_duration = new_sector.expiration - sector.power_base_epoch;
+    let new_duration = new_sector.expiration - new_sector.power_base_epoch;
 
     // Update the non-verified deal weights. This won't change power, it'll just keep it the same
     // relative to the updated power base epoch.
@@ -3881,6 +3881,7 @@ fn extend_non_simple_qap_sector(
     new_sector.expiration = new_expiration;
     new_sector.deal_weight = new_deal_weight;
     new_sector.verified_deal_weight = new_verified_deal_weight;
+    new_sector.power_base_epoch = curr_epoch;
 
     Ok(new_sector)
 }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3794,9 +3794,17 @@ fn extend_simple_qap_sector(
 
     new_sector.expiration = new_expiration;
     new_sector.power_base_epoch = curr_epoch;
-    if sector.verified_deal_weight > BigInt::zero() {
-        let old_duration = sector.expiration - sector.power_base_epoch;
-        let deal_space = &sector.deal_weight / old_duration;
+    let old_duration = sector.expiration - sector.power_base_epoch;
+    let new_duration = new_sector.expiration - sector.power_base_epoch;
+
+    // Update the non-verified deal weights. This won't change power, it'll just keep it the same
+    // relative to the updated power base epoch.
+    if sector.deal_weight.is_positive() {
+        new_sector.deal_weight = (&sector.deal_weight * new_duration) / old_duration;
+    }
+
+    // Update the verified deal weights, and pledge if necessary.
+    if sector.verified_deal_weight.is_positive() {
         let old_verified_deal_space = &sector.verified_deal_weight / old_duration;
         let (expected_verified_deal_space, new_verified_deal_space) = match claim_space_by_sector
             .get(&sector.sector_number)
@@ -3828,18 +3836,15 @@ fn extend_simple_qap_sector(
             ));
         }
 
-        new_sector.expiration = new_expiration;
-        // update deal weights to account for new duration
-        new_sector.deal_weight = deal_space * (new_sector.expiration - new_sector.power_base_epoch);
-        new_sector.verified_deal_weight = BigInt::from(*new_verified_deal_space)
-            * (new_sector.expiration - new_sector.power_base_epoch);
+        new_sector.verified_deal_weight = BigInt::from(*new_verified_deal_space) * new_duration;
+
+        // We only bother updating the pledge for verified deals as it can increase power.
         let qa_pow = qa_power_for_weight(
             sector_size,
-            new_sector.expiration - new_sector.power_base_epoch,
+            new_duration,
             &new_sector.deal_weight,
             &new_sector.verified_deal_weight,
         );
-        new_sector.power_base_epoch = curr_epoch;
         new_sector.expected_day_reward = expected_reward_for_power(
             &reward_stats.this_epoch_reward_smoothed,
             &power_stats.quality_adj_power_smoothed,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3739,7 +3739,7 @@ fn extend_sector_committment(
 
     if sector.verified_deal_weight.is_positive() {
         if !sector.simple_qa_power {
-            // divide by the old diration to get the verified deal size.
+            // divide by the old duration to get the verified deal size.
             // multiply by the remaining time to calculate the remaining weight. This remaining
             // weight will end up getting spread out over the _new_ duration.
             new_sector.verified_deal_weight =

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3854,11 +3854,14 @@ fn extend_simple_qap_sector(
             &qa_pow,
             fil_actors_runtime::network::EPOCHS_IN_DAY,
         );
-        new_sector.expected_storage_pledge = expected_reward_for_power(
-            &reward_stats.this_epoch_reward_smoothed,
-            &power_stats.quality_adj_power_smoothed,
-            &qa_pow,
-            INITIAL_PLEDGE_PROJECTION_PERIOD,
+        new_sector.expected_storage_pledge = max(
+            sector.expected_storage_pledge.clone(),
+            expected_reward_for_power(
+                &reward_stats.this_epoch_reward_smoothed,
+                &power_stats.quality_adj_power_smoothed,
+                &qa_pow,
+                INITIAL_PLEDGE_PROJECTION_PERIOD,
+            ),
         );
         new_sector.replaced_day_reward =
             max(sector.expected_day_reward.clone(), sector.replaced_day_reward.clone());

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1305,8 +1305,10 @@ impl Actor {
                         &new_sector_info.verified_deal_weight,
                     );
 
-                    new_sector_info.replaced_day_reward =
-                        with_details.sector_info.expected_day_reward.clone();
+                    new_sector_info.replaced_day_reward = max(
+                        with_details.sector_info.expected_day_reward.clone(),
+                        with_details.sector_info.replaced_day_reward.clone(),
+                    );
                     new_sector_info.expected_day_reward = expected_reward_for_power(
                         &rew.this_epoch_reward_smoothed,
                         &pow.quality_adj_power_smoothed,
@@ -2199,6 +2201,8 @@ impl Actor {
         kind: ExtensionKind,
     ) -> Result<(), ActorError> {
         let curr_epoch = rt.curr_epoch();
+        let reward_stats = &request_current_epoch_block_reward(rt)?;
+        let power_stats = &request_current_total_power(rt)?;
 
         /* Loop over sectors and do extension */
         let (power_delta, pledge_delta) = rt.transaction(|state: &mut State, rt| {
@@ -2291,8 +2295,11 @@ impl Actor {
                                 Some(claim_space_by_sector) => extend_sector_committment(
                                     rt.policy(),
                                     curr_epoch,
+                                    reward_stats,
+                                    power_stats,
                                     decl.new_expiration,
                                     sector,
+                                    info.sector_size,
                                     claim_space_by_sector,
                                 ),
                             },
@@ -3680,18 +3687,31 @@ fn validate_extension_declarations(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn extend_sector_committment(
     policy: &Policy,
     curr_epoch: ChainEpoch,
+    reward_stats: &ThisEpochRewardReturn,
+    power_stats: &ext::power::CurrentTotalPowerReturn,
     new_expiration: ChainEpoch,
     sector: &SectorOnChainInfo,
+    sector_size: SectorSize,
     claim_space_by_sector: &BTreeMap<SectorNumber, (u64, u64)>,
 ) -> Result<SectorOnChainInfo, ActorError> {
     validate_extended_expiration(policy, curr_epoch, new_expiration, sector)?;
 
     // all simple_qa_power sectors with VerifiedDealWeight > 0 MUST check all claims
     if sector.simple_qa_power {
-        extend_simple_qap_sector(policy, new_expiration, curr_epoch, sector, claim_space_by_sector)
+        extend_simple_qap_sector(
+            policy,
+            new_expiration,
+            curr_epoch,
+            reward_stats,
+            power_stats,
+            sector,
+            sector_size,
+            claim_space_by_sector,
+        )
     } else {
         extend_non_simple_qap_sector(new_expiration, curr_epoch, sector)
     }
@@ -3758,18 +3778,21 @@ fn validate_extended_expiration(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn extend_simple_qap_sector(
     policy: &Policy,
     new_expiration: ChainEpoch,
     curr_epoch: ChainEpoch,
+    reward_stats: &ThisEpochRewardReturn,
+    power_stats: &ext::power::CurrentTotalPowerReturn,
     sector: &SectorOnChainInfo,
+    sector_size: SectorSize,
     claim_space_by_sector: &BTreeMap<SectorNumber, (u64, u64)>,
 ) -> Result<SectorOnChainInfo, ActorError> {
     let mut new_sector = sector.clone();
-    // Update the power_base_epoch, assuming the sector is actually being extended
-    if sector.expiration != new_expiration {
-        new_sector.power_base_epoch = curr_epoch
-    }
+
+    new_sector.expiration = new_expiration;
+    new_sector.power_base_epoch = curr_epoch;
     if sector.verified_deal_weight > BigInt::zero() {
         let old_duration = sector.expiration - sector.power_base_epoch;
         let deal_space = &sector.deal_weight / old_duration;
@@ -3809,8 +3832,27 @@ fn extend_simple_qap_sector(
         new_sector.deal_weight = deal_space * (new_sector.expiration - new_sector.power_base_epoch);
         new_sector.verified_deal_weight = BigInt::from(*new_verified_deal_space)
             * (new_sector.expiration - new_sector.power_base_epoch);
-    } else {
-        new_sector.expiration = new_expiration
+        let qa_pow = qa_power_for_weight(
+            sector_size,
+            new_sector.expiration - new_sector.power_base_epoch,
+            &new_sector.deal_weight,
+            &new_sector.verified_deal_weight,
+        );
+        new_sector.power_base_epoch = curr_epoch;
+        new_sector.expected_day_reward = expected_reward_for_power(
+            &reward_stats.this_epoch_reward_smoothed,
+            &power_stats.quality_adj_power_smoothed,
+            &qa_pow,
+            fil_actors_runtime::network::EPOCHS_IN_DAY,
+        );
+        new_sector.expected_storage_pledge = expected_reward_for_power(
+            &reward_stats.this_epoch_reward_smoothed,
+            &power_stats.quality_adj_power_smoothed,
+            &qa_pow,
+            INITIAL_PLEDGE_PROJECTION_PERIOD,
+        );
+        new_sector.replaced_day_reward =
+            max(sector.expected_day_reward.clone(), sector.replaced_day_reward.clone());
     }
 
     Ok(new_sector)

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3800,7 +3800,10 @@ fn extend_simple_qap_sector(
     // Update the non-verified deal weights. This won't change power, it'll just keep it the same
     // relative to the updated power base epoch.
     if sector.deal_weight.is_positive() {
-        new_sector.deal_weight = (&sector.deal_weight * new_duration) / old_duration;
+        // (old_deal_weight) / old_duration -> old_space
+        // old_space * (old_expiration - curr_epoch) -> remaining spacetime in the deals.
+        new_sector.deal_weight =
+            &sector.deal_weight * (sector.expiration - curr_epoch) / old_duration;
     }
 
     // Update the verified deal weights, and pledge if necessary.

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1306,9 +1306,10 @@ impl Actor {
                     );
 
                     new_sector_info.replaced_day_reward = max(
-                        with_details.sector_info.expected_day_reward.clone(),
-                        with_details.sector_info.replaced_day_reward.clone(),
-                    );
+                        &with_details.sector_info.expected_day_reward,
+                        &with_details.sector_info.replaced_day_reward,
+                    )
+                    .clone();
                     new_sector_info.expected_day_reward = expected_reward_for_power(
                         &rew.this_epoch_reward_smoothed,
                         &pow.quality_adj_power_smoothed,

--- a/actors/miner/src/monies.rs
+++ b/actors/miner/src/monies.rs
@@ -15,7 +15,7 @@ use lazy_static::lazy_static;
 use num_traits::Zero;
 
 use super::{VestSpec, REWARD_VESTING_SPEC};
-use crate::detail::*;
+use crate::{detail::*, sdm_scale};
 
 /// Projection period of expected sector block reward for deposit required to pre-commit a sector.
 /// This deposit is lost if the pre-commitment is not timely followed up by a commitment proof.
@@ -183,10 +183,11 @@ pub fn pledge_penalty_for_termination(
     reward_estimate: &FilterEstimate,
     replaced_day_reward: &TokenAmount,
     replaced_sector_age: ChainEpoch,
+    current_extension_age: ChainEpoch,
 ) -> TokenAmount {
     // max(SP(t), BR(StartEpoch, 20d) + BR(StartEpoch, 1d) * terminationRewardFactor * min(SectorAgeInDays, 140))
     // and sectorAgeInDays = sectorAge / EpochsInDay
-    let lifetime_cap = TERMINATION_LIFETIME_CAP * EPOCHS_IN_DAY;
+    let lifetime_cap = sdm_scale(TERMINATION_LIFETIME_CAP, current_extension_age) * EPOCHS_IN_DAY;
     let capped_sector_age = std::cmp::min(sector_age, lifetime_cap);
 
     let mut expected_reward: TokenAmount = day_reward * capped_sector_age;

--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -138,7 +138,7 @@ pub fn qa_power_for_weight(
 
 /// Returns the quality-adjusted power for a sector.
 pub fn qa_power_for_sector(size: SectorSize, sector: &SectorOnChainInfo) -> StoragePower {
-    let duration = sector.expiration - sector.activation;
+    let duration = sector.expiration - sector.power_base_epoch;
     qa_power_for_weight(size, duration, &sector.deal_weight, &sector.verified_deal_weight)
 }
 

--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -83,6 +83,14 @@ pub fn check_state_invariants<BS: Blockstore>(
                 if !sector.deal_ids.is_empty() {
                     miner_summary.sectors_with_deals.insert(sector_number);
                 }
+                acc.require(
+                    sector.activation <= sector.power_base_epoch,
+                    format!("invalid power base for {sector_number}"),
+                );
+                acc.require(
+                    sector.power_base_epoch < sector.expiration,
+                    format!("power base epoch is not before the sector expiration {sector_number}"),
+                );
                 Ok(())
             });
 

--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -76,13 +76,9 @@ pub fn check_state_invariants<BS: Blockstore>(
                     ),
                 );
                 sector.deal_ids.iter().for_each(|&deal| {
-                    miner_summary.deals.insert(
-                        deal,
-                        DealSummary {
-                            sector_start: sector.activation,
-                            sector_expiration: sector.expiration,
-                        },
-                    );
+                    miner_summary
+                        .deals
+                        .insert(deal, DealSummary { sector_expiration: sector.expiration });
                 });
                 if !sector.deal_ids.is_empty() {
                     miner_summary.sectors_with_deals.insert(sector_number);
@@ -135,7 +131,6 @@ pub fn check_state_invariants<BS: Blockstore>(
 }
 
 pub struct DealSummary {
-    pub sector_start: ChainEpoch,
     pub sector_expiration: ChainEpoch,
 }
 

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -347,13 +347,13 @@ pub struct SectorOnChainInfo {
     pub verified_deal_weight: DealWeight,
     /// Pledge collected to commit this sector
     pub initial_pledge: TokenAmount,
-    /// Expected one day projection of reward for sector computed at activation time
+    /// Expected one day projection of reward for sector computed at activation / update / extension time
     pub expected_day_reward: TokenAmount,
-    /// Expected twenty day projection of reward for sector computed at activation time
+    /// Expected twenty day projection of reward for sector computed at activation / update / extension time
     pub expected_storage_pledge: TokenAmount,
     /// Epoch at which this sector's power was most recently updated
     pub power_base_epoch: ChainEpoch,
-    /// Day reward of this sector before its power was most recently updated
+    /// Maximum day reward this sector has had in previous iterations (zero for brand new sectors)
     pub replaced_day_reward: TokenAmount,
     /// The original SealedSectorCID, only gets set on the first ReplicaUpdate
     pub sector_key_cid: Option<Cid>,

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -351,9 +351,9 @@ pub struct SectorOnChainInfo {
     pub expected_day_reward: TokenAmount,
     /// Expected twenty day projection of reward for sector computed at activation time
     pub expected_storage_pledge: TokenAmount,
-    /// Age of sector this sector replaced or zero
-    pub replaced_sector_age: ChainEpoch,
-    /// Day reward of sector this sector replace or zero
+    /// Epoch at which this sector's power was most recently updated
+    pub power_base_epoch: ChainEpoch,
+    /// Day reward of this sector before its power was most recently updated
     pub replaced_day_reward: TokenAmount,
     /// The original SealedSectorCID, only gets set on the first ReplicaUpdate
     pub sector_key_cid: Option<Cid>,

--- a/actors/miner/tests/compact_partitions_test.rs
+++ b/actors/miner/tests/compact_partitions_test.rs
@@ -88,6 +88,7 @@ fn compacting_a_partition_with_both_live_and_dead_sectors_removes_dead_sectors_r
         INITIAL_PLEDGE_PROJECTION_PERIOD,
     );
     let sector_age = *rt.epoch.borrow() - terminated_sector.activation;
+    let extension_age = *rt.epoch.borrow() - terminated_sector.power_base_epoch;
     let expected_fee = pledge_penalty_for_termination(
         &day_reward,
         sector_age,
@@ -97,6 +98,7 @@ fn compacting_a_partition_with_both_live_and_dead_sectors_removes_dead_sectors_r
         &h.epoch_reward_smooth,
         &TokenAmount::zero(),
         0,
+        extension_age,
     );
 
     h.terminate_sectors(&rt, &bitfield_from_slice(&[sectors[0]]), expected_fee);

--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -23,6 +23,7 @@ use fvm_shared::{
 use std::collections::HashMap;
 
 mod util;
+
 use fil_actors_runtime::runtime::Policy;
 use itertools::Itertools;
 use test_case::test_case;
@@ -946,7 +947,7 @@ fn assert_sector_verified_space(
     let new_sector = h.get_sector(rt, sector_number);
     assert_eq!(
         DealWeight::from(v_deal_space),
-        new_sector.verified_deal_weight / (new_sector.expiration - new_sector.activation)
+        new_sector.verified_deal_weight / (new_sector.expiration - new_sector.power_base_epoch)
     );
 }
 

--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -120,6 +120,7 @@ fn rejects_extension_too_far_in_future(v2: bool) {
         ),
         res,
     );
+    rt.reset();
     h.check_state(&rt);
 }
 

--- a/actors/miner/tests/pledge_penalty_for_termination.rs
+++ b/actors/miner/tests/pledge_penalty_for_termination.rs
@@ -58,6 +58,7 @@ fn when_undeclared_fault_fee_exceeds_expected_reward_returns_undeclared_fault_fe
         &reward_estimate(),
         &TokenAmount::zero(),
         0,
+        sector_age,
     );
 
     assert_eq!(undeclared_penalty(), fee);
@@ -81,6 +82,7 @@ fn when_expected_reward_exceeds_undeclared_fault_fee_returns_expected_reward() {
         &reward_estimate(),
         &TokenAmount::zero(),
         0,
+        sector_age,
     );
 
     // expect fee to be pledge + br * age * factor where br = pledge/initialPledgeFactor
@@ -107,6 +109,7 @@ fn sector_age_is_capped() {
         &reward_estimate(),
         &TokenAmount::zero(),
         0,
+        sector_age,
     );
 
     // expect fee to be pledge * br * age-cap * factor where br = pledge/initialPledgeFactor
@@ -138,6 +141,7 @@ fn fee_for_replacement_eq_fee_for_original_sector_when_power_br_are_unchanged() 
         &reward_estimate(),
         &TokenAmount::zero(),
         0,
+        sector_age,
     );
 
     // actual fee including replacement parameters
@@ -150,6 +154,7 @@ fn fee_for_replacement_eq_fee_for_original_sector_when_power_br_are_unchanged() 
         &reward_estimate(),
         &day_reward,
         sector_age - replacement_age,
+        sector_age,
     );
 
     assert_eq!(unreplaced_fee, actual_fee);
@@ -177,6 +182,7 @@ fn fee_for_replacement_eq_fee_for_same_sector_without_replacement_after_lifetime
         &reward_estimate(),
         &TokenAmount::zero(),
         0,
+        sector_age,
     );
 
     // actual fee including replacement parameters
@@ -188,6 +194,7 @@ fn fee_for_replacement_eq_fee_for_same_sector_without_replacement_after_lifetime
         &power,
         &reward_estimate(),
         &day_reward,
+        sector_age,
         sector_age,
     );
 
@@ -224,6 +231,7 @@ fn charges_for_replaced_sector_at_replaced_sector_day_rate() {
         &reward_estimate(),
         &old_day_reward,
         old_sector_age,
+        replacement_age,
     );
 
     assert_eq!(expected_fee, fee);

--- a/actors/miner/tests/policy_test.rs
+++ b/actors/miner/tests/policy_test.rs
@@ -1,4 +1,7 @@
-use fil_actor_miner::{qa_power_for_weight, quality_for_weight, SECTOR_DURATION_MULTIPLIER_START};
+use fil_actor_miner::{
+    qa_power_for_weight, quality_for_weight, sdm_scale, SECTOR_DURATION_MULTIPLIER_END,
+    SECTOR_DURATION_MULTIPLIER_MAX, SECTOR_DURATION_MULTIPLIER_START,
+};
 use fil_actor_miner::{
     DEAL_WEIGHT_MULTIPLIER, QUALITY_BASE_MULTIPLIER, SECTOR_QUALITY_PRECISION,
     VERIFIED_DEAL_WEIGHT_MULTIPLIER,
@@ -238,6 +241,31 @@ fn demonstrate_standard_sectors() {
         half_verified_power,
         qa_power_for_weight(sector_size, sector_duration, &BigInt::zero(), &(sector_weight / 2))
     );
+}
+
+#[test]
+fn test_sdm() {
+    const TEST_VALUE: i64 = 10;
+    assert_eq!(
+        sdm_scale(TEST_VALUE, SECTOR_DURATION_MULTIPLIER_END),
+        SECTOR_DURATION_MULTIPLIER_MAX * TEST_VALUE
+    );
+    assert_eq!(
+        sdm_scale(TEST_VALUE, SECTOR_DURATION_MULTIPLIER_END + 1),
+        SECTOR_DURATION_MULTIPLIER_MAX * TEST_VALUE
+    );
+
+    let half_way = SECTOR_DURATION_MULTIPLIER_START
+        + (SECTOR_DURATION_MULTIPLIER_END - SECTOR_DURATION_MULTIPLIER_START) / 2
+        + 1; // doesn't divide quite evenly
+    assert_eq!(
+        sdm_scale(TEST_VALUE, half_way),
+        ((SECTOR_DURATION_MULTIPLIER_MAX - 1) * TEST_VALUE) / 2 + TEST_VALUE
+    );
+
+    assert_eq!(sdm_scale(TEST_VALUE, SECTOR_DURATION_MULTIPLIER_START), TEST_VALUE);
+    assert_eq!(sdm_scale(TEST_VALUE, 0), TEST_VALUE);
+    assert_eq!(sdm_scale(TEST_VALUE, SECTOR_DURATION_MULTIPLIER_START - 1), TEST_VALUE);
 }
 
 fn weight(size: SectorSize, duration: ChainEpoch) -> BigInt {

--- a/actors/miner/tests/policy_test.rs
+++ b/actors/miner/tests/policy_test.rs
@@ -1,4 +1,4 @@
-use fil_actor_miner::{qa_power_for_weight, quality_for_weight};
+use fil_actor_miner::{qa_power_for_weight, quality_for_weight, SECTOR_DURATION_MULTIPLIER_START};
 use fil_actor_miner::{
     DEAL_WEIGHT_MULTIPLIER, QUALITY_BASE_MULTIPLIER, SECTOR_QUALITY_PRECISION,
     VERIFIED_DEAL_WEIGHT_MULTIPLIER,
@@ -30,7 +30,7 @@ fn quality_is_independent_of_size_and_duration() {
         ChainEpoch::from(1),
         ChainEpoch::from(10),
         ChainEpoch::from(1000),
-        1000 * EPOCHS_IN_DAY,
+        SECTOR_DURATION_MULTIPLIER_START,
     ];
 
     for size in size_range {
@@ -104,7 +104,7 @@ fn empty_sector_has_power_equal_to_size() {
         ChainEpoch::from(1),
         ChainEpoch::from(10),
         ChainEpoch::from(1000),
-        1000 * EPOCHS_IN_DAY,
+        SECTOR_DURATION_MULTIPLIER_START,
     ];
     for size in size_range {
         for duration in &duration_range {
@@ -132,7 +132,7 @@ fn verified_sector_has_power_a_multiple_of_size() {
         ChainEpoch::from(1),
         ChainEpoch::from(10),
         ChainEpoch::from(1000),
-        1000 * EPOCHS_IN_DAY,
+        SECTOR_DURATION_MULTIPLIER_START,
     ];
     for size in size_range {
         for duration in &duration_range {

--- a/actors/miner/tests/sector_assignment.rs
+++ b/actors/miner/tests/sector_assignment.rs
@@ -30,6 +30,7 @@ fn new_sector_on_chain_info(
         sealed_cid,
         activation,
         expiration: 1,
+        power_base_epoch: activation,
         deal_weight: weight.clone(),
         verified_deal_weight: weight,
         ..SectorOnChainInfo::default()

--- a/actors/miner/tests/sectors_stores_test.rs
+++ b/actors/miner/tests/sectors_stores_test.rs
@@ -109,6 +109,7 @@ fn new_sector_on_chain_info(
         sealed_cid,
         deal_ids: vec![],
         activation,
+        power_base_epoch: activation,
         expiration: ChainEpoch::from(1),
         deal_weight: weight.clone(),
         verified_deal_weight: weight,

--- a/actors/miner/tests/terminate_sectors_test.rs
+++ b/actors/miner/tests/terminate_sectors_test.rs
@@ -252,6 +252,8 @@ fn calc_expected_fee_for_termination(
         INITIAL_PLEDGE_PROJECTION_PERIOD,
     );
     let sector_age = *rt.epoch.borrow() - sector.activation;
+    let extension_age = *rt.epoch.borrow() - sector.power_base_epoch;
+
     pledge_penalty_for_termination(
         &day_reward,
         sector_age,
@@ -261,5 +263,6 @@ fn calc_expected_fee_for_termination(
         &h.epoch_reward_smooth,
         &TokenAmount::zero(),
         0,
+        extension_age,
     )
 }

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2385,6 +2385,7 @@ impl ActorHarness {
     ) -> Result<Option<IpldBlock>, ActorError> {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
         rt.expect_validate_caller_addr(self.caller_addrs());
+        self.expect_query_network_info(rt);
 
         let mut qa_delta = BigInt::zero();
         for extension in params.extensions.iter_mut() {
@@ -2469,6 +2470,7 @@ impl ActorHarness {
             }
         }
 
+        self.expect_query_network_info(rt);
         // Handle QA power updates
         for extension in params.extensions.iter_mut() {
             for sector_nr in extension.sectors.validate().unwrap().iter() {

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2387,12 +2387,14 @@ impl ActorHarness {
         rt.expect_validate_caller_addr(self.caller_addrs());
         self.expect_query_network_info(rt);
 
+        let curr_epoch = *rt.epoch.borrow();
         let mut qa_delta = BigInt::zero();
         for extension in params.extensions.iter_mut() {
             for sector_nr in extension.sectors.validate().unwrap().iter() {
                 let sector = self.get_sector(&rt, sector_nr);
                 let mut new_sector = sector.clone();
                 new_sector.expiration = extension.new_expiration;
+                new_sector.power_base_epoch = curr_epoch;
                 qa_delta += qa_power_for_sector(self.sector_size, &new_sector)
                     - qa_power_for_sector(self.sector_size, &sector);
             }

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2475,6 +2475,7 @@ impl ActorHarness {
                 let sector = self.get_sector(&rt, sector_nr);
                 let mut new_sector = sector.clone();
                 new_sector.expiration = extension.new_expiration;
+                new_sector.power_base_epoch = *rt.epoch.borrow();
                 qa_delta += qa_power_for_sector(self.sector_size, &new_sector)
                     - qa_power_for_sector(self.sector_size, &sector);
             }
@@ -2487,13 +2488,14 @@ impl ActorHarness {
                     }
                 }
                 let sector = self.get_sector(&rt, sector_claim.sector_number);
-                let old_duration = sector.expiration - sector.activation;
+                let old_duration = sector.expiration - sector.power_base_epoch;
                 let old_verified_deal_space = &sector.verified_deal_weight / old_duration;
                 let new_verified_deal_space = old_verified_deal_space - dropped_space;
                 let mut new_sector = sector.clone();
                 new_sector.expiration = extension.new_expiration;
+                new_sector.power_base_epoch = *rt.epoch.borrow();
                 new_sector.verified_deal_weight = BigInt::from(new_verified_deal_space)
-                    * (new_sector.expiration - new_sector.activation);
+                    * (new_sector.expiration - new_sector.power_base_epoch);
                 qa_delta += qa_power_for_sector(self.sector_size, &new_sector)
                     - qa_power_for_sector(self.sector_size, &sector);
             }

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -336,7 +336,7 @@ pub mod policy_constants {
     /// Maximum number of epochs past the current epoch a sector may be set to expire.
     /// The actual maximum extension will be the minimum of CurrEpoch + MaximumSectorExpirationExtension
     /// and sector.ActivationEpoch+sealProof.SectorMaximumLifetime()
-    pub const MAX_SECTOR_EXPIRATION_EXTENSION: i64 = 540 * EPOCHS_IN_DAY;
+    pub const MAX_SECTOR_EXPIRATION_EXTENSION: i64 = 5 * EPOCHS_IN_YEAR;
 
     /// Ratio of sector size to maximum deals per sector.
     /// The maximum number of deals is the sector size divided by this number (2^27)

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -364,14 +364,6 @@ fn check_deal_states_against_sectors(
         };
 
         acc.require(
-            deal.sector_start_epoch == sector_deal.sector_start,
-            format!(
-                "deal state start {} does not match sector start {} for miner {}",
-                deal.sector_start_epoch, sector_deal.sector_start, deal.provider
-            ),
-        );
-
-        acc.require(
             deal.sector_start_epoch <= sector_deal.sector_expiration,
             format!(
                 "deal state start {} activated after sector expiration {} for miner {}",

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -541,6 +541,16 @@ pub fn miner_extend_sector_expiration2<BS: Blockstore>(
             ..Default::default()
         })
     }
+    subinvocs.push(ExpectInvocation {
+        to: REWARD_ACTOR_ADDR,
+        method: RewardMethod::ThisEpochReward as u64,
+        ..Default::default()
+    });
+    subinvocs.push(ExpectInvocation {
+        to: STORAGE_POWER_ACTOR_ADDR,
+        method: PowerMethod::CurrentTotalPower as u64,
+        ..Default::default()
+    });
     if !power_delta.is_zero() {
         subinvocs.push(ExpectInvocation {
             to: STORAGE_POWER_ACTOR_ADDR,

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -1,11 +1,19 @@
+use fil_actor_market::State as MarketState;
+use fil_actor_market::{DealMetaArray, Method as MarketMethod};
 use fil_actor_miner::{
-    max_prove_commit_duration, ExpirationExtension, ExpirationExtension2,
+    max_prove_commit_duration, power_for_sector, ExpirationExtension, ExpirationExtension2,
     ExtendSectorExpiration2Params, ExtendSectorExpirationParams, Method as MinerMethod, PowerPair,
-    Sectors, State as MinerState,
+    ProveReplicaUpdatesParams2, ReplicaUpdate2, SectorClaim, Sectors, State as MinerState,
 };
 use fil_actor_power::{Method as PowerMethod, UpdateClaimedPowerParams};
+use fil_actor_reward::Method as RewardMethod;
+use fil_actor_verifreg::Method as VerifregMethod;
 use fil_actors_runtime::runtime::Policy;
-use fil_actors_runtime::{DealWeight, EPOCHS_IN_DAY, STORAGE_POWER_ACTOR_ADDR};
+use fil_actors_runtime::test_utils::{make_piece_cid, make_sealed_cid};
+use fil_actors_runtime::{
+    DealWeight, EPOCHS_IN_DAY, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
+    STORAGE_POWER_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
@@ -17,10 +25,10 @@ use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
 use test_vm::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
-    advance_by_deadline_to_index, advance_to_proving_deadline, apply_ok, create_accounts,
+    advance_by_deadline_to_index, advance_to_proving_deadline, apply_ok, bf_all, create_accounts,
     create_miner, cron_tick, invariant_failure_patterns, market_add_balance, market_publish_deal,
-    miner_precommit_sector, miner_prove_sector, submit_windowed_post, verifreg_add_client,
-    verifreg_add_verifier,
+    miner_precommit_sector, miner_prove_sector, sector_deadline, submit_windowed_post,
+    verifreg_add_client, verifreg_add_verifier,
 };
 use test_vm::{ExpectInvocation, TestVM};
 
@@ -301,4 +309,229 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     v.expect_state_invariants(
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
     );
+}
+
+#[test]
+fn extend_updated_sector_with_claim() {
+    let store = MemoryBlockstore::new();
+    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let addrs = create_accounts(&v, 3, &TokenAmount::from_whole(10_000));
+    let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
+    let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);
+    let sector_number: SectorNumber = 100;
+    let policy = Policy::default();
+
+    // create miner
+    let miner_id = create_miner(
+        &mut v,
+        &owner,
+        &worker,
+        seal_proof.registered_window_post_proof().unwrap(),
+        &TokenAmount::from_whole(1_000),
+    )
+    .0;
+    let mut v = v.with_epoch(200);
+
+    //
+    // Precommit, prove and PoSt empty sector (more fully tested in TestCommitPoStFlow)
+    //
+
+    let expiration = v.get_epoch() + 360 * EPOCHS_IN_DAY;
+
+    miner_precommit_sector(&v, &worker, &miner_id, seal_proof, sector_number, vec![], expiration);
+
+    // advance time by a day and prove the sector
+    let prove_epoch = v.get_epoch() + EPOCHS_IN_DAY;
+    v = advance_by_deadline_to_epoch(v, miner_id, prove_epoch).0;
+    miner_prove_sector(&v, &worker, &miner_id, sector_number);
+    // trigger cron to validate the prove commit
+    cron_tick(&v);
+
+    // advance to proving period and submit post
+
+    let (deadline_info, partition_index, mut v) =
+        advance_to_proving_deadline(v, miner_id, sector_number);
+
+    let expected_power_delta =
+        PowerPair { raw: StoragePower::from(32u64 << 30), qa: StoragePower::from(32u64 << 30) };
+
+    submit_windowed_post(
+        &v,
+        &worker,
+        &miner_id,
+        deadline_info,
+        partition_index,
+        Some(expected_power_delta),
+    );
+
+    // move forward one deadline so sector is mutable
+    v = advance_by_deadline_to_index(
+        v,
+        miner_id,
+        deadline_info.index + 1 % policy.wpost_period_deadlines,
+    )
+    .0;
+
+    // Inspect basic sector info
+
+    let miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    let initial_sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    assert_eq!(expiration, initial_sector_info.expiration);
+    assert_eq!(StoragePower::zero(), initial_sector_info.deal_weight); // 0 space time
+    assert_eq!(StoragePower::zero(), initial_sector_info.verified_deal_weight); // 0 space time
+
+    // publish verified deals
+
+    // register verifier then verified client
+    let datacap = StoragePower::from(32_u128 << 40);
+    verifreg_add_verifier(&v, &verifier, datacap.clone());
+    verifreg_add_client(&v, &verifier, &verified_client, datacap);
+
+    // add market collateral for clients and miner
+    market_add_balance(&v, &verified_client, &verified_client, &TokenAmount::from_whole(3));
+    market_add_balance(&v, &worker, &miner_id, &TokenAmount::from_whole(64));
+
+    // create 1 verified deal for total sector capacity
+    let deal_start = v.get_epoch() + EPOCHS_IN_DAY;
+    let deal_ids = market_publish_deal(
+        &v,
+        &worker,
+        &verified_client,
+        &miner_id,
+        "deal1".to_string(),
+        PaddedPieceSize(32u64 << 30),
+        true,
+        deal_start,
+        340 * EPOCHS_IN_DAY,
+    )
+    .ids;
+
+    // replica update
+    let new_cid = make_sealed_cid(b"replica1");
+    let (d_idx, p_idx) = sector_deadline(&v, &miner_id, sector_number);
+    let replica_update = ReplicaUpdate2 {
+        sector_number,
+        deadline: d_idx,
+        partition: p_idx,
+        new_sealed_cid: new_cid,
+        deals: deal_ids.clone(),
+        update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
+        replica_proof: vec![],
+        new_unsealed_cid: make_piece_cid(b"unsealed from itest vm"),
+    };
+    let updated_sectors: BitField = apply_ok(
+        &v,
+        &worker,
+        &miner_id,
+        &TokenAmount::zero(),
+        MinerMethod::ProveReplicaUpdates2 as u64,
+        Some(ProveReplicaUpdatesParams2 { updates: vec![replica_update] }),
+    )
+    .deserialize()
+    .unwrap();
+    assert_eq!(vec![sector_number], bf_all(updated_sectors));
+
+    let old_power = power_for_sector(seal_proof.sector_size().unwrap(), &initial_sector_info);
+    let expected_update_claimed_power_params = UpdateClaimedPowerParams {
+        raw_byte_delta: StoragePower::zero(),
+        quality_adjusted_delta: 9 * old_power.qa, // sector now fully qap, 10x - x = 9x
+    };
+
+    // check for the expected subcalls
+    ExpectInvocation {
+        to: miner_id,
+        method: MinerMethod::ProveReplicaUpdates2 as u64,
+        subinvocs: Some(vec![
+            ExpectInvocation {
+                to: STORAGE_MARKET_ACTOR_ADDR,
+                method: MarketMethod::ActivateDeals as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: VERIFIED_REGISTRY_ACTOR_ADDR,
+                method: VerifregMethod::ClaimAllocations as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: STORAGE_MARKET_ACTOR_ADDR,
+                method: MarketMethod::VerifyDealsForActivation as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: REWARD_ACTOR_ADDR,
+                method: RewardMethod::ThisEpochReward as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::CurrentTotalPower as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::UpdatePledgeTotal as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::UpdateClaimedPower as u64,
+                params: Some(
+                    IpldBlock::serialize_cbor(&expected_update_claimed_power_params).unwrap(),
+                ),
+                ..Default::default()
+            },
+        ]),
+        ..Default::default()
+    }
+    .matches(v.take_invocations().last().unwrap());
+
+    // inspect sector info
+
+    let miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    let sector_info_after_update = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    assert_eq!(StoragePower::zero(), sector_info_after_update.deal_weight); // 0 space time
+
+    assert_eq!(
+        DealWeight::from((sector_info_after_update.expiration - v.get_epoch()) * (32i64 << 30)),
+        sector_info_after_update.verified_deal_weight
+    ); // 32 GiB * the remaining life of the sector
+
+    // extend the updated sector
+
+    let market_state: MarketState = v.get_state(&STORAGE_MARKET_ACTOR_ADDR).unwrap();
+    let deal_states = DealMetaArray::load(&market_state.states, v.store).unwrap();
+    let deal_state = deal_states.get(deal_ids[0]).unwrap().unwrap();
+    let claim_id = deal_state.verified_claim;
+
+    let extension_params = ExtendSectorExpiration2Params {
+        extensions: vec![ExpirationExtension2 {
+            deadline: d_idx,
+            partition: partition_index,
+            sectors: BitField::new(),
+            new_expiration: sector_info_after_update.expiration + 60 * EPOCHS_IN_DAY,
+            sectors_with_claims: vec![SectorClaim {
+                sector_number,
+                maintain_claims: vec![claim_id],
+                drop_claims: vec![],
+            }],
+        }],
+    };
+    apply_ok(
+        &v,
+        &worker,
+        &miner_id,
+        &TokenAmount::zero(),
+        MinerMethod::ExtendSectorExpiration2 as u64,
+        Some(extension_params),
+    );
+
+    let miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    let sector_info_after_extension =
+        miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    assert_eq!(StoragePower::zero(), sector_info_after_extension.deal_weight); // 0 space time
+
+    assert_eq!(
+        DealWeight::from((sector_info_after_extension.expiration - v.get_epoch()) * (32i64 << 30)),
+        sector_info_after_extension.verified_deal_weight
+    ); // 32 GiB * the remaining life of the sector
 }

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -245,10 +245,18 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     )
     .0;
 
-    // advance halfway through life and extend another 6 months
-    // verified deal weight /= 2
-    // power multiplier = (1/4)*10 + (3/4)*1 = 3.25
-    // power delta = (10-3.25)*32GiB = 6.75*32GiB
+    // Advance halfway through life and extend another 6 months. We need to spread the remaining 90
+    // days of 10x power over 90 + 180 days.
+    //
+    // subtract half the remaining deal weight:
+    //   - verified deal weight /= 2
+    //
+    // normalize 90 days of 10x power plus 180 days of 1x power over 90+180 days:
+    //   - multiplier = ((10 * 90) + (1 * 180)) / (90 + 180)
+    //   - multiplier = 4
+    //
+    // delta from the previous 10x power multiplier:
+    // - power delta = (10-4)*32GiB = 6*32GiB
     v = advance_by_deadline_to_epoch_while_proving(
         v,
         miner_id,
@@ -261,7 +269,7 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
 
     let mut expected_update_claimed_power_params = UpdateClaimedPowerParams {
         raw_byte_delta: StoragePower::zero(),
-        quality_adjusted_delta: StoragePower::from(-675 * (32i64 << 30) / 100),
+        quality_adjusted_delta: StoragePower::from(-6 * (32i64 << 30)),
     };
     let mut expected_update_claimed_power_params_ser =
         IpldBlock::serialize_cbor(&expected_update_claimed_power_params).unwrap().unwrap();
@@ -278,10 +286,23 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
         do_extend2,
     );
 
+    miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    assert_eq!(180 * 2 * EPOCHS_IN_DAY, sector_info.expiration - sector_info.activation);
+    assert_eq!(initial_deal_weight, sector_info.deal_weight); // 0 space time, unchanged
+    assert_eq!(&initial_verified_deal_weight / 2, sector_info.verified_deal_weight);
+
     // advance to 6 months (original expiration) and extend another 6 months
-    // verified deal weight /= 2
-    // power multiplier = (1/3)*3.25 + (2/3)*1 = 1.75
-    // power delta = (3.25 - 1.75)*32GiB = 1.5*32GiB
+    //
+    // We're 1/3rd of the way through the last extension, so keep 2/3 of the power.
+    //   - verified deal weight *= 2/3
+    //
+    // normalize 180 days of 4x power plus 180 days of 1x power over 180+180 days:
+    //   - multiplier = ((4 * 180) + (1 * 180)) / (90 + 180)
+    //   - multiplier = 2.5
+    //
+    // delta from the previous 4x power multiplier:
+    // - power delta = (4-2.5)*32GiB = 1.5*32GiB
 
     v = advance_by_deadline_to_epoch_while_proving(
         v,
@@ -315,8 +336,8 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
     assert_eq!(180 * 3 * EPOCHS_IN_DAY, sector_info.expiration - sector_info.activation);
     assert_eq!(initial_deal_weight, sector_info.deal_weight); // 0 space time, unchanged
-    assert_eq!(initial_verified_deal_weight / 4, sector_info.verified_deal_weight);
-    // two halvings => 1/4 initial verified deal weight
+    assert_eq!(initial_verified_deal_weight / 3, sector_info.verified_deal_weight);
+    // 1/2 * 2/3 -> 1/3
 
     v.expect_state_invariants(
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -102,12 +102,24 @@ fn extend<BS: Blockstore>(
     ExpectInvocation {
         to: maddr,
         method: extension_method,
-        subinvocs: Some(vec![ExpectInvocation {
-            to: STORAGE_POWER_ACTOR_ADDR,
-            method: PowerMethod::UpdateClaimedPower as u64,
-            params: Some(Some(power_update_params)),
-            ..Default::default()
-        }]),
+        subinvocs: Some(vec![
+            ExpectInvocation {
+                to: REWARD_ACTOR_ADDR,
+                method: RewardMethod::ThisEpochReward as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::CurrentTotalPower as u64,
+                ..Default::default()
+            },
+            ExpectInvocation {
+                to: STORAGE_POWER_ACTOR_ADDR,
+                method: PowerMethod::UpdateClaimedPower as u64,
+                params: Some(Some(power_update_params)),
+                ..Default::default()
+            },
+        ]),
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -709,6 +709,7 @@ fn extend_after_upgrade() {
     let (v, sector_info, worker, miner_id, deadline_index, partition_index, _) =
         create_miner_and_upgrade_sector(store, false);
     let sector_number = sector_info.sector_number;
+    let activation = sector_info.activation;
     let mut legacy_sector = sector_info;
     legacy_sector.simple_qa_power = false;
 
@@ -719,13 +720,12 @@ fn extend_after_upgrade() {
         st.sectors = sectors.amt.flush().unwrap();
     });
 
-    let extension_epoch = v.get_epoch();
     let extension_params = ExtendSectorExpirationParams {
         extensions: vec![ExpirationExtension {
             deadline: deadline_index,
             partition: partition_index,
             sectors: make_bitfield(&[sector_number]),
-            new_expiration: extension_epoch + policy.max_sector_expiration_extension - 1,
+            new_expiration: activation + policy.max_sector_expiration_extension - 1,
         }],
     };
 
@@ -742,7 +742,7 @@ fn extend_after_upgrade() {
     let final_sector_info = miner_state.get_sector(store, sector_number).unwrap().unwrap();
     assert_eq!(
         policy.max_sector_expiration_extension - 1,
-        final_sector_info.expiration - extension_epoch,
+        final_sector_info.expiration - activation,
     );
     v.assert_state_invariants();
 }

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -701,7 +701,7 @@ fn terminate_after_upgrade() {
     v.assert_state_invariants();
 }
 
-// Tests that an active CC sector can be correctly upgraded, and then the sector can be terminated
+// Tests that an active CC sector can be correctly upgraded, and then the sector can be extended
 #[test]
 fn extend_after_upgrade() {
     let store = &MemoryBlockstore::new();
@@ -719,12 +719,13 @@ fn extend_after_upgrade() {
         st.sectors = sectors.amt.flush().unwrap();
     });
 
+    let extension_epoch = v.get_epoch();
     let extension_params = ExtendSectorExpirationParams {
         extensions: vec![ExpirationExtension {
             deadline: deadline_index,
             partition: partition_index,
             sectors: make_bitfield(&[sector_number]),
-            new_expiration: v.get_epoch() + policy.max_sector_expiration_extension - 1,
+            new_expiration: extension_epoch + policy.max_sector_expiration_extension - 1,
         }],
     };
 
@@ -741,7 +742,7 @@ fn extend_after_upgrade() {
     let final_sector_info = miner_state.get_sector(store, sector_number).unwrap().unwrap();
     assert_eq!(
         policy.max_sector_expiration_extension - 1,
-        final_sector_info.expiration - final_sector_info.activation
+        final_sector_info.expiration - extension_epoch,
     );
     v.assert_state_invariants();
 }


### PR DESCRIPTION
Implement SDM ([FIP0057](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0057.md)). This builds on #1229 and uses the new "power base epoch" as the base epoch for computing the sector duration multiplier.

There are three main components of this PR:

1. Apply the SDM.
2. Update the initial pledge when we extend a sector. I've combined both extension functions (simple and non-simple) as they now share quite a bit of logic.
3. Record the extension-based pledge updates in the state.

One tricky part to note is that the power can now change multiple times over the lifetime of a sector, instead of just once. This makes termination penalties tricky as there should, in theory, be _multiple_ "replaced day rewards".

To simplify this situation, we:

1. Always update the "expected day reward" based on the latest power.
2. Always update the "replaced day rewards" to the maximum of the old power and the old replaced day rewards.

We do this for non-simple qap in addition to simple qap.

Finally, unlike the FIP (to be updated), this PR starts applying SDM from `540 * EPOCHS_IN_DAY` instead of `3/2 * EPOCHS_IN_YEAR` to match the current maximum sector duration extension. However, it keeps the same target 2x maximum multiplier.

TODO:

- [ ] Write tests.