### PR TITLE
Refactor some tests in the form of the abstract VM

### DIFF
--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -515,32 +515,6 @@ where
         self.store.get_cbor::<MinerInfo>(&st.info).unwrap().unwrap()
     }
 
-    pub fn get_network_stats(&self) -> NetworkStats {
-        let power_state = self.get_state::<PowerState>(&STORAGE_POWER_ACTOR_ADDR).unwrap();
-        let reward_state = self.get_state::<RewardState>(&REWARD_ACTOR_ADDR).unwrap();
-        let market_state = self.get_state::<MarketState>(&STORAGE_MARKET_ACTOR_ADDR).unwrap();
-
-        NetworkStats {
-            total_raw_byte_power: power_state.total_raw_byte_power,
-            total_bytes_committed: power_state.total_bytes_committed,
-            total_quality_adj_power: power_state.total_quality_adj_power,
-            total_qa_bytes_committed: power_state.total_qa_bytes_committed,
-            total_pledge_collateral: power_state.total_pledge_collateral,
-            this_epoch_raw_byte_power: power_state.this_epoch_raw_byte_power,
-            this_epoch_quality_adj_power: power_state.this_epoch_quality_adj_power,
-            this_epoch_pledge_collateral: power_state.this_epoch_pledge_collateral,
-            miner_count: power_state.miner_count,
-            miner_above_min_power_count: power_state.miner_above_min_power_count,
-            this_epoch_reward: reward_state.this_epoch_reward,
-            this_epoch_reward_smoothed: reward_state.this_epoch_reward_smoothed,
-            this_epoch_baseline_power: reward_state.this_epoch_baseline_power,
-            total_storage_power_reward: reward_state.total_storage_power_reward,
-            total_client_locked_collateral: market_state.total_client_locked_collateral,
-            total_provider_locked_collateral: market_state.total_provider_locked_collateral,
-            total_client_storage_fee: market_state.total_client_storage_fee,
-        }
-    }
-
     pub fn put_store<S>(&self, obj: &S) -> Cid
     where
         S: ser::Serialize,

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -839,6 +839,32 @@ pub fn expect_invariants<BS: Blockstore>(vm: &dyn VM<BS>, expected_patterns: &[R
     check_invariants(vm).unwrap().assert_expected(expected_patterns)
 }
 
+pub fn get_network_stats<BS: Blockstore>(vm: &dyn VM<BS>) -> NetworkStats {
+    let power_state: PowerState = get_state(vm, &STORAGE_POWER_ACTOR_ADDR).unwrap();
+    let reward_state: RewardState = get_state(vm, &REWARD_ACTOR_ADDR).unwrap();
+    let market_state: MarketState = get_state(vm, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
+
+    NetworkStats {
+        total_raw_byte_power: power_state.total_raw_byte_power,
+        total_bytes_committed: power_state.total_bytes_committed,
+        total_quality_adj_power: power_state.total_quality_adj_power,
+        total_qa_bytes_committed: power_state.total_qa_bytes_committed,
+        total_pledge_collateral: power_state.total_pledge_collateral,
+        this_epoch_raw_byte_power: power_state.this_epoch_raw_byte_power,
+        this_epoch_quality_adj_power: power_state.this_epoch_quality_adj_power,
+        this_epoch_pledge_collateral: power_state.this_epoch_pledge_collateral,
+        miner_count: power_state.miner_count,
+        miner_above_min_power_count: power_state.miner_above_min_power_count,
+        this_epoch_reward: reward_state.this_epoch_reward,
+        this_epoch_reward_smoothed: reward_state.this_epoch_reward_smoothed,
+        this_epoch_baseline_power: reward_state.this_epoch_baseline_power,
+        total_storage_power_reward: reward_state.total_storage_power_reward,
+        total_client_locked_collateral: market_state.total_client_locked_collateral,
+        total_provider_locked_collateral: market_state.total_provider_locked_collateral,
+        total_client_storage_fee: market_state.total_client_storage_fee,
+    }
+}
+
 pub fn get_beneficiary<BS: Blockstore>(
     v: &dyn VM<BS>,
     from: &Address,

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -14,7 +14,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
 use test_case::test_case;
 use test_vm::util::{
-    advance_to_proving_deadline, apply_ok, create_accounts, create_miner,
+    advance_to_proving_deadline, apply_ok, create_accounts, create_miner, get_network_stats,
     invariant_failure_patterns, precommit_sectors_v2, prove_commit_sectors, submit_windowed_post,
 };
 use test_vm::{TestVM, VM};
@@ -133,7 +133,7 @@ fn batch_onboarding(v2: bool) {
     let balances = v.get_miner_balance(&id_addr);
     assert!(balances.initial_pledge.is_positive());
 
-    let network_stats = v.get_network_stats();
+    let network_stats = get_network_stats(&v);
     let sector_size = seal_proof.sector_size().unwrap() as u64;
     assert_eq!(network_stats.total_bytes_committed, BigInt::from(sector_size * proven_count));
     assert!(network_stats.total_pledge_collateral.is_positive());

--- a/test_vm/tests/change_beneficiary_test.rs
+++ b/test_vm/tests/change_beneficiary_test.rs
@@ -1,29 +1,33 @@
 use fil_actor_miner::{
     ActiveBeneficiary, ChangeBeneficiaryParams, Method as MinerMethod, PendingBeneficiaryChange,
 };
-use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::RegisteredSealProof;
 use test_vm::util::{
-    apply_code, change_beneficiary, create_accounts, create_miner, get_beneficiary,
-    withdraw_balance,
+    apply_code, assert_invariants, change_beneficiary, create_accounts, create_miner,
+    get_beneficiary, withdraw_balance,
 };
-use test_vm::TestVM;
+use test_vm::{TestVM, VM};
 
 #[test]
 fn change_beneficiary_success() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 4, &TokenAmount::from_whole(10_000));
+    change_beneficiary_success_test(&v);
+}
+
+fn change_beneficiary_success_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, another_beneficiary, query_addr) =
         (addrs[0], addrs[0], addrs[1], addrs[2], addrs[3]);
 
     // create miner
     let miner_id = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -34,53 +38,57 @@ fn change_beneficiary_success() {
     //change from owner to beneficiary address
     let beneficiary_change_proposal =
         ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(100), 500);
-    change_beneficiary(&v, &owner, &miner_id, &beneficiary_change_proposal);
-    let mut get_beneficiary_return = get_beneficiary(&v, &query_addr, &miner_id);
+    change_beneficiary(v, &owner, &miner_id, &beneficiary_change_proposal);
+    let mut get_beneficiary_return = get_beneficiary(v, &query_addr, &miner_id);
     let pending_beneficiary_term = get_beneficiary_return.proposed.unwrap();
     assert_pending(&beneficiary_change_proposal, &pending_beneficiary_term);
     assert!(pending_beneficiary_term.approved_by_beneficiary);
     assert!(!pending_beneficiary_term.approved_by_nominee);
 
-    change_beneficiary(&v, &beneficiary, &miner_id, &beneficiary_change_proposal);
-    get_beneficiary_return = get_beneficiary(&v, &query_addr, &miner_id);
+    change_beneficiary(v, &beneficiary, &miner_id, &beneficiary_change_proposal);
+    get_beneficiary_return = get_beneficiary(v, &query_addr, &miner_id);
     assert!(get_beneficiary_return.proposed.is_none());
     assert_active(&beneficiary_change_proposal, &get_beneficiary_return.active);
 
     //change beneficiary to another address
     let change_another_beneificiary_proposal =
         ChangeBeneficiaryParams::new(another_beneficiary, TokenAmount::from_atto(100), 500);
-    change_beneficiary(&v, &owner, &miner_id, &change_another_beneificiary_proposal);
-    let mut get_beneficiary_return = get_beneficiary(&v, &query_addr, &miner_id);
+    change_beneficiary(v, &owner, &miner_id, &change_another_beneificiary_proposal);
+    let mut get_beneficiary_return = get_beneficiary(v, &query_addr, &miner_id);
     let mut pending_beneficiary_term = get_beneficiary_return.proposed.unwrap();
     assert_pending(&change_another_beneificiary_proposal, &pending_beneficiary_term);
     assert!(!pending_beneficiary_term.approved_by_beneficiary);
     assert!(!pending_beneficiary_term.approved_by_nominee);
 
-    change_beneficiary(&v, &another_beneficiary, &miner_id, &change_another_beneificiary_proposal);
-    get_beneficiary_return = get_beneficiary(&v, &query_addr, &miner_id);
+    change_beneficiary(v, &another_beneficiary, &miner_id, &change_another_beneificiary_proposal);
+    get_beneficiary_return = get_beneficiary(v, &query_addr, &miner_id);
     pending_beneficiary_term = get_beneficiary_return.proposed.unwrap();
     assert_pending(&change_another_beneificiary_proposal, &pending_beneficiary_term);
     assert!(!pending_beneficiary_term.approved_by_beneficiary);
     assert!(pending_beneficiary_term.approved_by_nominee);
 
-    change_beneficiary(&v, &beneficiary, &miner_id, &change_another_beneificiary_proposal);
-    get_beneficiary_return = get_beneficiary(&v, &query_addr, &miner_id);
+    change_beneficiary(v, &beneficiary, &miner_id, &change_another_beneificiary_proposal);
+    get_beneficiary_return = get_beneficiary(v, &query_addr, &miner_id);
     assert!(get_beneficiary_return.proposed.is_none());
     assert_active(&change_another_beneificiary_proposal, &get_beneficiary_return.active);
-    v.assert_state_invariants();
+    assert_invariants(v);
 }
 
 #[test]
 fn change_beneficiary_back_owner_success() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 3, &TokenAmount::from_whole(10_000));
