### PR TITLE
Hack: Force batch_proof_verify to succeed

### DIFF
--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -437,7 +437,6 @@ impl Actor {
                     }
                     Some(batch) => batch,
                 };
-                debug!("Had a valid batch");
                 let mmap = match Multimap::from_root(
                     rt.store(),
                     batch,
@@ -462,7 +461,6 @@ impl Actor {
                         return result;
                     }
                 };
-                debug!("Had valid claims");
 
                 if let Err(e) = mmap.for_all::<_, SealVerifyInfo>(|k, arr| {
                     let addr = match Address::from_bytes(&k.0) {
@@ -483,8 +481,6 @@ impl Actor {
                         debug!("skipping batch verifies for unknown miner: {}", addr);
                         return Ok(());
                     }
-
-                    debug!("Contains claims");
 
                     let num_proofs: usize = arr.count().try_into()?;
                     infos.reserve(num_proofs);
@@ -526,7 +522,6 @@ impl Actor {
 
         let mut res_iter = infos.iter().zip(res.iter().copied());
 
-        debug!("Miners {:?}", miners);
         for (m, count) in miners {
             let successful: Vec<_> = res_iter
                 .by_ref()
@@ -542,8 +537,6 @@ impl Actor {
                     move |snum| seen.insert(*snum)
                 })
                 .collect();
-
-            debug!("Miner {:?} success {:?}", m, successful);
 
             // Result intentionally ignored
             if successful.is_empty() {
@@ -599,7 +592,6 @@ impl Actor {
                         format!("failed to load cron events at {}", epoch),
                     )
                 })?;
-                debug!("epoch {} events: {:?}", epoch, epoch_events);
                 if epoch_events.is_empty() {
                     continue;
                 }

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -462,8 +462,9 @@ where
     }
 
     fn batch_verify_seals(&self, batch: &[SealVerifyInfo]) -> anyhow::Result<Vec<bool>> {
-        fvm::crypto::batch_verify_seals(batch)
-            .map_err(|e| anyhow!("failed to verify batch seals: {}", e))
+        // FIXME: patching this in for the time being, but we should really allow the actors to be built
+        // with a runtime that's suitable for benchmark testing
+        Ok(vec![true; batch.len()]) // everyone wins
     }
 
     fn verify_aggregate_seals(

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -231,14 +231,20 @@ where
         rand_epoch: ChainEpoch,
         entropy: &[u8],
     ) -> Result<[u8; RANDOMNESS_LENGTH], ActorError> {
-        fvm::rand::get_chain_randomness(personalization as i64, rand_epoch, entropy).map_err(|e| {
-            match e {
-                ErrorNumber::LimitExceeded => {
-                    actor_error!(illegal_argument; "randomness lookback exceeded: {}", e)
-                }
-                e => actor_error!(assertion_failed; "get chain randomness failed with an unexpected error: {}", e),
-            }
-        })
+        // FIXME: Temp
+        const TEST_VM_RAND_ARRAY: [u8; 32] = [
+            1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31, 32,
+        ];
+        Ok(TEST_VM_RAND_ARRAY)
+        // fvm::rand::get_chain_randomness(personalization as i64, rand_epoch, entropy).map_err(|e| {
+        //     match e {
+        //         ErrorNumber::LimitExceeded => {
+        //             actor_error!(illegal_argument; "randomness lookback exceeded: {}", e)
+        //         }
+        //         e => actor_error!(assertion_failed; "get chain randomness failed with an unexpected error: {}", e),
+        //     }
+        // })
     }
 
     fn get_randomness_from_beacon(

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -124,6 +124,7 @@ where
     invocations: RefCell<Vec<InvocationTrace>>,
 }
 
+#[derive(Debug)]
 pub struct MinerBalances {
     pub available_balance: TokenAmount,
     pub vesting_balance: TokenAmount,


### PR DESCRIPTION
Do not merge: hacky patch for unblocking some benchmarking on a real FVM.

Changing runtime/src/runtime/fvm.rs for `batch_verify_seals` updates the wasm-built actors to always succeed.

The builtin actors should support building the wasm actors with different runtime implementations via the trampoline