### PR TITLE
Batch ClaimAllocations during ProveCommitAggregate

### DIFF
--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -216,7 +216,6 @@ pub mod verifreg {
         #[serde(with = "bigint_ser")]
         pub claimed_space: BigInt,
         pub sector: SectorNumber,
-        pub sector_expiry: ChainEpoch,
     }
 
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -221,6 +221,8 @@ pub mod verifreg {
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
     #[serde(transparent)]
     pub struct ClaimAllocationsReturn {
+        /// claim_results is parallel to ClaimAllocationsParams.allocations with failed allocations
+        /// being represented by claimed_space == BigInt::zero()
         pub claim_results: Vec<SectorAllocationClaimResult>,
     }
 }

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -57,7 +57,7 @@ pub mod market {
         }
     }
 
-    #[derive(Serialize_tuple, Deserialize_tuple)]
+    #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
     pub struct ActivateDealsResult {
         #[serde(with = "bigint_ser")]
         pub nonverified_deal_space: BigInt,
@@ -210,10 +210,18 @@ pub mod verifreg {
         pub sectors: Vec<SectorAllocationClaim>,
         pub all_or_nothing: bool,
     }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+    pub struct SectorAllocationClaimResult {
+        #[serde(with = "bigint_ser")]
+        pub claimed_space: BigInt,
+        pub sector: SectorNumber,
+        pub sector_expiry: ChainEpoch,
+    }
+
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
     pub struct ClaimAllocationsReturn {
         pub batch_info: BatchReturn,
-        #[serde(with = "bigint_ser")]
-        pub claimed_space: BigInt,
+        pub claim_results: Vec<SectorAllocationClaimResult>,
     }
 }

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -207,7 +207,7 @@ pub mod verifreg {
 
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
     pub struct ClaimAllocationsParams {
-        pub sectors: Vec<SectorAllocationClaim>,
+        pub allocations: Vec<SectorAllocationClaim>,
         pub all_or_nothing: bool,
     }
 

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -211,16 +211,16 @@ pub mod verifreg {
         pub all_or_nothing: bool,
     }
 
-    #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+    #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize_tuple, Deserialize_tuple)]
+    #[serde(transparent)]
     pub struct SectorAllocationClaimResult {
         #[serde(with = "bigint_ser")]
         pub claimed_space: BigInt,
-        pub sector: SectorNumber,
     }
 
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+    #[serde(transparent)]
     pub struct ClaimAllocationsReturn {
-        pub batch_info: BatchReturn,
         pub claim_results: Vec<SectorAllocationClaimResult>,
     }
 }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -5012,7 +5012,7 @@ fn batch_activate_deals_and_claim_allocations(
     }
 
     // When all prove commits have failed abort early