+    change_beneficiary_back_owner_success_test(&v);
+}
+
+fn change_beneficiary_back_owner_success_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, query_addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);
 
     // create miner
     let miner_id = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -90,35 +98,35 @@ fn change_beneficiary_back_owner_success() {
 
     let quota = TokenAmount::from_atto(100);
     let beneficiary_change_proposal = ChangeBeneficiaryParams::new(beneficiary, quota.clone(), 500);
-    change_beneficiary(&v, &owner, &miner_id, &beneficiary_change_proposal);
-    change_beneficiary(&v, &beneficiary, &miner_id, &beneficiary_change_proposal);
+    change_beneficiary(v, &owner, &miner_id, &beneficiary_change_proposal);
+    change_beneficiary(v, &beneficiary, &miner_id, &beneficiary_change_proposal);
 
     //case1 need beneficiary(non-main) to confirm
     let back_owner_proposal = ChangeBeneficiaryParams::new(owner, TokenAmount::zero(), 0);
-    change_beneficiary(&v, &owner, &miner_id, &back_owner_proposal);
-    change_beneficiary(&v, &beneficiary, &miner_id, &back_owner_proposal);
+    change_beneficiary(v, &owner, &miner_id, &back_owner_proposal);
+    change_beneficiary(v, &beneficiary, &miner_id, &back_owner_proposal);
 
-    let get_beneficiary_return = get_beneficiary(&v, &query_addr, &miner_id);
+    let get_beneficiary_return = get_beneficiary(v, &query_addr, &miner_id);
     assert!(get_beneficiary_return.proposed.is_none());
     assert_active(&back_owner_proposal, &get_beneficiary_return.active);
 
     //case2 beneficiary(non-main) used up
-    change_beneficiary(&v, &owner, &miner_id, &beneficiary_change_proposal);
-    change_beneficiary(&v, &beneficiary, &miner_id, &beneficiary_change_proposal);
-    withdraw_balance(&v, &beneficiary, &miner_id, &quota, &quota);
+    change_beneficiary(v, &owner, &miner_id, &beneficiary_change_proposal);
+    change_beneficiary(v, &beneficiary, &miner_id, &beneficiary_change_proposal);
+    withdraw_balance(v, &beneficiary, &miner_id, &quota, &quota);
 
-    change_beneficiary(&v, &owner, &miner_id, &back_owner_proposal);
-    let get_beneficiary_return = get_beneficiary(&v, &query_addr, &miner_id);
+    change_beneficiary(v, &owner, &miner_id, &back_owner_proposal);
+    let get_beneficiary_return = get_beneficiary(v, &query_addr, &miner_id);
     assert!(get_beneficiary_return.proposed.is_none());
     assert_active(&back_owner_proposal, &get_beneficiary_return.active);
 
     //case2 beneficiary(non-main) expiration
-    change_beneficiary(&v, &owner, &miner_id, &beneficiary_change_proposal);
-    change_beneficiary(&v, &beneficiary, &miner_id, &beneficiary_change_proposal);
+    change_beneficiary(v, &owner, &miner_id, &beneficiary_change_proposal);
+    change_beneficiary(v, &beneficiary, &miner_id, &beneficiary_change_proposal);
 
-    let v = v.with_epoch(1000);
-    change_beneficiary(&v, &owner, &miner_id, &back_owner_proposal);
-    let get_beneficiary_return = get_beneficiary(&v, &query_addr, &miner_id);
+    v.set_epoch(1000);
+    change_beneficiary(v, &owner, &miner_id, &back_owner_proposal);
+    let get_beneficiary_return = get_beneficiary(v, &query_addr, &miner_id);
     assert!(get_beneficiary_return.proposed.is_none());
     assert_active(&back_owner_proposal, &get_beneficiary_return.active);
 }
