### PR TITLE
`prove_commit_aggregate`: should check `is_empty` before indexing into `precommits`

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -838,6 +838,13 @@ impl Actor {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get precommits")
             })?;
 
+        if precommits.is_empty() {
+            return Err(actor_error!(
+                illegal_state,
+                "bitfield non-empty but zero precommits read from state"
+            ));
+        }
+
         // validate each precommit
         let mut precommits_to_confirm = Vec::new();
         for (i, precommit) in precommits.iter().enumerate() {
@@ -920,12 +927,6 @@ impl Actor {
         }
 
         let seal_proof = precommits[0].info.seal_proof;
-        if precommits.is_empty() {
-            return Err(actor_error!(
-                illegal_state,
-                "bitfield non-empty but zero precommits read from state"
-            ));
-        }
         rt.verify_aggregate_seals(&AggregateSealVerifyProofAndInfos {
             miner: miner_actor_id,
             seal_proof,


### PR DESCRIPTION
The [original code](https://github.com/filecoin-project/builtin-actors/blob/master/actors/miner/src/lib.rs#L922-L923) indexes into `precommits` before check `is_empty`. This PR moves the check right after `precommits` is assigned.