### PR TITLE
Extract trace/expectations from test VM and add expectation builders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,6 +4502,7 @@ dependencies = [
  "fil_actors_evm_shared",
  "fil_actors_runtime",
  "fil_builtin_actors_state",
+ "frc42_dispatch",
  "frc46_token",
  "fvm_actor_utils",
  "fvm_ipld_bitfield",

--- a/actors/miner/src/beneficiary.rs
+++ b/actors/miner/src/beneficiary.rs
@@ -48,7 +48,7 @@ impl BeneficiaryTerm {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct PendingBeneficiaryChange {
     pub new_beneficiary: Address,
     pub new_quota: TokenAmount,

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -374,20 +374,20 @@ pub struct ApplyRewardParams {
     pub penalty: TokenAmount,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Serialize_tuple, Deserialize_tuple)]
 pub struct DisputeWindowedPoStParams {
     pub deadline: u64,
     pub post_index: u64, // only one is allowed at a time to avoid loading too many sector infos.
 }
 
-#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct ProveCommitAggregateParams {
     pub sector_numbers: BitField,
     #[serde(with = "strict_bytes")]
     pub aggregate_proof: Vec<u8>,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ReplicaUpdate {
     pub sector_number: SectorNumber,
     pub deadline: u64,
@@ -399,12 +399,12 @@ pub struct ReplicaUpdate {
     pub replica_proof: Vec<u8>,
 }
 
-#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ProveReplicaUpdatesParams {
     pub updates: Vec<ReplicaUpdate>,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ReplicaUpdate2 {
     pub sector_number: SectorNumber,
     pub deadline: u64,
@@ -417,12 +417,12 @@ pub struct ReplicaUpdate2 {
     pub replica_proof: Vec<u8>,
 }
 
-#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ProveReplicaUpdatesParams2 {
     pub updates: Vec<ReplicaUpdate2>,
 }
 
-#[derive(Debug, Clone, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ChangeBeneficiaryParams {
     pub new_beneficiary: Address,
     pub new_quota: TokenAmount,
@@ -439,43 +439,43 @@ impl ChangeBeneficiaryParams {
     }
 }
 
-#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ActiveBeneficiary {
     pub beneficiary: Address,
     pub term: BeneficiaryTerm,
 }
 
-#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct GetBeneficiaryReturn {
     pub active: ActiveBeneficiary,
     pub proposed: Option<PendingBeneficiaryChange>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct GetOwnerReturn {
     pub owner: Address,
     pub proposed: Option<Address>,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 #[serde(transparent)]
 pub struct IsControllingAddressParam {
     pub address: Address,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 #[serde(transparent)]
 pub struct IsControllingAddressReturn {
     pub is_controlling: bool,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 #[serde(transparent)]
 pub struct GetSectorSizeReturn {
     pub sector_size: SectorSize,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 #[serde(transparent)]
 pub struct GetAvailableBalanceReturn {
     pub available_balance: TokenAmount,
@@ -486,13 +486,13 @@ pub struct GetVestingFundsReturn {
     pub vesting_funds: Vec<(ChainEpoch, TokenAmount)>,
 }
 
-#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct GetPeerIDReturn {
     #[serde(with = "strict_bytes")]
     pub peer_id: Vec<u8>,
 }
 
-#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct GetMultiaddrsReturn {
     pub multi_addrs: Vec<BytesDe>,
 }

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -33,6 +33,7 @@ anyhow = "1.0.65"
 bimap = { version = "0.6.2" }
 blake2b_simd = "1.0"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+frc42_dispatch = "3.2.0"
 frc46_token = "6.0.0"
 fvm_actor_utils = "6.0.0"
 fvm_ipld_bitfield = "0.5.4"

--- a/test_vm/src/expects.rs
+++ b/test_vm/src/expects.rs
@@ -1,0 +1,289 @@
+use frc46_token::receiver::{FRC46TokenReceived, FRC46_TOKEN_TYPE};
+use frc46_token::token::types::BurnParams;
+use fvm_actor_utils::receiver::UniversalReceiverParams;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::Address;
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::deal::DealID;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::{ActorID, METHOD_SEND};
+use num_traits::Zero;
+
+use fil_actor_account::types::AuthenticateMessageParams;
+use fil_actor_datacap::BalanceParams;
+use fil_actor_market::{
+    ActivateDealsParams, OnMinerSectorsTerminateParams, SectorDeals, VerifyDealsForActivationParams,
+};
+use fil_actor_miner::ext::verifreg::ClaimID;
+use fil_actor_miner::{IsControllingAddressParam, PowerPair};
+use fil_actor_power::{UpdateClaimedPowerParams, UpdatePledgeTotalParams};
+use fil_actor_verifreg::GetClaimsParams;
+use fil_actors_runtime::{
+    BURNT_FUNDS_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR,
+};
+
+use crate::trace::ExpectInvocation;
+
+/// Static helper functions for creating invocation expectations.
+pub struct Expect {}
+
+impl Expect {
+    pub fn send(from: Address, to: Address, v: Option<TokenAmount>) -> ExpectInvocation {
+        ExpectInvocation { from, to, method: METHOD_SEND, value: v, ..Default::default() }
+    }
+    pub fn burn(from: Address, v: Option<TokenAmount>) -> ExpectInvocation {
+        Self::send(from, BURNT_FUNDS_ACTOR_ADDR, v)
+    }
+    pub fn market_activate_deals(
+        from: Address,
+        deals: Vec<DealID>,
+        sector_expiry: ChainEpoch,
+    ) -> ExpectInvocation {
+        let params =
+            IpldBlock::serialize_cbor(&ActivateDealsParams { deal_ids: deals, sector_expiry })
+                .unwrap();
+        ExpectInvocation {
+            from,
+            to: STORAGE_MARKET_ACTOR_ADDR,
+            method: fil_actor_market::Method::ActivateDeals as u64,
+            params: Some(params),
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn market_sectors_terminate(
+        from: Address,
+        epoch: ChainEpoch,
+        deal_ids: Vec<DealID>,
+    ) -> ExpectInvocation {
+        let params =
+            IpldBlock::serialize_cbor(&OnMinerSectorsTerminateParams { epoch, deal_ids }).unwrap();
+        ExpectInvocation {
+            from,
+            to: STORAGE_MARKET_ACTOR_ADDR,
+            method: fil_actor_market::Method::OnMinerSectorsTerminate as u64,
+            params: Some(params),
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn market_verify_deals(from: Address, sectors: Vec<SectorDeals>) -> ExpectInvocation {
+        let params =
+            IpldBlock::serialize_cbor(&VerifyDealsForActivationParams { sectors }).unwrap();
+        ExpectInvocation {
+            from,
+            to: STORAGE_MARKET_ACTOR_ADDR,
+            method: fil_actor_market::Method::VerifyDealsForActivation as u64,
+            params: Some(params),
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn miner_cron(to: Address) -> ExpectInvocation {
+        ExpectInvocation {
+            from: STORAGE_POWER_ACTOR_ADDR,
+            to,
+            method: fil_actor_miner::Method::OnDeferredCronEvent as u64,
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn miner_is_controlling_address(
+        from: Address,
+        to: Address,
+        address: Address,
+    ) -> ExpectInvocation {
+        let params = IpldBlock::serialize_cbor(&IsControllingAddressParam { address }).unwrap();
+        ExpectInvocation {
+            from,
+            to,
+            method: fil_actor_miner::Method::IsControllingAddressExported as u64,
+            params: Some(params),
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn power_current_total(from: Address) -> ExpectInvocation {
+        ExpectInvocation {
+            from,
+            to: STORAGE_POWER_ACTOR_ADDR,
+            method: fil_actor_power::Method::CurrentTotalPower as u64,
+            subinvocs: Some(vec![]),
+            value: Some(TokenAmount::zero()),
+            ..Default::default()
+        }
+    }
+    pub fn power_enrol_cron(from: Address) -> ExpectInvocation {
+        // Note: params are unchecked.
+        ExpectInvocation {
+            from,
+            to: STORAGE_POWER_ACTOR_ADDR,
+            method: fil_actor_power::Method::EnrollCronEvent as u64,
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn power_submit_porep(from: Address) -> ExpectInvocation {
+        // Note: params are unchecked.
+        ExpectInvocation {
+            from,
+            to: STORAGE_POWER_ACTOR_ADDR,
+            method: fil_actor_power::Method::SubmitPoRepForBulkVerify as u64,
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn power_update_claim(from: Address, delta: PowerPair) -> ExpectInvocation {
+        let params = IpldBlock::serialize_cbor(&UpdateClaimedPowerParams {
+            raw_byte_delta: delta.raw,
+            quality_adjusted_delta: delta.qa,
+        })
+        .unwrap();
+        ExpectInvocation {
+            from,
+            to: STORAGE_POWER_ACTOR_ADDR,
+            method: fil_actor_power::Method::UpdateClaimedPower as u64,
+            params: Some(params),
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn power_update_pledge(from: Address, amount: Option<TokenAmount>) -> ExpectInvocation {
+        let params = amount.map(|a| {
+            IpldBlock::serialize_cbor(&UpdatePledgeTotalParams { pledge_delta: a }).unwrap()
+        });
+        ExpectInvocation {
+            from,
+            to: STORAGE_POWER_ACTOR_ADDR,
+            method: fil_actor_power::Method::UpdatePledgeTotal as u64,
+            params,
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn reward_update_kpi() -> ExpectInvocation {
+        // Note: params are unchecked
+        ExpectInvocation {
+            from: STORAGE_POWER_ACTOR_ADDR,
+            to: REWARD_ACTOR_ADDR,
+            method: fil_actor_reward::Method::UpdateNetworkKPI as u64,
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn reward_this_epoch(from: Address) -> ExpectInvocation {
+        ExpectInvocation {
+            from,
+            to: REWARD_ACTOR_ADDR,
+            method: fil_actor_reward::Method::ThisEpochReward as u64,
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn verifreg_get_claims(
+        from: Address,
+        miner: ActorID,
+        ids: Vec<ClaimID>,
+    ) -> ExpectInvocation {
+        let params =
+            IpldBlock::serialize_cbor(&GetClaimsParams { provider: miner, claim_ids: ids })
+                .unwrap();
+        ExpectInvocation {
+            from,
+            to: VERIFIED_REGISTRY_ACTOR_ADDR,
+            method: fil_actor_verifreg::Method::GetClaims as u64,
+            params: Some(params),
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn frc42_balance(from: Address, to: Address, address: Address) -> ExpectInvocation {
+        let params = Some(IpldBlock::serialize_cbor(&BalanceParams { address }).unwrap());
+        ExpectInvocation {
+            from,
+            to,
+            method: frc42_dispatch::method_hash!("Balance"),
+            params,
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn frc44_authenticate(
+        from: Address,
+        to: Address,
+        message: Vec<u8>,
+        signature: Vec<u8>,
+    ) -> ExpectInvocation {
+        let params =
+            IpldBlock::serialize_cbor(&AuthenticateMessageParams { message, signature }).unwrap();
+        ExpectInvocation {
+            from,
+            to,
+            method: frc42_dispatch::method_hash!("AuthenticateMessage"),
+            params: Some(params),
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn frc46_burn(from: Address, to: Address, amount: TokenAmount) -> ExpectInvocation {
+        let params = IpldBlock::serialize_cbor(&BurnParams { amount }).unwrap();
+        ExpectInvocation {
+            from,
+            to,
+            method: frc42_dispatch::method_hash!("Burn"),
+            params: Some(params),
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+    pub fn frc46_receiver(
+        from: Address,
+        to: Address,
+        payer: ActorID,
+        beneficiary: ActorID,
+        operator: ActorID,
+        amount: TokenAmount,
+        operator_data: Option<RawBytes>,
+    ) -> ExpectInvocation {
+        let payload = IpldBlock::serialize_cbor(&FRC46TokenReceived {
+            from: payer,
+            to: beneficiary,
+            operator,
+            amount,
+            operator_data: operator_data.unwrap_or_default(),
+            token_data: RawBytes::default(),
+        })
+        .unwrap();
+        let params = IpldBlock::serialize_cbor(&UniversalReceiverParams {
+            type_: FRC46_TOKEN_TYPE,
+            payload: payload.unwrap().data.into(),
+        })
+        .unwrap();
+        ExpectInvocation {
+            from,
+            to,
+            method: frc42_dispatch::method_hash!("Receive"),
+            params: Some(params),
+            value: Some(TokenAmount::zero()),
+            subinvocs: Some(vec![]),
+            ..Default::default()
+        }
+    }
+}

--- a/test_vm/src/trace.rs
+++ b/test_vm/src/trace.rs
@@ -1,0 +1,143 @@
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fvm_shared::address::Address;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
+use fvm_shared::MethodNum;
+
+/// A trace of an actor method invocation.
+#[derive(Clone, Debug)]
+pub struct InvocationTrace {
+    pub from: Address,
+    pub to: Address,
+    pub value: TokenAmount,
+    pub method: MethodNum,
+    pub params: Option<IpldBlock>,
+    pub code: ExitCode,
+    pub ret: Option<IpldBlock>,
+    pub subinvocations: Vec<InvocationTrace>,
+}
+
+/// An expectation for a method invocation trace.
+/// Non-optional fields must always be specified, and are always checked against any trace.
+/// Optional fields are ignored when checking the expectation against a trace.
+// Future work:
+// - Add mutator or factory methods to allow builder-style customisation of expectations.
+// - Add a capture() option on value, params, ret etc to enable extraction of internal values
+//   while matching with an invocation trace.
+// - Make value mandatory (requires specifying the currently unknown ones).
+// - Return a top-level ExpectInvocation from helpers like util::apply_ok to save caller
+//   constructing it.
+#[derive(Clone, Debug)]
+pub struct ExpectInvocation {
+    pub from: Address,
+    pub to: Address,
+    pub method: MethodNum,
+    pub value: Option<TokenAmount>,
+    pub params: Option<Option<IpldBlock>>,
+    pub code: ExitCode,
+    pub ret: Option<Option<IpldBlock>>,
+    pub subinvocs: Option<Vec<ExpectInvocation>>,
+}
+
+impl ExpectInvocation {
+    /// Asserts that a trace matches this expectation, including subinvocations.
+    pub fn matches(&self, invoc: &InvocationTrace) {
+        let id = format!("[{}→{}:{}]", invoc.from, invoc.to, invoc.method);
+        self.quick_match(invoc, String::new());
+        assert_eq!(
+            self.code, invoc.code,
+            "{} unexpected code expected: {}, was: {}",
+            id, self.code, invoc.code
+        );
+        if let Some(v) = &self.value {
+            assert_eq!(
+                v, &invoc.value,
+                "{} unexpected value: expected: {}, was: {} ",
+                id, v, invoc.value
+            );
+        }
+        if let Some(p) = &self.params {
+            assert_eq!(
+                p, &invoc.params,
+                "{} unexpected params: expected: {:x?}, was: {:x?}",
+                id, p, invoc.params
+            );
+        }
+        if let Some(r) = &self.ret {
+            assert_eq!(
+                r, &invoc.ret,
+                "{} unexpected ret: expected: {:x?}, was: {:x?}",
+                id, r, invoc.ret
+            );
+        }
+        if let Some(expect_subinvocs) = &self.subinvocs {
+            let subinvocs = &invoc.subinvocations;
+
+            let panic_str = format!(
+                "unexpected subinvocs:\n expected: \n[\n{}]\n was:\n[\n{}]\n",
+                self.fmt_expect_invocs(expect_subinvocs),
+                self.fmt_invocs(subinvocs)
+            );
+            assert_eq!(subinvocs.len(), expect_subinvocs.len(), "{} {}", id, panic_str);
+
+            for (i, invoc) in subinvocs.iter().enumerate() {
+                let expect_invoc = expect_subinvocs.get(i).unwrap();
+                // only try to match if required fields match
+                expect_invoc.quick_match(invoc, panic_str.clone());
+                expect_invoc.matches(invoc);
+            }
+        }
+    }
+
+    pub fn fmt_invocs(&self, invocs: &[InvocationTrace]) -> String {
+        invocs
+            .iter()
+            .enumerate()
+            .map(|(i, invoc)| format!("{}: [{}:{}],\n", i, invoc.to, invoc.method))
+            .collect()
+    }
+
+    pub fn fmt_expect_invocs(&self, exs: &[ExpectInvocation]) -> String {
+        exs.iter()
+            .enumerate()
+            .map(|(i, ex)| format!("{}: [{}:{}],\n", i, ex.to, ex.method))
+            .collect()
+    }
+
+    pub fn quick_match(&self, invoc: &InvocationTrace, extra_msg: String) {
+        let id = format!("[{}→{}:{}]", invoc.from, invoc.to, invoc.method);
+        assert_eq!(
+            self.from, invoc.from,
+            "{} unexpected from addr: expected: {}, was: {} \n{}",
+            id, self.from, invoc.from, extra_msg
+        );
+        assert_eq!(
+            self.to, invoc.to,
+            "{} unexpected to addr: expected: {}, was: {} \n{}",
+            id, self.to, invoc.to, extra_msg
+        );
+        assert_eq!(
+            self.method, invoc.method,
+            "{} unexpected method: expected: {}, was: {} \n{}",
+            id, self.method, invoc.from, extra_msg
+        );
+    }
+}
+
+impl Default for ExpectInvocation {
+    // Defaults are mainly useful for ignoring optional fields with a ..Default::default() clause.
+    // The addresses must generally be provided explicitly.
+    // Defaults include successful exit code.
+    fn default() -> Self {
+        Self {
+            from: Address::new_id(0),
+            to: Address::new_id(0),
+            method: 0,
+            value: None,
+            params: None,
+            code: ExitCode::OK,
+            ret: None,
+            subinvocs: None,
+        }
+    }
+}

--- a/test_vm/tests/multisig_test.rs
+++ b/test_vm/tests/multisig_test.rs
@@ -16,8 +16,10 @@ use fvm_shared::METHOD_SEND;
 use integer_encoding::VarInt;
 use std::collections::HashSet;
 use std::iter::FromIterator;
+use test_vm::expects::Expect;
+use test_vm::trace::ExpectInvocation;
 use test_vm::util::{apply_code, apply_ok, assert_invariants, create_accounts, get_state};
-use test_vm::{ExpectInvocation, TestVM, VM};
+use test_vm::{TestVM, VM};
 
 #[test]
 fn proposal_hash() {
@@ -91,11 +93,12 @@ fn proposal_hash_test<BS: Blockstore>(v: &dyn VM<BS>, addrs: &[Address]) -> Toke
         Some(correct_approval_params),
     );
     let expect = ExpectInvocation {
+        from: bob,
         to: msig_addr,
         method: MsigMethod::Approve as u64,
         subinvocs: Some(vec![
             // Tx goes through to fund the system actor
-            ExpectInvocation { to: SYSTEM_ACTOR_ADDR, method: METHOD_SEND, ..Default::default() },
+            Expect::send(msig_addr, SYSTEM_ACTOR_ADDR, Some(fil_delta.clone())),
         ]),
         ..Default::default()
     };


### PR DESCRIPTION
This is a clean-up and improvement of integration test support code. A few considerations:
- Strengthen expectations to always check from address and exit code, and almost always check value
- Decouple trace and expectations from TestVM internals so they can later be moved to FVM repos and shared with other integration test frameworks (like anorth/fvm-workbench)
- Reduce noise associated specifying expectation details in tests with builder style constructors

Limitations:
- No handling yet for subinvocations in builder methods

Future work
- Add customisation methods to, e.g. `Expect::send(...).with_exit(ErrInsufficientFunds)`.
- Add support for subinvocations in builder
- Add workflow-style builders that encapsulate expectations for a multi-call sequence between actors.