### PR TITLE
fix def_primop

### DIFF
--- a/actors/evm/src/interpreter/instructions/mod.rs
+++ b/actors/evm/src/interpreter/instructions/mod.rs
@@ -58,7 +58,7 @@ macro_rules! def_primop {
     ($op:ident () => $impl:path) => {
         def_op!{ $op (m) => {
             m.state.stack.ensure_one();
-            let result = $impl($($arg),*);
+            let result = $impl();
             m.state.stack.push_unchecked(result);
             m.pc += 1;
             Ok(())


### PR DESCRIPTION
In this context, `$arg` is undefined. In fact the zero arg case is not used, so it's also safe to remove it entirely.