### PR TITLE
More test refactors

### DIFF
--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -215,7 +215,7 @@ where
             new_actor_addr_count: RefCell::new(0),
             circ_supply: TokenAmount::from_whole(1_000_000_000),
         };
-        let msg = InternalMessage { from: *from, to: *to, value: value.clone(), method, params };
+        let msg = InternalMessage { from: *from_id, to: *to, value: value.clone(), method, params };
         let mut new_ctx = InvocationCtx {
             v: self,
             top,

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -124,6 +124,11 @@ pub fn apply_code<S: Serialize, BS: Blockstore>(
     res.ret.map_or(RawBytes::default(), |b| RawBytes::new(b.data))
 }
 
+/// Convenience function to create an IpldBlock from a serializable object
+pub fn serialize_ok<S: Serialize>(s: &S) -> IpldBlock {
+    IpldBlock::serialize_cbor(s).unwrap().unwrap()
+}
+
 pub fn cron_tick<BS: Blockstore>(v: &dyn VM<BS>) {
     apply_ok(
         v,

--- a/test_vm/tests/evm_test.rs
+++ b/test_vm/tests/evm_test.rs
@@ -5,15 +5,18 @@ use ethers::providers::Provider;
 use ethers::{core::types::Address as EthAddress, prelude::builders::ContractCall};
 use fil_actors_evm_shared::uints::U256;
 use fil_actors_runtime::{
-    test_utils::{ETHACCOUNT_ACTOR_CODE_ID, EVM_ACTOR_CODE_ID},
-    EAM_ACTOR_ADDR, EAM_ACTOR_ID,
+    test_utils::ETHACCOUNT_ACTOR_CODE_ID, test_utils::EVM_ACTOR_CODE_ID, EAM_ACTOR_ADDR,
+    EAM_ACTOR_ID,
 };
-use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::{strict_bytes, BytesDe, RawBytes};
 use fvm_shared::{address::Address, econ::TokenAmount};
 use fvm_shared::{ActorID, METHOD_SEND};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
+use test_vm::util::serialize_ok;
+use test_vm::VM;
 use test_vm::{
     util::{apply_ok, create_accounts},
     TestVM, TEST_FAUCET_ADDR,
@@ -36,12 +39,15 @@ fn id_to_eth(id: ActorID) -> EthAddress {
 struct ContractParams(#[serde(with = "strict_bytes")] pub Vec<u8>);
 
 #[test]
-fn test_evm_call() {
+fn evm_call() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
-    let account = create_accounts(&v, 1, &TokenAmount::from_whole(10_000))[0];
+    evm_call_test(&v);
+}
 
+fn evm_call_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let account = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
     let address = id_to_eth(account.id().unwrap());
     let (client, _mock) = Provider::mocked();
     let contract = Recursive::new(address, Arc::new(client));
@@ -50,12 +56,12 @@ fn test_evm_call() {
         hex::decode(include_str!("../../actors/evm/tests/contracts/Recursive.hex")).unwrap();
 
     let create_result = v
-        .apply_message(
+        .execute_message(
             &account,
             &EAM_ACTOR_ADDR,
             &TokenAmount::zero(),
             fil_actor_eam::Method::CreateExternal as u64,
-            Some(fil_actor_eam::CreateExternalParams(bytecode)),
+            Some(serialize_ok(&fil_actor_eam::CreateExternalParams(bytecode))),
         )
         .unwrap();
 
@@ -70,15 +76,16 @@ fn test_evm_call() {
 
     let contract_params = contract.enter().calldata().expect("should serialize");
     let call_result = v
-        .apply_message(
+        .execute_message(
             &account,
             &create_return.robust_address.unwrap(),
             &TokenAmount::zero(),
             fil_actor_evm::Method::InvokeContract as u64,
-            Some(ContractParams(contract_params.to_vec())),
+            Some(serialize_ok(&ContractParams(contract_params.to_vec()))),
         )
         .unwrap();
     assert!(call_result.code.is_success(), "failed to call the new actor {}", call_result.message);
+
     let BytesDe(return_value) =
         call_result.ret.unwrap().deserialize().expect("failed to deserialize results");
     let evm_ret: u32 = contract
@@ -88,11 +95,15 @@ fn test_evm_call() {
 }
 
 #[test]
-fn test_evm_create() {
+fn evm_create() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
-    let account = create_accounts(&v, 1, &TokenAmount::from_whole(10_000))[0];
+    evm_create_test(&v);
+}
+
+fn evm_create_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let account = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
 
     let address = id_to_eth(account.id().unwrap());
     let (client, _mock) = Provider::mocked();
@@ -104,12 +115,12 @@ fn test_evm_create() {
         hex::decode(include_str!("../../actors/evm/tests/contracts/Lifecycle.hex")).unwrap();
 
     let create_result = v
-        .apply_message(
+        .execute_message(
             &account,
             &EAM_ACTOR_ADDR,
             &TokenAmount::zero(),
             fil_actor_eam::Method::CreateExternal as u64,
-            Some(fil_actor_eam::CreateExternalParams(bytecode)),
+            Some(serialize_ok(&fil_actor_eam::CreateExternalParams(bytecode))),
         )
         .unwrap();
 
@@ -126,12 +137,12 @@ fn test_evm_create() {
         let child_addr_eth: EthAddress = {
             let call_params = create_func.calldata().expect("should serialize");
             let call_result = v
-                .apply_message(
+                .execute_message(
                     &account,
                     &create_return.robust_address.unwrap(),
                     &TokenAmount::zero(),
                     fil_actor_evm::Method::InvokeContract as u64,
-                    Some(ContractParams(call_params.to_vec())),
+                    Some(serialize_ok(&ContractParams(call_params.to_vec()))),
                 )
                 .unwrap();
             assert!(
@@ -153,12 +164,12 @@ fn test_evm_create() {
             let func = factory_child.get_value();
             let call_params = func.calldata().expect("should serialize");
             let call_result = v
-                .apply_message(
+                .execute_message(
                     &account,
                     &child_addr,
                     &TokenAmount::zero(),
                     fil_actor_evm::Method::InvokeContract as u64,
-                    Some(ContractParams(call_params.to_vec())),
+                    Some(serialize_ok(&ContractParams(call_params.to_vec()))),
                 )
                 .unwrap();
             assert!(
@@ -179,12 +190,12 @@ fn test_evm_create() {
             let func = factory_child.die();
             let call_params = func.calldata().expect("should serialize");
             let call_result = v
-                .apply_message(
+                .execute_message(
                     &account,
                     &child_addr,
                     &TokenAmount::zero(),
                     fil_actor_evm::Method::InvokeContract as u64,
-                    Some(ContractParams(call_params.to_vec())),
+                    Some(serialize_ok(&ContractParams(call_params.to_vec()))),
                 )
                 .unwrap();
             assert!(
@@ -199,12 +210,12 @@ fn test_evm_create() {
             let func = factory_child.get_value();
             let call_params = func.calldata().expect("should serialize");
             let call_result = v
-                .apply_message(
+                .execute_message(
                     &account,
                     &child_addr,
                     &TokenAmount::zero(),
                     fil_actor_evm::Method::InvokeContract as u64,
-                    Some(ContractParams(call_params.to_vec())),
+                    Some(serialize_ok(&ContractParams(call_params.to_vec()))),
                 )
                 .unwrap();
             assert!(
@@ -231,34 +242,46 @@ fn test_evm_create() {
 }
 
 #[test]
-fn test_evm_eth_create_external() {
+fn evm_eth_create_external() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
+    evm_eth_create_external_test(&v, &v);
+}
+
+// Concrete use of TestVM is required here to run `set_actor`
+// Removing it will depend on https://github.com/filecoin-project/builtin-actors/issues/1297
+fn evm_eth_create_external_test<BS: Blockstore>(
+    v: &dyn VM<BS>,
+    _v_concrete: &TestVM<MemoryBlockstore>,
+) {
     // create the EthAccount
     let eth_bits = hex_literal::hex!("FEEDFACECAFEBEEF000000000000000000000000");
     let eth_addr = Address::new_delegated(EAM_ACTOR_ID, &eth_bits).unwrap();
     apply_ok(
-        &v,
+        v,
         &TEST_FAUCET_ADDR,
         &eth_addr,
         &TokenAmount::from_whole(10_000),
         METHOD_SEND,
         None::<RawBytes>,
     );
-    let account = v.normalize_address(&eth_addr).unwrap();
-    let mut actor = v.get_actor(&account).unwrap();
+
+    let account = v.resolve_id_address(&eth_addr).unwrap();
+
+    let mut actor = v.actor(&account).unwrap();
     actor.code = *ETHACCOUNT_ACTOR_CODE_ID;
-    v.set_actor(&account, actor);
+    _v_concrete.set_actor(&account, actor);
 
     // now create an empty contract
+    let params = IpldBlock::serialize_cbor(&fil_actor_eam::CreateExternalParams(vec![])).unwrap();
     let create_result = v
-        .apply_message(
+        .execute_message(
             &account,
             &EAM_ACTOR_ADDR,
             &TokenAmount::zero(),
             fil_actor_eam::Method::CreateExternal as u64,
-            Some(fil_actor_eam::CreateExternalParams(vec![])),
+            params,
         )
         .unwrap();
 
@@ -274,31 +297,36 @@ fn test_evm_eth_create_external() {
 
     let robust_addr = create_return.robust_address.unwrap();
 
+    let params = IpldBlock::serialize_cbor(&ContractParams(vec![])).unwrap();
     let call_result = v
-        .apply_message(
+        .execute_message(
             &account,
             &robust_addr,
             &TokenAmount::zero(),
             fil_actor_evm::Method::InvokeContract as u64,
-            Some(ContractParams(vec![])),
+            params,
         )
         .unwrap();
     assert!(call_result.code.is_success(), "failed to call the new actor {}", call_result.message);
 }
 
 #[test]
-fn test_evm_empty_initcode() {
+fn evm_empty_initcode() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
-    let account = create_accounts(&v, 1, &TokenAmount::from_whole(10_000))[0];
+    evm_empty_initcode_test(&v);
+}
+
+fn evm_empty_initcode_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let account = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
     let create_result = v
-        .apply_message(
+        .execute_message(
             &account,
             &EAM_ACTOR_ADDR,
             &TokenAmount::zero(),
             fil_actor_eam::Method::CreateExternal as u64,
-            Some(fil_actor_eam::CreateExternalParams(vec![])),
+            Some(serialize_ok(&fil_actor_eam::CreateExternalParams(vec![]))),
         )
         .unwrap();
 
@@ -310,8 +338,15 @@ fn test_evm_empty_initcode() {
 }
 
 #[test]
+fn evm_staticcall() {
+    let store = MemoryBlockstore::new();
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+
+    evm_staticcall_test(&v);
+}
+
 #[allow(non_snake_case)]
-fn test_evm_staticcall() {
+fn evm_staticcall_test<BS: Blockstore>(v: &dyn VM<BS>) {
     // test scenarios:
     // one hop:
     // A -> staticcall -> B (read) OK
@@ -319,11 +354,7 @@ fn test_evm_staticcall() {
     // two hop sticky:
     // A -> staticcall -> B -> call -> C (read) OK
     // A -> staticcall -> B -> call -> C (write) FAIL
-
-    let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-
-    let accounts = create_accounts(&v, 3, &TokenAmount::from_whole(10_000));
+    let accounts = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
 
     let bytecode =
         hex::decode(include_str!("../../actors/evm/tests/contracts/callvariants.hex")).unwrap();
@@ -332,12 +363,12 @@ fn test_evm_staticcall() {
         .iter()
         .map(|account| {
             let create_result = v
-                .apply_message(
+                .execute_message(
                     account,
                     &EAM_ACTOR_ADDR,
                     &TokenAmount::zero(),
                     fil_actor_eam::Method::CreateExternal as u64,
-                    Some(fil_actor_eam::CreateExternalParams(bytecode.clone())),
+                    Some(serialize_ok(&fil_actor_eam::CreateExternalParams(bytecode.clone()))),
                 )
                 .unwrap();
 
@@ -352,8 +383,8 @@ fn test_evm_staticcall() {
 
             // Make sure we deployed an EVM actor.
             assert_eq!(
-                &v.get_actor(&Address::new_id(create_return.actor_id)).unwrap().code,
-                &*EVM_ACTOR_CODE_ID
+                &v.actor(&Address::new_id(create_return.actor_id)).unwrap().code,
+                &*EVM_ACTOR_CODE_ID,
             );
 
             create_return
@@ -370,12 +401,12 @@ fn test_evm_staticcall() {
         params[16..].copy_from_slice(B.as_ref());
 
         let call_result = v
-            .apply_message(
+            .execute_message(
                 &A_act,
                 &A_robust_addr,
                 &TokenAmount::zero(),
                 fil_actor_evm::Method::InvokeContract as u64,
-                Some(ContractParams(params.to_vec())),
+                Some(serialize_ok(&ContractParams(params.to_vec()))),
             )
             .unwrap();
         assert!(
@@ -398,12 +429,12 @@ fn test_evm_staticcall() {
         params[16..].copy_from_slice(B.as_ref());
 
         let call_result = v
-            .apply_message(
+            .execute_message(
                 &A_act,
                 &A_robust_addr,
                 &TokenAmount::zero(),
                 fil_actor_evm::Method::InvokeContract as u64,
-                Some(ContractParams(params.to_vec())),
+                Some(serialize_ok(&ContractParams(params.to_vec()))),
             )
             .unwrap();
         assert_eq!(call_result.code.value(), 33, "static call mutation did not revert");
@@ -421,12 +452,12 @@ fn test_evm_staticcall() {
         params[48..].copy_from_slice(C.as_ref());
 
         let call_result = v
-            .apply_message(
+            .execute_message(
                 &A_act,
                 &A_robust_addr,
                 &TokenAmount::zero(),
                 fil_actor_evm::Method::InvokeContract as u64,
-                Some(ContractParams(params.to_vec())),
+                Some(serialize_ok(&ContractParams(params.to_vec()))),
             )
             .unwrap();
         assert!(
@@ -451,12 +482,12 @@ fn test_evm_staticcall() {
         params[48..].copy_from_slice(C.as_ref());
 
         let call_result = v
-            .apply_message(
+            .execute_message(
                 &A_act,
                 &A_robust_addr,
                 &TokenAmount::zero(),
                 fil_actor_evm::Method::InvokeContract as u64,
-                Some(ContractParams(params.to_vec())),
+                Some(serialize_ok(&ContractParams(params.to_vec()))),
             )
             .unwrap();
         assert_eq!(call_result.code.value(), 33, "static call mutation did not revert");
@@ -464,8 +495,15 @@ fn test_evm_staticcall() {
 }
 
 #[test]
+fn evm_delegatecall() {
+    let store = MemoryBlockstore::new();
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+
+    evm_delegatecall_test(&v);
+}
+
 #[allow(non_snake_case)]
-fn test_evm_delegatecall() {
+fn evm_delegatecall_test<BS: Blockstore>(v: &dyn VM<BS>) {
     // test scenarios:
     // one hop:
     // A -> delegatecall -> B (read) OK
@@ -473,11 +511,7 @@ fn test_evm_delegatecall() {
     // two hop with sticky staticcall:
     // A -> staticcall -> B -> delegatecall -> C (read) OK
     // A -> staticcall -> B -> delegatecall -> C (write) FAIL
-
-    let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-
-    let accounts = create_accounts(&v, 3, &TokenAmount::from_whole(10_000));
+    let accounts = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
 
     let bytecode =
         hex::decode(include_str!("../../actors/evm/tests/contracts/callvariants.hex")).unwrap();
@@ -486,12 +520,12 @@ fn test_evm_delegatecall() {
         .iter()
         .map(|account| {
             let create_result = v
-                .apply_message(
+                .execute_message(
                     account,
                     &EAM_ACTOR_ADDR,
                     &TokenAmount::zero(),
                     fil_actor_eam::Method::CreateExternal as u64,
-                    Some(fil_actor_eam::CreateExternalParams(bytecode.clone())),
+                    Some(serialize_ok(&fil_actor_eam::CreateExternalParams(bytecode.clone()))),
                 )
                 .unwrap();
 
@@ -506,7 +540,7 @@ fn test_evm_delegatecall() {
 
             // Make sure we deployed an EVM actor.
             assert_eq!(
-                &v.get_actor(&Address::new_id(create_return.actor_id)).unwrap().code,
+                &v.actor(&Address::new_id(create_return.actor_id)).unwrap().code,
                 &*EVM_ACTOR_CODE_ID
             );
 
@@ -524,12 +558,12 @@ fn test_evm_delegatecall() {
         params[16..].copy_from_slice(B.as_ref());
 
         let call_result = v
-            .apply_message(
+            .execute_message(
                 &A_act,
                 &A_robust_addr,
                 &TokenAmount::zero(),
                 fil_actor_evm::Method::InvokeContract as u64,
-                Some(ContractParams(params.to_vec())),
+                Some(serialize_ok(&ContractParams(params.to_vec()))),
             )
             .unwrap();
         assert!(
@@ -552,12 +586,12 @@ fn test_evm_delegatecall() {
         params[16..].copy_from_slice(B.as_ref());
 
         let call_result = v
-            .apply_message(
+            .execute_message(
                 &A_act,
                 &A_robust_addr,
                 &TokenAmount::zero(),
                 fil_actor_evm::Method::InvokeContract as u64,
-                Some(ContractParams(params.to_vec())),
+                Some(serialize_ok(&ContractParams(params.to_vec()))),
             )
             .unwrap();
         assert!(
@@ -582,12 +616,12 @@ fn test_evm_delegatecall() {
         let value = TokenAmount::from_whole(123);
 
         let call_result = v
-            .apply_message(
+            .execute_message(
                 &A_act,
                 &A_robust_addr,
                 &value,
                 fil_actor_evm::Method::InvokeContract as u64,
-                Some(ContractParams(params.to_vec())),
+                Some(serialize_ok(&ContractParams(params.to_vec()))),
             )
             .unwrap();
         assert!(
@@ -602,8 +636,15 @@ fn test_evm_delegatecall() {
 }
 
 #[test]
+fn evm_staticcall_delegatecall() {
+    let store = MemoryBlockstore::new();
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+
+    evm_staticcall_delegatecall_test(&v);
+}
+
 #[allow(non_snake_case)]
-fn test_evm_staticcall_delegatecall() {
+fn evm_staticcall_delegatecall_test<BS: Blockstore>(v: &dyn VM<BS>) {
     // test scenarios:
     // one hop:
     // A -> delegatecall -> B (read) OK
@@ -612,10 +653,7 @@ fn test_evm_staticcall_delegatecall() {
     // A -> staticcall -> B -> delegatecall -> C (read) OK
     // A -> staticcall -> B -> delegatecall -> C (write) FAIL
 
-    let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-
-    let accounts = create_accounts(&v, 3, &TokenAmount::from_whole(10_000));
+    let accounts = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
 
     let bytecode =
         hex::decode(include_str!("../../actors/evm/tests/contracts/callvariants.hex")).unwrap();
@@ -624,12 +662,12 @@ fn test_evm_staticcall_delegatecall() {
         .iter()
         .map(|account| {
             let create_result = v
-                .apply_message(
+                .execute_message(
                     account,
                     &EAM_ACTOR_ADDR,
                     &TokenAmount::zero(),
                     fil_actor_eam::Method::CreateExternal as u64,
-                    Some(fil_actor_eam::CreateExternalParams(bytecode.clone())),
+                    Some(serialize_ok(&fil_actor_eam::CreateExternalParams(bytecode.clone()))),
                 )
                 .unwrap();
 
@@ -644,7 +682,7 @@ fn test_evm_staticcall_delegatecall() {
 
             // Make sure we deployed an EVM actor.
             assert_eq!(
-                &v.get_actor(&Address::new_id(create_return.actor_id)).unwrap().code,
+                &v.actor(&Address::new_id(create_return.actor_id)).unwrap().code,
                 &*EVM_ACTOR_CODE_ID
             );
 
@@ -664,12 +702,12 @@ fn test_evm_staticcall_delegatecall() {
         params[48..].copy_from_slice(C.as_ref());
 
         let call_result = v
-            .apply_message(
+            .execute_message(
                 &A_act,
                 &A_robust_addr,
                 &TokenAmount::zero(),
                 fil_actor_evm::Method::InvokeContract as u64,
-                Some(ContractParams(params.to_vec())),
+                Some(serialize_ok(&ContractParams(params.to_vec()))),
             )
             .unwrap();
         assert!(
@@ -679,8 +717,7 @@ fn test_evm_staticcall_delegatecall() {
         );
         let BytesDe(return_value) =
             call_result.ret.unwrap().deserialize().expect("failed to deserialize results");
-        //assert_eq!(&return_value[12..], &created[1].eth_address.0);
-        println!("return {:?}", return_value)
+        assert_eq!(&return_value[12..], &created[1].eth_address.0);
     }
 
     // A -> staticcall -> B -> delegatecall -> C (write) FAIL
@@ -695,12 +732,12 @@ fn test_evm_staticcall_delegatecall() {
         params[48..].copy_from_slice(C.as_ref());
 
         let call_result = v
-            .apply_message(
+            .execute_message(
                 &A_act,
                 &A_robust_addr,
                 &TokenAmount::zero(),
                 fil_actor_evm::Method::InvokeContract as u64,
-                Some(ContractParams(params.to_vec())),
+                Some(serialize_ok(&ContractParams(params.to_vec()))),
             )
             .unwrap();
         assert_eq!(call_result.code.value(), 33, "static call mutation did not revert");
@@ -708,13 +745,17 @@ fn test_evm_staticcall_delegatecall() {
 }
 
 #[test]
-fn test_evm_init_revert_data() {
+fn evm_init_revert_data() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
-    let account = create_accounts(&v, 1, &TokenAmount::from_whole(10_000))[0];
+    evm_init_revert_data_test(&v);
+}
+
+fn evm_init_revert_data_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let account = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
     let create_result = v
-        .apply_message(
+        .execute_message(
             &account,
             &EAM_ACTOR_ADDR,
             &TokenAmount::zero(),
@@ -722,9 +763,9 @@ fn test_evm_init_revert_data() {
             // init code:
             // PUSH1 0x42; PUSH1 0x0; MSTORE;
             // PUSH1 0x20; PUSH1 0x0; REVERT
-            Some(fil_actor_eam::CreateExternalParams(vec![
+            Some(serialize_ok(&fil_actor_eam::CreateExternalParams(vec![
                 0x60, 0x42, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xfd,
-            ])),
+            ]))),
         )
         .unwrap();
 

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -26,25 +26,29 @@ use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
 use test_vm::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
     advance_by_deadline_to_index, advance_to_proving_deadline, apply_ok, bf_all, create_accounts,
-    create_miner, cron_tick, invariant_failure_patterns, market_add_balance, market_publish_deal,
-    miner_precommit_sector, miner_prove_sector, sector_deadline, submit_windowed_post,
-    verifreg_add_client, verifreg_add_verifier,
+    create_miner, cron_tick, expect_invariants, get_state, invariant_failure_patterns,
+    market_add_balance, market_publish_deal, miner_precommit_sector, miner_prove_sector,
+    sector_deadline, submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
 };
 use test_vm::{ExpectInvocation, TestVM, VM};
 
 #[test]
 fn extend_legacy_sector_with_deals() {
-    extend_legacy_sector_with_deals_inner(false);
+    let store = MemoryBlockstore::new();
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    extend_legacy_sector_with_deals_inner(&v, false, &v);
 }
 
 #[test]
 fn extend2_legacy_sector_with_deals() {
-    extend_legacy_sector_with_deals_inner(true);
+    let store = MemoryBlockstore::new();
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    extend_legacy_sector_with_deals_inner(&v, true, &v);
 }
 
 #[allow(clippy::too_many_arguments)]
 fn extend<BS: Blockstore>(
-    v: &TestVM<BS>,
+    v: &dyn VM<BS>,
     worker: Address,
     maddr: Address,
     deadline_index: u64,
@@ -130,10 +134,14 @@ fn extend<BS: Blockstore>(
     .matches(v.take_invocations().last().unwrap());
 }
 
-fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
-    let store = MemoryBlockstore::new();
-    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 3, &TokenAmount::from_whole(10_000));
+// TODO: remove usage of _v_concrete which is currently required by mutate_state
+// https://github.com/filecoin-project/builtin-actors/issues/1297
+fn extend_legacy_sector_with_deals_inner<BS: Blockstore>(
+    v: &dyn VM<BS>,
+    do_extend2: bool,
+    _v_concrete: &TestVM<BS>,
+) {
+    let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let sector_number: SectorNumber = 100;
@@ -141,14 +149,14 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
 
     // create miner
     let miner_id = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
         &TokenAmount::from_whole(1_000),
     )
     .0;
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     //
     // publish verified deals
@@ -156,17 +164,17 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
 
     // register verifier then verified client
     let datacap = StoragePower::from(32_u128 << 40);
-    verifreg_add_verifier(&v, &verifier, datacap.clone());
-    verifreg_add_client(&v, &verifier, &verified_client, datacap);
+    verifreg_add_verifier(v, &verifier, datacap.clone());
+    verifreg_add_client(v, &verifier, &verified_client, datacap);
 
     // add market collateral for clients and miner
-    market_add_balance(&v, &verified_client, &verified_client, &TokenAmount::from_whole(3));
-    market_add_balance(&v, &worker, &miner_id, &TokenAmount::from_whole(64));
+    market_add_balance(v, &verified_client, &verified_client, &TokenAmount::from_whole(3));
+    market_add_balance(v, &worker, &miner_id, &TokenAmount::from_whole(64));
 
     // create 1 verified deal for total sector capacity for 6 months
     let deal_start = v.epoch() + max_prove_commit_duration(&Policy::default(), seal_proof).unwrap();
     let deals = market_publish_deal(
-        &v,
+        v,
         &worker,
         &verified_client,
         &miner_id,
@@ -183,7 +191,7 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     //
 
     miner_precommit_sector(
-        &v,
+        v,
         &worker,
         &miner_id,
         seal_proof,
@@ -193,15 +201,15 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     );
 
     // advance time to max seal duration and prove the sector
-    advance_by_deadline_to_epoch(&v, &miner_id, deal_start);
-    miner_prove_sector(&v, &worker, &miner_id, sector_number);
+    advance_by_deadline_to_epoch(v, &miner_id, deal_start);
+    miner_prove_sector(v, &worker, &miner_id, sector_number);
     // trigger cron to validate the prove commit
-    cron_tick(&v);
+    cron_tick(v);
 
     // inspect sector info
 
-    let mut miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
-    let mut sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    let miner_state: MinerState = get_state(v, &miner_id).unwrap();
+    let mut sector_info = miner_state.get_sector(*v.blockstore(), sector_number).unwrap().unwrap();
     assert_eq!(180 * EPOCHS_IN_DAY, sector_info.expiration - sector_info.activation);
     assert_eq!(StoragePower::zero(), sector_info.deal_weight); // 0 space time
     assert_eq!(
@@ -213,9 +221,10 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     // because legacy and simple qa power deal weight calculations line up for fully packed sectors
     // We do need to set simple_qa_power to false
     sector_info.simple_qa_power = false;
+
     // Manually craft state to match legacy sectors
-    v.mutate_state(&miner_id, |st: &mut MinerState| {
-        let mut sectors = Sectors::load(&store, &st.sectors).unwrap();
+    _v_concrete.mutate_state(&miner_id, |st: &mut MinerState| {
+        let mut sectors = Sectors::load(*v.blockstore(), &st.sectors).unwrap();
         sectors.store(vec![sector_info.clone()]).unwrap();
         st.sectors = sectors.amt.flush().unwrap();
     });
@@ -224,8 +233,7 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     let initial_deal_weight = sector_info.deal_weight;
 
     // advance to proving period and submit post
-    let (deadline_info, partition_index) =
-        advance_to_proving_deadline(&v, &miner_id, sector_number);
+    let (deadline_info, partition_index) = advance_to_proving_deadline(v, &miner_id, sector_number);
 
     let expected_power_delta = PowerPair {
         raw: StoragePower::from(32u64 << 30),
@@ -233,7 +241,7 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     };
 
     submit_windowed_post(
-        &v,
+        v,
         &worker,
         &miner_id,
         deadline_info,
@@ -243,7 +251,7 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
 
     // move forward one deadline so advanceWhileProving doesn't fail double submitting posts
     advance_by_deadline_to_index(
-        &v,
+        v,
         &miner_id,
         deadline_info.index + 1 % policy.wpost_period_deadlines,
     );
@@ -260,7 +268,7 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     // delta from the previous 10x power multiplier:
     // - power delta = (10-4)*32GiB = 6*32GiB
     advance_by_deadline_to_epoch_while_proving(
-        &v,
+        v,
         &miner_id,
         &worker,
         sector_number,
@@ -277,7 +285,7 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
         IpldBlock::serialize_cbor(&expected_update_claimed_power_params).unwrap().unwrap();
 
     extend(
-        &v,
+        v,
         worker,
         miner_id,
         deadline_info.index,
@@ -288,8 +296,8 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
         do_extend2,
     );
 
-    miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
-    sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    let miner_state: MinerState = get_state(v, &miner_id).unwrap();
+    sector_info = miner_state.get_sector(*v.blockstore(), sector_number).unwrap().unwrap();
     assert_eq!(180 * 2 * EPOCHS_IN_DAY, sector_info.expiration - sector_info.activation);
     assert_eq!(initial_deal_weight, sector_info.deal_weight); // 0 space time, unchanged
     assert_eq!(&initial_verified_deal_weight / 2, sector_info.verified_deal_weight);
@@ -307,7 +315,7 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
     // - power delta = (4-2.5)*32GiB = 1.5*32GiB
 
     advance_by_deadline_to_epoch_while_proving(
-        &v,
+        v,
         &miner_id,
         &worker,
         sector_number,
@@ -323,7 +331,7 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
         IpldBlock::serialize_cbor(&expected_update_claimed_power_params).unwrap().unwrap();
 
     extend(
-        &v,
+        v,
         worker,
         miner_id,
         deadline_info.index,
@@ -334,16 +342,15 @@ fn extend_legacy_sector_with_deals_inner(do_extend2: bool) {
         do_extend2,
     );
 
-    miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
-    sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    let miner_state: MinerState = get_state(v, &miner_id).unwrap();
+    let sector_info = miner_state.get_sector(*v.blockstore(), sector_number).unwrap().unwrap();
     assert_eq!(180 * 3 * EPOCHS_IN_DAY, sector_info.expiration - sector_info.activation);
-    assert_eq!(initial_deal_weight, sector_info.deal_weight); // 0 space time, unchanged
-    assert_eq!(initial_verified_deal_weight / 3, sector_info.verified_deal_weight);
+    // 0 space time, unchanged
+    assert_eq!(initial_deal_weight, sector_info.deal_weight);
     // 1/2 * 2/3 -> 1/3
+    assert_eq!(initial_verified_deal_weight / 3, sector_info.verified_deal_weight);
 
-    v.expect_state_invariants(
-        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
-    );
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -408,7 +415,7 @@ fn extend_updated_sector_with_claim() {
 
     // Inspect basic sector info
 
-    let miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    let miner_state: MinerState = get_state(&v, &miner_id).unwrap();
     let initial_sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
     assert_eq!(expiration, initial_sector_info.expiration);
     assert!(initial_sector_info.deal_weight.is_zero()); // 0 space time
@@ -520,7 +527,7 @@ fn extend_updated_sector_with_claim() {
 
     // inspect sector info
 
-    let miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    let miner_state: MinerState = get_state(&v, &miner_id).unwrap();
     let sector_info_after_update = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
     assert_eq!(StoragePower::zero(), sector_info_after_update.deal_weight); // 0 space time
 
@@ -535,7 +542,7 @@ fn extend_updated_sector_with_claim() {
     let curr_epoch = v.epoch();
     let v = v.with_epoch(curr_epoch + 1);
 
-    let market_state: MarketState = v.get_state(&STORAGE_MARKET_ACTOR_ADDR).unwrap();
+    let market_state: MarketState = get_state(&v, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
     let deal_states = DealMetaArray::load(&market_state.states, v.store).unwrap();
     let deal_state = deal_states.get(deal_ids[0]).unwrap().unwrap();
     let claim_id = deal_state.verified_claim;
@@ -562,7 +569,7 @@ fn extend_updated_sector_with_claim() {
         Some(extension_params),
     );
 
-    let miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    let miner_state: MinerState = get_state(&v, &miner_id).unwrap();
     let sector_info_after_extension =
         miner_state.get_sector(&store, sector_number).unwrap().unwrap();
     assert_eq!(StoragePower::zero(), sector_info_after_extension.deal_weight); // 0 space time
@@ -624,7 +631,7 @@ fn extend_sector_up_to_max_relative_extension() {
     cron_tick(&v);
 
     // inspect sector info
-    let mut miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    let mut miner_state: MinerState = get_state(&v, &miner_id).unwrap();
     let mut sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
     assert_eq!(180 * EPOCHS_IN_DAY, sector_info.expiration - sector_info.activation);
 
@@ -666,7 +673,7 @@ fn extend_sector_up_to_max_relative_extension() {
         false,
     );
 
-    miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
+    miner_state = get_state(&v, &miner_id).unwrap();
     sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
     assert_eq!(policy.max_sector_expiration_extension, sector_info.expiration - v.epoch());
 }
@@ -675,7 +682,11 @@ fn extend_sector_up_to_max_relative_extension() {
 fn commit_sector_with_max_duration_deal() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let addrs = create_accounts(&v, 3, &TokenAmount::from_whole(10_000));
+    commit_sector_with_max_duration_deal_test(&v);
+}
+
+fn commit_sector_with_max_duration_deal_test<BS: Blockstore>(v: &dyn VM<BS>) {
+    let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let sector_number: SectorNumber = 100;
@@ -683,14 +694,14 @@ fn commit_sector_with_max_duration_deal() {
 
     // create miner
     let miner_id = create_miner(
-        &v,
+        v,
         &owner,
         &worker,
         seal_proof.registered_window_post_proof().unwrap(),
         &TokenAmount::from_whole(1_000),
     )
     .0;
-    let v = v.with_epoch(200);
+    v.set_epoch(200);
 
     //
     // publish verified deals
@@ -698,19 +709,19 @@ fn commit_sector_with_max_duration_deal() {
 
     // register verifier then verified client
     let datacap = StoragePower::from(32_u128 << 40);
-    verifreg_add_verifier(&v, &verifier, datacap.clone());
-    verifreg_add_client(&v, &verifier, &verified_client, datacap);
+    verifreg_add_verifier(v, &verifier, datacap.clone());
+    verifreg_add_client(v, &verifier, &verified_client, datacap);
 
     // add market collateral for clients and miner
-    market_add_balance(&v, &verified_client, &verified_client, &TokenAmount::from_whole(3));
-    market_add_balance(&v, &worker, &miner_id, &TokenAmount::from_whole(64));
+    market_add_balance(v, &verified_client, &verified_client, &TokenAmount::from_whole(3));
+    market_add_balance(v, &worker, &miner_id, &TokenAmount::from_whole(64));
 
     let deal_lifetime = policy.max_sector_expiration_extension
         - max_prove_commit_duration(&policy, seal_proof).unwrap_or_default();
     // create 1 verified deal for total sector capacity for 6 months
     let deal_start = v.epoch() + max_prove_commit_duration(&Policy::default(), seal_proof).unwrap();
     let deals = market_publish_deal(
-        &v,
+        v,
         &worker,
         &verified_client,
         &miner_id,
@@ -726,7 +737,7 @@ fn commit_sector_with_max_duration_deal() {
     // Precommit, prove and PoSt empty sector (more fully tested in TestCommitPoStFlow)
     //
     miner_precommit_sector(
-        &v,
+        v,
         &worker,
         &miner_id,
         seal_proof,
@@ -736,14 +747,13 @@ fn commit_sector_with_max_duration_deal() {
     );
 
     // advance time to max seal duration and prove the sector
-    advance_by_deadline_to_epoch(&v, &miner_id, deal_start);
-    miner_prove_sector(&v, &worker, &miner_id, sector_number);
+    advance_by_deadline_to_epoch(v, &miner_id, deal_start);
+    miner_prove_sector(v, &worker, &miner_id, sector_number);
     // trigger cron to validate the prove commit
-    cron_tick(&v);
+    cron_tick(v);
 
     // advance to proving period and submit post
-    let (deadline_info, partition_index) =
-        advance_to_proving_deadline(&v, &miner_id, sector_number);
+    let (deadline_info, partition_index) = advance_to_proving_deadline(v, &miner_id, sector_number);
 
     let expected_power_delta = PowerPair {
         raw: StoragePower::from(32u64 << 30),
@@ -751,7 +761,7 @@ fn commit_sector_with_max_duration_deal() {
     };
 
     submit_windowed_post(
-        &v,
+        v,
         &worker,
         &miner_id,
         deadline_info,
@@ -759,7 +769,7 @@ fn commit_sector_with_max_duration_deal() {
         Some(expected_power_delta),
     );
     // inspect sector info
-    let miner_state = v.get_state::<MinerState>(&miner_id).unwrap();
-    let sector_info = miner_state.get_sector(&store, sector_number).unwrap().unwrap();
+    let miner_state: MinerState = get_state(v, &miner_id).unwrap();
+    let sector_info = miner_state.get_sector(*v.blockstore(), sector_number).unwrap().unwrap();
     assert_eq!(deal_lifetime, sector_info.expiration - sector_info.activation);
 }


### PR DESCRIPTION
- Adds a utility function for serializing cbor params
- Fixes a bug in the test_vm that was causing some message invocations to fail
- More of the easily transferred tests are ported to use the new dyn VM trait