@@ -127,13 +135,17 @@ fn change_beneficiary_back_owner_success() {
 fn change_beneficiary_fail() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 3, &TokenAmount::from_whole(10_000));
+    change_beneficiary_fail_test(&v);
+}
+
+fn change_beneficiary_fail_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);
 
     // create miner
     let miner_id = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -142,7 +154,7 @@ fn change_beneficiary_fail() {
     .0;
 
     apply_code(
-        &v,
+        v,
         &addr,
         &miner_id,
         &TokenAmount::zero(),
@@ -153,11 +165,11 @@ fn change_beneficiary_fail() {
 
     let beneficiary_change_proposal =
         ChangeBeneficiaryParams::new(beneficiary, TokenAmount::from_atto(100), 500);
-    change_beneficiary(&v, &owner, &miner_id, &beneficiary_change_proposal);
+    change_beneficiary(v, &owner, &miner_id, &beneficiary_change_proposal);
 
     //argument not match with pending
     apply_code(
-        &v,
+        v,
         &beneficiary,
         &miner_id,
         &TokenAmount::zero(),
@@ -167,7 +179,7 @@ fn change_beneficiary_fail() {
     );
 
     apply_code(
-        &v,
+        v,
         &beneficiary,
         &miner_id,
         &TokenAmount::zero(),
@@ -177,7 +189,7 @@ fn change_beneficiary_fail() {
     );
 
     apply_code(
-        &v,
+        v,
         &beneficiary,
         &miner_id,
         &TokenAmount::zero(),
@@ -188,7 +200,7 @@ fn change_beneficiary_fail() {
 
     //message from must be owner/beneficiary/new beneficiary
     apply_code(
-        &v,
+        v,
         &addr,
         &miner_id,
         &TokenAmount::zero(),
@@ -196,11 +208,11 @@ fn change_beneficiary_fail() {
         Some(beneficiary_change_proposal.clone()),
         ExitCode::USR_FORBIDDEN,
     );
-    change_beneficiary(&v, &beneficiary, &miner_id, &beneficiary_change_proposal);
+    change_beneficiary(v, &beneficiary, &miner_id, &beneficiary_change_proposal);
 
     //change back to owner, quota and expiration must be zero
     apply_code(
-        &v,
+        v,
         &owner,
         &miner_id,
         &TokenAmount::zero(),
@@ -209,7 +221,7 @@ fn change_beneficiary_fail() {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
     apply_code(
-        &v,
+        v,
         &owner,
         &miner_id,
         &TokenAmount::zero(),
@@ -220,9 +232,10 @@ fn change_beneficiary_fail() {
 
     //success change back to owner
     let back_owner_proposal = ChangeBeneficiaryParams::new(owner, TokenAmount::zero(), 0);
-    change_beneficiary(&v, &owner, &miner_id, &back_owner_proposal);
-    change_beneficiary(&v, &beneficiary, &miner_id, &back_owner_proposal);
-    v.assert_state_invariants();
+    change_beneficiary(v, &owner, &miner_id, &back_owner_proposal);
+    change_beneficiary(v, &beneficiary, &miner_id, &back_owner_proposal);
+
+    assert_invariants(v)
 }
 
 fn assert_pending(

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -25,8 +25,8 @@ use fvm_shared::sector::{PoStProof, RegisteredSealProof, SectorNumber, MAX_SECTO
 use fvm_shared::METHOD_SEND;
 use test_vm::util::{
     advance_by_deadline_to_epoch, advance_to_proving_deadline, apply_code, apply_ok,
-    create_accounts, create_miner, invariant_failure_patterns, precommit_sectors,
-    submit_windowed_post,
+    create_accounts, create_miner, get_network_stats, invariant_failure_patterns,
+    precommit_sectors, submit_windowed_post,
 };
 use test_vm::{ExpectInvocation, TestVM, TEST_VM_RAND_ARRAY, VM};
 
@@ -148,7 +148,7 @@ fn setup(store: &'_ MemoryBlockstore) -> (TestVM<MemoryBlockstore>, MinerInfo, S
 
     // power unproven so network stats are the same
 
-    let network_stats = v.get_network_stats();
+    let network_stats = get_network_stats(&v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
 
@@ -225,7 +225,7 @@ fn skip_sector() {
     assert!(balances.initial_pledge.is_positive());
 
     // power unproven so network stats are the same
-    let network_stats = v.get_network_stats();
+    let network_stats = get_network_stats(&v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
 
@@ -294,7 +294,7 @@ fn missed_first_post_deadline() {
     .matches(v.take_invocations().last().unwrap());
 
     // power unproven so network stats are the same
-    let network_stats = v.get_network_stats();
+    let network_stats = get_network_stats(&v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
 
@@ -407,7 +407,7 @@ fn overdue_precommit() {
     assert!(balances.initial_pledge.is_zero());
     assert!(balances.pre_commit_deposit.is_zero());
 
-    let network_stats = v.get_network_stats();
+    let network_stats = get_network_stats(&v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_zero());
     assert!(network_stats.total_raw_byte_power.is_zero());

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -37,9 +37,10 @@ use test_case::test_case;
 use test_vm::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_index, advance_to_proving_deadline,
     apply_code, apply_ok, bf_all, check_sector_active, check_sector_faulty, create_accounts,
-    create_miner, deadline_state, declare_recovery, invariant_failure_patterns, make_bitfield,
-    market_publish_deal, miner_power, precommit_sectors, prove_commit_sectors, sector_info,
-    submit_invalid_post, submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
+    create_miner, deadline_state, declare_recovery, get_network_stats, invariant_failure_patterns,
+    make_bitfield, market_publish_deal, miner_power, precommit_sectors, prove_commit_sectors,
+    sector_info, submit_invalid_post, submit_windowed_post, verifreg_add_client,
+    verifreg_add_verifier,
 };
 use test_vm::TestVM;
 // ---- Success cases ----
@@ -670,7 +671,7 @@ fn terminate_after_upgrade() {
     assert!(miner_balances.initial_pledge.is_zero());
     assert!(miner_balances.pre_commit_deposit.is_zero());
 
-    let network_stats = v.get_network_stats();
+    let network_stats = get_network_stats(&v);
     assert!(network_stats.miner_above_min_power_count.is_zero());
     assert!(network_stats.total_raw_byte_power.is_zero());
     assert!(network_stats.total_quality_adj_power.is_zero());


### PR DESCRIPTION
- Adds more methods to the VM trait in order to be able to implement check_invariants as a free method on the abstract trait
- Refactors a number of simple tests to take in the VM trait rather than a concrete TestVM