-    if activation_results.is_empty() {
+    if activation_results.iter().all(|res| res.is_none()) {
         return Err(actor_error!(illegal_argument, "all sectors failed to activate"));
     }
 

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -5040,7 +5040,7 @@ fn batch_activate_deals_and_claim_allocations(
             &VERIFIED_REGISTRY_ACTOR_ADDR,
             ext::verifreg::CLAIM_ALLOCATIONS_METHOD,
             IpldBlock::serialize_cbor(&ext::verifreg::ClaimAllocationsParams {
-                sectors: sectors_claims,
+                allocations: sectors_claims,
                 all_or_nothing: true,
             })?,
             TokenAmount::zero(),
@@ -5130,7 +5130,7 @@ fn activate_deals_and_claim_allocations(
         &VERIFIED_REGISTRY_ACTOR_ADDR,
         ext::verifreg::CLAIM_ALLOCATIONS_METHOD,
         IpldBlock::serialize_cbor(&ext::verifreg::ClaimAllocationsParams {
-            sectors: sector_claims,
+            allocations: sector_claims,
             all_or_nothing: true,
         })?,
         TokenAmount::zero(),

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -380,13 +380,6 @@ pub struct DisputeWindowedPoStParams {
     pub post_index: u64, // only one is allowed at a time to avoid loading too many sector infos.
 }
 
-#[derive(Debug, Clone)]
-pub struct DealsActivationInfo {
-    pub deal_ids: Vec<DealID>,
-    pub sector_expiry: ChainEpoch,
-    pub sector_number: SectorNumber,
-}
-
 #[derive(Debug, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct ProveCommitAggregateParams {
     pub sector_numbers: BitField,

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -380,6 +380,13 @@ pub struct DisputeWindowedPoStParams {
     pub post_index: u64, // only one is allowed at a time to avoid loading too many sector infos.
 }
 
+#[derive(Debug, Clone)]
+pub struct DealsActivationInfo {
+    pub deal_ids: Vec<DealID>,
+    pub sector_expiry: ChainEpoch,
+    pub sector_number: SectorNumber,
+}
+
 #[derive(Debug, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct ProveCommitAggregateParams {
     pub sector_numbers: BitField,

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1116,31 +1116,32 @@ impl ActorHarness {
             }
         }
 
-        let claim_allocation_params =
-            ClaimAllocationsParams { sectors: sectors_claims.clone(), all_or_nothing: true };
+        if !sectors_claims.is_empty() {
+            let claim_allocation_params =
+                ClaimAllocationsParams { sectors: sectors_claims.clone(), all_or_nothing: true };
 
-        // TODO handle failures of claim allocations
-        // use exit code map for claim allocations in config
+            // TODO handle failures of claim allocations
+            // use exit code map for claim allocations in config
 
-        let claim_allocs_ret = ClaimAllocationsReturn {
-            batch_info: BatchReturn::ok(sectors_claims.len() as u32),
-            claim_results: sectors_claims
-                .iter()
-                .map(|claim| SectorAllocationClaimResult {
-                    claimed_space: claim.size.0.into(),
-                    sector: claim.sector,
-                    sector_expiry: claim.sector_expiry,
-                })
-                .collect(),
-        };
-        rt.expect_send_simple(
-            VERIFIED_REGISTRY_ACTOR_ADDR,
-            CLAIM_ALLOCATIONS_METHOD as u64,
-            IpldBlock::serialize_cbor(&claim_allocation_params).unwrap(),
-            TokenAmount::zero(),
-            IpldBlock::serialize_cbor(&claim_allocs_ret).unwrap(),
-            ExitCode::OK,
-        );
+            let claim_allocs_ret = ClaimAllocationsReturn {
+                batch_info: BatchReturn::ok(sectors_claims.len() as u32),
+                claim_results: sectors_claims
+                    .iter()
+                    .map(|claim| SectorAllocationClaimResult {
+                        claimed_space: claim.size.0.into(),
+                        sector: claim.sector,
+                    })
+                    .collect(),
+            };
+            rt.expect_send_simple(
+                VERIFIED_REGISTRY_ACTOR_ADDR,
+                CLAIM_ALLOCATIONS_METHOD as u64,
+                IpldBlock::serialize_cbor(&claim_allocation_params).unwrap(),
+                TokenAmount::zero(),
+                IpldBlock::serialize_cbor(&claim_allocs_ret).unwrap(),
+                ExitCode::OK,
+            );
+        }
 
         if !valid_pcs.is_empty() {
             let mut expected_pledge = TokenAmount::zero();

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1117,8 +1117,10 @@ impl ActorHarness {
         }
 
         if !sectors_claims.is_empty() {
-            let claim_allocation_params =
-                ClaimAllocationsParams { sectors: sectors_claims.clone(), all_or_nothing: true };
+            let claim_allocation_params = ClaimAllocationsParams {
+                allocations: sectors_claims.clone(),
+                all_or_nothing: true,
+            };
 
             // TODO handle failures of claim allocations
             // use exit code map for claim allocations in config

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -9,7 +9,8 @@ use fil_actor_market::{
 use fil_actor_miner::ext::market::ON_MINER_SECTORS_TERMINATE_METHOD;
 use fil_actor_miner::ext::power::{UPDATE_CLAIMED_POWER_METHOD, UPDATE_PLEDGE_TOTAL_METHOD};
 use fil_actor_miner::ext::verifreg::{
-    ClaimAllocationsParams, ClaimAllocationsReturn, SectorAllocationClaim, CLAIM_ALLOCATIONS_METHOD,
+    ClaimAllocationsParams, ClaimAllocationsReturn, SectorAllocationClaim,
+    SectorAllocationClaimResult, CLAIM_ALLOCATIONS_METHOD,
 };
 use fil_actor_miner::{
     aggregate_pre_commit_network_fee, aggregate_prove_commit_network_fee, consensus_fault_penalty,
@@ -1053,6 +1054,9 @@ impl ActorHarness {
         pcs: &[SectorPreCommitOnChainInfo],
     ) {
         let mut valid_pcs = Vec::new();
+        // claim FIL+ allocations
+        let mut sectors_claims: Vec<SectorAllocationClaim> = Vec::new();
+
         for pc in pcs {
             if !pc.info.deal_ids.is_empty() {
                 let deal_spaces = cfg.deal_spaces(&pc.info.sector_number);
@@ -1091,8 +1095,7 @@ impl ActorHarness {
                         valid_pcs.push(pc);
                     }
                 } else {
-                    // calim FIL+ allocations
-                    let sector_claims = ret
+                    let mut sector_claims: Vec<SectorAllocationClaim> = ret
                         .verified_infos
                         .iter()
                         .map(|info| SectorAllocationClaim {
@@ -1104,30 +1107,40 @@ impl ActorHarness {
                             sector_expiry: pc.info.expiration,
                         })
                         .collect();
-
-                    let claim_allocation_params =
-                        ClaimAllocationsParams { sectors: sector_claims, all_or_nothing: true };
-
-                    // TODO handle failures of claim allocations
-                    // use exit code map for claim allocations in config
+                    sectors_claims.append(&mut sector_claims);
                     valid_pcs.push(pc);
-                    let claim_allocs_ret = ClaimAllocationsReturn {
-                        batch_info: BatchReturn::ok(ret.verified_infos.len() as u32),
-                        claimed_space: deal_spaces.verified_deal_space,
-                    };
-                    rt.expect_send_simple(
-                        VERIFIED_REGISTRY_ACTOR_ADDR,
-                        CLAIM_ALLOCATIONS_METHOD as u64,
-                        IpldBlock::serialize_cbor(&claim_allocation_params).unwrap(),
-                        TokenAmount::zero(),
-                        IpldBlock::serialize_cbor(&claim_allocs_ret).unwrap(),
-                        ExitCode::OK,
-                    );
                 }
             } else {
+                // empty deal ids
                 valid_pcs.push(pc);
             }
         }
+
+        let claim_allocation_params =
+            ClaimAllocationsParams { sectors: sectors_claims.clone(), all_or_nothing: true };
+
+        // TODO handle failures of claim allocations
+        // use exit code map for claim allocations in config
+
+        let claim_allocs_ret = ClaimAllocationsReturn {
+            batch_info: BatchReturn::ok(sectors_claims.len() as u32),
+            claim_results: sectors_claims
+                .iter()
+                .map(|claim| SectorAllocationClaimResult {
+                    claimed_space: claim.size.0.into(),
+                    sector: claim.sector,
+                    sector_expiry: claim.sector_expiry,
+                })
+                .collect(),
+        };
+        rt.expect_send_simple(
+            VERIFIED_REGISTRY_ACTOR_ADDR,
+            CLAIM_ALLOCATIONS_METHOD as u64,
+            IpldBlock::serialize_cbor(&claim_allocation_params).unwrap(),
+            TokenAmount::zero(),
+            IpldBlock::serialize_cbor(&claim_allocs_ret).unwrap(),
+            ExitCode::OK,
+        );
 
         if !valid_pcs.is_empty() {
             let mut expected_pledge = TokenAmount::zero();

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -44,7 +44,7 @@ use fil_actor_miner::ext::verifreg::{
 };
 
 use fil_actors_runtime::runtime::{DomainSeparationTag, Policy, Runtime, RuntimePolicy};
-use fil_actors_runtime::{test_utils::*, BatchReturn, BatchReturnGen};
+use fil_actors_runtime::{test_utils::*, BatchReturnGen};
 use fil_actors_runtime::{
     ActorDowncast, ActorError, Array, DealWeight, MessageAccumulator, BURNT_FUNDS_ACTOR_ADDR,
     INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
@@ -1126,13 +1126,9 @@ impl ActorHarness {
             // use exit code map for claim allocations in config
 
             let claim_allocs_ret = ClaimAllocationsReturn {
-                batch_info: BatchReturn::ok(sectors_claims.len() as u32),
                 claim_results: sectors_claims
                     .iter()
-                    .map(|claim| SectorAllocationClaimResult {
-                        claimed_space: claim.size.0.into(),
-                        sector: claim.sector,
-                    })
+                    .map(|claim| SectorAllocationClaimResult { claimed_space: claim.size.0.into() })
                     .collect(),
             };
             rt.expect_send_simple(

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -449,7 +449,6 @@ impl Actor {
                     sector_allocations.push(SectorAllocationClaimResult {
                         claimed_space: claim_alloc.size.0.into(),
                         sector: claim_alloc.sector,
-                        sector_expiry: claim_alloc.sector_expiry,
                     });
                 }
                 st.save_allocs(&mut allocs)?;

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -706,14 +706,6 @@ impl Actor {
     }
 }
 
-// Gets the total claimed_power_across sectors for a claim_allocation
-pub fn total_claimed_space(claim_allocations_ret: &ClaimAllocationsReturn) -> BigInt {
-    claim_allocations_ret
-        .claim_results
-        .iter()
-        .fold(BigInt::zero(), |acc, claim_result| acc + claim_result.claimed_space.clone())
-}
-
 // Checks whether an address has a verifier entry (which could be zero).
 fn is_verifier(rt: &impl Runtime, st: &State, address: Address) -> Result<bool, ActorError> {
     let verifiers =

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -137,10 +137,17 @@ pub struct ClaimAllocationsParams {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct ClaimAllocationsReturn {
-    pub batch_info: BatchReturn,
+pub struct SectorAllocationClaimResult {
     #[serde(with = "bigint_ser")]
     pub claimed_space: BigInt,
+    pub sector: SectorNumber,
+    pub sector_expiry: ChainEpoch,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct ClaimAllocationsReturn {
+    pub batch_info: BatchReturn,
+    pub claim_results: Vec<SectorAllocationClaimResult>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -136,16 +136,16 @@ pub struct ClaimAllocationsParams {
     pub all_or_nothing: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
 pub struct SectorAllocationClaimResult {
     #[serde(with = "bigint_ser")]
     pub claimed_space: BigInt,
-    pub sector: SectorNumber,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
 pub struct ClaimAllocationsReturn {
-    pub batch_info: BatchReturn,
     pub claim_results: Vec<SectorAllocationClaimResult>,
 }
 

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -146,6 +146,8 @@ pub struct SectorAllocationClaimResult {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 #[serde(transparent)]
 pub struct ClaimAllocationsReturn {
+    /// claim_results is parallel to ClaimAllocationsParams.allocations with failed allocations
+    /// being represented by claimed_space == BigInt::zero()
     pub claim_results: Vec<SectorAllocationClaimResult>,
 }
 

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -141,7 +141,6 @@ pub struct SectorAllocationClaimResult {
     #[serde(with = "bigint_ser")]
     pub claimed_space: BigInt,
     pub sector: SectorNumber,
-    pub sector_expiry: ChainEpoch,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -132,7 +132,7 @@ pub struct SectorAllocationClaim {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ClaimAllocationsParams {
-    pub sectors: Vec<SectorAllocationClaim>,
+    pub allocations: Vec<SectorAllocationClaim>,
     pub all_or_nothing: bool,
 }
 

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -278,7 +278,7 @@ impl Harness {
             );
         }
 
-        let params = ClaimAllocationsParams { sectors: claim_allocs, all_or_nothing };
+        let params = ClaimAllocationsParams { allocations: claim_allocs, all_or_nothing };
         let ret = rt
             .call::<VerifregActor>(
                 Method::ClaimAllocations as MethodNum,

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -502,8 +502,8 @@ mod allocs_claims {
     use std::str::FromStr;
 
     use fil_actor_verifreg::{
-        Actor, AllocationID, ClaimTerm, DataCap, ExtendClaimTermsParams, GetClaimsParams,
-        GetClaimsReturn, Method, State,
+        total_claimed_space, Actor, AllocationID, ClaimTerm, DataCap, ExtendClaimTermsParams,
+        GetClaimsParams, GetClaimsReturn, Method, State,
     };
     use fil_actor_verifreg::{Claim, ExtendClaimTermsReturn};
     use fil_actors_runtime::runtime::policy_constants::{
@@ -645,7 +645,7 @@ mod allocs_claims {
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, size * 2, false).unwrap();
 
             assert_eq!(ret.batch_info.codes(), vec![ExitCode::OK, ExitCode::OK]);
-            assert_eq!(ret.claimed_space, BigInt::from(2 * size));
+            assert_eq!(total_claimed_space(&ret), BigInt::from(2 * size));
             assert_alloc_claimed(&rt, CLIENT1, PROVIDER1, 1, &alloc1, 0, sector);
             assert_alloc_claimed(&rt, CLIENT2, PROVIDER1, 2, &alloc2, 0, sector);
             h.check_state(&rt);
@@ -660,7 +660,7 @@ mod allocs_claims {
             reqs[1].client = CLIENT1;
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, size, false).unwrap();
             assert_eq!(ret.batch_info.codes(), vec![ExitCode::OK, ExitCode::USR_NOT_FOUND]);
-            assert_eq!(ret.claimed_space, BigInt::from(size));
+            assert_eq!(total_claimed_space(&ret), BigInt::from(size));
             assert_alloc_claimed(&rt, CLIENT1, PROVIDER1, 1, &alloc1, 0, sector);
             assert_allocation(&rt, CLIENT2, 2, &alloc2);
             h.check_state(&rt);
@@ -674,7 +674,7 @@ mod allocs_claims {
             ];
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, size, false).unwrap();
             assert_eq!(ret.batch_info.codes(), vec![ExitCode::OK, ExitCode::USR_FORBIDDEN]);
-            assert_eq!(ret.claimed_space, BigInt::from(size));
+            assert_eq!(total_claimed_space(&ret), BigInt::from(size));
             assert_alloc_claimed(&rt, CLIENT1, PROVIDER1, 2, &alloc2, 0, sector);
             assert_allocation(&rt, CLIENT1, 3, &alloc3);
             h.check_state(&rt);
@@ -695,7 +695,7 @@ mod allocs_claims {
                 ret.batch_info.codes(),
                 vec![ExitCode::USR_FORBIDDEN, ExitCode::USR_FORBIDDEN]
             );
-            assert_eq!(ret.claimed_space, BigInt::zero());
+            assert_eq!(total_claimed_space(&ret), BigInt::zero());
             h.check_state(&rt);
         }
         {
@@ -705,7 +705,7 @@ mod allocs_claims {
             rt.set_epoch(alloc1.expiration + 1);
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
             assert_eq!(ret.batch_info.codes(), vec![ExitCode::USR_FORBIDDEN]);
-            assert_eq!(ret.claimed_space, BigInt::zero());
+            assert_eq!(total_claimed_space(&ret), BigInt::zero());
             h.check_state(&rt);
         }
         {
@@ -718,7 +718,7 @@ mod allocs_claims {
             let reqs = vec![make_claim_req(1, &alloc1, sector, alloc1.term_max + 1)];
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
             assert_eq!(ret.batch_info.codes(), vec![ExitCode::USR_FORBIDDEN]);
-            assert_eq!(ret.claimed_space, BigInt::zero());
+            assert_eq!(total_claimed_space(&ret), BigInt::zero());
             h.check_state(&rt);
         }
     }

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -724,8 +724,10 @@ mod allocs_claims {
             // Sector expiration too soon
             rt.replace_state(&prior_state);
             let reqs = vec![make_claim_req(1, &alloc1, sector, alloc1.term_min - 1)];
-            let _ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
-            // assert_eq!(ret.batch_info.codes(), vec![ExitCode::USR_FORBIDDEN]);
+            let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
+            assert_eq!(ret.claim_results.len(), 1);
+            assert_eq!(total_claimed_space(&ret), BigInt::zero());
+
             // Sector expiration too late
             let reqs = vec![make_claim_req(1, &alloc1, sector, alloc1.term_max + 1)];
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -705,8 +705,8 @@ mod allocs_claims {
             reqs[1].size = PaddedPieceSize(size + 1);
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
             assert_eq!(ret.claim_results.len(), 2);
-            assert!(!ret.claim_results[0].claimed_space.is_zero());
-            assert!(!ret.claim_results[1].claimed_space.is_zero());
+            assert!(ret.claim_results[0].claimed_space.is_zero());
+            assert!(ret.claim_results[1].claimed_space.is_zero());
             assert_eq!(total_claimed_space(&ret), BigInt::zero());
             h.check_state(&rt);
         }


### PR DESCRIPTION
Work towards #1278.

TODOs
- [x] Make existing tests pass with new expectations
- [x] Fix return values so that a followup can support partially successful batches of DealActivation

Batching of claim allocations saves both messaging overheads and state mutation costs by only updating the DataCap actor once. The full stack traces can be found [here](https://gist.github.com/alexytsu/8981c9bfe9525fc18d5a058f7d590c30).

The total gas costs for the PCA message drops approximately ~25%

Before:
```
Span[Root, self: {sum=0, none=0}, total: {sum=322,973,688, OnVerifyAggregateSeals=115,956,010, OnBlockLink=101,446,488, wasm_exec=43,387,915, OnBlockOpenBase=31,302,480, OnSyscall=14,112,000, wasm_memory_init=12,504,269, OnMethodInvocation=2,100,000, wasm_memory_grow=760,218, OnActorUpdate=475,000, OnBlockOpenPerByte=382,410, OnGetRandomness=344,160, OnBlockCreate=171,410, OnBlockRead=15,907, OnHashing=9,422, OnValueTransfer=6,000, OnGetActorCodeCid=0, OnBlockStat=0, OnNetworkContext=0, OnSelfBalance=0, OnGetBuiltinActorType=0, OnMessageContext=0, none=0}]
```

After:
```
Span[Root, self: {sum=0, none=0}, total: {sum=239,773,152, OnVerifyAggregateSeals=115,956,010, OnBlockLink=51,931,891, wasm_exec=32,281,749, OnBlockOpenBase=22,117,920, OnSyscall=8,526,000, wasm_memory_init=6,265,242, OnMethodInvocation=1,050,000, OnActorUpdate=475,000, wasm_memory_grow=393,216, OnGetRandomness=344,160, OnBlockOpenPerByte=308,670, OnBlockCreate=95,210, OnBlockRead=12,859, OnHashing=9,226, OnValueTransfer=6,000, none=0, OnGetBuiltinActorType=0, OnGetActorCodeCid=0, OnNetworkContext=0, OnBlockStat=0, OnMessageContext=0, OnSelfBalance=0}]
```