### PR TITLE
Refactor remaining tests with abstract VM trait

### DIFF
--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -13,7 +13,7 @@ use fil_actors_runtime::{
     STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fvm_ipld_bitfield::BitField;
-use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
@@ -25,8 +25,8 @@ use fvm_shared::sector::{PoStProof, RegisteredSealProof, SectorNumber, MAX_SECTO
 use fvm_shared::METHOD_SEND;
 use test_vm::util::{
     advance_by_deadline_to_epoch, advance_to_proving_deadline, apply_code, apply_ok,
-    create_accounts, create_miner, get_network_stats, invariant_failure_patterns,
-    precommit_sectors, submit_windowed_post,
+    assert_invariants, create_accounts, create_miner, expect_invariants, get_network_stats,
+    get_state, invariant_failure_patterns, miner_balance, precommit_sectors, submit_windowed_post,
 };
 use test_vm::{ExpectInvocation, TestVM, TEST_VM_RAND_ARRAY, VM};
 
@@ -56,13 +56,13 @@ fn setup(store: &'_ MemoryBlockstore) -> (TestVM<MemoryBlockstore>, MinerInfo, S
         seal_proof.registered_window_post_proof().unwrap(),
         &TokenAmount::from_whole(10_000),
     );
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
     precommit_sectors(&v, 1, 1, &worker, &id_addr, seal_proof, sector_number, true, None);
 
-    let balances = v.get_miner_balance(&id_addr);
+    let balances = miner_balance(&v, &id_addr);
     assert!(balances.pre_commit_deposit.is_positive());
 
     let prove_time = v.epoch() + Policy::default().pre_commit_challenge_delay + 1;
@@ -92,12 +92,12 @@ fn setup(store: &'_ MemoryBlockstore) -> (TestVM<MemoryBlockstore>, MinerInfo, S
     }
     .matches(v.take_invocations().last().unwrap());
     let res = v
-        .apply_message(
+        .execute_message(
             &SYSTEM_ACTOR_ADDR,
             &CRON_ACTOR_ADDR,
             &TokenAmount::zero(),
             CronMethod::EpochTick as u64,
-            None::<RawBytes>,
+            None,
         )
         .unwrap();
     assert_eq!(ExitCode::OK, res.code);
@@ -142,7 +142,7 @@ fn setup(store: &'_ MemoryBlockstore) -> (TestVM<MemoryBlockstore>, MinerInfo, S
     }
     .matches(v.take_invocations().last().unwrap());
     // pcd is released ip is added
-    let balances = v.get_miner_balance(&id_addr);
+    let balances = miner_balance(&v, &id_addr);
     assert!(balances.initial_pledge.is_positive());
     assert!(balances.pre_commit_deposit.is_zero());
 
@@ -170,30 +170,46 @@ fn setup(store: &'_ MemoryBlockstore) -> (TestVM<MemoryBlockstore>, MinerInfo, S
 fn submit_post_succeeds() {
     let store = MemoryBlockstore::new();
     let (v, miner_info, sector_info) = setup(&store);
+    submit_post_succeeds_test(&v, miner_info, sector_info);
+}
+
+fn submit_post_succeeds_test<BS: Blockstore>(
+    v: &dyn VM<BS>,
+    miner_info: MinerInfo,
+    sector_info: SectorInfo,
+) {
     // submit post
-    let st = v.get_state::<MinerState>(&miner_info.miner_id).unwrap();
-    let sector = st.get_sector(v.store, sector_info.number).unwrap().unwrap();
+    let st: MinerState = get_state(v, &miner_info.miner_id).unwrap();
+    let sector = st.get_sector(*v.blockstore(), sector_info.number).unwrap().unwrap();
     let sector_power = power_for_sector(miner_info.seal_proof.sector_size().unwrap(), &sector);
     submit_windowed_post(
-        &v,
+        v,
         &miner_info.worker,
         &miner_info.miner_id,
         sector_info.deadline_info,
         sector_info.partition_index,
         Some(sector_power.clone()),
     );
-    let balances = v.get_miner_balance(&miner_info.miner_id);
+    let balances = miner_balance(v, &miner_info.miner_id);
     assert!(balances.initial_pledge.is_positive());
-    let p_st = v.get_state::<PowerState>(&STORAGE_POWER_ACTOR_ADDR).unwrap();
+    let p_st: PowerState = get_state(v, &STORAGE_POWER_ACTOR_ADDR).unwrap();
     assert_eq!(sector_power.raw, p_st.total_bytes_committed);
 
-    v.assert_state_invariants();
+    assert_invariants(v);
 }
 
 #[test]
 fn skip_sector() {
     let store = MemoryBlockstore::new();
     let (v, miner_info, sector_info) = setup(&store);
+    skip_sector_test(&v, sector_info, miner_info);
+}
+
+fn skip_sector_test<BS: Blockstore>(
+    v: &dyn VM<BS>,
+    sector_info: SectorInfo,
+    miner_info: MinerInfo,
+) {
     // submit post, but skip the only sector in it
     let params = SubmitWindowedPoStParams {
         deadline: sector_info.deadline_info.index,
@@ -211,7 +227,7 @@ fn skip_sector() {
 
     // PoSt is rejected for skipping all sectors.
     apply_code(
-        &v,
+        v,
         &miner_info.worker,
         &miner_info.miner_id,
         &TokenAmount::zero(),
@@ -221,15 +237,14 @@ fn skip_sector() {
     );
 
     // miner still has initial pledge
-    let balances = v.get_miner_balance(&miner_info.miner_id);
+    let balances = miner_balance(v, &miner_info.miner_id);
     assert!(balances.initial_pledge.is_positive());
 
     // power unproven so network stats are the same
-    let network_stats = get_network_stats(&v);
+    let network_stats = get_network_stats(v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
-
-    v.assert_state_invariants();
+    assert_invariants(v)
 }
 
 #[test]
@@ -237,13 +252,20 @@ fn missed_first_post_deadline() {
     let store = MemoryBlockstore::new();
     let (v, miner_info, sector_info) = setup(&store);
 
+    missed_first_post_deadline_test(&v, sector_info, miner_info);
+}
+
+fn missed_first_post_deadline_test<BS: Blockstore>(
+    v: &dyn VM<BS>,
+    sector_info: SectorInfo,
+    miner_info: MinerInfo,
+) {
     // move to proving period end
     v.set_epoch(sector_info.deadline_info.last());
 
     // Run cron to detect missing PoSt
-
     apply_ok(
-        &v,
+        v,
         &SYSTEM_ACTOR_ADDR,
         &CRON_ACTOR_ADDR,
         &TokenAmount::zero(),
@@ -294,46 +316,49 @@ fn missed_first_post_deadline() {
     .matches(v.take_invocations().last().unwrap());
 
     // power unproven so network stats are the same
-    let network_stats = get_network_stats(&v);
+    let network_stats = get_network_stats(v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
 
-    v.expect_state_invariants(
-        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
-    );
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
 fn overdue_precommit() {
     let store = MemoryBlockstore::new();
-    let policy = &Policy::default();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(10_000));
+
+    overdue_precommit_test(&v);
+}
+
+fn overdue_precommit_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let policy = &Policy::default();
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
     let id_addr = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
         &TokenAmount::from_whole(10_000),
     )
     .0;
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
     let precommit =
-        precommit_sectors(&v, 1, 1, &worker, &id_addr, seal_proof, sector_number, true, None)
+        precommit_sectors(v, 1, 1, &worker, &id_addr, seal_proof, sector_number, true, None)
             .get(0)
             .unwrap()
             .clone();
 
-    let balances = v.get_miner_balance(&id_addr);
+    let balances = miner_balance(v, &id_addr);
     assert!(balances.pre_commit_deposit.is_positive());
 
     let prove_time = v.epoch() + max_prove_commit_duration(policy, seal_proof).unwrap() + 1;
-    advance_by_deadline_to_epoch(&v, &id_addr, prove_time);
+    advance_by_deadline_to_epoch(v, &id_addr, prove_time);
 
     //
     // overdue precommit
@@ -341,14 +366,14 @@ fn overdue_precommit() {
 
     // advance time to precommit clean up epoch
     let cleanup_time = prove_time + policy.expired_pre_commit_clean_up_delay;
-    let deadline_info = advance_by_deadline_to_epoch(&v, &id_addr, cleanup_time);
+    let deadline_info = advance_by_deadline_to_epoch(v, &id_addr, cleanup_time);
 
     // advance one more deadline so precommit clean up is reached
     v.set_epoch(deadline_info.close);
 
     // run cron which should clean up precommit
     apply_ok(
-        &v,
+        v,
         &SYSTEM_ACTOR_ADDR,
         &CRON_ACTOR_ADDR,
         &TokenAmount::zero(),
@@ -403,36 +428,38 @@ fn overdue_precommit() {
     }
     .matches(v.take_invocations().last().unwrap());
 
-    let balances = v.get_miner_balance(&id_addr);
+    let balances = miner_balance(v, &id_addr);
     assert!(balances.initial_pledge.is_zero());
     assert!(balances.pre_commit_deposit.is_zero());
 
-    let network_stats = get_network_stats(&v);
+    let network_stats = get_network_stats(v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_zero());
     assert!(network_stats.total_raw_byte_power.is_zero());
     assert!(network_stats.total_quality_adj_power.is_zero());
 
-    v.expect_state_invariants(
-        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
-    );
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
 fn aggregate_bad_sector_number() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(10_000));
+    aggregate_bad_sector_number_test(&v);
+}
+
+fn aggregate_bad_sector_number_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
     let (id_addr, robust_addr) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
         &TokenAmount::from_whole(10_000),
     );
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
     let policy = &Policy::default();
 
     //
@@ -443,7 +470,7 @@ fn aggregate_bad_sector_number() {
     let sector_number: SectorNumber = 100;
     let mut precommited_sector_nos = BitField::try_from_bits(
         precommit_sectors(
-            &v,
+            v,
             4,
             policy.pre_commit_sector_batch_max_size as i64,
             &worker,
@@ -465,7 +492,7 @@ fn aggregate_bad_sector_number() {
     // advance time to max seal duration
 
     let prove_time = v.epoch() + policy.pre_commit_challenge_delay + 1;
-    advance_by_deadline_to_epoch(&v, &id_addr, prove_time);
+    advance_by_deadline_to_epoch(v, &id_addr, prove_time);
 
     // construct invalid bitfield with a non-committed sector number > abi.MaxSectorNumber
 
@@ -477,7 +504,7 @@ fn aggregate_bad_sector_number() {
     };
     let prove_params_ser = IpldBlock::serialize_cbor(&prove_params).unwrap();
     apply_code(
-        &v,
+        v,
         &worker,
         &robust_addr,
         &TokenAmount::zero(),
@@ -493,27 +520,30 @@ fn aggregate_bad_sector_number() {
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
-    v.expect_state_invariants(
-        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
-    );
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
 fn aggregate_size_limits() {
-    let oversized_batch = 820;
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(100_000));
+    aggregate_size_limits_test(&v);
+}
+
+fn aggregate_size_limits_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let oversized_batch = 820;
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
     let (id_addr, robust_addr) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
         &TokenAmount::from_whole(100_000),
     );
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
     let policy = &Policy::default();
 
     //
@@ -524,7 +554,7 @@ fn aggregate_size_limits() {
     let sector_number: SectorNumber = 100;
     let precommited_sector_nos = BitField::try_from_bits(
         precommit_sectors(
-            &v,
+            v,
             oversized_batch,
             policy.pre_commit_sector_batch_max_size as i64,
             &worker,
@@ -544,19 +574,17 @@ fn aggregate_size_limits() {
     //
 
     // advance time to max seal duration
-
     let prove_time = v.epoch() + policy.pre_commit_challenge_delay + 1;
-    advance_by_deadline_to_epoch(&v, &id_addr, prove_time);
+    advance_by_deadline_to_epoch(v, &id_addr, prove_time);
 
     // Fail with too many sectors
-
     let mut prove_params = ProveCommitAggregateParams {
         sector_numbers: precommited_sector_nos.clone(),
         aggregate_proof: vec![],
     };
     let mut prove_params_ser = IpldBlock::serialize_cbor(&prove_params).unwrap();
     apply_code(
-        &v,
+        v,
         &worker,
         &robust_addr,
         &TokenAmount::zero(),
@@ -574,7 +602,6 @@ fn aggregate_size_limits() {
     .matches(v.take_invocations().last().unwrap());
 
     // Fail with too few sectors
-
     let too_few_sector_nos_bf =
         precommited_sector_nos.slice(0, policy.min_aggregated_sectors - 1).unwrap();
     prove_params = ProveCommitAggregateParams {
@@ -583,7 +610,7 @@ fn aggregate_size_limits() {
     };
     prove_params_ser = IpldBlock::serialize_cbor(&prove_params).unwrap();
     apply_code(
-        &v,
+        v,
         &worker,
         &robust_addr,
         &TokenAmount::zero(),
@@ -601,7 +628,6 @@ fn aggregate_size_limits() {
     .matches(v.take_invocations().last().unwrap());
 
     // Fail with proof too big
-
     let just_right_sectors_no_bf =
         precommited_sector_nos.slice(0, policy.max_aggregated_sectors).unwrap();
     prove_params = ProveCommitAggregateParams {
@@ -611,7 +637,7 @@ fn aggregate_size_limits() {
 
     prove_params_ser = IpldBlock::serialize_cbor(&prove_params).unwrap();
     apply_code(
-        &v,
+        v,
         &worker,
         &robust_addr,
         &TokenAmount::zero(),
@@ -627,26 +653,29 @@ fn aggregate_size_limits() {
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
-    v.expect_state_invariants(
-        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
-    );
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
 fn aggregate_bad_sender() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 2, &TokenAmount::from_whole(10_000));
+    aggregate_bad_sender_test(&v);
+}
+
+fn aggregate_bad_sender_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 2, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
     let (id_addr, robust_addr) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
         &TokenAmount::from_whole(10_000),
     );
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
     let policy = &Policy::default();
 
     //
@@ -657,7 +686,7 @@ fn aggregate_bad_sender() {
     let sector_number: SectorNumber = 100;
     let precommited_sector_nos = BitField::try_from_bits(
         precommit_sectors(
-            &v,
+            v,
             4,
             policy.pre_commit_sector_batch_max_size as i64,
             &worker,
@@ -679,7 +708,7 @@ fn aggregate_bad_sender() {
     // advance time to max seal duration
 
     let prove_time = v.epoch() + policy.pre_commit_challenge_delay + 1;
-    advance_by_deadline_to_epoch(&v, &id_addr, prove_time);
+    advance_by_deadline_to_epoch(v, &id_addr, prove_time);
 
     let prove_params = ProveCommitAggregateParams {
         sector_numbers: precommited_sector_nos,
@@ -687,7 +716,7 @@ fn aggregate_bad_sender() {
     };
     let prove_params_ser = IpldBlock::serialize_cbor(&prove_params).unwrap();
     apply_code(
-        &v,
+        v,
         &addrs[1],
         &robust_addr,
         &TokenAmount::zero(),
@@ -703,26 +732,29 @@ fn aggregate_bad_sender() {
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
-    v.expect_state_invariants(
-        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
-    );
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
 fn aggregate_one_precommit_expires() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(10_000));
+    aggregate_one_precommit_expires_test(&v);
+}
+
+fn aggregate_one_precommit_expires_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
     let (id_addr, robust_addr) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
         &TokenAmount::from_whole(10_000),
     );
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
     let policy = &Policy::default();
 
     //
@@ -734,7 +766,7 @@ fn aggregate_one_precommit_expires() {
     // early precommit
     let early_precommit_time = v.epoch();
     let early_precommits = precommit_sectors(
-        &v,
+        v,
         1,
         policy.pre_commit_sector_batch_max_size as i64,
         &worker,
@@ -748,12 +780,12 @@ fn aggregate_one_precommit_expires() {
     let early_pre_commit_invalid =
         early_precommit_time + max_prove_commit_duration(policy, seal_proof).unwrap() + 1;
 
-    advance_by_deadline_to_epoch(&v, &id_addr, early_pre_commit_invalid);
+    advance_by_deadline_to_epoch(v, &id_addr, early_pre_commit_invalid);
 
     // later precommits
 
     let later_precommits = precommit_sectors(
-        &v,
+        v,
         3,
         policy.pre_commit_sector_batch_max_size as i64,
         &worker,
@@ -772,8 +804,8 @@ fn aggregate_one_precommit_expires() {
     // Advance minimum epochs past later precommits for later commits to be valid
 
     let prove_time = v.epoch() + policy.pre_commit_challenge_delay + 1;
-    let deadline_info = advance_by_deadline_to_epoch(&v, &id_addr, prove_time);
-    advance_by_deadline_to_epoch(&v, &id_addr, deadline_info.close);
+    let deadline_info = advance_by_deadline_to_epoch(v, &id_addr, prove_time);
+    advance_by_deadline_to_epoch(v, &id_addr, deadline_info.close);
 
     // Assert that precommit should not yet be cleaned up. This makes fixing this test easier if parameters change.
     assert!(
@@ -794,7 +826,7 @@ fn aggregate_one_precommit_expires() {
         ProveCommitAggregateParams { sector_numbers: sector_nos_bf, aggregate_proof: vec![] };
     let prove_params_ser = IpldBlock::serialize_cbor(&prove_params).unwrap();
     apply_ok(
-        &v,
+        v,
         &worker,
         &robust_addr,
         &TokenAmount::zero(),
@@ -831,11 +863,9 @@ fn aggregate_one_precommit_expires() {
     }
     .matches(v.take_invocations().last().unwrap());
 
-    let balances = v.get_miner_balance(&id_addr);
+    let balances = miner_balance(v, &id_addr);
     assert!(balances.initial_pledge.is_positive());
     assert!(balances.pre_commit_deposit.is_positive());
 
-    v.expect_state_invariants(
-        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
-    );
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/init_test.rs
+++ b/test_vm/tests/init_test.rs
@@ -6,13 +6,12 @@ use fil_actors_runtime::{
     EAM_ACTOR_ADDR, EAM_ACTOR_ID, INIT_ACTOR_ADDR,
 };
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
-use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, METHOD_SEND};
 use num_traits::Zero;
-use test_vm::{actor, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
+use test_vm::{actor, util::serialize_ok, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
 
-fn assert_placeholder_actor<BS: Blockstore>(exp_bal: TokenAmount, v: &TestVM<BS>, addr: Address) {
-    let act = v.get_actor(&addr).unwrap();
+fn assert_placeholder_actor<BS: Blockstore>(exp_bal: TokenAmount, v: &dyn VM<BS>, addr: Address) {
+    let act = v.actor(&addr).unwrap();
     assert_eq!(EMPTY_ARR_CID, act.head);
     assert_eq!(*PLACEHOLDER_ACTOR_CODE_ID, act.code);
     assert_eq!(exp_bal, act.balance);
@@ -33,22 +32,23 @@ fn placeholder_deploy() {
 
     let subaddr = b"foobar";
     let addr = Address::new_delegated(EAM_ACTOR_ID, subaddr).unwrap();
-    assert!(v
-        .apply_message(
+    assert!(
+        v.execute_message(
             &TEST_FAUCET_ADDR,
             &addr,
             &TokenAmount::from_atto(42u8),
             METHOD_SEND,
-            None::<RawBytes>,
+            None,
         )
         .unwrap()
         .code
-        .is_success());
+        .is_success()
+    );
     let expect_id_addr = Address::new_id(FIRST_TEST_USER_ADDR);
     assert_placeholder_actor(TokenAmount::from_atto(42u8), &v, expect_id_addr);
 
     // Make sure we assigned the right f4 address.
-    assert_eq!(v.normalize_address(&addr).unwrap(), expect_id_addr);
+    assert_eq!(v.resolve_id_address(&addr).unwrap(), expect_id_addr);
 
     // Deploy a multisig to the placeholder.
     let msig_ctor_params = serialize(
@@ -63,16 +63,16 @@ fn placeholder_deploy() {
     .unwrap();
 
     let deploy = || {
-        v.apply_message(
+        v.execute_message(
             &EAM_ACTOR_ADDR, // so this works even if "m2-native" is disabled.
             &INIT_ACTOR_ADDR,
             &TokenAmount::zero(),
             fil_actor_init::Method::Exec4 as u64,
-            Some(fil_actor_init::Exec4Params {
+            Some(serialize_ok(&fil_actor_init::Exec4Params {
                 code_cid: *MULTISIG_ACTOR_CODE_ID,
                 constructor_params: msig_ctor_params.clone(),
                 subaddress: subaddr[..].to_owned().into(),
-            }),
+            })),
         )
         .unwrap()
     };

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -11,7 +11,7 @@ use fil_actors_runtime::test_utils::make_sealed_cid;
 use fil_actors_runtime::{
     CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
 };
-use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::{BytesDe, RawBytes};
 use fvm_shared::address::Address;
 
@@ -21,22 +21,27 @@ use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof};
 use fvm_shared::METHOD_SEND;
 use num_traits::Zero;
 use test_vm::util::{
-    apply_ok, create_accounts, create_miner, invariant_failure_patterns, miner_dline_info,
+    apply_ok, assert_invariants, create_accounts, create_miner, expect_invariants,
+    invariant_failure_patterns, miner_dline_info, serialize_ok,
 };
 use test_vm::{ExpectInvocation, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
 
 #[test]
-fn create_miner_test() {
+fn power_create_miner() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
+    power_create_miner_test(&v);
+}
+
+fn power_create_miner_test<BS: Blockstore>(v: &dyn VM<BS>) {
     let owner = Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();
-    v.apply_message(
+    v.execute_message(
         &TEST_FAUCET_ADDR,
         &owner,
         &TokenAmount::from_atto(10_000u32),
         METHOD_SEND,
-        None::<RawBytes>,
+        None,
     )
     .unwrap();
     let multiaddrs = vec![BytesDe("multiaddr".as_bytes().to_vec())];
@@ -50,12 +55,12 @@ fn create_miner_test() {
     };
 
     let res = v
-        .apply_message(
+        .execute_message(
             &owner,
             &STORAGE_POWER_ACTOR_ADDR,
             &TokenAmount::from_atto(1000u32),
             PowerMethod::CreateMiner as u64,
-            Some(params.clone()),
+            Some(serialize_ok(&params)),
         )
         .unwrap();
 
@@ -92,8 +97,9 @@ fn create_miner_test() {
         ]),
         ..Default::default()
     };
+
     expect.matches(v.take_invocations().last().unwrap());
-    v.assert_state_invariants();
+    assert_invariants(v);
 }
 
 #[test]
@@ -225,7 +231,5 @@ fn test_cron_tick() {
     }
     .matches(v.take_invocations().first().unwrap());
 
-    v.expect_state_invariants(
-        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
-    );
+    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -36,20 +36,20 @@ use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
 use test_case::test_case;
 use test_vm::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_index, advance_to_proving_deadline,
-    apply_code, apply_ok, bf_all, check_sector_active, check_sector_faulty, create_accounts,
-    create_miner, deadline_state, declare_recovery, get_network_stats, invariant_failure_patterns,
-    make_bitfield, market_publish_deal, miner_power, precommit_sectors, prove_commit_sectors,
-    sector_info, submit_invalid_post, submit_windowed_post, verifreg_add_client,
-    verifreg_add_verifier,
+    apply_code, apply_ok, assert_invariants, bf_all, check_sector_active, check_sector_faulty,
+    create_accounts, create_miner, deadline_state, declare_recovery, expect_invariants,
+    get_network_stats, get_state, invariant_failure_patterns, make_bitfield, market_publish_deal,
+    miner_balance, miner_power, precommit_sectors, prove_commit_sectors, sector_info,
+    submit_invalid_post, submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
 };
 use test_vm::TestVM;
-// ---- Success cases ----
 
+// ---- Success cases ----
 // Tests that an active CC sector can be correctly upgraded, and the expected state changes occur
 #[test_case(false; "v1")]
 #[test_case(true; "v2")]
 fn replica_update_simple_path_success(v2: bool) {
-    create_miner_and_upgrade_sector(&MemoryBlockstore::new(), v2).0.assert_state_invariants();
+    assert_invariants(&create_miner_and_upgrade_sector(&MemoryBlockstore::new(), v2).0);
 }
 
 // Tests a successful upgrade, followed by the sector going faulty and recovering
@@ -60,12 +60,35 @@ fn replica_update_full_path_success(v2: bool) {
     let policy = Policy::default();
     let (v, sector_info, worker, miner_id, deadline_index, partition_index, sector_size) =
         create_miner_and_upgrade_sector(store, v2);
+    replica_update_full_path_success_test(
+        &v,
+        sector_info,
+        miner_id,
+        worker,
+        partition_index,
+        deadline_index,
+        policy,
+        sector_size,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn replica_update_full_path_success_test<BS: Blockstore>(
+    v: &dyn VM<BS>,
+    sector_info: SectorOnChainInfo,
+    miner_id: Address,
+    worker: Address,
+    partition_index: u64,
+    deadline_index: u64,
+    policy: Policy,
+    sector_size: SectorSize,
+) {
     let sector_number = sector_info.sector_number;
 
     // submit post successfully
-    let (mut deadline_info, _) = advance_to_proving_deadline(&v, &miner_id, sector_number);
+    let (mut deadline_info, _) = advance_to_proving_deadline(v, &miner_id, sector_number);
     submit_windowed_post(
-        &v,
+        v,
         &worker,
         &miner_id,
         deadline_info,
@@ -74,22 +97,22 @@ fn replica_update_full_path_success(v2: bool) {
     );
 
     // move out of the sector's deadline
-    advance_by_deadline_to_index(&v, &miner_id, deadline_index + 1 % policy.wpost_period_deadlines);
-    assert!(check_sector_active(&v, &miner_id, sector_number));
+    advance_by_deadline_to_index(v, &miner_id, deadline_index + 1 % policy.wpost_period_deadlines);
+    assert!(check_sector_active(v, &miner_id, sector_number));
 
     // miss next post, lose power, become faulty :'(
-    advance_by_deadline_to_index(&v, &miner_id, deadline_index);
-    advance_by_deadline_to_index(&v, &miner_id, deadline_index + 1 % policy.wpost_period_deadlines);
-    assert!(!check_sector_active(&v, &miner_id, sector_number));
-    assert!(check_sector_faulty(&v, &miner_id, deadline_index, partition_index, sector_number));
+    advance_by_deadline_to_index(v, &miner_id, deadline_index);
+    advance_by_deadline_to_index(v, &miner_id, deadline_index + 1 % policy.wpost_period_deadlines);
+    assert!(!check_sector_active(v, &miner_id, sector_number));
+    assert!(check_sector_faulty(v, &miner_id, deadline_index, partition_index, sector_number));
 
-    assert!(miner_power(&v, &miner_id).is_zero());
+    assert!(miner_power(v, &miner_id).is_zero());
 
-    declare_recovery(&v, &worker, &miner_id, deadline_index, partition_index, sector_number);
-    (deadline_info, _) = advance_to_proving_deadline(&v, &miner_id, sector_number);
+    declare_recovery(v, &worker, &miner_id, deadline_index, partition_index, sector_number);
+    (deadline_info, _) = advance_to_proving_deadline(v, &miner_id, sector_number);
 
     submit_windowed_post(
-        &v,
+        v,
         &worker,
         &miner_id,
         deadline_info,
@@ -100,31 +123,55 @@ fn replica_update_full_path_success(v2: bool) {
         }),
     );
 
-    assert!(check_sector_active(&v, &miner_id, sector_number));
-    assert!(!check_sector_faulty(&v, &miner_id, deadline_index, partition_index, sector_number));
-    assert_eq!(miner_power(&v, &miner_id).raw, BigInt::from(sector_size as i64));
-    v.assert_state_invariants();
+    assert!(check_sector_active(v, &miner_id, sector_number));
+    assert!(!check_sector_faulty(v, &miner_id, deadline_index, partition_index, sector_number));
+    assert_eq!(miner_power(v, &miner_id).raw, BigInt::from(sector_size as i64));
+
+    assert_invariants(v)
 }
 
 #[test_case(false; "v1")]
 #[test_case(true; "v2")]
 fn upgrade_and_miss_post(v2: bool) {
     let store = &MemoryBlockstore::new();
-    let policy = Policy::default();
     let (v, sector_info, worker, miner_id, deadline_index, partition_index, sector_size) =
         create_miner_and_upgrade_sector(store, v2);
-    let sector_number = sector_info.sector_number;
+    upgrade_and_miss_post_test::<MemoryBlockstore>(
+        &v,
+        sector_info,
+        miner_id,
+        deadline_index,
+        store,
+        worker,
+        partition_index,
+        sector_size,
+    );
+}
 
-    let power_after_update = miner_power(&v, &miner_id);
+#[allow(clippy::too_many_arguments)]
+fn upgrade_and_miss_post_test<BS: Blockstore>(
+    v: &dyn VM<BS>,
+    sector_info: SectorOnChainInfo,
+    miner_id: Address,
+    deadline_index: u64,
+    store: &MemoryBlockstore,
+    worker: Address,
+    partition_index: u64,
+    sector_size: SectorSize,
+) {
+    let sector_number = sector_info.sector_number;
+    let policy = Policy::default();
+
+    let power_after_update = miner_power(v, &miner_id);
     assert!(!power_after_update.is_zero());
 
     // immediately miss post, lose power, become faulty
-    advance_by_deadline_to_index(&v, &miner_id, deadline_index);
-    advance_by_deadline_to_index(&v, &miner_id, deadline_index + 1 % policy.wpost_period_deadlines);
-    assert!(!check_sector_active(&v, &miner_id, sector_number));
-    assert!(check_sector_faulty(&v, &miner_id, deadline_index, partition_index, sector_number));
+    advance_by_deadline_to_index(v, &miner_id, deadline_index);
+    advance_by_deadline_to_index(v, &miner_id, deadline_index + 1 % policy.wpost_period_deadlines);
+    assert!(!check_sector_active(v, &miner_id, sector_number));
+    assert!(check_sector_faulty(v, &miner_id, deadline_index, partition_index, sector_number));
 
-    let deadline_state = deadline_state(&v, &miner_id, deadline_index);
+    let deadline_state = deadline_state(v, &miner_id, deadline_index);
     assert_eq!(power_after_update, deadline_state.faulty_power);
 
     let empty_sectors_array =
@@ -133,13 +180,13 @@ fn upgrade_and_miss_post(v2: bool) {
             .unwrap();
     assert_eq!(deadline_state.sectors_snapshot, empty_sectors_array);
 
-    assert!(miner_power(&v, &miner_id).is_zero());
+    assert!(miner_power(v, &miner_id).is_zero());
 
-    declare_recovery(&v, &worker, &miner_id, deadline_index, partition_index, sector_number);
-    let (deadline_info, _) = advance_to_proving_deadline(&v, &miner_id, sector_number);
+    declare_recovery(v, &worker, &miner_id, deadline_index, partition_index, sector_number);
+    let (deadline_info, _) = advance_to_proving_deadline(v, &miner_id, sector_number);
 
     submit_windowed_post(
-        &v,
+        v,
         &worker,
         &miner_id,
         deadline_info,
@@ -150,29 +197,35 @@ fn upgrade_and_miss_post(v2: bool) {
         }),
     );
 
-    assert!(check_sector_active(&v, &miner_id, sector_number));
-    assert!(!check_sector_faulty(&v, &miner_id, deadline_index, partition_index, sector_number));
-    assert_eq!(miner_power(&v, &miner_id).raw, BigInt::from(sector_size as i64));
-    v.assert_state_invariants();
+    assert!(check_sector_active(v, &miner_id, sector_number));
+    assert!(!check_sector_faulty(v, &miner_id, deadline_index, partition_index, sector_number));
+    assert_eq!(miner_power(v, &miner_id).raw, BigInt::from(sector_size as i64));
+
+    assert_invariants(v)
 }
 
 #[test]
 fn prove_replica_update_multi_dline() {
     let store = &MemoryBlockstore::new();
-    let policy = Policy::default();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(1_000_000));
+    prove_replica_update_multi_dline_test(&v);
+}
+
+fn prove_replica_update_multi_dline_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let policy = Policy::default();
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(1_000_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (maddr, _) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
         &TokenAmount::from_whole(100_000),
     );
 
-    v.set_epoch(1440); // something offset far away from deadline 0 and 1
+    v.set_epoch(1440);
+    // something offset far away from deadline 0 and 1
 
     /* Commit enough sectors to pack two partitions */
     let more_than_one_partition = 2440;
@@ -182,7 +235,7 @@ fn prove_replica_update_multi_dline() {
     let expiration = v.epoch() + policy.max_sector_expiration_extension;
 
     let new_precommits = precommit_sectors(
-        &v,
+        v,
         more_than_one_partition,
         batch_size,
         &worker,
@@ -197,51 +250,51 @@ fn prove_replica_update_multi_dline() {
     let to_prove = precommits;
 
     let prove_time = v.epoch() + policy.pre_commit_challenge_delay + 1;
-    advance_by_deadline_to_epoch(&v, &maddr, prove_time);
+    advance_by_deadline_to_epoch(v, &maddr, prove_time);
 
-    prove_commit_sectors(&v, &worker, &maddr, to_prove, batch_size);
+    prove_commit_sectors(v, &worker, &maddr, to_prove, batch_size);
 
     /* This is a mess, but it just ensures activation of both partitions by posting, cronning and checking */
 
     // advance to proving period and submit post for first partition
     let (deadline_info, partition_index) =
-        advance_to_proving_deadline(&v, &maddr, first_sector_number_p1);
+        advance_to_proving_deadline(v, &maddr, first_sector_number_p1);
 
     // first partition shouldn't be active until PoSt
-    assert!(!check_sector_active(&v, &maddr, deadline_info.index));
-    submit_windowed_post(&v, &worker, &maddr, deadline_info, partition_index, None);
+    assert!(!check_sector_active(v, &maddr, deadline_info.index));
+    submit_windowed_post(v, &worker, &maddr, deadline_info, partition_index, None);
 
     // move into the next deadline so that the first batch of created sectors are active
     let current_deadline_info = advance_by_deadline_to_index(
-        &v,
+        v,
         &maddr,
         deadline_info.index + 1 % policy.wpost_period_deadlines,
     );
 
     // hooray, first partition is now active
     assert_eq!(1, current_deadline_info.index);
-    assert!(check_sector_active(&v, &maddr, first_sector_number_p1));
-    assert!(check_sector_active(&v, &maddr, first_sector_number_p1 + 1));
-    assert!(check_sector_active(&v, &maddr, first_sector_number_p1 + 2));
-    assert!(check_sector_active(&v, &maddr, first_sector_number_p1 + 2300));
+    assert!(check_sector_active(v, &maddr, first_sector_number_p1));
+    assert!(check_sector_active(v, &maddr, first_sector_number_p1 + 1));
+    assert!(check_sector_active(v, &maddr, first_sector_number_p1 + 2));
+    assert!(check_sector_active(v, &maddr, first_sector_number_p1 + 2300));
 
     // second partition shouldn't be active until PoSt
-    assert!(!check_sector_active(&v, &maddr, first_sector_number_p2));
-    submit_windowed_post(&v, &worker, &maddr, current_deadline_info, 0, None);
+    assert!(!check_sector_active(v, &maddr, first_sector_number_p2));
+    submit_windowed_post(v, &worker, &maddr, current_deadline_info, 0, None);
 
     // move into the next deadline so that the second batch of created sectors are active
     advance_by_deadline_to_index(
-        &v,
+        v,
         &maddr,
         deadline_info.index + 2 % policy.wpost_period_deadlines,
     );
-    assert!(check_sector_active(&v, &maddr, first_sector_number_p2));
+    assert!(check_sector_active(v, &maddr, first_sector_number_p2));
 
     /* Replica Update across two deadlines */
-    let old_sector_commr_p1 = sector_info(&v, &maddr, first_sector_number_p1).sealed_cid;
-    let old_sector_commr_p2 = sector_info(&v, &maddr, first_sector_number_p2).sealed_cid;
+    let old_sector_commr_p1 = sector_info(v, &maddr, first_sector_number_p1).sealed_cid;
+    let old_sector_commr_p2 = sector_info(v, &maddr, first_sector_number_p2).sealed_cid;
 
-    let deal_ids = create_deals(2, &v, worker, worker, maddr);
+    let deal_ids = create_deals(2, v, worker, worker, maddr);
 
     let new_sealed_cid1 = make_sealed_cid(b"replica1");
     let replica_update_1 = ReplicaUpdate {
@@ -266,7 +319,7 @@ fn prove_replica_update_multi_dline() {
     };
 
     let ret_bf: BitField = apply_ok(
-        &v,
+        v,
         &worker,
         &maddr,
         &TokenAmount::zero(),
@@ -280,17 +333,18 @@ fn prove_replica_update_multi_dline() {
     assert!(ret_bf.get(first_sector_number_p1));
     assert!(ret_bf.get(first_sector_number_p2));
 
-    let new_sector_info_p1 = sector_info(&v, &maddr, first_sector_number_p1);
+    let new_sector_info_p1 = sector_info(v, &maddr, first_sector_number_p1);
     assert_eq!(deal_ids[0], new_sector_info_p1.deal_ids[0]);
     assert_eq!(1, new_sector_info_p1.deal_ids.len());
     assert_eq!(old_sector_commr_p1, new_sector_info_p1.sector_key_cid.unwrap());
     assert_eq!(new_sealed_cid1, new_sector_info_p1.sealed_cid);
-    let new_sector_info_p2 = sector_info(&v, &maddr, first_sector_number_p2);
+    let new_sector_info_p2 = sector_info(v, &maddr, first_sector_number_p2);
     assert_eq!(deal_ids[1], new_sector_info_p2.deal_ids[0]);
     assert_eq!(1, new_sector_info_p2.deal_ids.len());
     assert_eq!(old_sector_commr_p2, new_sector_info_p2.sector_key_cid.unwrap());
     assert_eq!(new_sealed_cid2, new_sector_info_p2.sealed_cid);
-    v.assert_state_invariants();
+
+    assert_invariants(v);
 }
 
 // ---- Failure cases ----
@@ -300,11 +354,15 @@ fn prove_replica_update_multi_dline() {
 fn immutable_deadline_failure() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(100_000));
+    immutable_deadline_failure_test(&v);
+}
+
+fn immutable_deadline_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (maddr, robust) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -312,16 +370,16 @@ fn immutable_deadline_failure() {
     );
 
     // advance to have seal randomness epoch in the past
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     let sector_number = 100;
-    let (v, d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
+    let (d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
 
     // make some deals
-    let deal_ids = create_deals(1, &v, worker, worker, maddr);
+    let deal_ids = create_deals(1, v, worker, worker, maddr);
 
     // Advance back into the sector's deadline
-    advance_to_proving_deadline(&v, &maddr, sector_number);
+    advance_to_proving_deadline(v, &maddr, sector_number);
 
     // replicaUpdate the sector
     let new_cid = make_sealed_cid(b"replica1");
@@ -335,7 +393,7 @@ fn immutable_deadline_failure() {
         replica_proof: vec![],
     };
     apply_code(
-        &v,
+        v,
         &worker,
         &robust,
         &TokenAmount::zero(),
@@ -343,19 +401,24 @@ fn immutable_deadline_failure() {
         Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-    v.assert_state_invariants();
+
+    assert_invariants(v)
 }
 
 #[test]
 fn unhealthy_sector_failure() {
     let store = &MemoryBlockstore::new();
-    let policy = Policy::default();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(100_000));
+    unhealthy_sector_failure_test(&v);
+}
+
+fn unhealthy_sector_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let policy = Policy::default();
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (maddr, robust) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -363,19 +426,19 @@ fn unhealthy_sector_failure() {
     );
 
     // advance to have seal randomness epoch in the past
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     let sector_number = 100;
-    let (v, d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
+    let (d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
 
     // make some deals
-    let deal_ids = create_deals(1, &v, worker, worker, maddr);
+    let deal_ids = create_deals(1, v, worker, worker, maddr);
 
     // ffw 2 days, missing posts
     let two_days_later = v.epoch() + policy.wpost_proving_period * 2;
-    advance_by_deadline_to_epoch(&v, &maddr, two_days_later);
-    assert!(!check_sector_active(&v, &maddr, sector_number));
-    assert!(check_sector_faulty(&v, &maddr, d_idx, p_idx, sector_number));
+    advance_by_deadline_to_epoch(v, &maddr, two_days_later);
+    assert!(!check_sector_active(v, &maddr, sector_number));
+    assert!(check_sector_faulty(v, &maddr, d_idx, p_idx, sector_number));
 
     // replicaUpdate the sector
     let new_cid = make_sealed_cid(b"replica1");
@@ -389,7 +452,7 @@ fn unhealthy_sector_failure() {
         replica_proof: vec![],
     };
     apply_code(
-        &v,
+        v,
         &worker,
         &robust,
         &TokenAmount::zero(),
@@ -397,20 +460,23 @@ fn unhealthy_sector_failure() {
         Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-    v.expect_state_invariants(
-        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
-    );
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
 fn terminated_sector_failure() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(100_000));
+    terminated_sector_failure_test(&v);
+}
+
+fn terminated_sector_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (maddr, robust) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -418,13 +484,13 @@ fn terminated_sector_failure() {
     );
 
     // advance to have seal randomness epoch in the past
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     let sector_number = 100;
-    let (v, d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
+    let (d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
 
     // make some deals
-    let deal_ids = create_deals(1, &v, worker, worker, maddr);
+    let deal_ids = create_deals(1, v, worker, worker, maddr);
 
     // terminate sector
 
@@ -436,7 +502,7 @@ fn terminated_sector_failure() {
         }],
     };
     apply_ok(
-        &v,
+        v,
         &worker,
         &maddr,
         &TokenAmount::zero(),
@@ -456,7 +522,7 @@ fn terminated_sector_failure() {
         replica_proof: vec![],
     };
     apply_code(
-        &v,
+        v,
         &worker,
         &robust,
         &TokenAmount::zero(),
@@ -464,19 +530,24 @@ fn terminated_sector_failure() {
         Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-    v.assert_state_invariants();
+
+    assert_invariants(v)
 }
 
 #[test]
 fn bad_batch_size_failure() {
     let store = &MemoryBlockstore::new();
-    let policy = Policy::default();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(100_000));
+    bad_batch_size_failure_test(&v);
+}
+
+fn bad_batch_size_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let policy = Policy::default();
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (maddr, robust) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -484,13 +555,13 @@ fn bad_batch_size_failure() {
     );
 
     // advance to have seal randomness epoch in the past
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     let sector_number = 100;
-    let (v, d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
+    let (d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
 
     // make some deals
-    let deal_ids = create_deals(1, &v, worker, worker, maddr);
+    let deal_ids = create_deals(1, v, worker, worker, maddr);
 
     // fail to replicaUpdate more sectors than batch size
     let new_cid = make_sealed_cid(b"replica1");
@@ -509,7 +580,7 @@ fn bad_batch_size_failure() {
     }
 
     apply_code(
-        &v,
+        v,
         &worker,
         &robust,
         &TokenAmount::zero(),
@@ -517,7 +588,8 @@ fn bad_batch_size_failure() {
         Some(ProveReplicaUpdatesParams { updates }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-    v.assert_state_invariants();
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -526,9 +598,18 @@ fn no_dispute_after_upgrade() {
     let (v, _, worker, miner_id, deadline_index, _, _) =
         create_miner_and_upgrade_sector(store, false);
 
+    nodispute_after_upgrade_test(&v, deadline_index, worker, miner_id);
+}
+
+fn nodispute_after_upgrade_test<BS: Blockstore>(
+    v: &dyn VM<BS>,
+    deadline_index: u64,
+    worker: Address,
+    miner_id: Address,
+) {
     let dispute_params = DisputeWindowedPoStParams { deadline: deadline_index, post_index: 0 };
     apply_code(
-        &v,
+        v,
         &worker,
         &miner_id,
         &TokenAmount::zero(),
@@ -536,44 +617,69 @@ fn no_dispute_after_upgrade() {
         Some(dispute_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-    v.assert_state_invariants();
+
+    assert_invariants(v)
 }
 
 #[test]
 fn upgrade_bad_post_dispute() {
     let store = &MemoryBlockstore::new();
-    let policy = Policy::default();
     let (v, sector_info, worker, miner_id, deadline_index, partition_index, _) =
         create_miner_and_upgrade_sector(store, false);
+
+    upgrade_bad_post_dispute_test(
+        &v,
+        sector_info,
+        miner_id,
+        worker,
+        partition_index,
+        deadline_index,
+    );
+}
+
+fn upgrade_bad_post_dispute_test<BS: Blockstore>(
+    v: &dyn VM<BS>,
+    sector_info: SectorOnChainInfo,
+    miner_id: Address,
+    worker: Address,
+    partition_index: u64,
+    deadline_index: u64,
+) {
+    let policy = Policy::default();
     let sector_number = sector_info.sector_number;
 
-    let (deadline_info, _) = advance_to_proving_deadline(&v, &miner_id, sector_number);
-    submit_invalid_post(&v, &worker, &miner_id, deadline_info, partition_index);
+    let (deadline_info, _) = advance_to_proving_deadline(v, &miner_id, sector_number);
+    submit_invalid_post(v, &worker, &miner_id, deadline_info, partition_index);
 
-    advance_by_deadline_to_index(&v, &miner_id, deadline_index + 2 % policy.wpost_period_deadlines);
+    advance_by_deadline_to_index(v, &miner_id, deadline_index + 2 % policy.wpost_period_deadlines);
 
     let dispute_params = DisputeWindowedPoStParams { deadline: deadline_index, post_index: 0 };
     apply_ok(
-        &v,
+        v,
         &worker,
         &miner_id,
         &TokenAmount::zero(),
         MinerMethod::DisputeWindowedPoSt as u64,
         Some(dispute_params),
     );
-    v.assert_state_invariants();
+
+    assert_invariants(v)
 }
 
 #[test]
 fn bad_post_upgrade_dispute() {
     let store = &MemoryBlockstore::new();
-    let policy = Policy::default();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(100_000));
+    bad_post_upgrade_dispute_test(&v);
+}
+
+fn bad_post_upgrade_dispute_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let policy = Policy::default();
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (maddr, robust) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -581,20 +687,20 @@ fn bad_post_upgrade_dispute() {
     );
 
     // advance to have seal randomness epoch in the past
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     let sector_number = 100;
-    let (v, d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
-    let old_sector_info = sector_info(&v, &maddr, sector_number);
+    let (d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
+    let old_sector_info = sector_info(v, &maddr, sector_number);
 
     // submit an invalid post
-    let (deadline_info, _) = advance_to_proving_deadline(&v, &maddr, sector_number);
+    let (deadline_info, _) = advance_to_proving_deadline(v, &maddr, sector_number);
 
-    submit_invalid_post(&v, &worker, &maddr, deadline_info, p_idx);
-    advance_by_deadline_to_index(&v, &maddr, d_idx + 2 % policy.wpost_period_deadlines);
+    submit_invalid_post(v, &worker, &maddr, deadline_info, p_idx);
+    advance_by_deadline_to_index(v, &maddr, d_idx + 2 % policy.wpost_period_deadlines);
 
     // make some deals
-    let deal_ids = create_deals(1, &v, worker, worker, maddr);
+    let deal_ids = create_deals(1, v, worker, worker, maddr);
 
     // replicaUpdate the sector -- it succeeds
     let new_cid = make_sealed_cid(b"replica1");
@@ -609,7 +715,7 @@ fn bad_post_upgrade_dispute() {
     };
 
     let updated_sectors: BitField = apply_ok(
-        &v,
+        v,
         &worker,
         &robust,
         &TokenAmount::zero(),
@@ -621,7 +727,7 @@ fn bad_post_upgrade_dispute() {
     assert_eq!(vec![100], bf_all(updated_sectors));
 
     // sanity check the sector after update
-    let new_sector_info = sector_info(&v, &maddr, sector_number);
+    let new_sector_info = sector_info(v, &maddr, sector_number);
     assert_eq!(1, new_sector_info.deal_ids.len());
     assert_eq!(deal_ids[0], new_sector_info.deal_ids[0]);
     assert_eq!(old_sector_info.sealed_cid, new_sector_info.sector_key_cid.unwrap());
@@ -631,14 +737,15 @@ fn bad_post_upgrade_dispute() {
 
     let dispute_params = DisputeWindowedPoStParams { deadline: d_idx, post_index: 0 };
     apply_ok(
-        &v,
+        v,
         &worker,
         &maddr,
         &TokenAmount::zero(),
         MinerMethod::DisputeWindowedPoSt as u64,
         Some(dispute_params),
     );
-    v.assert_state_invariants();
+
+    assert_invariants(v)
 }
 
 // Tests that an active CC sector can be correctly upgraded, and then the sector can be terminated
@@ -647,6 +754,24 @@ fn terminate_after_upgrade() {
     let store = &MemoryBlockstore::new();
     let (v, sector_info, worker, miner_id, deadline_index, partition_index, _) =
         create_miner_and_upgrade_sector(store, false);
+    terminate_after_upgrade_test(
+        &v,
+        sector_info,
+        worker,
+        miner_id,
+        deadline_index,
+        partition_index,
+    );
+}
+
+fn terminate_after_upgrade_test<BS: Blockstore>(
+    v: &dyn VM<BS>,
+    sector_info: SectorOnChainInfo,
+    worker: Address,
+    miner_id: Address,
+    deadline_index: u64,
+    partition_index: u64,
+) {
     let sector_number = sector_info.sector_number;
 
     let terminate_params = TerminateSectorsParams {
@@ -658,7 +783,7 @@ fn terminate_after_upgrade() {
     };
 
     apply_ok(
-        &v,
+        v,
         &worker,
         &miner_id,
         &TokenAmount::zero(),
@@ -667,11 +792,11 @@ fn terminate_after_upgrade() {
     );
 
     // expect power, market and miner to be in base state
-    let miner_balances = v.get_miner_balance(&miner_id);
+    let miner_balances = miner_balance(v, &miner_id);
     assert!(miner_balances.initial_pledge.is_zero());
     assert!(miner_balances.pre_commit_deposit.is_zero());
 
-    let network_stats = get_network_stats(&v);
+    let network_stats = get_network_stats(v);
     assert!(network_stats.miner_above_min_power_count.is_zero());
     assert!(network_stats.total_raw_byte_power.is_zero());
     assert!(network_stats.total_quality_adj_power.is_zero());
@@ -679,14 +804,13 @@ fn terminate_after_upgrade() {
     assert!(network_stats.total_qa_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_zero());
 
-    v.assert_state_invariants();
+    assert_invariants(v);
 }
 
 // Tests that an active CC sector can be correctly upgraded, and then the sector can be extended
 #[test]
 fn extend_after_upgrade() {
     let store = &MemoryBlockstore::new();
-    let policy = Policy::default();
     let (v, sector_info, worker, miner_id, deadline_index, partition_index, _) =
         create_miner_and_upgrade_sector(store, false);
     let sector_number = sector_info.sector_number;
@@ -700,6 +824,28 @@ fn extend_after_upgrade() {
         st.sectors = sectors.amt.flush().unwrap();
     });
 
+    extend_after_upgrade_test::<MemoryBlockstore>(
+        &v,
+        miner_id,
+        store,
+        worker,
+        deadline_index,
+        partition_index,
+        sector_number,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn extend_after_upgrade_test<BS: Blockstore>(
+    v: &dyn VM<BS>,
+    miner_id: Address,
+    store: &MemoryBlockstore,
+    worker: Address,
+    deadline_index: u64,
+    partition_index: u64,
+    sector_number: SectorNumber,
+) {
+    let policy = Policy::default();
     let extension_epoch = v.epoch();
     let extension_params = ExtendSectorExpirationParams {
         extensions: vec![ExpirationExtension {
@@ -711,7 +857,7 @@ fn extend_after_upgrade() {
     };
 
     apply_ok(
-        &v,
+        v,
         &worker,
         &miner_id,
         &TokenAmount::zero(),
@@ -719,25 +865,31 @@ fn extend_after_upgrade() {
         Some(extension_params),
     );
 
-    let miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    let miner_state: MinerState = get_state(v, &miner_id).unwrap();
     let final_sector_info = miner_state.get_sector(store, sector_number).unwrap().unwrap();
     assert_eq!(
         policy.max_sector_expiration_extension - 1,
         final_sector_info.expiration - extension_epoch,
     );
-    v.assert_state_invariants();
+
+    assert_invariants(v)
 }
 
 #[test]
 fn wrong_deadline_index_failure() {
     let store = &MemoryBlockstore::new();
-    let policy = Policy::default();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(100_000));
+
+    wrong_deadline_index_failure_test(&v);
+}
+
+fn wrong_deadline_index_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let policy = Policy::default();
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (maddr, robust) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -745,14 +897,14 @@ fn wrong_deadline_index_failure() {
     );
 
     // advance to have seal randomness epoch in the past
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     let sector_number = 100;
-    let (v, d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
-    let old_sector_info = sector_info(&v, &maddr, sector_number);
+    let (d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
+    let old_sector_info = sector_info(v, &maddr, sector_number);
 
     // make some deals
-    let deal_ids = create_deals(1, &v, worker, worker, maddr);
+    let deal_ids = create_deals(1, v, worker, worker, maddr);
 
     // fail to replicaUpdate more sectors than batch size
     let new_cid = make_sealed_cid(b"replica1");
@@ -771,7 +923,7 @@ fn wrong_deadline_index_failure() {
     }
 
     apply_code(
-        &v,
+        v,
         &worker,
         &robust,
         &TokenAmount::zero(),
@@ -780,21 +932,27 @@ fn wrong_deadline_index_failure() {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    let new_sector_info = sector_info(&v, &maddr, sector_number);
+    let new_sector_info = sector_info(v, &maddr, sector_number);
     assert_eq!(old_sector_info, new_sector_info);
-    v.assert_state_invariants();
+
+    assert_invariants(v)
 }
 
 #[test]
 fn wrong_partition_index_failure() {
     let store = &MemoryBlockstore::new();
-    let policy = Policy::default();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(100_000));
+
+    wrong_partition_index_failure_test(&v);
+}
+
+fn wrong_partition_index_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let policy = Policy::default();
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (maddr, robust) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -802,14 +960,14 @@ fn wrong_partition_index_failure() {
     );
 
     // advance to have seal randomness epoch in the past
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     let sector_number = 100;
-    let (v, d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
-    let old_sector_info = sector_info(&v, &maddr, sector_number);
+    let (d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
+    let old_sector_info = sector_info(v, &maddr, sector_number);
 
     // make some deals
-    let deal_ids = create_deals(1, &v, worker, worker, maddr);
+    let deal_ids = create_deals(1, v, worker, worker, maddr);
 
     // fail to replicaUpdate more sectors than batch size
     let new_cid = make_sealed_cid(b"replica1");
@@ -828,7 +986,7 @@ fn wrong_partition_index_failure() {
     }
 
     apply_code(
-        &v,
+        v,
         &worker,
         &robust,
         &TokenAmount::zero(),
@@ -837,21 +995,26 @@ fn wrong_partition_index_failure() {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    let new_sector_info = sector_info(&v, &maddr, sector_number);
+    let new_sector_info = sector_info(v, &maddr, sector_number);
     assert_eq!(old_sector_info, new_sector_info);
-    v.assert_state_invariants();
+
+    assert_invariants(v)
 }
 
 #[test]
 fn deal_included_in_multiple_sectors_failure() {
     let store = &MemoryBlockstore::new();
-    let policy = Policy::default();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(100_000));
+    deal_included_in_multiple_sectors_failure_test(&v);
+}
+
+fn deal_included_in_multiple_sectors_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let policy = Policy::default();
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (maddr, _) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -862,10 +1025,9 @@ fn deal_included_in_multiple_sectors_failure() {
     // preCommit two sectors
     //
     //
-
     let first_sector_number = 100;
     let precommits = precommit_sectors(
-        &v,
+        v,
         policy.min_aggregated_sectors,
         policy.pre_commit_sector_batch_max_size as i64,
         &worker,
@@ -878,17 +1040,17 @@ fn deal_included_in_multiple_sectors_failure() {
 
     assert_eq!(policy.min_aggregated_sectors, precommits.len() as u64);
 
-    let miner_balance = v.get_miner_balance(&maddr);
+    let miner_balance = miner_balance(v, &maddr);
     assert!(miner_balance.pre_commit_deposit.is_positive());
 
     let prove_time = v.epoch() + policy.pre_commit_challenge_delay + 1;
-    advance_by_deadline_to_epoch(&v, &maddr, prove_time);
+    advance_by_deadline_to_epoch(v, &maddr, prove_time);
 
-    prove_commit_sectors(&v, &worker, &maddr, precommits, 100);
+    prove_commit_sectors(v, &worker, &maddr, precommits, 100);
 
     // In the same epoch, trigger cron to validate prove commit
     apply_ok(
-        &v,
+        v,
         &SYSTEM_ACTOR_ADDR,
         &CRON_ACTOR_ADDR,
         &TokenAmount::zero(),
@@ -898,31 +1060,29 @@ fn deal_included_in_multiple_sectors_failure() {
 
     // advance to proving period and submit post
     let (deadline_info, partition_index) =
-        advance_to_proving_deadline(&v, &maddr, first_sector_number);
+        advance_to_proving_deadline(v, &maddr, first_sector_number);
 
     // sector shouldn't be active until PoSt
-    assert!(!check_sector_active(&v, &maddr, first_sector_number));
-    assert!(!check_sector_active(&v, &maddr, first_sector_number + 1));
+    assert!(!check_sector_active(v, &maddr, first_sector_number));
+    assert!(!check_sector_active(v, &maddr, first_sector_number + 1));
 
-    submit_windowed_post(&v, &worker, &maddr, deadline_info, partition_index, None);
+    submit_windowed_post(v, &worker, &maddr, deadline_info, partition_index, None);
 
     // move into the next deadline so that the created sectors are mutable
     advance_by_deadline_to_index(
-        &v,
+        v,
         &maddr,
         deadline_info.index + 1 % policy.wpost_period_deadlines,
     );
 
     // sectors are now active!
-    assert!(check_sector_active(&v, &maddr, first_sector_number));
-    assert!(check_sector_active(&v, &maddr, first_sector_number + 1));
+    assert!(check_sector_active(v, &maddr, first_sector_number));
+    assert!(check_sector_active(v, &maddr, first_sector_number + 1));
 
     // make some unverified deals
-
-    let deal_ids = create_deals_frac(2, &v, worker, worker, maddr, 2, false, 180 * EPOCHS_IN_DAY);
+    let deal_ids = create_deals_frac(2, v, worker, worker, maddr, 2, false, 180 * EPOCHS_IN_DAY);
 
     // replicaUpdate the sector
-
     let new_sealed_cid1 = make_sealed_cid(b"replica1");
     let replica_update_1 = ReplicaUpdate {
         sector_number: first_sector_number,
@@ -946,7 +1106,7 @@ fn deal_included_in_multiple_sectors_failure() {
     };
 
     let ret_bf: BitField = apply_ok(
-        &v,
+        v,
         &worker,
         &maddr,
         &TokenAmount::zero(),
@@ -960,26 +1120,32 @@ fn deal_included_in_multiple_sectors_failure() {
     assert!(ret_bf.get(first_sector_number));
     assert!(!ret_bf.get(first_sector_number + 1));
 
-    let new_sector_info_p1 = sector_info(&v, &maddr, first_sector_number);
+    let new_sector_info_p1 = sector_info(v, &maddr, first_sector_number);
     assert_eq!(deal_ids, new_sector_info_p1.deal_ids);
     assert_eq!(new_sealed_cid1, new_sector_info_p1.sealed_cid);
 
-    let new_sector_info_p2 = sector_info(&v, &maddr, first_sector_number + 1);
+    let new_sector_info_p2 = sector_info(v, &maddr, first_sector_number + 1);
     assert!(new_sector_info_p2.deal_ids.len().is_zero());
     assert_ne!(new_sealed_cid2, new_sector_info_p2.sealed_cid);
-    v.assert_state_invariants();
+
+    assert_invariants(v)
 }
 
 #[test]
 fn replica_update_verified_deal() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    let addrs = create_accounts(&v, 3, &TokenAmount::from_whole(100_000));
+
+    replica_update_verified_deal_test(&v);
+}
+
+fn replica_update_verified_deal_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 3, &TokenAmount::from_whole(100_000));
     let (worker, owner, client, verifier) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let policy = Policy::default();
     let (maddr, robust) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -988,21 +1154,21 @@ fn replica_update_verified_deal() {
 
     // Get client verified
     let datacap = StoragePower::from(32_u128 << 30);
-    verifreg_add_verifier(&v, &verifier, datacap.clone());
-    verifreg_add_client(&v, &verifier, &client, datacap);
+    verifreg_add_verifier(v, &verifier, datacap.clone());
+    verifreg_add_client(v, &verifier, &client, datacap);
 
     // advance to have seal randomness epoch in the past
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     let sector_number = 100;
-    let (v, d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
+    let (d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
 
-    let old_sector_info = sector_info(&v, &maddr, sector_number);
+    let old_sector_info = sector_info(v, &maddr, sector_number);
     // make some deals, chop off market's alloc term buffer from deal lifetime.  This way term max can
     // line up with sector lifetime AND the deal has buffer room to start a bit later while still fitting in the sector
     let deal_ids = create_verified_deals(
         1,
-        &v,
+        v,
         client,
         worker,
         maddr,
@@ -1022,7 +1188,7 @@ fn replica_update_verified_deal() {
         new_unsealed_cid: make_piece_cid(b"unsealed from itest vm"),
     };
     let updated_sectors: BitField = apply_ok(
-        &v,
+        v,
         &worker,
         &robust,
         &TokenAmount::zero(),
@@ -1087,7 +1253,7 @@ fn replica_update_verified_deal() {
     .matches(v.take_invocations().last().unwrap());
 
     // sanity check the sector after update
-    let new_sector_info = sector_info(&v, &maddr, sector_number);
+    let new_sector_info = sector_info(v, &maddr, sector_number);
     assert_eq!(1, new_sector_info.deal_ids.len());
     assert_eq!(deal_ids[0], new_sector_info.deal_ids[0]);
     assert_eq!(old_sector_info.sealed_cid, new_sector_info.sector_key_cid.unwrap());
@@ -1098,12 +1264,16 @@ fn replica_update_verified_deal() {
 fn replica_update_verified_deal_max_term_violated() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    let addrs = create_accounts(&v, 3, &TokenAmount::from_whole(100_000));
+    replica_update_verified_deal_max_term_violated_test(&v);
+}
+
+fn replica_update_verified_deal_max_term_violated_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 3, &TokenAmount::from_whole(100_000));
     let (worker, owner, client, verifier) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let policy = Policy::default();
     let (maddr, robust) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
@@ -1112,21 +1282,21 @@ fn replica_update_verified_deal_max_term_violated() {
 
     // Get client verified
     let datacap = StoragePower::from(32_u128 << 30);
-    verifreg_add_verifier(&v, &verifier, datacap.clone());
-    verifreg_add_client(&v, &verifier, &client, datacap);
+    verifreg_add_verifier(v, &verifier, datacap.clone());
+    verifreg_add_client(v, &verifier, &client, datacap);
 
     // advance to have seal randomness epoch in the past
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     let sector_number = 100;
-    let (v, d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
+    let (d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
 
-    let old_sector_info = sector_info(&v, &maddr, sector_number);
+    let old_sector_info = sector_info(v, &maddr, sector_number);
     // term max of claim is 1 epoch less than the remaining sector lifetime causing get claims validation failure
     let sector_lifetime = old_sector_info.expiration - v.epoch();
     let deal_ids = create_verified_deals(
         1,
-        &v,
+        v,
         client,
         worker,
         maddr,
@@ -1146,7 +1316,7 @@ fn replica_update_verified_deal_max_term_violated() {
         new_unsealed_cid: make_piece_cid(b"unsealed from itest vm"),
     };
     apply_code(
-        &v,
+        v,
         &worker,
         &robust,
         &TokenAmount::zero(),
@@ -1173,10 +1343,10 @@ fn create_miner_and_upgrade_sector(
     );
 
     // advance to have seal randomness epoch in the past
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     let sector_number = 100;
-    let (v, d_idx, p_idx) = create_sector(v, worker, maddr, sector_number, seal_proof);
+    let (d_idx, p_idx) = create_sector(&v, worker, maddr, sector_number, seal_proof);
 
     let old_sector_info = sector_info(&v, &maddr, sector_number);
     // make some deals
@@ -1242,27 +1412,27 @@ fn create_miner_and_upgrade_sector(
 // - fastforwarding out of the proving period into a new deadline
 // This method assumes that this is a miners first and only sector
 fn create_sector<BS: Blockstore>(
-    v: TestVM<BS>,
+    v: &dyn VM<BS>,
     worker: Address,
     maddr: Address,
     sector_number: SectorNumber,
     seal_proof: RegisteredSealProof,
-) -> (TestVM<BS>, u64, u64) {
+) -> (u64, u64) {
     // precommit
     let exp = v.epoch() + Policy::default().max_sector_expiration_extension;
     let precommits =
-        precommit_sectors(&v, 1, 1, &worker, &maddr, seal_proof, sector_number, true, Some(exp));
+        precommit_sectors(v, 1, 1, &worker, &maddr, seal_proof, sector_number, true, Some(exp));
     assert_eq!(1, precommits.len());
     assert_eq!(sector_number, precommits[0].info.sector_number);
-    let balances = v.get_miner_balance(&maddr);
+    let balances = miner_balance(v, &maddr);
     assert!(balances.pre_commit_deposit.is_positive());
 
     // prove commit
     let prove_time = v.epoch() + Policy::default().pre_commit_challenge_delay + 1;
-    advance_by_deadline_to_epoch(&v, &maddr, prove_time);
+    advance_by_deadline_to_epoch(v, &maddr, prove_time);
     let prove_commit_params = ProveCommitSectorParams { sector_number, proof: vec![] };
     apply_ok(
-        &v,
+        v,
         &worker,
         &maddr,
         &TokenAmount::zero(),
@@ -1270,42 +1440,42 @@ fn create_sector<BS: Blockstore>(
         Some(prove_commit_params),
     );
     let res = v
-        .apply_message(
+        .execute_message(
             &SYSTEM_ACTOR_ADDR,
             &CRON_ACTOR_ADDR,
             &TokenAmount::zero(),
             CronMethod::EpochTick as u64,
-            None::<RawBytes>,
+            None,
         )
         .unwrap();
     assert_eq!(ExitCode::OK, res.code);
-    let (dline_info, p_idx) = advance_to_proving_deadline(&v, &maddr, sector_number);
+    let (dline_info, p_idx) = advance_to_proving_deadline(v, &maddr, sector_number);
     let d_idx = dline_info.index;
     // not active until post
-    assert!(!check_sector_active(&v, &maddr, sector_number));
-    let m_st = v.get_state::<MinerState>(&maddr).unwrap();
-    let sector = m_st.get_sector(v.store, sector_number).unwrap().unwrap();
+    assert!(!check_sector_active(v, &maddr, sector_number));
+    let m_st: MinerState = get_state(v, &maddr).unwrap();
+    let sector = m_st.get_sector(*v.blockstore(), sector_number).unwrap().unwrap();
     let sector_power = power_for_sector(seal_proof.sector_size().unwrap(), &sector);
-    submit_windowed_post(&v, &worker, &maddr, dline_info, p_idx, Some(sector_power));
+    submit_windowed_post(v, &worker, &maddr, dline_info, p_idx, Some(sector_power));
 
     // move to next deadline to activate power
-    advance_by_deadline_to_index(&v, &maddr, d_idx + 1 % Policy::default().wpost_period_deadlines);
+    advance_by_deadline_to_index(v, &maddr, d_idx + 1 % Policy::default().wpost_period_deadlines);
 
     // hooray sector is now active
-    assert!(check_sector_active(&v, &maddr, sector_number));
+    assert!(check_sector_active(v, &maddr, sector_number));
 
     // sanity check the sector
-    let old_sector_info = sector_info(&v, &maddr, sector_number);
+    let old_sector_info = sector_info(v, &maddr, sector_number);
     assert!(old_sector_info.deal_ids.is_empty());
     assert_eq!(None, old_sector_info.sector_key_cid);
-    let miner_power = miner_power(&v, &maddr);
+    let miner_power = miner_power(v, &maddr);
     assert_eq!(StoragePower::from(seal_proof.sector_size().unwrap() as u64), miner_power.raw);
 
-    (v, d_idx, p_idx)
+    (d_idx, p_idx)
 }
 fn create_deals<BS: Blockstore>(
     num_deals: u32,
-    v: &TestVM<BS>,
+    v: &dyn VM<BS>,
     client: Address,
     worker: Address,
     maddr: Address,
@@ -1315,7 +1485,7 @@ fn create_deals<BS: Blockstore>(
 
 fn create_verified_deals<BS: Blockstore>(
     num_deals: u32,
-    v: &TestVM<BS>,
+    v: &dyn VM<BS>,
     client: Address,
     worker: Address,
     maddr: Address,
@@ -1327,7 +1497,7 @@ fn create_verified_deals<BS: Blockstore>(
 #[allow(clippy::too_many_arguments)]
 fn create_deals_frac<BS: Blockstore>(
     num_deals: u32,
-    v: &TestVM<BS>,
+    v: &dyn VM<BS>,
     client: Address,
     worker: Address,
     maddr: Address,

--- a/test_vm/tests/test_vm_test.rs
+++ b/test_vm/tests/test_vm_test.rs
@@ -3,14 +3,13 @@ use fil_actors_runtime::test_utils::{
     make_identity_cid, ACCOUNT_ACTOR_CODE_ID, PAYCH_ACTOR_CODE_ID,
 };
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
-use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::METHOD_SEND;
 use num_traits::Zero;
-use test_vm::util::pk_addrs_from;
-use test_vm::{actor, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR};
+use test_vm::util::{assert_invariants, check_invariants, get_state, pk_addrs_from};
+use test_vm::{actor, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
 
 #[test]
 fn state_control() {
@@ -48,7 +47,7 @@ fn state_control() {
     assert_eq!(None, v.get_actor(&addr2));
     assert_eq!(v.get_actor(&addr1).unwrap(), a1);
 
-    let invariants_check = v.check_state_invariants();
+    let invariants_check = check_invariants(&v);
     assert!(invariants_check.is_err());
     assert!(invariants_check.unwrap_err().to_string().contains("AccountState is empty"));
 }
@@ -61,7 +60,7 @@ fn assert_account_actor<BS: Blockstore>(
     addr: Address,
 ) {
     let act = v.get_actor(&addr).unwrap();
-    let st = v.get_state::<AccountState>(&addr).unwrap();
+    let st: AccountState = get_state(v, &addr).unwrap();
     assert_eq!(exp_call_seq, act.call_seq_num);
     assert_eq!(*ACCOUNT_ACTOR_CODE_ID, act.code);
     assert_eq!(exp_bal, act.balance);
@@ -75,57 +74,48 @@ fn test_sent() {
 
     // send to uninitialized account actor
     let addr1 = Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();
-    v.apply_message(
-        &TEST_FAUCET_ADDR,
-        &addr1,
-        &TokenAmount::from_atto(42u8),
-        METHOD_SEND,
-        None::<RawBytes>,
-    )
-    .unwrap();
+    v.execute_message(&TEST_FAUCET_ADDR, &addr1, &TokenAmount::from_atto(42u8), METHOD_SEND, None)
+        .unwrap();
     let expect_id_addr1 = Address::new_id(FIRST_TEST_USER_ADDR);
     assert_account_actor(0, TokenAmount::from_atto(42u8), addr1, &v, expect_id_addr1);
 
     // send from this account actor to another uninit account actor
     let addr2 = Address::new_bls(&[2; fvm_shared::address::BLS_PUB_LEN]).unwrap();
-    v.apply_message(&addr1, &addr2, &TokenAmount::from_atto(41u8), METHOD_SEND, None::<RawBytes>)
-        .unwrap();
+    v.execute_message(&addr1, &addr2, &TokenAmount::from_atto(41u8), METHOD_SEND, None).unwrap();
     let expect_id_addr2 = Address::new_id(FIRST_TEST_USER_ADDR + 1);
     assert_account_actor(0, TokenAmount::from_atto(41u8), addr2, &v, expect_id_addr2);
 
     // send between two initialized account actors
-    v.apply_message(&addr2, &addr1, &TokenAmount::from_atto(41u8), METHOD_SEND, None::<RawBytes>)
-        .unwrap();
+    v.execute_message(&addr2, &addr1, &TokenAmount::from_atto(41u8), METHOD_SEND, None).unwrap();
     assert_account_actor(1, TokenAmount::from_atto(42u8), addr1, &v, expect_id_addr1);
     assert_account_actor(1, TokenAmount::zero(), addr2, &v, expect_id_addr2);
 
     // self send is noop
-    v.apply_message(&addr1, &addr1, &TokenAmount::from_atto(1u8), METHOD_SEND, None::<RawBytes>)
-        .unwrap();
+    v.execute_message(&addr1, &addr1, &TokenAmount::from_atto(1u8), METHOD_SEND, None).unwrap();
     assert_account_actor(2, TokenAmount::from_atto(42u8), addr1, &v, expect_id_addr1);
 
     // fail with insufficient funds
-    let mres = v
-        .apply_message(&addr2, &addr1, &TokenAmount::from_atto(1u8), METHOD_SEND, None::<RawBytes>)
-        .unwrap();
+    let mres =
+        v.execute_message(&addr2, &addr1, &TokenAmount::from_atto(1u8), METHOD_SEND, None).unwrap();
     assert_eq!(ExitCode::SYS_INSUFFICIENT_FUNDS, mres.code);
     assert_account_actor(2, TokenAmount::from_atto(42u8), addr1, &v, expect_id_addr1);
     assert_account_actor(2, TokenAmount::zero(), addr2, &v, expect_id_addr2);
 
     // fail to send to non existent id actor (vm doesn't create those on send)
     let mres = v
-        .apply_message(
+        .execute_message(
             &addr1,
             &Address::new_id(88),
             &TokenAmount::from_atto(1u8),
             METHOD_SEND,
-            None::<RawBytes>,
+            None,
         )
         .unwrap();
     assert_eq!(ExitCode::SYS_INVALID_RECEIVER, mres.code);
     assert_account_actor(3, TokenAmount::from_atto(42u8), addr1, &v, expect_id_addr1);
     assert_account_actor(2, TokenAmount::zero(), addr2, &v, expect_id_addr2);
-    v.assert_state_invariants();
+
+    assert_invariants(&v)
 }
 
 #[test]

--- a/test_vm/tests/verified_claim_test.rs
+++ b/test_vm/tests/verified_claim_test.rs
@@ -1,4 +1,4 @@
-use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PaddedPieceSize;
@@ -29,10 +29,10 @@ use fil_actors_runtime::{
 use test_vm::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
     advance_by_deadline_to_index, advance_to_proving_deadline, apply_ok, create_accounts,
-    create_miner, cron_tick, datacap_extend_claim, datacap_get_balance, invariant_failure_patterns,
-    market_add_balance, market_publish_deal, miner_extend_sector_expiration2,
-    miner_precommit_sector, miner_prove_sector, sector_deadline, submit_windowed_post,
-    verifreg_add_client, verifreg_add_verifier, verifreg_extend_claim_terms,
+    create_miner, cron_tick, datacap_extend_claim, datacap_get_balance, expect_invariants,
+    get_state, invariant_failure_patterns, market_add_balance, market_publish_deal,
+    miner_extend_sector_expiration2, miner_precommit_sector, miner_prove_sector, sector_deadline,
+    submit_windowed_post, verifreg_add_client, verifreg_add_verifier, verifreg_extend_claim_terms,
     verifreg_remove_expired_allocations,
 };
 use test_vm::{TestVM, VM};
@@ -44,7 +44,11 @@ use test_vm::{TestVM, VM};
 fn verified_claim_scenario() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 4, &TokenAmount::from_whole(10_000));
+    verified_claim_scenario_test(&v);
+}
+
+fn verified_claim_scenario_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client, verified_client2) =
         (addrs[0], addrs[0], addrs[1], addrs[2], addrs[3]);
@@ -53,24 +57,24 @@ fn verified_claim_scenario() {
 
     // Create miner
     let (miner_id, _) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
         &TokenAmount::from_whole(1_000),
     );
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     // Register verifier and verified clients
     let datacap = StoragePower::from(32_u128 << 40);
-    verifreg_add_verifier(&v, &verifier, &datacap * 2);
-    verifreg_add_client(&v, &verifier, &verified_client, datacap.clone());
-    verifreg_add_client(&v, &verifier, &verified_client2, datacap.clone());
+    verifreg_add_verifier(v, &verifier, &datacap * 2);
+    verifreg_add_client(v, &verifier, &verified_client, datacap.clone());
+    verifreg_add_client(v, &verifier, &verified_client2, datacap.clone());
 
     // Add market collateral for client and miner
     // Client2 doesn't need collateral because they won't make a new deal, only extend a claim.
-    market_add_balance(&v, &verified_client, &verified_client, &TokenAmount::from_whole(3));
-    market_add_balance(&v, &worker, &miner_id, &TokenAmount::from_whole(64));
+    market_add_balance(v, &verified_client, &verified_client, &TokenAmount::from_whole(3));
+    market_add_balance(v, &worker, &miner_id, &TokenAmount::from_whole(64));
 
     // Publish a verified deal for total sector capacity with min term of 6 months
     let deal_start = v.epoch() + max_prove_commit_duration(&Policy::default(), seal_proof).unwrap();
@@ -78,7 +82,7 @@ fn verified_claim_scenario() {
 
     let deal_size = 32u64 << 30;
     let deals = market_publish_deal(
-        &v,
+        v,
         &worker,
         &verified_client,
         &miner_id,
@@ -93,7 +97,7 @@ fn verified_claim_scenario() {
     // Precommit and prove the sector for the max term allowed by the deal.
     let sector_term = deal_term_min + MARKET_DEFAULT_ALLOCATION_TERM_BUFFER;
     let _precommit = miner_precommit_sector(
-        &v,
+        v,
         &worker,
         &miner_id,
         seal_proof,
@@ -103,14 +107,14 @@ fn verified_claim_scenario() {
     );
 
     // Advance time to max seal duration and prove the sector
-    advance_by_deadline_to_epoch(&v, &miner_id, deal_start);
-    miner_prove_sector(&v, &worker, &miner_id, sector_number);
+    advance_by_deadline_to_epoch(v, &miner_id, deal_start);
+    miner_prove_sector(v, &worker, &miner_id, sector_number);
     // Trigger cron to validate the prove commit
-    cron_tick(&v);
+    cron_tick(v);
 
     // Verify sector info
-    let miner_state: MinerState = v.get_state(&miner_id).unwrap();
-    let sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    let miner_state: MinerState = get_state(v, &miner_id).unwrap();
+    let sector_info = miner_state.get_sector(*v.blockstore(), sector_number).unwrap().unwrap();
     assert_eq!(sector_term, sector_info.expiration - sector_info.activation);
     assert_eq!(DealWeight::zero(), sector_info.deal_weight);
     // Verified weight is sector term * 32 GiB, using simple QAP
@@ -118,27 +122,27 @@ fn verified_claim_scenario() {
     assert_eq!(verified_weight, sector_info.verified_deal_weight);
 
     // Verify deal state.
-    let market_state: MarketState = v.get_state(&STORAGE_MARKET_ACTOR_ADDR).unwrap();
-    let deal_states = DealMetaArray::load(&market_state.states, v.store).unwrap();
+    let market_state: MarketState = get_state(v, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
+    let deal_states = DealMetaArray::load(&market_state.states, *v.blockstore()).unwrap();
     let deal_state = deal_states.get(deals[0]).unwrap().unwrap();
     let claim_id = deal_state.verified_claim;
     assert_ne!(0, claim_id);
 
     // Verify datacap state
-    let datacap_state: DatacapState = v.get_state(&DATACAP_TOKEN_ACTOR_ADDR).unwrap();
+    let datacap_state: DatacapState = get_state(v, &DATACAP_TOKEN_ACTOR_ADDR).unwrap();
     assert_eq!(
         TokenAmount::from_whole(datacap.clone()) - TokenAmount::from_whole(deal_size), // Spent deal size
-        datacap_state.token.get_balance(&v.store, verified_client.id().unwrap()).unwrap()
+        datacap_state.token.get_balance(*v.blockstore(), verified_client.id().unwrap()).unwrap()
     );
     assert_eq!(
         TokenAmount::from_whole(datacap.clone()), // Nothing spent
-        datacap_state.token.get_balance(&v.store, verified_client2.id().unwrap()).unwrap()
+        datacap_state.token.get_balance(*v.blockstore(), verified_client2.id().unwrap()).unwrap()
     );
     assert_eq!(
         TokenAmount::zero(), // Burnt when the allocation was claimed
         datacap_state
             .token
-            .get_balance(&v.store, VERIFIED_REGISTRY_ACTOR_ADDR.id().unwrap())
+            .get_balance(*v.blockstore(), VERIFIED_REGISTRY_ACTOR_ADDR.id().unwrap())
             .unwrap()
     );
     assert_eq!(
@@ -147,8 +151,8 @@ fn verified_claim_scenario() {
     );
 
     // Verify claim state
-    let verifreg_state: VerifregState = v.get_state(&VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
-    let mut claims = verifreg_state.load_claims(v.store).unwrap();
+    let verifreg_state: VerifregState = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
+    let mut claims = verifreg_state.load_claims(*v.blockstore()).unwrap();
     let claim = claims.get(miner_id.id().unwrap(), claim_id).unwrap().unwrap();
     assert_eq!(sector_number, claim.sector);
     assert_eq!(
@@ -166,13 +170,12 @@ fn verified_claim_scenario() {
     );
 
     // Advance to proving period and submit post
-    let (deadline_info, partition_index) =
-        advance_to_proving_deadline(&v, &miner_id, sector_number);
+    let (deadline_info, partition_index) = advance_to_proving_deadline(v, &miner_id, sector_number);
 
     let expected_power =
         PowerPair { raw: StoragePower::from(deal_size), qa: StoragePower::from(10 * deal_size) };
     submit_windowed_post(
-        &v,
+        v,
         &worker,
         &miner_id,
         deadline_info,
@@ -181,21 +184,21 @@ fn verified_claim_scenario() {
     );
 
     // Verify miner power
-    let power_state: PowerState = v.get_state(&STORAGE_POWER_ACTOR_ADDR).unwrap();
-    let power_claim = power_state.get_claim(v.store, &miner_id).unwrap().unwrap();
+    let power_state: PowerState = get_state(v, &STORAGE_POWER_ACTOR_ADDR).unwrap();
+    let power_claim = power_state.get_claim(*v.blockstore(), &miner_id).unwrap().unwrap();
     assert_eq!(power_claim.raw_byte_power, expected_power.raw);
     assert_eq!(power_claim.quality_adj_power, expected_power.qa);
 
     // move forward one deadline so advanceWhileProving doesn't fail double submitting posts.
     advance_by_deadline_to_index(
-        &v,
+        v,
         &miner_id,
         deadline_info.index + 1 % policy.wpost_period_deadlines,
     );
 
     // Advance past the deal's minimum term (the claim remains valid).
     advance_by_deadline_to_epoch_while_proving(
-        &v,
+        v,
         &miner_id,
         &worker,
         sector_number,
@@ -203,13 +206,13 @@ fn verified_claim_scenario() {
     );
 
     // The client extends the verified claim term out to 12 months.
-    verifreg_extend_claim_terms(&v, &verified_client, &miner_id, claim_id, 360 * EPOCHS_IN_DAY);
+    verifreg_extend_claim_terms(v, &verified_client, &miner_id, claim_id, 360 * EPOCHS_IN_DAY);
 
     // Now the miner can extend the sector's expiration to the same.
-    let (didx, pidx) = sector_deadline(&v, &miner_id, sector_number);
+    let (didx, pidx) = sector_deadline(v, &miner_id, sector_number);
     let extended_expiration_1 = deal_start + 360 * EPOCHS_IN_DAY;
     miner_extend_sector_expiration2(
-        &v,
+        v,
         &worker,
         &miner_id,
         didx,
@@ -222,7 +225,7 @@ fn verified_claim_scenario() {
 
     // Advance toward the sector's expiration
     advance_by_deadline_to_epoch_while_proving(
-        &v,
+        v,
         &miner_id,
         &worker,
         sector_number,
@@ -235,12 +238,12 @@ fn verified_claim_scenario() {
     let new_max_term = new_claim_expiry_epoch - claim.term_start;
     assert!(new_max_term > original_max_term);
 
-    datacap_extend_claim(&v, &verified_client2, &miner_id, claim_id, deal_size, new_max_term);
+    datacap_extend_claim(v, &verified_client2, &miner_id, claim_id, deal_size, new_max_term);
 
     // The miner extends the sector into the second year.
     let extended_expiration_2 = extended_expiration_1 + 60 * EPOCHS_IN_DAY;
     miner_extend_sector_expiration2(
-        &v,
+        v,
         &worker,
         &miner_id,
         didx,
@@ -253,7 +256,7 @@ fn verified_claim_scenario() {
 
     // Advance toward the sector's new expiration
     advance_by_deadline_to_epoch_while_proving(
-        &v,
+        v,
         &miner_id,
         &worker,
         sector_number,
@@ -264,7 +267,7 @@ fn verified_claim_scenario() {
     let expected_power_delta =
         PowerPair::new(StoragePower::zero(), StoragePower::from(9 * deal_size).neg());
     miner_extend_sector_expiration2(
-        &v,
+        v,
         &worker,
         &miner_id,
         didx,
@@ -276,27 +279,28 @@ fn verified_claim_scenario() {
     );
 
     // Verify sector info
-    let miner_state: MinerState = v.get_state(&miner_id).unwrap();
-    let sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    let miner_state: MinerState = get_state(v, &miner_id).unwrap();
+    let sector_info = miner_state.get_sector(*v.blockstore(), sector_number).unwrap().unwrap();
     assert_eq!(extended_expiration_2, sector_info.expiration);
     assert_eq!(DealWeight::zero(), sector_info.deal_weight);
-    assert_eq!(DealWeight::zero(), sector_info.verified_deal_weight); // No longer verified
+    assert_eq!(DealWeight::zero(), sector_info.verified_deal_weight);
+    // No longer verified
 
     // Verify datacap state
-    let datacap_state: DatacapState = v.get_state(&DATACAP_TOKEN_ACTOR_ADDR).unwrap();
+    let datacap_state: DatacapState = get_state(v, &DATACAP_TOKEN_ACTOR_ADDR).unwrap();
     assert_eq!(
         TokenAmount::from_whole(datacap.clone()) - TokenAmount::from_whole(deal_size), // Spent deal size
-        datacap_state.token.get_balance(&v.store, verified_client.id().unwrap()).unwrap()
+        datacap_state.token.get_balance(*v.blockstore(), verified_client.id().unwrap()).unwrap()
     );
     assert_eq!(
         TokenAmount::from_whole(datacap.clone()) - TokenAmount::from_whole(deal_size), // Also spent deal size
-        datacap_state.token.get_balance(&v.store, verified_client2.id().unwrap()).unwrap()
+        datacap_state.token.get_balance(*v.blockstore(), verified_client2.id().unwrap()).unwrap()
     );
     assert_eq!(
         TokenAmount::zero(), // All burnt
         datacap_state
             .token
-            .get_balance(&v.store, VERIFIED_REGISTRY_ACTOR_ADDR.id().unwrap())
+            .get_balance(*v.blockstore(), VERIFIED_REGISTRY_ACTOR_ADDR.id().unwrap())
             .unwrap()
     );
     assert_eq!(
@@ -306,20 +310,20 @@ fn verified_claim_scenario() {
 
     // Advance sector to expiration
     advance_by_deadline_to_epoch_while_proving(
-        &v,
+        v,
         &miner_id,
         &worker,
         sector_number,
         extended_expiration_2,
     );
     // And advance vm past the claim's max term (no more sector exists to prove)
-    let v = v.with_epoch(new_claim_expiry_epoch);
+    v.set_epoch(new_claim_expiry_epoch);
     // Expired claim can now be cleaned up
     let cleanup_claims =
         RemoveExpiredClaimsParams { provider: miner_id.id().unwrap(), claim_ids: vec![claim_id] };
 
     let ret_raw = apply_ok(
-        &v,
+        v,
         &worker,
         &VERIFIED_REGISTRY_ACTOR_ADDR,
         &TokenAmount::zero(),
@@ -330,37 +334,39 @@ fn verified_claim_scenario() {
     assert_eq!(vec![claim_id], ret.considered);
     assert!(ret.results.all_ok(), "results had failures {}", ret.results);
 
-    v.expect_state_invariants(
-        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
-    );
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
 fn expired_allocations() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 3, &TokenAmount::from_whole(10_000));
+    expired_allocations_test(&v);
+}
+
+fn expired_allocations_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);
 
     // Create miner
     let (miner_id, _) = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
         &TokenAmount::from_whole(1_000),
     );
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     // Register verifier and verified clients
     let datacap = StoragePower::from(32_u128 << 40);
-    verifreg_add_verifier(&v, &verifier, &datacap * 2);
-    verifreg_add_client(&v, &verifier, &verified_client, datacap.clone());
+    verifreg_add_verifier(v, &verifier, &datacap * 2);
+    verifreg_add_client(v, &verifier, &verified_client, datacap.clone());
 
     // Add market collateral for client and miner
-    market_add_balance(&v, &verified_client, &verified_client, &TokenAmount::from_whole(3));
-    market_add_balance(&v, &worker, &miner_id, &TokenAmount::from_whole(64));
+    market_add_balance(v, &verified_client, &verified_client, &TokenAmount::from_whole(3));
+    market_add_balance(v, &worker, &miner_id, &TokenAmount::from_whole(64));
 
     // Publish 2 verified deals
     let deal1_start =
@@ -369,7 +375,7 @@ fn expired_allocations() {
 
     let deal_size = 32u64 << 30;
     let deal1 = market_publish_deal(
-        &v,
+        v,
         &worker,
         &verified_client,
         &miner_id,
@@ -384,21 +390,21 @@ fn expired_allocations() {
     // Client datacap balance reduced
     assert_eq!(
         TokenAmount::from_whole(datacap.clone()) - TokenAmount::from_whole(deal_size),
-        datacap_get_balance(&v, &verified_client)
+        datacap_get_balance(v, &verified_client)
     );
 
     // Advance to after the first deal's start
-    let v = v.with_epoch(deal1_start + DEAL_UPDATES_INTERVAL);
-    cron_tick(&v);
+    v.set_epoch(deal1_start + DEAL_UPDATES_INTERVAL);
+    cron_tick(v);
 
     // Deal has expired and cleaned up.
-    let market_state: MarketState = v.get_state(&STORAGE_MARKET_ACTOR_ADDR).unwrap();
-    let proposals: DealArray<MemoryBlockstore> =
-        DealArray::load(&market_state.proposals, v.store).unwrap();
+    let market_state: MarketState = get_state(v, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
+    let proposals: DealArray<BS> =
+        DealArray::load(&market_state.proposals, *v.blockstore()).unwrap();
     assert!(proposals.get(deal1).unwrap().is_none());
-    let pending_deal_allocs: Map<MemoryBlockstore, AllocationID> = make_map_with_root_and_bitwidth(
+    let pending_deal_allocs: Map<BS, AllocationID> = make_map_with_root_and_bitwidth(
         &market_state.pending_deal_allocation_ids,
-        v.store,
+        *v.blockstore(),
         HAMT_BIT_WIDTH,
     )
     .unwrap();
@@ -406,21 +412,19 @@ fn expired_allocations() {
 
     // Allocation still exists until explicit cleanup
     let alloc_id = 1;
-    let verifreg_state: VerifregState = v.get_state(&VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
-    let mut allocs = verifreg_state.load_allocs(v.store).unwrap();
+    let verifreg_state: VerifregState = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
+    let mut allocs = verifreg_state.load_allocs(*v.blockstore()).unwrap();
     assert!(allocs.get(verified_client.id().unwrap(), alloc_id).unwrap().is_some());
 
-    verifreg_remove_expired_allocations(&v, &worker, &verified_client, vec![], deal_size);
+    verifreg_remove_expired_allocations(v, &worker, &verified_client, vec![], deal_size);
 
     // Allocation is gone
-    let verifreg_state: VerifregState = v.get_state(&VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
-    let mut allocs = verifreg_state.load_allocs(v.store).unwrap();
+    let verifreg_state: VerifregState = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
+    let mut allocs = verifreg_state.load_allocs(*v.blockstore()).unwrap();
     assert!(allocs.get(verified_client.id().unwrap(), alloc_id).unwrap().is_none());
 
     // Client has original datacap balance
-    assert_eq!(TokenAmount::from_whole(datacap), datacap_get_balance(&v, &verified_client));
+    assert_eq!(TokenAmount::from_whole(datacap), datacap_get_balance(v, &verified_client));
 
-    v.expect_state_invariants(
-        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
-    );
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }


### PR DESCRIPTION
Simple refactors of remaining tests. At this point all testing functionality has simple 1-1 ports. 

Then deduplicates some code in the TestVM
- removes apply_message (replaced by execute_message)
- TestVM::normalize_address, TestVM::get_state, TestVM::get_miner_balance, TestVM::get_miner_info replaced by free functions accepting a &dyn VM