### PR TITLE
Revert activation bug fix and FIP 0052

### DIFF
--- a/actors/market/src/policy.rs
+++ b/actors/market/src/policy.rs
@@ -20,7 +20,7 @@ pub mod detail {
 
 /// Bounds (inclusive) on deal duration.
 pub(super) fn deal_duration_bounds(_size: PaddedPieceSize) -> (ChainEpoch, ChainEpoch) {
-    (180 * EPOCHS_IN_DAY, 1278 * EPOCHS_IN_DAY)
+    (180 * EPOCHS_IN_DAY, 540 * EPOCHS_IN_DAY)
 }
 
 pub(super) fn deal_price_per_epoch_bounds(

--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -174,7 +174,7 @@ pub fn qa_power_for_weight(
 
 /// Returns the quality-adjusted power for a sector.
 pub fn qa_power_for_sector(size: SectorSize, sector: &SectorOnChainInfo) -> StoragePower {
-    let duration = sector.expiration - sector.power_base_epoch;
+    let duration = sector.expiration - sector.activation;
     qa_power_for_weight(size, duration, &sector.deal_weight, &sector.verified_deal_weight)
 }
 

--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -87,14 +87,6 @@ pub fn check_state_invariants<BS: Blockstore>(
                 if !sector.deal_ids.is_empty() {
                     miner_summary.sectors_with_deals.insert(sector_number);
                 }
-                acc.require(
-                    sector.activation <= sector.power_base_epoch,
-                    format!("invalid power base for {sector_number}"),
-                );
-                acc.require(
-                    sector.power_base_epoch < sector.expiration,
-                    format!("power base epoch is not before the sector expiration {sector_number}"),
-                );
                 Ok(())
             });
 

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -347,13 +347,13 @@ pub struct SectorOnChainInfo {
     pub verified_deal_weight: DealWeight,
     /// Pledge collected to commit this sector
     pub initial_pledge: TokenAmount,
-    /// Expected one day projection of reward for sector computed at activation / update / extension time
+    /// Expected one day projection of reward for sector computed at activation time
     pub expected_day_reward: TokenAmount,
-    /// Expected twenty day projection of reward for sector computed at activation / update / extension time
+    /// Expected twenty day projection of reward for sector computed at activation time
     pub expected_storage_pledge: TokenAmount,
-    /// Epoch at which this sector's power was most recently updated
-    pub power_base_epoch: ChainEpoch,
-    /// Maximum day reward this sector has had in previous iterations (zero for brand new sectors)
+    /// Age of sector this sector replaced or zero
+    pub replaced_sector_age: ChainEpoch,
+    /// Day reward of sector this sector replace or zero
     pub replaced_day_reward: TokenAmount,
     /// The original SealedSectorCID, only gets set on the first ReplicaUpdate
     pub sector_key_cid: Option<Cid>,

--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -23,7 +23,6 @@ use fvm_shared::{
 use std::collections::HashMap;
 
 mod util;
-
 use fil_actors_runtime::runtime::Policy;
 use itertools::Itertools;
 use test_case::test_case;
@@ -947,7 +946,7 @@ fn assert_sector_verified_space(
     let new_sector = h.get_sector(rt, sector_number);
     assert_eq!(
         DealWeight::from(v_deal_space),
-        new_sector.verified_deal_weight / (new_sector.expiration - new_sector.power_base_epoch)
+        new_sector.verified_deal_weight / (new_sector.expiration - new_sector.activation)
     );
 }
 

--- a/actors/miner/tests/sector_assignment.rs
+++ b/actors/miner/tests/sector_assignment.rs
@@ -30,7 +30,6 @@ fn new_sector_on_chain_info(
         sealed_cid,
         activation,
         expiration: 1,
-        power_base_epoch: activation,
         deal_weight: weight.clone(),
         verified_deal_weight: weight,
         ..SectorOnChainInfo::default()

--- a/actors/miner/tests/sectors_stores_test.rs
+++ b/actors/miner/tests/sectors_stores_test.rs
@@ -109,7 +109,6 @@ fn new_sector_on_chain_info(
         sealed_cid,
         deal_ids: vec![],
         activation,
-        power_base_epoch: activation,
         expiration: ChainEpoch::from(1),
         deal_weight: weight.clone(),
         verified_deal_weight: weight,

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -337,7 +337,7 @@ pub mod policy_constants {
     /// Maximum number of epochs past the current epoch a sector may be set to expire.
     /// The actual maximum extension will be the minimum of CurrEpoch + MaximumSectorExpirationExtension
     /// and sector.ActivationEpoch+sealProof.SectorMaximumLifetime()
-    pub const MAX_SECTOR_EXPIRATION_EXTENSION: i64 = 1278 * EPOCHS_IN_DAY;
+    pub const MAX_SECTOR_EXPIRATION_EXTENSION: i64 = 540 * EPOCHS_IN_DAY;
 
     /// Ratio of sector size to maximum deals per sector.
     /// The maximum number of deals is the sector size divided by this number (2^27)

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -364,7 +364,7 @@ fn check_deal_states_against_sectors(
         };
 
         acc.require(
-            deal.sector_start_epoch >= sector_deal.sector_start,
+            deal.sector_start_epoch == sector_deal.sector_start,
             format!(
                 "deal state start {} does not match sector start {} for miner {}",
                 deal.sector_start_epoch, sector_deal.sector_start, deal.provider

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -545,16 +545,6 @@ pub fn miner_extend_sector_expiration2<BS: Blockstore>(
             ..Default::default()
         })
     }
-    subinvocs.push(ExpectInvocation {
-        to: REWARD_ACTOR_ADDR,
-        method: RewardMethod::ThisEpochReward as u64,
-        ..Default::default()
-    });
-    subinvocs.push(ExpectInvocation {
-        to: STORAGE_POWER_ACTOR_ADDR,
-        method: PowerMethod::CurrentTotalPower as u64,
-        ..Default::default()
-    });
     if !power_delta.is_zero() {
         subinvocs.push(ExpectInvocation {
             to: STORAGE_POWER_ACTOR_ADDR,

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -1,5 +1,4 @@
-use fil_actor_market::State as MarketState;
-use fil_actor_market::{DealMetaArray, Method as MarketMethod};
+use fil_actor_market::{DealMetaArray, Method as MarketMethod, State as MarketState};
 use fil_actor_miner::{
     max_prove_commit_duration, power_for_sector, ExpirationExtension, ExpirationExtension2,
     ExtendSectorExpiration2Params, ExtendSectorExpirationParams, Method as MinerMethod, PowerPair,
@@ -99,32 +98,15 @@ fn extend<BS: Blockstore>(
         }
     };
 
-    let mut expect_invoke = vec![
-        ExpectInvocation {
-            to: REWARD_ACTOR_ADDR,
-            method: RewardMethod::ThisEpochReward as u64,
-            ..Default::default()
-        },
-        ExpectInvocation {
-            to: STORAGE_POWER_ACTOR_ADDR,
-            method: PowerMethod::CurrentTotalPower as u64,
-            ..Default::default()
-        },
-    ];
-
-    if power_update_params.is_some() {
-        expect_invoke.push(ExpectInvocation {
+    ExpectInvocation {
+        to: maddr,
+        method: extension_method,
+        subinvocs: Some(vec![ExpectInvocation {
             to: STORAGE_POWER_ACTOR_ADDR,
             method: PowerMethod::UpdateClaimedPower as u64,
             params: Some(power_update_params),
             ..Default::default()
-        });
-    }
-
-    ExpectInvocation {
-        to: maddr,
-        method: extension_method,
-        subinvocs: Some(expect_invoke),
+        }]),
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
@@ -248,17 +230,10 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
         deadline_info.index + 1 % policy.wpost_period_deadlines,
     );
 
-    // Advance halfway through life and extend another 6 months. We need to spread the remaining 90
-    // days of 10x power over 90 + 180 days
-    // subtract half the remaining deal weight:
-    //   - verified deal weight /= 2
-    //
-    // normalize 90 days of 10x power plus 180 days of 1x power over 90+180 days:
-    //   - multiplier = ((10 * 90) + (1 * 180)) / (90 + 180)
-    //   - multiplier = 4
-    //
-    // delta from the previous 10x power multiplier:
-    // - power delta = (10-4)*32GiB = 6*32GiB
+    // advance halfway through life and extend another 6 months
+    // verified deal weight /= 2
+    // power multiplier = (1/4)*10 + (3/4)*1 = 3.25
+    // power delta = (10-3.25)*32GiB = 6.75*32GiB
     advance_by_deadline_to_epoch_while_proving(
         &v,
         &miner_id,
@@ -271,7 +246,7 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
 
     let mut expected_update_claimed_power_params = UpdateClaimedPowerParams {
         raw_byte_delta: StoragePower::zero(),
-        quality_adjusted_delta: StoragePower::from(-6 * (32i64 << 30)),
+        quality_adjusted_delta: StoragePower::from(-675 * (32i64 << 30) / 100),
     };
     let mut expected_update_claimed_power_params_ser =
         IpldBlock::serialize_cbor(&expected_update_claimed_power_params).unwrap().unwrap();
@@ -288,23 +263,10 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
         do_extend2,
     );
 
-    miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
-    sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
-    assert_eq!(180 * 2 * EPOCHS_IN_DAY, sector_info.expiration - sector_info.activation);
-    assert_eq!(initial_deal_weight, sector_info.deal_weight); // 0 space time, unchanged
-    assert_eq!(&initial_verified_deal_weight / 2, sector_info.verified_deal_weight);
-
     // advance to 6 months (original expiration) and extend another 6 months
-    //
-    // We're 1/3rd of the way through the last extension, so keep 2/3 of the power.
-    //   - verified deal weight *= 2/3
-    //
-    // normalize 180 days of 4x power plus 180 days of 1x power over 180+180 days:
-    //   - multiplier = ((4 * 180) + (1 * 180)) / (90 + 180)
-    //   - multiplier = 2.5
-    //
-    // delta from the previous 4x power multiplier:
-    // - power delta = (4-2.5)*32GiB = 1.5*32GiB
+    // verified deal weight /= 2
+    // power multiplier = (1/3)*3.25 + (2/3)*1 = 1.75
+    // power delta = (3.25 - 1.75)*32GiB = 1.5*32GiB
 
     advance_by_deadline_to_epoch_while_proving(
         &v,
@@ -338,8 +300,8 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
     assert_eq!(180 * 3 * EPOCHS_IN_DAY, sector_info.expiration - sector_info.activation);
     assert_eq!(initial_deal_weight, sector_info.deal_weight); // 0 space time, unchanged
-    assert_eq!(initial_verified_deal_weight / 3, sector_info.verified_deal_weight);
-    // 1/2 * 2/3 -> 1/3
+    assert_eq!(initial_verified_deal_weight / 4, sector_info.verified_deal_weight);
+    // two halvings => 1/4 initial verified deal weight
 
     v.expect_state_invariants(
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
@@ -572,12 +534,7 @@ fn extend_updated_sector_with_claim() {
         sector_info_after_extension.verified_deal_weight
     ); // 32 GiB * the remaining life of the sector
 
-    assert_eq!(sector_info_after_extension.power_base_epoch, v.epoch());
     assert_eq!(sector_info_after_update.activation, sector_info_after_extension.activation);
-    assert_eq!(
-        sector_info_after_extension.replaced_day_reward,
-        sector_info_after_update.expected_day_reward
-    );
 }
 
 #[test]

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -530,7 +530,10 @@ fn extend_updated_sector_with_claim() {
     assert_eq!(StoragePower::zero(), sector_info_after_extension.deal_weight); // 0 space time
 
     assert_eq!(
-        DealWeight::from((sector_info_after_extension.expiration - v.epoch()) * (32i64 << 30)),
+        DealWeight::from(
+            (sector_info_after_extension.expiration - sector_info_after_update.activation)
+                * (32i64 << 30)
+        ),
         sector_info_after_extension.verified_deal_weight
     ); // 32 GiB * the remaining life of the sector
 

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -513,7 +513,6 @@ fn psd_bad_sig() {
     };
 
     let invalid_sig_bytes = "very_invalid_sig".as_bytes().to_vec();
-
     let publish_params = PublishStorageDealsParams {
         deals: vec![ClientDealProposal {
             proposal: proposal.clone(),
@@ -523,6 +522,7 @@ fn psd_bad_sig() {
             },
         }],
     };
+
     let ret = v
         .apply_message(
             &a.worker,
@@ -591,61 +591,6 @@ fn psd_all_deals_are_good() {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 2, 3, 4], good_inputs);
-    v.assert_state_invariants();
-}
-
-#[test]
-fn psd_valid_deals_with_ones_longer_than_540() {
-    let store = MemoryBlockstore::new();
-    let (v, a, deal_start) = setup(&store);
-    let mut batcher =
-        DealBatcher::new(&v, a.maddr, PaddedPieceSize(1 << 30), false, deal_start, DEAL_LIFETIME);
-
-    // good deals
-    batcher.stage(
-        a.client1,
-        "deal0",
-        DealOptions { deal_lifetime: Option::from(541 * EPOCHS_IN_DAY), ..Default::default() },
-    );
-    batcher.stage(
-        a.client1,
-        "deal1",
-        DealOptions { deal_lifetime: Option::from(1278 * EPOCHS_IN_DAY), ..Default::default() },
-    );
-    batcher.stage(a.client1, "deal2", DealOptions::default());
-
-    let deal_ret = batcher.publish_ok(a.worker);
-    let good_inputs = bf_all(deal_ret.valid_deals);
-    assert_eq!(vec![0, 1, 2], good_inputs);
-    v.assert_state_invariants();
-}
-
-#[test]
-fn psd_deal_duration_too_long() {
-    let store = MemoryBlockstore::new();
-    let (v, a, deal_start) = setup(&store);
-    let mut batcher =
-        DealBatcher::new(&v, a.maddr, PaddedPieceSize(1 << 30), false, deal_start, DEAL_LIFETIME);
-
-    // good deals
-    batcher.stage(
-        a.client1,
-        "deal0",
-        DealOptions { deal_lifetime: Option::from(541 * EPOCHS_IN_DAY), ..Default::default() },
-    );
-
-    batcher.stage(a.client1, "deal1", DealOptions::default());
-
-    //bad deal - duration > max deal
-    batcher.stage(
-        a.client1,
-        "deal2",
-        DealOptions { deal_lifetime: Option::from(1279 * EPOCHS_IN_DAY), ..Default::default() },
-    );
-
-    let deal_ret = batcher.publish_ok(a.worker);
-    let good_inputs = bf_all(deal_ret.valid_deals);
-    assert_eq!(vec![0, 1], good_inputs);
     v.assert_state_invariants();
 }
 

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -681,7 +681,7 @@ fn terminate_after_upgrade() {
     v.assert_state_invariants();
 }
 
-// Tests that an active CC sector can be correctly upgraded, and then the sector can be extended
+// Tests that an active CC sector can be correctly upgraded, and then the sector can be terminated
 #[test]
 fn extend_after_upgrade() {
     let store = &MemoryBlockstore::new();
@@ -699,13 +699,12 @@ fn extend_after_upgrade() {
         st.sectors = sectors.amt.flush().unwrap();
     });
 
-    let extension_epoch = v.epoch();
     let extension_params = ExtendSectorExpirationParams {
         extensions: vec![ExpirationExtension {
             deadline: deadline_index,
             partition: partition_index,
             sectors: make_bitfield(&[sector_number]),
-            new_expiration: extension_epoch + policy.max_sector_expiration_extension - 1,
+            new_expiration: v.epoch() + policy.max_sector_expiration_extension - 1,
         }],
     };
 
@@ -722,7 +721,7 @@ fn extend_after_upgrade() {
     let final_sector_info = miner_state.get_sector(store, sector_number).unwrap().unwrap();
     assert_eq!(
         policy.max_sector_expiration_extension - 1,
-        final_sector_info.expiration - extension_epoch,
+        final_sector_info.expiration - final_sector_info.activation
     );
     v.assert_state_invariants();
 }


### PR DESCRIPTION
This PR speculatively reverts two of the code changes scoped for nv19 to accelerate the nv19 timeline and reduce upgrade risk
1. Sector activation bug fix: reverting this removes migration risk which is a requirement for accelerating the timeline and likely the right thing to do with the current timeline
2. FIP 0052 is reverted because it requires the sector activation bug fix to maintain the security invariant that sectors live no more than 5 years beyond their time of sealing.