### PR TITLE
PCA: batch internal calls

### DIFF
--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -13,6 +13,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PaddedPieceSize;
+use fvm_shared::sector::SectorNumber;
 use fvm_shared::ActorID;
 
 use crate::Label;
@@ -115,6 +116,16 @@ pub struct ActivateDealsResult {
     #[serde(with = "bigint_ser")]
     pub nonverified_deal_space: BigInt,
     pub verified_infos: Vec<VerifiedDealInfo>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+pub struct ActivateDealsBatchParams {
+    pub sectors: Vec<(ActivateDealsParams, SectorNumber)>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+pub struct ActivateDealsBatchResult {
+    pub sectors: Vec<(ActivateDealsResult, SectorNumber, ChainEpoch)>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -24,6 +24,8 @@ pub mod market {
     pub const ACTIVATE_DEALS_METHOD: u64 = 6;
     pub const ON_MINER_SECTORS_TERMINATE_METHOD: u64 = 7;
     pub const COMPUTE_DATA_COMMITMENT_METHOD: u64 = 8;
+    pub const ACTIVATE_DEALS_BATCH_EXPORTED: u64 =
+        frc42_dispatch::method_hash!("ActivateDealsBatch");
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct SectorDeals {
@@ -36,6 +38,16 @@ pub mod market {
     pub struct ActivateDealsParams {
         pub deal_ids: Vec<DealID>,
         pub sector_expiry: ChainEpoch,
+    }
+
+    #[derive(Serialize_tuple, Deserialize_tuple)]
+    pub struct ActivateDealsBatchParams {
+        pub sectors: Vec<(ActivateDealsParams, SectorNumber)>,
+    }
+
+    #[derive(Serialize_tuple, Deserialize_tuple)]
+    pub struct ActivateDealsBatchResult {
+        pub sectors: Vec<(ActivateDealsResult, SectorNumber, ChainEpoch)>,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
@@ -160,6 +172,8 @@ pub mod verifreg {
 
     pub const GET_CLAIMS_METHOD: u64 = 10;
     pub const CLAIM_ALLOCATIONS_METHOD: u64 = 9;
+    pub const CLAIM_ALLOCATIONS_BATCH_METHOD: u64 =
+        frc42_dispatch::method_hash!("ClaimAllocationsBatch");
 
     pub type ClaimID = u64;
     pub type AllocationID = u64;
@@ -215,5 +229,15 @@ pub mod verifreg {
         pub batch_info: BatchReturn,
         #[serde(with = "bigint_ser")]
         pub claimed_space: BigInt,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+    pub struct ClaimAllocationsBatchParams {
+        pub claims: Vec<ClaimAllocationsParams>,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+    pub struct ClaimAllocationsBatchReturn {
+        pub claims: Vec<ClaimAllocationsReturn>,
     }
 }

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -71,6 +71,7 @@ pub enum Method {
     ExtendClaimTermsExported = frc42_dispatch::method_hash!("ExtendClaimTerms"),
     RemoveExpiredClaimsExported = frc42_dispatch::method_hash!("RemoveExpiredClaims"),
     UniversalReceiverHook = frc42_dispatch::method_hash!("Receive"),
+    ClaimAllocationsBatch = frc42_dispatch::method_hash!("ClaimAllocationsBatch"),
 }
 
 pub struct Actor;
@@ -363,6 +364,110 @@ impl Actor {
         })
     }
 
+    pub fn claim_allocations_batch(
+        rt: &impl Runtime,
+        params: ClaimAllocationsBatchParams,
+    ) -> Result<ClaimAllocationsBatchReturn, ActorError> {
+        rt.validate_immediate_caller_type(std::iter::once(&Type::Miner))?;
+        let provider = rt.message().caller().id().unwrap();
+        if params.claims.iter().all(|claim| claim.sectors.is_empty()) {
+            return Err(actor_error!(illegal_argument, "claim allocations called with no claims"));
+        }
+
+        let mut rets: Vec<ClaimAllocationsReturn> = Vec::new();
+
+        for p in params.claims {
+            let mut datacap_claimed = DataCap::zero();
+            let mut ret_gen = BatchReturnGen::new(p.sectors.len());
+            let all_or_nothing = p.all_or_nothing;
+            rt.transaction(|st: &mut State, rt| {
+                let mut claims = st.load_claims(rt.store())?;
+                let mut allocs = st.load_allocs(rt.store())?;
+
+                for claim_alloc in p.sectors {
+                    let maybe_alloc = state::get_allocation(
+                        &mut allocs,
+                        claim_alloc.client,
+                        claim_alloc.allocation_id,
+                    )?;
+                    let alloc: &Allocation = match maybe_alloc {
+                        None => {
+                            ret_gen.add_fail(ExitCode::USR_NOT_FOUND);
+                            info!(
+                                "no allocation {} for client {}",
+                                claim_alloc.allocation_id, claim_alloc.client,
+                            );
+                            continue;
+                        }
+                        Some(a) => a,
+                    };
+
+                    if !can_claim_alloc(&claim_alloc, provider, alloc, rt.curr_epoch()) {
+                        ret_gen.add_fail(ExitCode::USR_FORBIDDEN);
+                        info!(
+                            "invalid sector {:?} for allocation {}",
+                            claim_alloc.sector, claim_alloc.allocation_id,
+                        );
+                        continue;
+                    }
+
+                    let new_claim = Claim {
+                        provider,
+                        client: alloc.client,
+                        data: alloc.data,
+                        size: alloc.size,
+                        term_min: alloc.term_min,
+                        term_max: alloc.term_max,
+                        term_start: rt.curr_epoch(),
+                        sector: claim_alloc.sector,
+                    };
+
+                    let inserted = claims
+                        .put_if_absent(provider, claim_alloc.allocation_id, new_claim)
+                        .context_code(
+                            ExitCode::USR_ILLEGAL_STATE,
+                            format!("failed to write claim {}", claim_alloc.allocation_id),
+                        )?;
+                    if !inserted {
+                        ret_gen.add_fail(ExitCode::USR_ILLEGAL_STATE);
+                        // should be unreachable since claim and alloc can't exist at once
+                        info!(
+                            "claim for allocation {} could not be inserted as it already exists",
+                            claim_alloc.allocation_id,
+                        );
+                        continue;
+                    }
+
+                    allocs.remove(claim_alloc.client, claim_alloc.allocation_id).context_code(
+                        ExitCode::USR_ILLEGAL_STATE,
+                        format!("failed to remove allocation {}", claim_alloc.allocation_id),
+                    )?;
+
+                    datacap_claimed += DataCap::from(claim_alloc.size.0);
+                    ret_gen.add_success();
+                }
+                st.save_allocs(&mut allocs)?;
+                st.save_claims(&mut claims)?;
+                Ok(())
+            })
+            .context("state transaction failed")?;
+            let batch_info = ret_gen.gen();
+            if all_or_nothing && !batch_info.all_ok() {
+                return Err(actor_error!(
+                    illegal_argument,
+                    "all or nothing call contained failures: {}",
+                    batch_info.to_string()
+                ));
+            }
+
+            // Burn the datacap tokens from verified registry's own balance.
+            burn(rt, &datacap_claimed)?;
+
+            rets.push(ClaimAllocationsReturn { batch_info, claimed_space: datacap_claimed });
+        }
+
+        Ok(ClaimAllocationsBatchReturn { claims: rets })
+    }
     // Called by storage provider actor to claim allocations for data provably committed to storage.
     // For each allocation claim, the registry checks that the provided piece CID
     // and size match that of the allocation.
@@ -1089,5 +1194,6 @@ impl ActorCode for Actor {
         ExtendClaimTerms|ExtendClaimTermsExported => extend_claim_terms,
         RemoveExpiredClaims|RemoveExpiredClaimsExported => remove_expired_claims,
         UniversalReceiverHook => universal_receiver_hook,
+        ClaimAllocationsBatch => claim_allocations_batch,
     }
 }

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -144,6 +144,16 @@ pub struct ClaimAllocationsReturn {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct ClaimAllocationsBatchParams {
+    pub claims: Vec<ClaimAllocationsParams>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct ClaimAllocationsBatchReturn {
+    pub claims: Vec<ClaimAllocationsReturn>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ClaimTerm {
     pub provider: ActorID,
     pub claim_id: ClaimID,

--- a/test_vm/tests/batch_onboarding_deals_test.rs
+++ b/test_vm/tests/batch_onboarding_deals_test.rs
@@ -11,8 +11,8 @@ use num_traits::Zero;
 
 use fil_actor_market::{deal_id_key, DealProposal};
 use fil_actor_miner::{
-    max_prove_commit_duration, power_for_sector, CompactCommD, SectorPreCommitOnChainInfo,
-    State as MinerState,
+    max_prove_commit_duration, power_for_sector, CompactCommD, SectorPreCommitInfo,
+    SectorPreCommitOnChainInfo, State as MinerState,
 };
 use fil_actor_miner::{Method as MinerMethod, ProveCommitAggregateParams};
 use fil_actors_runtime::runtime::policy::policy_constants::PRE_COMMIT_CHALLENGE_DELAY;
@@ -94,7 +94,7 @@ pub fn batch_onboarding_deals_test<BS: Blockstore>(v: &dyn VM<BS>) {
         .collect();
 
     // Pre-commit as single batch.
-    let precommits = precommit_sectors_v2(
+    let mut precommits = precommit_sectors_v2(
         v,
         BATCH_SIZE,
         BATCH_SIZE,
@@ -108,6 +108,13 @@ pub fn batch_onboarding_deals_test<BS: Blockstore>(v: &dyn VM<BS>) {
         PRECOMMIT_V2,
     );
     let first_sector_no = precommits[0].info.sector_number;
+
+    // add a bad precommit to the batch
+    precommits.push(SectorPreCommitOnChainInfo {
+        info: SectorPreCommitInfo { ..Default::default() },
+        pre_commit_deposit: TokenAmount::from_atto(1000),
+        pre_commit_epoch: ChainEpoch::default(),
+    });
 
     // Prove-commit as a single aggregate.
     v.set_epoch(v.epoch() + PRE_COMMIT_CHALLENGE_DELAY + 1);


### PR DESCRIPTION
WIP for https://github.com/filecoin-project/builtin-actors/issues/1278

A preliminary attempt at batching some of the internal calls of PCA in order to reduce gas usage. The code factoring is in need of improvement but this is just an early attempt to see the impact of batching multiple calls into one. This PR introduces batchy versions of:
- Market::ActivateDeals
- Registry::ClaimAllocations

The initial traces show a ~7-10% reduction in gas usage when a batch of 8 sectors are proved together. Which can be seen [here](https://gist.github.com/alexytsu/8981c9bfe9525fc18d5a058f7d590c30)

The total message cost goes down even less ~5%. There's may be internal optimisations to make the batchy methods more efficient but simply batching the method calls seems to only have a smallish effect.
