### PR TITLE
Investigate increased CI time

### DIFF
--- a/actors/market/src/testing.rs
+++ b/actors/market/src/testing.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     convert::TryFrom,
+    fmt::Debug,
 };
 
 use cid::Cid;
@@ -60,7 +61,7 @@ pub struct StateSummary {
 }
 
 /// Checks internal invariants of market state
-pub fn check_state_invariants<BS: Blockstore>(
+pub fn check_state_invariants<BS: Blockstore + Debug>(
     state: &State,
     store: &BS,
     balance: &TokenAmount,
@@ -228,10 +229,7 @@ pub fn check_state_invariants<BS: Blockstore>(
             let ret = pending_proposals.for_each(|key, _| {
                 let proposal_cid = Cid::try_from(key.0.to_owned())?;
 
-                acc.require(
-                    proposal_cids.contains(&proposal_cid),
-                    format!("pending proposal with cid {proposal_cid} not found within proposals"),
-                );
+                acc.require(proposal_cids.contains(&proposal_cid), format!("pending proposal with cid {proposal_cid} not found within proposals {pending_proposals:?}"));
 
                 pending_proposal_count += 1;
                 Ok(())

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -1355,7 +1355,7 @@ fn fail_when_deal_is_activated_but_proposal_is_not_found() {
         &rt,
         &[
             Regex::new("no deal proposal for deal state \\d+").unwrap(),
-            Regex::new("pending proposal with cid \\w+ not found within proposals").unwrap(),
+            Regex::new("pending proposal with cid \\w+ not found within proposals .*").unwrap(),
             Regex::new("deal op found for deal id \\d+ with missing proposal at epoch \\d+")
                 .unwrap(),
         ],

--- a/actors/miner/tests/sectors.rs
+++ b/actors/miner/tests/sectors.rs
@@ -17,7 +17,7 @@ fn make_sector(i: u64) -> SectorOnChainInfo {
     }
 }
 
-fn setup_sectors(store: &'_ MemoryBlockstore) -> Sectors<MemoryBlockstore> {
+fn setup_sectors(store: &'_ MemoryBlockstore) -> Sectors<'_, MemoryBlockstore> {
     sectors_arr_mbs(store, vec![make_sector(0), make_sector(1), make_sector(5)])
 }
 

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2967,7 +2967,7 @@ pub fn test_sector(
 pub fn sectors_arr_mbs(
     store: &'_ MemoryBlockstore,
     sectors_info: Vec<SectorOnChainInfo>,
-) -> Sectors<MemoryBlockstore> {
+) -> Sectors<'_, MemoryBlockstore> {
     let empty_array =
         Amt::<(), _>::new_with_bit_width(store, SECTORS_AMT_BITWIDTH).flush().unwrap();
     let mut sectors = Sectors::load(store, &empty_array).unwrap();
@@ -3294,7 +3294,7 @@ pub fn select_sectors(sectors: &[SectorOnChainInfo], field: &BitField) -> Vec<Se
 #[allow(dead_code)]
 pub fn require_no_expiration_groups_before(
     epoch: ChainEpoch,
-    queue: &mut ExpirationQueue<MemoryBlockstore>,
+    queue: &mut ExpirationQueue<'_, MemoryBlockstore>,
 ) {
     queue.amt.flush().unwrap();
 

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -113,7 +113,7 @@ macro_rules! get_state {
 // to match the Manifest implementation in the FVM.
 // It could be replaced with a custom mapping trait (while Rust doesn't support
 // abstract collection traits).
-pub fn check_state_invariants<'a, BS: Blockstore>(
+pub fn check_state_invariants<'a, BS: Blockstore + Debug>(
     manifest: &BiBTreeMap<Cid, Type>,
     policy: &Policy,
     tree: Tree<'a, BS>,

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -73,16 +73,12 @@ fn new_bls_from_rng(rng: &mut ChaCha8Rng) -> Address {
 
 const ACCOUNT_SEED: u64 = 93837778;
 
-pub fn create_accounts<BS: Blockstore>(
-    v: &TestVM<BS>,
-    count: u64,
-    balance: TokenAmount,
-) -> Vec<Address> {
+pub fn create_accounts(v: &TestVM, count: u64, balance: TokenAmount) -> Vec<Address> {
     create_accounts_seeded(v, count, balance, ACCOUNT_SEED)
 }
 
-pub fn create_accounts_seeded<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn create_accounts_seeded(
+    v: &TestVM,
     count: u64,
     balance: TokenAmount,
     seed: u64,
@@ -96,8 +92,8 @@ pub fn create_accounts_seeded<BS: Blockstore>(
     pk_addrs.iter().map(|&pk_addr| v.normalize_address(&pk_addr).unwrap()).collect()
 }
 
-pub fn apply_ok<BS: Blockstore, S: Serialize>(
-    v: &TestVM<BS>,
+pub fn apply_ok<S: Serialize>(
+    v: &TestVM,
     from: Address,
     to: Address,
     value: TokenAmount,
@@ -107,8 +103,8 @@ pub fn apply_ok<BS: Blockstore, S: Serialize>(
     apply_code(v, from, to, value, method, params, ExitCode::OK)
 }
 
-pub fn apply_code<BS: Blockstore, S: Serialize>(
-    v: &TestVM<BS>,
+pub fn apply_code<S: Serialize>(
+    v: &TestVM,
     from: Address,
     to: Address,
     value: TokenAmount,
@@ -121,7 +117,7 @@ pub fn apply_code<BS: Blockstore, S: Serialize>(
     res.ret.map_or(RawBytes::default(), |b| RawBytes::new(b.data))
 }
 
-pub fn cron_tick<BS: Blockstore>(v: &TestVM<BS>) {
+pub fn cron_tick(v: &TestVM) {
     apply_ok(
         v,
         SYSTEM_ACTOR_ADDR,
@@ -132,8 +128,8 @@ pub fn cron_tick<BS: Blockstore>(v: &TestVM<BS>) {
     );
 }
 
-pub fn create_miner<BS: Blockstore>(
-    v: &mut TestVM<BS>,
+pub fn create_miner(
+    v: &mut TestVM,
     owner: Address,
     worker: Address,
     post_proof_type: RegisteredPoStProof,
@@ -165,8 +161,8 @@ pub fn create_miner<BS: Blockstore>(
     (res.id_address, res.robust_address)
 }
 
-pub fn miner_precommit_sector<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn miner_precommit_sector(
+    v: &TestVM,
     worker: Address,
     miner_id: Address,
     seal_proof: RegisteredSealProof,
@@ -202,8 +198,8 @@ pub fn miner_precommit_sector<BS: Blockstore>(
     state.get_precommitted_sector(v.store, sector_number).unwrap().unwrap()
 }
 
-pub fn miner_prove_sector<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn miner_prove_sector(
+    v: &TestVM,
     worker: Address,
     miner_id: Address,
     sector_number: SectorNumber,
@@ -233,8 +229,8 @@ pub fn miner_prove_sector<BS: Blockstore>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn precommit_sectors_v2<BS: Blockstore>(
-    v: &mut TestVM<BS>,
+pub fn precommit_sectors_v2(
+    v: &mut TestVM,
     count: u64,
     batch_size: i64,
     worker: Address,
@@ -394,8 +390,8 @@ pub fn precommit_sectors_v2<BS: Blockstore>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn precommit_sectors<BS: Blockstore>(
-    v: &mut TestVM<BS>,
+pub fn precommit_sectors(
+    v: &mut TestVM,
     count: u64,
     batch_size: i64,
     worker: Address,
@@ -419,8 +415,8 @@ pub fn precommit_sectors<BS: Blockstore>(
     )
 }
 
-pub fn prove_commit_sectors<BS: Blockstore>(
-    v: &mut TestVM<BS>,
+pub fn prove_commit_sectors(
+    v: &mut TestVM,
     worker: Address,
     maddr: Address,
     precommits: Vec<SectorPreCommitOnChainInfo>,
@@ -483,8 +479,8 @@ pub fn prove_commit_sectors<BS: Blockstore>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn miner_extend_sector_expiration2<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn miner_extend_sector_expiration2(
+    v: &TestVM,
     worker: Address,
     miner_id: Address,
     deadline: u64,
@@ -560,32 +556,28 @@ pub fn miner_extend_sector_expiration2<BS: Blockstore>(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn advance_by_deadline_to_epoch<BS: Blockstore>(
-    v: TestVM<BS>,
+pub fn advance_by_deadline_to_epoch(
+    v: TestVM,
     maddr: Address,
     e: ChainEpoch,
-) -> (TestVM<BS>, DeadlineInfo) {
+) -> (TestVM, DeadlineInfo) {
     // keep advancing until the epoch of interest is within the deadline
     // if e is dline.last() == dline.close -1 cron is not run
     let (v, dline_info) = advance_by_deadline(v, maddr, |dline_info| dline_info.close < e);
     (v.with_epoch(e), dline_info)
 }
 
-pub fn advance_by_deadline_to_index<BS: Blockstore>(
-    v: TestVM<BS>,
-    maddr: Address,
-    i: u64,
-) -> (TestVM<BS>, DeadlineInfo) {
+pub fn advance_by_deadline_to_index(v: TestVM, maddr: Address, i: u64) -> (TestVM, DeadlineInfo) {
     advance_by_deadline(v, maddr, |dline_info| dline_info.index != i)
 }
 
-pub fn advance_by_deadline_to_epoch_while_proving<BS: Blockstore>(
-    mut v: TestVM<BS>,
+pub fn advance_by_deadline_to_epoch_while_proving(
+    mut v: TestVM,
     maddr: Address,
     worker: Address,
     s: SectorNumber,
     e: ChainEpoch,
-) -> TestVM<BS> {
+) -> TestVM {
     let mut dline_info;
     let (d, p_idx) = sector_deadline(&v, maddr, s);
     loop {
@@ -607,24 +599,19 @@ pub fn advance_by_deadline_to_epoch_while_proving<BS: Blockstore>(
     }
 }
 
-pub fn advance_to_proving_deadline<BS: Blockstore>(
-    v: TestVM<BS>,
+pub fn advance_to_proving_deadline(
+    v: TestVM,
     maddr: Address,
     s: SectorNumber,
-) -> (DeadlineInfo, u64, TestVM<BS>) {
+) -> (DeadlineInfo, u64, TestVM) {
     let (d, p) = sector_deadline(&v, maddr, s);
     let (v, dline_info) = advance_by_deadline_to_index(v, maddr, d);
     let v = v.with_epoch(dline_info.open);
     (dline_info, p, v)
 }
 
-fn advance_by_deadline<BS, F>(
-    mut v: TestVM<BS>,
-    maddr: Address,
-    more: F,
-) -> (TestVM<BS>, DeadlineInfo)
+fn advance_by_deadline<F>(mut v: TestVM, maddr: Address, more: F) -> (TestVM, DeadlineInfo)
 where
-    BS: Blockstore,
     F: Fn(DeadlineInfo) -> bool,
 {
     loop {
@@ -640,7 +627,7 @@ where
     }
 }
 
-pub fn miner_dline_info<BS: Blockstore>(v: &TestVM<BS>, m: Address) -> DeadlineInfo {
+pub fn miner_dline_info(v: &TestVM, m: Address) -> DeadlineInfo {
     let st = v.get_state::<MinerState>(m).unwrap();
     new_deadline_info_from_offset_and_epoch(
         &Policy::default(),
@@ -649,19 +636,19 @@ pub fn miner_dline_info<BS: Blockstore>(v: &TestVM<BS>, m: Address) -> DeadlineI
     )
 }
 
-pub fn sector_deadline<BS: Blockstore>(v: &TestVM<BS>, m: Address, s: SectorNumber) -> (u64, u64) {
+pub fn sector_deadline(v: &TestVM, m: Address, s: SectorNumber) -> (u64, u64) {
     let st = v.get_state::<MinerState>(m).unwrap();
     st.find_sector(&Policy::default(), v.store, s).unwrap()
 }
 
-pub fn check_sector_active<BS: Blockstore>(v: &TestVM<BS>, m: Address, s: SectorNumber) -> bool {
+pub fn check_sector_active(v: &TestVM, m: Address, s: SectorNumber) -> bool {
     let (d_idx, p_idx) = sector_deadline(v, m, s);
     let st = v.get_state::<MinerState>(m).unwrap();
     st.check_sector_active(&Policy::default(), v.store, d_idx, p_idx, s, true).unwrap()
 }
 
-pub fn check_sector_faulty<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn check_sector_faulty(
+    v: &TestVM,
     m: Address,
     d_idx: u64,
     p_idx: u64,
@@ -674,29 +661,25 @@ pub fn check_sector_faulty<BS: Blockstore>(
     partition.faults.get(s)
 }
 
-pub fn deadline_state<BS: Blockstore>(v: &TestVM<BS>, m: Address, d_idx: u64) -> Deadline {
+pub fn deadline_state(v: &TestVM, m: Address, d_idx: u64) -> Deadline {
     let st = v.get_state::<MinerState>(m).unwrap();
     let deadlines = st.load_deadlines(v.store).unwrap();
     deadlines.load_deadline(&Policy::default(), v.store, d_idx).unwrap()
 }
 
-pub fn sector_info<BS: Blockstore>(
-    v: &TestVM<BS>,
-    m: Address,
-    s: SectorNumber,
-) -> SectorOnChainInfo {
+pub fn sector_info(v: &TestVM, m: Address, s: SectorNumber) -> SectorOnChainInfo {
     let st = v.get_state::<MinerState>(m).unwrap();
     st.get_sector(v.store, s).unwrap().unwrap()
 }
 
-pub fn miner_power<BS: Blockstore>(v: &TestVM<BS>, m: Address) -> PowerPair {
+pub fn miner_power(v: &TestVM, m: Address) -> PowerPair {
     let st = v.get_state::<PowerState>(STORAGE_POWER_ACTOR_ADDR).unwrap();
     let claim = st.get_claim(v.store, &m).unwrap().unwrap();
     PowerPair::new(claim.raw_byte_power, claim.quality_adj_power)
 }
 
-pub fn declare_recovery<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn declare_recovery(
+    v: &TestVM,
     worker: Address,
     maddr: Address,
     deadline: u64,
@@ -721,8 +704,8 @@ pub fn declare_recovery<BS: Blockstore>(
     );
 }
 
-pub fn submit_windowed_post<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn submit_windowed_post(
+    v: &TestVM,
     worker: Address,
     maddr: Address,
     dline_info: DeadlineInfo,
@@ -775,8 +758,8 @@ pub fn submit_windowed_post<BS: Blockstore>(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn change_beneficiary<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn change_beneficiary(
+    v: &TestVM,
     from: Address,
     maddr: Address,
     beneficiary_change_proposal: &ChangeBeneficiaryParams,
@@ -791,11 +774,7 @@ pub fn change_beneficiary<BS: Blockstore>(
     );
 }
 
-pub fn get_beneficiary<BS: Blockstore>(
-    v: &TestVM<BS>,
-    from: Address,
-    m_addr: Address,
-) -> GetBeneficiaryReturn {
+pub fn get_beneficiary(v: &TestVM, from: Address, m_addr: Address) -> GetBeneficiaryReturn {
     apply_ok(
         v,
         from,
@@ -808,12 +787,7 @@ pub fn get_beneficiary<BS: Blockstore>(
     .unwrap()
 }
 
-pub fn change_owner_address<BS: Blockstore>(
-    v: &TestVM<BS>,
-    from: Address,
-    m_addr: Address,
-    new_miner_addr: Address,
-) {
+pub fn change_owner_address(v: &TestVM, from: Address, m_addr: Address, new_miner_addr: Address) {
     apply_ok(
         v,
         from,
@@ -824,8 +798,8 @@ pub fn change_owner_address<BS: Blockstore>(
     );
 }
 
-pub fn withdraw_balance<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn withdraw_balance(
+    v: &TestVM,
     from: Address,
     m_addr: Address,
     to_withdraw_amount: TokenAmount,
@@ -863,8 +837,8 @@ pub fn withdraw_balance<BS: Blockstore>(
     assert_eq!(expect_withdraw_amount, withdraw_return.amount_withdrawn);
 }
 
-pub fn submit_invalid_post<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn submit_invalid_post(
+    v: &TestVM,
     worker: Address,
     maddr: Address,
     dline_info: DeadlineInfo,
@@ -890,11 +864,7 @@ pub fn submit_invalid_post<BS: Blockstore>(
     );
 }
 
-pub fn verifreg_add_verifier<BS: Blockstore>(
-    v: &TestVM<BS>,
-    verifier: Address,
-    data_cap: StoragePower,
-) {
+pub fn verifreg_add_verifier(v: &TestVM, verifier: Address, data_cap: StoragePower) {
     let add_verifier_params = VerifierParams { address: verifier, allowance: data_cap };
     // root address is msig, send proposal from root key
     let proposal = ProposeParams {
@@ -933,8 +903,8 @@ pub fn verifreg_add_verifier<BS: Blockstore>(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn verifreg_add_client<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn verifreg_add_client(
+    v: &TestVM,
     verifier: Address,
     client: Address,
     allowance: StoragePower,
@@ -972,8 +942,8 @@ pub fn verifreg_add_client<BS: Blockstore>(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn verifreg_extend_claim_terms<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn verifreg_extend_claim_terms(
+    v: &TestVM,
     client: Address,
     provider: Address,
     claim: ClaimID,
@@ -996,8 +966,8 @@ pub fn verifreg_extend_claim_terms<BS: Blockstore>(
     );
 }
 
-pub fn verifreg_remove_expired_allocations<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn verifreg_remove_expired_allocations(
+    v: &TestVM,
     caller: Address,
     client: Address,
     ids: Vec<AllocationID>,
@@ -1035,7 +1005,7 @@ pub fn verifreg_remove_expired_allocations<BS: Blockstore>(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn datacap_get_balance<BS: Blockstore>(v: &TestVM<BS>, address: Address) -> TokenAmount {
+pub fn datacap_get_balance(v: &TestVM, address: Address) -> TokenAmount {
     let ret = apply_ok(
         v,
         address,
@@ -1047,8 +1017,8 @@ pub fn datacap_get_balance<BS: Blockstore>(v: &TestVM<BS>, address: Address) -> 
     deserialize(&ret, "balance of return value").unwrap()
 }
 
-pub fn datacap_extend_claim<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn datacap_extend_claim(
+    v: &TestVM,
     client: Address,
     provider: Address,
     claim: ClaimID,
@@ -1121,12 +1091,7 @@ pub fn datacap_extend_claim<BS: Blockstore>(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn market_add_balance<BS: Blockstore>(
-    v: &TestVM<BS>,
-    sender: Address,
-    beneficiary: Address,
-    amount: TokenAmount,
-) {
+pub fn market_add_balance(v: &TestVM, sender: Address, beneficiary: Address, amount: TokenAmount) {
     apply_ok(
         v,
         sender,
@@ -1138,8 +1103,8 @@ pub fn market_add_balance<BS: Blockstore>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn market_publish_deal<BS: Blockstore>(
-    v: &TestVM<BS>,
+pub fn market_publish_deal(
+    v: &TestVM,
     worker: Address,
     deal_client: Address,
     miner_id: Address,

--- a/test_vm/tests/authenticate_message_test.rs
+++ b/test_vm/tests/authenticate_message_test.rs
@@ -15,7 +15,7 @@ use test_vm::TestVM;
 #[test]
 fn account_authenticate_message() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addr = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
 
     let proposal =

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -49,7 +49,7 @@ impl Onboarding {
 #[test_case(true; "v2")]
 fn batch_onboarding(v2: bool) {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);

--- a/test_vm/tests/change_beneficiary_test.rs
+++ b/test_vm/tests/change_beneficiary_test.rs
@@ -15,7 +15,7 @@ use test_vm::TestVM;
 #[test]
 fn change_beneficiary_success() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, another_beneficiary, query_addr) =
@@ -73,7 +73,7 @@ fn change_beneficiary_success() {
 #[test]
 fn change_beneficiary_back_owner_success() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, query_addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -126,7 +126,7 @@ fn change_beneficiary_back_owner_success() {
 #[test]
 fn change_beneficiary_fail() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/change_owner_test.rs
+++ b/test_vm/tests/change_owner_test.rs
@@ -13,7 +13,7 @@ use test_vm::TestVM;
 #[test]
 fn change_owner_success() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -50,7 +50,7 @@ fn change_owner_success() {
 #[test]
 fn keep_beneficiary_when_owner_changed() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -92,7 +92,7 @@ fn keep_beneficiary_when_owner_changed() {
 #[test]
 fn change_owner_fail() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -44,8 +44,8 @@ struct MinerInfo {
     _miner_robust: Address,
 }
 
-fn setup(store: &'_ MemoryBlockstore) -> (TestVM<MemoryBlockstore>, MinerInfo, SectorInfo) {
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+fn setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, MinerInfo, SectorInfo) {
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -308,7 +308,7 @@ fn missed_first_post_deadline() {
 fn overdue_precommit() {
     let store = MemoryBlockstore::new();
     let policy = &Policy::default();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -422,7 +422,7 @@ fn overdue_precommit() {
 #[test]
 fn aggregate_bad_sector_number() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -503,7 +503,7 @@ fn aggregate_bad_sector_number() {
 fn aggregate_size_limits() {
     let oversized_batch = 820;
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -636,7 +636,7 @@ fn aggregate_size_limits() {
 #[test]
 fn aggregate_bad_sender() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 2, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -712,7 +712,7 @@ fn aggregate_bad_sender() {
 #[test]
 fn aggregate_one_precommit_expires() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);

--- a/test_vm/tests/datacap_tests.rs
+++ b/test_vm/tests/datacap_tests.rs
@@ -23,7 +23,7 @@ use fvm_ipld_encoding::RawBytes;
 fn datacap_transfer_scenario() {
     let policy = Policy::default();
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let (client, operator, owner) = (addrs[0], addrs[1], addrs[2]);
 
@@ -203,7 +203,7 @@ fn datacap_transfer_scenario() {
 #[test]
 fn call_name_symbol() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(10_000));
     let sender = addrs[0];
 

--- a/test_vm/tests/evm_test.rs
+++ b/test_vm/tests/evm_test.rs
@@ -38,7 +38,7 @@ struct ContractParams(#[serde(with = "strict_bytes")] pub Vec<u8>);
 #[test]
 fn test_evm_call() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
 
@@ -90,7 +90,7 @@ fn test_evm_call() {
 #[test]
 fn test_evm_create() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
 
@@ -233,7 +233,7 @@ fn test_evm_create() {
 #[test]
 fn test_evm_eth_create_external() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     // create the EthAccount
     let eth_bits = hex_literal::hex!("FEEDFACECAFEBEEF000000000000000000000000");
@@ -289,7 +289,7 @@ fn test_evm_eth_create_external() {
 #[test]
 fn test_evm_empty_initcode() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
     let create_result = v
@@ -321,7 +321,7 @@ fn test_evm_staticcall() {
     // A -> staticcall -> B -> call -> C (write) FAIL
 
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let accounts = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
@@ -475,7 +475,7 @@ fn test_evm_delegatecall() {
     // A -> staticcall -> B -> delegatecall -> C (write) FAIL
 
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let accounts = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
@@ -613,7 +613,7 @@ fn test_evm_staticcall_delegatecall() {
     // A -> staticcall -> B -> delegatecall -> C (write) FAIL
 
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let accounts = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
@@ -710,7 +710,7 @@ fn test_evm_staticcall_delegatecall() {
 #[test]
 fn test_evm_init_revert_data() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let account = create_accounts(&v, 1, TokenAmount::from_whole(10_000))[0];
     let create_result = v

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -7,7 +7,7 @@ use fil_actor_power::{Method as PowerMethod, UpdateClaimedPowerParams};
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{DealWeight, EPOCHS_IN_DAY, STORAGE_POWER_ACTOR_ADDR};
 use fvm_ipld_bitfield::BitField;
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
@@ -35,8 +35,8 @@ fn extend2_legacy_sector_with_deals() {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn extend<BS: Blockstore>(
-    v: &TestVM<BS>,
+fn extend(
+    v: &TestVM,
     worker: Address,
     maddr: Address,
     deadline_index: u64,
@@ -107,7 +107,7 @@ fn extend<BS: Blockstore>(
 
 fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/init_test.rs
+++ b/test_vm/tests/init_test.rs
@@ -5,13 +5,13 @@ use fil_actors_runtime::{
     test_utils::{EAM_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID, PLACEHOLDER_ACTOR_CODE_ID},
     EAM_ACTOR_ADDR, EAM_ACTOR_ID, INIT_ACTOR_ADDR,
 };
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, METHOD_SEND};
 use num_traits::Zero;
 use test_vm::{actor, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
 
-fn assert_placeholder_actor<BS: Blockstore>(exp_bal: TokenAmount, v: &TestVM<BS>, addr: Address) {
+fn assert_placeholder_actor(exp_bal: TokenAmount, v: &TestVM, addr: Address) {
     let act = v.get_actor(addr).unwrap();
     assert_eq!(EMPTY_ARR_CID, act.head);
     assert_eq!(*PLACEHOLDER_ACTOR_CODE_ID, act.code);
@@ -21,7 +21,7 @@ fn assert_placeholder_actor<BS: Blockstore>(exp_bal: TokenAmount, v: &TestVM<BS>
 #[test]
 fn placeholder_deploy() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     // Create a "fake" eam.
     v.set_actor(

--- a/test_vm/tests/market_miner_withdrawal_test.rs
+++ b/test_vm/tests/market_miner_withdrawal_test.rs
@@ -4,7 +4,6 @@ use fil_actor_miner::Method as MinerMethod;
 use fil_actor_miner::WithdrawBalanceParams as MinerWithdrawBalanceParams;
 use fil_actors_runtime::test_utils::{MARKET_ACTOR_CODE_ID, MINER_ACTOR_CODE_ID};
 use fil_actors_runtime::STORAGE_MARKET_ACTOR_ADDR;
-use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
@@ -143,8 +142,8 @@ mod miner_tests {
 // 1. Add collateral to escrow address
 // 2. Send a withdraw message attempting to remove `requested` funds
 // 3. Assert correct return value and actor balance transfer
-fn assert_add_collateral_and_withdraw<BS: Blockstore>(
-    v: &TestVM<BS>,
+fn assert_add_collateral_and_withdraw(
+    v: &TestVM,
     collateral: TokenAmount,
     expected_withdrawn: TokenAmount,
     requested: TokenAmount,
@@ -220,22 +219,20 @@ fn assert_add_collateral_and_withdraw<BS: Blockstore>(
     assert_eq!(caller_initial_balance, c.balance);
 }
 
-fn require_actor<BS: Blockstore>(v: &TestVM<BS>, addr: Address) -> Actor {
+fn require_actor(v: &TestVM, addr: Address) -> Actor {
     v.get_actor(addr).unwrap()
 }
 
-fn market_setup(store: &'_ MemoryBlockstore) -> (TestVM<MemoryBlockstore>, Address) {
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+fn market_setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, Address) {
+    let v = TestVM::new_with_singletons(store);
     let initial_balance = TokenAmount::from_whole(6);
     let addrs = create_accounts(&v, 1, initial_balance);
     let caller = addrs[0];
     (v, caller)
 }
 
-fn miner_setup(
-    store: &'_ MemoryBlockstore,
-) -> (TestVM<MemoryBlockstore>, Address, Address, Address) {
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+fn miner_setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, Address, Address, Address) {
+    let mut v = TestVM::new_with_singletons(store);
     let initial_balance = TokenAmount::from_whole(10_000);
     let addrs = create_accounts(&v, 2, initial_balance);
     let (worker, owner) = (addrs[0], addrs[1]);

--- a/test_vm/tests/multisig_test.rs
+++ b/test_vm/tests/multisig_test.rs
@@ -6,7 +6,7 @@ use fil_actor_multisig::{
 use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::test_utils::*;
 use fil_actors_runtime::{make_map_with_root, INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR};
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
@@ -22,7 +22,7 @@ use test_vm::{ExpectInvocation, TestVM};
 #[test]
 fn test_proposal_hash() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let alice = addrs[0];
     let bob = addrs[1];
@@ -102,7 +102,7 @@ fn test_proposal_hash() {
 fn test_delete_self() {
     let test = |threshold: usize, signers: u64, remove_idx: usize| {
         let store = MemoryBlockstore::new();
-        let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+        let v = TestVM::new_with_singletons(&store);
         let addrs = create_accounts(&v, signers, TokenAmount::from_whole(10_000));
 
         let msig_addr = create_msig(&v, addrs.clone(), threshold as u64);
@@ -174,7 +174,7 @@ fn test_delete_self() {
 #[test]
 fn swap_self_1_of_2() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
 
     let (alice, bob, chuck) = (addrs[0], addrs[1], addrs[2]);
@@ -203,7 +203,7 @@ fn swap_self_1_of_2() {
 #[test]
 fn swap_self_2_of_3() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let (alice, bob, chuck, dinesh) = (addrs[0], addrs[1], addrs[2], addrs[3]);
 
@@ -273,7 +273,7 @@ fn swap_self_2_of_3() {
     v.assert_state_invariants();
 }
 
-fn create_msig<BS: Blockstore>(v: &TestVM<BS>, signers: Vec<Address>, threshold: u64) -> Address {
+fn create_msig(v: &TestVM, signers: Vec<Address>, threshold: u64) -> Address {
     assert!(!signers.is_empty());
     let msig_ctor_params = serialize(
         &fil_actor_multisig::ConstructorParams {
@@ -301,11 +301,7 @@ fn create_msig<BS: Blockstore>(v: &TestVM<BS>, signers: Vec<Address>, threshold:
     msig_ctor_ret.id_address
 }
 
-fn check_txs<BS: Blockstore>(
-    v: &TestVM<BS>,
-    msig_addr: Address,
-    mut expect_txns: Vec<(TxnID, Transaction)>,
-) {
+fn check_txs(v: &TestVM, msig_addr: Address, mut expect_txns: Vec<(TxnID, Transaction)>) {
     let st = v.get_state::<MsigState>(msig_addr).unwrap();
     let ptx = make_map_with_root::<_, Transaction>(&st.pending_txs, v.store).unwrap();
     let mut actual_txns = Vec::new();

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -28,7 +28,7 @@ use test_vm::{ExpectInvocation, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
 #[test]
 fn create_miner_test() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     let owner = Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();
     v.apply_message(
@@ -99,7 +99,7 @@ fn create_miner_test() {
 #[test]
 fn test_cron_tick() {
     let store = MemoryBlockstore::new();
-    let mut vm = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut vm = TestVM::new_with_singletons(&store);
 
     let addrs = create_accounts(&vm, 1, TokenAmount::from_whole(10_000));
 

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -2,7 +2,6 @@ use fil_actor_market::{
     ClientDealProposal, DealProposal, Label, Method as MarketMethod, PublishStorageDealsParams,
     PublishStorageDealsReturn,
 };
-use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::crypto::signature::{Signature, SignatureType};
 
 use fil_actor_account::types::AuthenticateMessageParams;
@@ -54,8 +53,8 @@ fn token_defaults() -> (TokenAmount, TokenAmount, TokenAmount) {
 }
 
 // create miner and client and add collateral
-fn setup(store: &MemoryBlockstore) -> (TestVM<MemoryBlockstore>, Addrs, ChainEpoch) {
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+fn setup(store: &'_ MemoryBlockstore) -> (TestVM<'_>, Addrs, ChainEpoch) {
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 7, TokenAmount::from_whole(10_000));
     let (worker, client1, client2, not_miner, cheap_client, verifier, verified_client) =
         (addrs[0], addrs[1], addrs[2], addrs[3], addrs[4], addrs[5], addrs[6]);
@@ -606,12 +605,9 @@ struct DealOptions {
     client_collateral: Option<TokenAmount>,
 }
 
-struct DealBatcher<'bs, BS>
-where
-    BS: Blockstore,
-{
+struct DealBatcher<'bs> {
     deals: Vec<DealProposal>,
-    v: &'bs TestVM<'bs, BS>,
+    v: &'bs TestVM<'bs>,
     default_provider: Address,
     default_piece_size: PaddedPieceSize,
     default_verified: bool,
@@ -622,12 +618,9 @@ where
     default_client_collateral: TokenAmount,
 }
 
-impl<'bs, BS> DealBatcher<'bs, BS>
-where
-    BS: Blockstore,
-{
+impl<'bs> DealBatcher<'bs> {
     fn new(
-        v: &'bs TestVM<'bs, BS>,
+        v: &'bs TestVM<'bs>,
         default_provider: Address,
         default_piece_size: PaddedPieceSize,
         default_verified: bool,

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -21,7 +21,7 @@ use fil_actors_runtime::{
     SYSTEM_ACTOR_ADDR,
 };
 use fvm_ipld_bitfield::BitField;
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
@@ -174,7 +174,7 @@ fn upgrade_and_miss_post(v2: bool) {
 fn prove_replica_update_multi_dline() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(1_000_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -313,7 +313,7 @@ fn prove_replica_update_multi_dline() {
 #[test]
 fn immutable_deadline_failure() {
     let store = &MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -364,7 +364,7 @@ fn immutable_deadline_failure() {
 fn unhealthy_sector_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -419,7 +419,7 @@ fn unhealthy_sector_failure() {
 #[test]
 fn terminated_sector_failure() {
     let store = &MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -485,7 +485,7 @@ fn terminated_sector_failure() {
 fn bad_batch_size_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -587,7 +587,7 @@ fn upgrade_bad_post_dispute() {
 fn bad_post_upgrade_dispute() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -750,7 +750,7 @@ fn extend_after_upgrade() {
 fn wrong_deadline_index_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -807,7 +807,7 @@ fn wrong_deadline_index_failure() {
 fn wrong_partition_index_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -864,7 +864,7 @@ fn wrong_partition_index_failure() {
 fn deal_included_in_multiple_sectors_failure() {
     let store = &MemoryBlockstore::new();
     let policy = Policy::default();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -992,7 +992,7 @@ fn deal_included_in_multiple_sectors_failure() {
 #[test]
 fn replica_update_verified_deal() {
     let store = &MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(100_000));
     let (worker, owner, client, verifier) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1116,7 +1116,7 @@ fn replica_update_verified_deal() {
 #[test]
 fn replica_update_verified_deal_max_term_violated() {
     let store = &MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(100_000));
     let (worker, owner, client, verifier) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1178,8 +1178,8 @@ fn replica_update_verified_deal_max_term_violated() {
 fn create_miner_and_upgrade_sector(
     store: &MemoryBlockstore,
     v2: bool,
-) -> (TestVM<MemoryBlockstore>, SectorOnChainInfo, Address, Address, u64, u64, SectorSize) {
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
+) -> (TestVM, SectorOnChainInfo, Address, Address, u64, u64, SectorSize) {
+    let mut v = TestVM::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1260,13 +1260,13 @@ fn create_miner_and_upgrade_sector(
 // - fastforwarding to its Proving period and PoSting it
 // - fastforwarding out of the proving period into a new deadline
 // This method assumes that this is a miners first and only sector
-fn create_sector<BS: Blockstore>(
-    mut v: TestVM<BS>,
+fn create_sector(
+    mut v: TestVM,
     worker: Address,
     maddr: Address,
     sector_number: SectorNumber,
     seal_proof: RegisteredSealProof,
-) -> (TestVM<BS>, u64, u64) {
+) -> (TestVM, u64, u64) {
     // precommit
     let exp = v.get_epoch() + Policy::default().max_sector_expiration_extension;
     let precommits =
@@ -1327,9 +1327,9 @@ fn create_sector<BS: Blockstore>(
 
     (v, d_idx, p_idx)
 }
-fn create_deals<BS: Blockstore>(
+fn create_deals(
     num_deals: u32,
-    v: &TestVM<BS>,
+    v: &TestVM,
     client: Address,
     worker: Address,
     maddr: Address,
@@ -1337,9 +1337,9 @@ fn create_deals<BS: Blockstore>(
     create_deals_frac(num_deals, v, client, worker, maddr, 1, false, 180 * EPOCHS_IN_DAY)
 }
 
-fn create_verified_deals<BS: Blockstore>(
+fn create_verified_deals(
     num_deals: u32,
-    v: &TestVM<BS>,
+    v: &TestVM,
     client: Address,
     worker: Address,
     maddr: Address,
@@ -1349,9 +1349,9 @@ fn create_verified_deals<BS: Blockstore>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn create_deals_frac<BS: Blockstore>(
+fn create_deals_frac(
     num_deals: u32,
-    v: &TestVM<BS>,
+    v: &TestVM,
     client: Address,
     worker: Address,
     maddr: Address,

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -36,7 +36,7 @@ use test_vm::{ExpectInvocation, TestVM};
 #[test]
 fn terminate_sectors() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let (owner, verifier, unverified_client, verified_client) =
         (addrs[0], addrs[1], addrs[2], addrs[3]);

--- a/test_vm/tests/test_vm_test.rs
+++ b/test_vm/tests/test_vm_test.rs
@@ -2,7 +2,7 @@ use fil_actor_account::State as AccountState;
 use fil_actors_runtime::test_utils::{
     make_identity_cid, ACCOUNT_ACTOR_CODE_ID, PAYCH_ACTOR_CODE_ID,
 };
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
@@ -15,7 +15,7 @@ use test_vm::{actor, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
 #[test]
 fn state_control() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new(&store);
+    let v = TestVM::new(&store);
     let addr1 = Address::new_id(1000);
     let addr2 = Address::new_id(2222);
 
@@ -53,11 +53,11 @@ fn state_control() {
     assert!(invariants_check.unwrap_err().to_string().contains("AccountState is empty"));
 }
 
-fn assert_account_actor<BS: Blockstore>(
+fn assert_account_actor(
     exp_call_seq: u64,
     exp_bal: TokenAmount,
     exp_pk_addr: Address,
-    v: &TestVM<BS>,
+    v: &TestVM,
     addr: Address,
 ) {
     let act = v.get_actor(addr).unwrap();
@@ -71,7 +71,7 @@ fn assert_account_actor<BS: Blockstore>(
 #[test]
 fn test_sent() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
 
     // send to uninitialized account actor
     let addr1 = Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();

--- a/test_vm/tests/verified_claim_test.rs
+++ b/test_vm/tests/verified_claim_test.rs
@@ -43,7 +43,7 @@ use test_vm::TestVM;
 #[test]
 fn verified_claim_scenario() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client, verified_client2) =
@@ -339,7 +339,7 @@ fn verified_claim_scenario() {
 #[test]
 fn expired_allocations() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -33,7 +33,7 @@ use test_vm::{ExpectInvocation, TestVM, TEST_VERIFREG_ROOT_ADDR};
 #[test]
 fn remove_datacap_simple_successful_path() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 4, TokenAmount::from_whole(10_000));
     let (verifier1, verifier2, verified_client) = (addrs[0], addrs[1], addrs[2]);
 
@@ -283,7 +283,7 @@ fn remove_datacap_simple_successful_path() {
 #[test]
 fn remove_datacap_fails_on_verifreg() {
     let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 2, TokenAmount::from_whole(10_000));
     let (verifier1, verifier2) = (addrs[0], addrs[1]);
 

--- a/test_vm/tests/withdraw_balance_test.rs
+++ b/test_vm/tests/withdraw_balance_test.rs
@@ -12,7 +12,7 @@ use test_vm::TestVM;
 #[test]
 fn withdraw_balance_success() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 2, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary) = (addrs[0], addrs[0], addrs[1]);
@@ -54,7 +54,7 @@ fn withdraw_balance_success() {
 #[test]
 fn withdraw_balance_fail() {
     let store = MemoryBlockstore::new();
-    let mut v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    let mut v = TestVM::new_with_singletons(&store);
     let addrs = create_accounts(&v, 3, TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);


### PR DESCRIPTION
The change in https://github.com/filecoin-project/builtin-actors/pull/1259 has caused a significant increase in CI times for this repo.

https://github.com/filecoin-project/builtin-actors/actions/runs/4527273009/jobs/7972963894 took around 18 minutes and has **doubled** (34 minutes) both when it landed on master: https://github.com/filecoin-project/builtin-actors/actions/runs/4538508299/jobs/7997478197 and when it ran on the PR branch (35 minutes) https://github.com/filecoin-project/builtin-actors/actions/runs/4528315067/jobs/7974981200

This PR reverts commit 424669ba4e38a1a8557626d411cd0c89389f4fcd to see if that commit caused the increase in CI times. (It does)

By switching to a generic trait, the compiler will monomorphize the TestVM code. This should not in fact affect test execution times but running this PR to make sure. Locally I see that the time taken to build the TestVM tests has more than doubled ~2:30 -> 6 minutes whilst time taken to run the tests remains roughly the same ~4 minutes. 