### PR TITLE
Batch deal activations

### DIFF
--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -550,15 +550,6 @@ impl Actor {
             for p in params.sectors {
                 let proposal_array = st.get_proposal_array(rt.store())?;
 
-                if p.deal_ids.is_empty() {
-                    activations.push(DealActivation {
-                        nonverified_deal_space: BigInt::default(),
-                        verified_infos: Vec::default(),
-                    });
-                    batch_gen.add_success();
-                    continue;
-                }
-
                 let proposals = match get_proposals(&proposal_array, &p.deal_ids, st.next_id) {
                     Ok(proposals) => proposals,
                     Err(e) => {

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -592,7 +592,9 @@ impl Actor {
                     proposals.into_iter().try_for_each(|(deal_id, proposal)| {
                         // This construction could be replaced with a single "update deal state"
                         // state method, possibly batched over all deal ids at once.
-                        let s = st.find_deal_state(rt.store(), deal_id)?;
+                        let s = st
+                            .find_deal_state(rt.store(), deal_id)
+                            .context(format!("error looking up deal state for {}", deal_id))?;
 
                         if s.is_some() {
                             return Err(actor_error!(
@@ -618,7 +620,11 @@ impl Actor {
 
                         // Extract and remove any verified allocation ID for the pending deal.
                         let allocation = st
-                            .remove_pending_deal_allocation_id(rt.store(), &deal_id_key(deal_id))?
+                            .remove_pending_deal_allocation_id(rt.store(), &deal_id_key(deal_id))
+                            .context(format!(
+                                "failed to remove pending deal allocation id {}",
+                                deal_id
+                            ))?
                             .unwrap_or((BytesKey(vec![]), NO_ALLOCATION_ID))
                             .1;
 

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -545,12 +545,12 @@ impl Actor {
         let sector_results = rt.transaction(|st: &mut State, rt| {
             let mut deal_states: Vec<(DealID, DealState)> = vec![];
 
-            let sector_results: Vec<Option<ActivateDealsResult>> = params
+            let sector_results: Vec<Option<DealActivation>> = params
                 .sectors
                 .iter()
                 .map(|p| {
                     if p.deal_ids.is_empty() {
-                        return Some(ActivateDealsResult {
+                        return Some(DealActivation {
                             nonverified_deal_space: BigInt::default(),
                             verified_infos: Vec::default(),
                         });
@@ -696,7 +696,7 @@ impl Actor {
                         }
                     }
 
-                    Some(ActivateDealsResult {
+                    Some(DealActivation {
                         nonverified_deal_space: deal_spaces.deal_space,
                         verified_infos,
                     })

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -541,6 +541,7 @@ impl Actor {
 
         let sector_results = rt.transaction(|st: &mut State, rt| {
             let mut sector_results: Vec<Option<ActivateDealsResult>> = Vec::new();
+            let mut deal_states: Vec<(DealID, DealState)> = vec![];
             for p in params.sectors {
                 let proposal_array = st.get_proposal_array(rt.store())?;
                 let proposals = get_proposals(&proposal_array, &p.deal_ids, st.next_id)?;
@@ -558,7 +559,6 @@ impl Actor {
 
                 // Update deal states
                 let mut verified_infos = Vec::new();
-                let mut deal_states: Vec<(DealID, DealState)> = vec![];
 
                 for (deal_id, proposal) in proposals {
                     // This construction could be replaced with a single "update deal state"
@@ -613,13 +613,12 @@ impl Actor {
                     ));
                 }
 
-                st.put_deal_states(rt.store(), &deal_states)?;
-
                 sector_results.push(Some(ActivateDealsResult {
                     nonverified_deal_space: deal_spaces.deal_space,
                     verified_infos,
                 }));
             }
+            st.put_deal_states(rt.store(), &deal_states)?;
             Ok(sector_results)
         })?;
 

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -590,8 +590,6 @@ impl Actor {
                 // state method, possibly batched over all deal ids at once.
                 let update_result: Result<(), ActorError> =
                     proposals.into_iter().try_for_each(|(deal_id, proposal)| {
-                        // This construction could be replaced with a single "update deal state"
-                        // state method, possibly batched over all deal ids at once.
                         let s = st
                             .find_deal_state(rt.store(), deal_id)
                             .context(format!("error looking up deal state for {}", deal_id))?;

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -688,20 +688,14 @@ impl Actor {
                         ));
                     }
 
-                    match st.put_deal_states(rt.store(), &deal_states) {
-                        Ok(_) => {}
-                        Err(e) => {
-                            log::warn!("failed to add new deals {:?}", e);
-                            return None;
-                        }
-                    }
-
                     Some(DealActivation {
                         nonverified_deal_space: deal_spaces.deal_space,
                         verified_infos,
                     })
                 })
                 .collect();
+
+            st.put_deal_states(rt.store(), &deal_states)?;
 
             Ok(sector_results)
         })?;

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -4,6 +4,7 @@
 use super::ext::verifreg::AllocationID;
 use cid::Cid;
 use fil_actors_runtime::Array;
+use fil_actors_runtime::BatchReturn;
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_encoding::strict_bytes;
 use fvm_ipld_encoding::tuple::*;
@@ -118,9 +119,9 @@ pub struct DealActivation {
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
-#[serde(transparent)]
 pub struct BatchActivateDealsResult {
-    pub sectors: Vec<Option<DealActivation>>,
+    pub activation_results: BatchReturn,
+    pub activations: Vec<DealActivation>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -97,15 +97,9 @@ pub struct SectorDealData {
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
-pub struct ActivateDealsParams {
-    pub deal_ids: Vec<DealID>,
-    pub sector_expiry: ChainEpoch,
-}
-
-#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
 #[serde(transparent)]
 pub struct BatchActivateDealsParams {
-    pub sectors: Vec<ActivateDealsParams>,
+    pub sectors: Vec<SectorDeals>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -117,7 +117,7 @@ pub struct VerifiedDealInfo {
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
-pub struct ActivateDealsResult {
+pub struct DealActivation {
     #[serde(with = "bigint_ser")]
     pub nonverified_deal_space: BigInt,
     pub verified_infos: Vec<VerifiedDealInfo>,
@@ -126,7 +126,7 @@ pub struct ActivateDealsResult {
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
 #[serde(transparent)]
 pub struct BatchActivateDealsResult {
-    pub sectors: Vec<Option<ActivateDealsResult>>,
+    pub sectors: Vec<Option<DealActivation>>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -103,6 +103,12 @@ pub struct ActivateDealsParams {
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct BatchActivateDealsParams {
+    pub sectors: Vec<ActivateDealsParams>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
 pub struct VerifiedDealInfo {
     pub client: ActorID,
     pub allocation_id: AllocationID,
@@ -115,6 +121,12 @@ pub struct ActivateDealsResult {
     #[serde(with = "bigint_ser")]
     pub nonverified_deal_space: BigInt,
     pub verified_infos: Vec<VerifiedDealInfo>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct BatchActivateDealsResult {
+    pub sectors: Vec<Option<ActivateDealsResult>>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]

--- a/actors/market/tests/activate_deal_failures.rs
+++ b/actors/market/tests/activate_deal_failures.rs
@@ -34,7 +34,7 @@ fn fail_when_caller_is_not_the_provider_of_the_deal() {
     expect_abort(
         ExitCode::USR_FORBIDDEN,
         rt.call::<MarketActor>(
-            Method::ActivateDeals as u64,
+            Method::BatchActivateDeals as u64,
             IpldBlock::serialize_cbor(&params).unwrap(),
         ),
     );
@@ -53,7 +53,7 @@ fn fail_when_caller_is_not_a_storage_miner_actor() {
     expect_abort(
         ExitCode::USR_FORBIDDEN,
         rt.call::<MarketActor>(
-            Method::ActivateDeals as u64,
+            Method::BatchActivateDeals as u64,
             IpldBlock::serialize_cbor(&params).unwrap(),
         ),
     );
@@ -72,7 +72,7 @@ fn fail_when_deal_has_not_been_published_before() {
     expect_abort(
         ExitCode::USR_NOT_FOUND,
         rt.call::<MarketActor>(
-            Method::ActivateDeals as u64,
+            Method::BatchActivateDeals as u64,
             IpldBlock::serialize_cbor(&params).unwrap(),
         ),
     );
@@ -103,7 +103,7 @@ fn fail_when_deal_has_already_been_activated() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         rt.call::<MarketActor>(
-            Method::ActivateDeals as u64,
+            Method::BatchActivateDeals as u64,
             IpldBlock::serialize_cbor(&params).unwrap(),
         ),
     );

--- a/actors/market/tests/activate_deal_failures.rs
+++ b/actors/market/tests/activate_deal_failures.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fil_actor_market::{Actor as MarketActor, Method, SectorDeals, State};
+use fil_actor_market::{Actor as MarketActor, Method, SectorDeals, State, EX_DEAL_EXPIRED};
 use fil_actor_market::{BatchActivateDealsParams, BatchActivateDealsResult};
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::builtins::Type;
@@ -47,7 +47,7 @@ fn fail_when_caller_is_not_the_provider_of_the_deal() {
         .unwrap()
         .unwrap();
     let res: BatchActivateDealsResult = IpldBlock::deserialize(&res).unwrap();
-    assert_eq!(res.sectors, vec![None]);
+    assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_FORBIDDEN]);
 
     rt.verify();
     check_state(&rt);
@@ -99,7 +99,7 @@ fn fail_when_deal_has_not_been_published_before() {
         .unwrap()
         .unwrap();
     let res: BatchActivateDealsResult = IpldBlock::deserialize(&res).unwrap();
-    assert_eq!(res.sectors, vec![None]);
+    assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_NOT_FOUND]);
 
     rt.verify();
     check_state(&rt);
@@ -136,7 +136,7 @@ fn fail_when_deal_has_already_been_activated() {
         .unwrap()
         .unwrap();
     let res: BatchActivateDealsResult = IpldBlock::deserialize(&res).unwrap();
-    assert_eq!(res.sectors, vec![None]);
+    assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_ILLEGAL_ARGUMENT]);
 
     rt.verify();
     check_state(&rt);
@@ -178,5 +178,5 @@ fn fail_when_deal_has_already_been_expired() {
     st.next_id = deal_id + 1;
 
     let res = activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id]);
-    assert_eq!(res.sectors, vec![None])
+    assert_eq!(res.activation_results.codes(), vec![EX_DEAL_EXPIRED])
 }

--- a/actors/market/tests/batch_activate_deals.rs
+++ b/actors/market/tests/batch_activate_deals.rs
@@ -1,0 +1,191 @@
+use fil_actor_market::{
+    BatchActivateDealsResult, DealMetaArray, SectorDeals, State, NO_ALLOCATION_ID,
+};
+use fil_actors_runtime::test_utils::ACCOUNT_ACTOR_CODE_ID;
+use fil_actors_runtime::EPOCHS_IN_DAY;
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
+use fvm_shared::sector::RegisteredSealProof;
+use num_traits::Zero;
+
+mod harness;
+use harness::*;
+
+const START_EPOCH: ChainEpoch = 10;
+const CURR_EPOCH: ChainEpoch = START_EPOCH;
+const END_EPOCH: ChainEpoch = 200 * EPOCHS_IN_DAY;
+const SECTOR_EXPIRY: ChainEpoch = END_EPOCH + 200;
+const MINER_ADDRESSES: MinerAddresses = MinerAddresses {
+    owner: OWNER_ADDR,
+    worker: WORKER_ADDR,
+    provider: PROVIDER_ADDR,
+    control: vec![],
+};
+
+#[test]
+fn activate_deals_across_multiple_sectors() {
+    let rt = setup();
+    let create_deal = |end_epoch, verified| {
+        create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, end_epoch, verified)
+    };
+    let verified_deal_1 = create_deal(END_EPOCH, true);
+    let unverified_deal_1 = create_deal(END_EPOCH, false);
+    let verified_deal_2 = create_deal(END_EPOCH + 1, true);
+    let unverified_deal_2 = create_deal(END_EPOCH + 2, false);
+
+    let deals =
+        [verified_deal_1.clone(), unverified_deal_1, verified_deal_2.clone(), unverified_deal_2];
+
+    let next_allocation_id = 1;
+    let datacap_required =
+        TokenAmount::from_whole(verified_deal_1.piece_size.0 + verified_deal_2.piece_size.0);
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids =
+        publish_deals(&rt, &MINER_ADDRESSES, &deals, datacap_required, next_allocation_id);
+    assert_eq!(4, deal_ids.len());
+
+    let verified_deal_1_id = deal_ids[0];
+    let unverified_deal_1_id = deal_ids[1];
+    let verified_deal_2_id = deal_ids[2];
+    let unverified_deal_2_id = deal_ids[3];
+
+    // group into sectors
+    let sectors = [
+        (END_EPOCH, vec![verified_deal_1_id, unverified_deal_1_id]), // contains both verified and unverified deals
+        (END_EPOCH + 1, vec![verified_deal_2_id]),                   // contains verified deal only
+        (END_EPOCH + 2, vec![unverified_deal_2_id]), // contains unverified deal only
+    ];
+
+    let res = batch_activate_deals(&rt, PROVIDER_ADDR, &sectors);
+
+    // three sectors activated successfully
+    assert!(res.activation_results.all_ok());
+    assert_eq!(vec![ExitCode::OK, ExitCode::OK, ExitCode::OK], res.activation_results.codes());
+
+    // all four deals were activated
+    let verified_deal_1 = get_deal_state(&rt, verified_deal_1_id);
+    let unverified_deal_1 = get_deal_state(&rt, unverified_deal_1_id);
+    let verified_deal_2 = get_deal_state(&rt, verified_deal_2_id);
+    let unverified_deal_2 = get_deal_state(&rt, unverified_deal_2_id);
+
+    // allocations were claimed successfully
+    assert_eq!(next_allocation_id, verified_deal_1.verified_claim);
+    assert_eq!(next_allocation_id + 1, verified_deal_2.verified_claim);
+    assert_eq!(NO_ALLOCATION_ID, unverified_deal_1.verified_claim);
+    assert_eq!(NO_ALLOCATION_ID, unverified_deal_2.verified_claim);
+
+    // all activated during same epoch
+    assert_eq!(0, verified_deal_1.sector_start_epoch);
+    assert_eq!(0, verified_deal_2.sector_start_epoch);
+    assert_eq!(0, unverified_deal_1.sector_start_epoch);
+    assert_eq!(0, unverified_deal_2.sector_start_epoch);
+
+    check_state(&rt);
+}
+
+#[test]
+fn sectors_fail_and_succeed_independently_during_batch_activation() {
+    let rt = setup();
+    let deal_1 = create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH, false);
+    let deal_2 = create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH, true);
+    let deal_3 = create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH + 1, false);
+    let deal_4 = create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH + 2, false);
+
+    let deals = [deal_1, deal_2.clone(), deal_3, deal_4];
+
+    let next_allocation_id = 1;
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids = publish_deals(
+        &rt,
+        &MINER_ADDRESSES,
+        &deals,
+        TokenAmount::from_whole(deal_2.piece_size.0),
+        next_allocation_id,
+    );
+    assert_eq!(4, deal_ids.len());
+
+    let id_1 = deal_ids[0];
+    let id_2 = deal_ids[1];
+    let id_3 = deal_ids[2];
+    let id_4 = deal_ids[3];
+
+    // activate the first deal so it will fail later
+    activate_deals(&rt, END_EPOCH, PROVIDER_ADDR, 0, &[id_1]);
+    // activate the third deal so it will fail later
+    activate_deals(&rt, END_EPOCH + 1, PROVIDER_ADDR, 0, &[id_3]);
+
+    let sector_type = RegisteredSealProof::StackedDRG8MiBV1;
+    // group into sectors
+    let sectors_deals = vec![
+        SectorDeals { deal_ids: vec![id_1, id_2], sector_type, sector_expiry: END_EPOCH }, // 1 bad deal causes whole sector to fail
+        SectorDeals { deal_ids: vec![id_3], sector_type, sector_expiry: END_EPOCH + 1 }, // bad deal causes whole sector to fail
+        SectorDeals { deal_ids: vec![id_4], sector_type, sector_expiry: END_EPOCH + 2 }, // sector succeeds
+    ];
+
+    let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals).unwrap();
+    let res: BatchActivateDealsResult =
+        res.unwrap().deserialize().expect("VerifyDealsForActivation failed!");
+
+    // first two sectors should fail
+    assert_eq!(1, res.activation_results.success_count);
+    assert_eq!(
+        vec![ExitCode::USR_ILLEGAL_ARGUMENT, ExitCode::USR_ILLEGAL_ARGUMENT, ExitCode::OK],
+        res.activation_results.codes()
+    );
+
+    // originally activated deals should still be active
+    let deal_1 = get_deal_state(&rt, id_1);
+    assert_eq!(0, deal_1.sector_start_epoch);
+    let deal_3 = get_deal_state(&rt, id_3);
+    assert_eq!(0, deal_3.sector_start_epoch);
+
+    // newly activated deal should be active
+    let deal_4 = get_deal_state(&rt, id_4);
+    assert_eq!(0, deal_4.sector_start_epoch);
+
+    // no state for deal2 means deal2 was not activated
+    let st: State = rt.get_state();
+    let states = DealMetaArray::load(&st.states, &rt.store).unwrap();
+    let s = states.get(id_2).unwrap();
+    assert!(s.is_none());
+
+    check_state(&rt);
+}
+
+#[test]
+fn handles_sectors_empty_of_deals_gracefully() {
+    let rt = setup();
+    let deal_1 = create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH, false);
+
+    let next_allocation_id = 1;
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids =
+        publish_deals(&rt, &MINER_ADDRESSES, &[deal_1], TokenAmount::zero(), next_allocation_id);
+    assert_eq!(1, deal_ids.len());
+
+    let id_1 = deal_ids[0];
+
+    let sector_type = RegisteredSealProof::StackedDRG8MiBV1;
+    // group into sectors
+    let sectors_deals = vec![
+        SectorDeals { deal_ids: vec![], sector_type, sector_expiry: END_EPOCH }, // empty sector
+        SectorDeals { deal_ids: vec![id_1], sector_type, sector_expiry: END_EPOCH + 1 }, // sector with one valid deal
+        SectorDeals { deal_ids: vec![], sector_type, sector_expiry: END_EPOCH + 2 }, // empty sector
+    ];
+
+    let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals).unwrap();
+    let res: BatchActivateDealsResult =
+        res.unwrap().deserialize().expect("VerifyDealsForActivation failed!");
+
+    // all sectors should succeed
+    assert!(res.activation_results.all_ok());
+    // should treat empty sectors as success
+    assert_eq!(3, res.activation_results.success_count);
+
+    // deal should have activated
+    let deal_1 = get_deal_state(&rt, id_1);
+    assert_eq!(0, deal_1.sector_start_epoch);
+
+    check_state(&rt);
+}

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -321,7 +321,7 @@ pub fn activate_deals_raw(
     let params = ActivateDealsParams { deal_ids: deal_ids.to_vec(), sector_expiry };
 
     let ret = rt.call::<MarketActor>(
-        Method::ActivateDeals as u64,
+        Method::BatchActivateDeals as u64,
         IpldBlock::serialize_cbor(&params).unwrap(),
     )?;
     rt.verify();

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use cid::Cid;
+use fil_actor_market::{BatchActivateDealsParams, BatchActivateDealsResult};
 use frc46_token::token::types::{TransferFromParams, TransferFromReturn};
 use num_traits::{FromPrimitive, Zero};
 use regex::Regex;
@@ -12,12 +13,12 @@ use fil_actor_market::ext::account::{AuthenticateMessageParams, AUTHENTICATE_MES
 use fil_actor_market::ext::verifreg::{AllocationID, AllocationRequest, AllocationsResponse};
 use fil_actor_market::{
     deal_id_key, ext, ext::miner::GetControlAddressesReturnParams, next_update_epoch,
-    testing::check_state_invariants, ActivateDealsParams, ActivateDealsResult,
-    Actor as MarketActor, ClientDealProposal, DealArray, DealMetaArray, DealProposal, DealState,
-    GetBalanceReturn, Label, MarketNotifyDealParams, Method, OnMinerSectorsTerminateParams,
-    PublishStorageDealsParams, PublishStorageDealsReturn, SectorDeals, State,
-    VerifyDealsForActivationParams, VerifyDealsForActivationReturn, WithdrawBalanceParams,
-    WithdrawBalanceReturn, MARKET_NOTIFY_DEAL_METHOD, NO_ALLOCATION_ID, PROPOSALS_AMT_BITWIDTH,
+    testing::check_state_invariants, ActivateDealsParams, Actor as MarketActor, ClientDealProposal,
+    DealArray, DealMetaArray, DealProposal, DealState, GetBalanceReturn, Label,
+    MarketNotifyDealParams, Method, OnMinerSectorsTerminateParams, PublishStorageDealsParams,
+    PublishStorageDealsReturn, SectorDeals, State, VerifyDealsForActivationParams,
+    VerifyDealsForActivationReturn, WithdrawBalanceParams, WithdrawBalanceReturn,
+    MARKET_NOTIFY_DEAL_METHOD, NO_ALLOCATION_ID, PROPOSALS_AMT_BITWIDTH,
 };
 use fil_actor_power::{CurrentTotalPowerReturn, Method as PowerMethod};
 use fil_actor_reward::Method as RewardMethod;
@@ -302,7 +303,7 @@ pub fn activate_deals(
     provider: Address,
     current_epoch: ChainEpoch,
     deal_ids: &[DealID],
-) -> ActivateDealsResult {
+) -> BatchActivateDealsResult {
     let ret = activate_deals_raw(rt, sector_expiry, provider, current_epoch, deal_ids).unwrap();
     ret.unwrap().deserialize().expect("VerifyDealsForActivation failed!")
 }
@@ -319,6 +320,7 @@ pub fn activate_deals_raw(
     rt.expect_validate_caller_type(vec![Type::Miner]);
 
     let params = ActivateDealsParams { deal_ids: deal_ids.to_vec(), sector_expiry };
+    let params = BatchActivateDealsParams { sectors: vec![params] };
 
     let ret = rt.call::<MarketActor>(
         Method::BatchActivateDeals as u64,

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -317,9 +317,10 @@ pub fn activate_deals(
     let ret: BatchActivateDealsResult =
         ret.unwrap().deserialize().expect("VerifyDealsForActivation failed!");
 
-    for (d, res) in deal_ids.iter().zip(&ret.sectors) {
-        if res.is_some() {
-            let s = get_deal_state(rt, *d);
+    // batch size was 1
+    if ret.activation_results.all_ok() {
+        for deal in deal_ids {
+            let s = get_deal_state(rt, *deal);
             assert_eq!(current_epoch, s.sector_start_epoch);
         }
     }

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -297,6 +297,20 @@ pub fn withdraw_client_balance(
     );
 }
 
+pub fn create_deal(
+    rt: &MockRuntime,
+    client_addr: Address,
+    miner_addrs: &MinerAddresses,
+    start_epoch: ChainEpoch,
+    end_epoch: ChainEpoch,
+    verified: bool,
+) -> DealProposal {
+    let mut deal =
+        generate_deal_and_add_funds(rt, client_addr, miner_addrs, start_epoch, end_epoch);
+    deal.verified_deal = verified;
+    deal
+}
+
 /// Activate a single sector of deals
 pub fn activate_deals(
     rt: &MockRuntime,
@@ -353,14 +367,7 @@ pub fn batch_activate_deals(
         ret.unwrap().deserialize().expect("VerifyDealsForActivation failed!");
 
     // check all deals were activated correctly
-    if ret.activation_results.all_ok() {
-        for (epoch, deal_ids) in sectors {
-            for deal in deal_ids {
-                let s = get_deal_state(rt, *deal);
-                assert_eq!(epoch, &s.sector_start_epoch);
-            }
-        }
-    }
+    assert!(ret.activation_results.all_ok());
 
     ret
 }

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -1705,7 +1705,7 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
         .unwrap()
         .unwrap();
     let res: BatchActivateDealsResult = IpldBlock::deserialize(&res).unwrap();
-    assert_eq!(res.sectors, vec![None]);
+    assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_ILLEGAL_ARGUMENT]);
 
     rt.verify();
     check_state(&rt);
@@ -1741,7 +1741,7 @@ fn fail_when_end_epoch_of_deal_greater_than_sector_expiry() {
         .unwrap()
         .unwrap();
     let res: BatchActivateDealsResult = IpldBlock::deserialize(&res).unwrap();
-    assert_eq!(res.sectors, vec![None]);
+    assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_ILLEGAL_ARGUMENT]);
 
     rt.verify();
     check_state(&rt);
@@ -1788,7 +1788,7 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
         .unwrap()
         .unwrap();
     let res: BatchActivateDealsResult = IpldBlock::deserialize(&res).unwrap();
-    assert_eq!(res.sectors, vec![None]);
+    assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_ILLEGAL_ARGUMENT]);
     rt.verify();
 
     // no state for deal2 means deal2 activation has failed

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -1695,7 +1695,7 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         rt.call::<MarketActor>(
-            Method::ActivateDeals as u64,
+            Method::BatchActivateDeals as u64,
             IpldBlock::serialize_cbor(&params).unwrap(),
         ),
     );
@@ -1724,7 +1724,7 @@ fn fail_when_end_epoch_of_deal_greater_than_sector_expiry() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         rt.call::<MarketActor>(
-            Method::ActivateDeals as u64,
+            Method::BatchActivateDeals as u64,
             IpldBlock::serialize_cbor(&params).unwrap(),
         ),
     );
@@ -1764,7 +1764,7 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         rt.call::<MarketActor>(
-            Method::ActivateDeals as u64,
+            Method::BatchActivateDeals as u64,
             IpldBlock::serialize_cbor(&params).unwrap(),
         ),
     );

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -5,10 +5,10 @@ use fil_actor_market::balance_table::BALANCE_TABLE_BITWIDTH;
 use fil_actor_market::policy::detail::DEAL_MAX_LABEL_SIZE;
 use fil_actor_market::{
     deal_id_key, ext, next_update_epoch, ActivateDealsParams, Actor as MarketActor,
-    ClientDealProposal, DealArray, DealMetaArray, Label, MarketNotifyDealParams, Method,
-    PublishStorageDealsParams, PublishStorageDealsReturn, State, WithdrawBalanceParams,
-    EX_DEAL_EXPIRED, MARKET_NOTIFY_DEAL_METHOD, NO_ALLOCATION_ID, PROPOSALS_AMT_BITWIDTH,
-    STATES_AMT_BITWIDTH,
+    BatchActivateDealsParams, ClientDealProposal, DealArray, DealMetaArray, Label,
+    MarketNotifyDealParams, Method, PublishStorageDealsParams, PublishStorageDealsReturn, State,
+    WithdrawBalanceParams, EX_DEAL_EXPIRED, MARKET_NOTIFY_DEAL_METHOD, NO_ALLOCATION_ID,
+    PROPOSALS_AMT_BITWIDTH, STATES_AMT_BITWIDTH,
 };
 use fil_actors_runtime::cbor::{deserialize, serialize};
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
@@ -1692,6 +1692,7 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
     rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
     rt.set_epoch(start_epoch + 1);
     let params = ActivateDealsParams { deal_ids: vec![deal_id], sector_expiry };
+    let params = BatchActivateDealsParams { sectors: vec![params] };
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         rt.call::<MarketActor>(
@@ -1721,6 +1722,7 @@ fn fail_when_end_epoch_of_deal_greater_than_sector_expiry() {
     rt.expect_validate_caller_type(vec![Type::Miner]);
     rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
     let params = ActivateDealsParams { deal_ids: vec![deal_id], sector_expiry: end_epoch - 1 };
+    let params = BatchActivateDealsParams { sectors: vec![params] };
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         rt.call::<MarketActor>(
@@ -1761,6 +1763,7 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
     rt.expect_validate_caller_type(vec![Type::Miner]);
     rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
     let params = ActivateDealsParams { deal_ids: vec![deal_id1, deal_id2], sector_expiry };
+    let params = BatchActivateDealsParams { sectors: vec![params] };
     expect_abort(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         rt.call::<MarketActor>(

--- a/actors/market/tests/random_cron_epoch_during_publish.rs
+++ b/actors/market/tests/random_cron_epoch_during_publish.rs
@@ -135,7 +135,7 @@ fn activation_after_deal_start_epoch_but_before_it_is_processed_fails() {
     rt.set_epoch(curr_epoch);
 
     let res = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, curr_epoch, &[deal_id]);
-    assert_eq!(res.sectors, vec![None]);
+    assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_ILLEGAL_ARGUMENT]);
     check_state(&rt);
 }
 

--- a/actors/market/tests/random_cron_epoch_during_publish.rs
+++ b/actors/market/tests/random_cron_epoch_during_publish.rs
@@ -3,7 +3,6 @@
 
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::Policy;
-use fil_actors_runtime::test_utils::*;
 use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::error::ExitCode;
@@ -135,10 +134,8 @@ fn activation_after_deal_start_epoch_but_before_it_is_processed_fails() {
     let curr_epoch = START_EPOCH + 1;
     rt.set_epoch(curr_epoch);
 
-    expect_abort(
-        ExitCode::USR_ILLEGAL_ARGUMENT,
-        activate_deals_raw(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, curr_epoch, &[deal_id]),
-    );
+    let res = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, curr_epoch, &[deal_id]);
+    assert_eq!(res.sectors, vec![None]);
     check_state(&rt);
 }
 

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -50,10 +50,11 @@ fn verify_deal_and_activate_to_get_deal_space_for_unverified_deal_proposal() {
         |_| None,
     );
     let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
+    let s_response = a_response.sectors[0].clone().unwrap();
     assert_eq!(1, v_response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), v_response.sectors[0].commd);
-    assert!(a_response.verified_infos.is_empty());
-    assert_eq!(BigInt::from(deal_proposal.piece_size.0), a_response.nonverified_deal_space);
+    assert!(s_response.verified_infos.is_empty());
+    assert_eq!(BigInt::from(deal_proposal.piece_size.0), s_response.nonverified_deal_space);
 
     check_state(&rt);
 }
@@ -84,16 +85,17 @@ fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
     );
 
     let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
+    let s_response = a_response.sectors[0].clone().unwrap();
 
     assert_eq!(1, response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), response.sectors[0].commd);
-    assert_eq!(1, a_response.verified_infos.len());
-    assert_eq!(deal_proposal.piece_size, a_response.verified_infos[0].size);
-    assert_eq!(deal_proposal.client.id().unwrap(), a_response.verified_infos[0].client);
-    assert_eq!(deal_proposal.piece_cid, a_response.verified_infos[0].data);
-    assert_eq!(next_allocation_id, a_response.verified_infos[0].allocation_id);
+    assert_eq!(1, s_response.verified_infos.len());
+    assert_eq!(deal_proposal.piece_size, s_response.verified_infos[0].size);
+    assert_eq!(deal_proposal.client.id().unwrap(), s_response.verified_infos[0].client);
+    assert_eq!(deal_proposal.piece_cid, s_response.verified_infos[0].data);
+    assert_eq!(next_allocation_id, s_response.verified_infos[0].allocation_id);
 
-    assert_eq!(BigInt::zero(), a_response.nonverified_deal_space);
+    assert_eq!(BigInt::zero(), s_response.nonverified_deal_space);
 
     check_state(&rt);
 }
@@ -147,12 +149,13 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
         BigInt::from(unverified_deal_1.piece_size.0 + unverified_deal_2.piece_size.0);
 
     let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &deal_ids);
+    let s_response = a_response.sectors[0].clone().unwrap();
 
     assert_eq!(1, response.sectors.len());
     let returned_verified_space: BigInt =
-        a_response.verified_infos.iter().map(|info| BigInt::from(info.size.0)).sum();
+        s_response.verified_infos.iter().map(|info| BigInt::from(info.size.0)).sum();
     assert_eq!(verified_space, returned_verified_space);
-    assert_eq!(unverified_space, a_response.nonverified_deal_space);
+    assert_eq!(unverified_space, s_response.nonverified_deal_space);
 
     check_state(&rt);
 }

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -50,7 +50,7 @@ fn verify_deal_and_activate_to_get_deal_space_for_unverified_deal_proposal() {
         |_| None,
     );
     let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
-    let s_response = a_response.sectors[0].clone().unwrap();
+    let s_response = a_response.activations.get(0).unwrap();
     assert_eq!(1, v_response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), v_response.sectors[0].commd);
     assert!(s_response.verified_infos.is_empty());
@@ -85,7 +85,7 @@ fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
     );
 
     let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
-    let s_response = a_response.sectors[0].clone().unwrap();
+    let s_response = a_response.activations.get(0).unwrap();
 
     assert_eq!(1, response.sectors.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), response.sectors[0].commd);
@@ -149,7 +149,7 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
         BigInt::from(unverified_deal_1.piece_size.0 + unverified_deal_2.piece_size.0);
 
     let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &deal_ids);
-    let s_response = a_response.sectors[0].clone().unwrap();
+    let s_response = a_response.activations.get(0).unwrap();
 
     assert_eq!(1, response.sectors.len());
     let returned_verified_space: BigInt =

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -104,10 +104,7 @@ fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
 fn verification_and_weights_for_verified_and_unverified_deals() {
     let rt = setup();
     let create_deal = |end_epoch, verified| {
-        let mut deal =
-            generate_deal_and_add_funds(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, end_epoch);
-        deal.verified_deal = verified;
-        deal
+        create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, end_epoch, verified)
     };
 
     let verified_deal_1 = create_deal(END_EPOCH, true);

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -65,9 +65,9 @@ pub mod market {
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
-    #[serde(transparent)]
     pub struct BatchActivateDealsResult {
-        pub sectors: Vec<Option<DealActivation>>,
+        pub activation_results: BatchReturn,
+        pub activations: Vec<DealActivation>,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone, Default)]

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -64,7 +64,7 @@ pub mod market {
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
-    pub struct ActivateDealsResult {
+    pub struct DealActivation {
         #[serde(with = "bigint_ser")]
         pub nonverified_deal_space: BigInt,
         pub verified_infos: Vec<VerifiedDealInfo>,
@@ -73,7 +73,7 @@ pub mod market {
     #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
     #[serde(transparent)]
     pub struct BatchActivateDealsResult {
-        pub sectors: Vec<Option<ActivateDealsResult>>,
+        pub sectors: Vec<Option<DealActivation>>,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone, Default)]

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -33,15 +33,9 @@ pub mod market {
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
-    pub struct ActivateDealsParams {
-        pub deal_ids: Vec<DealID>,
-        pub sector_expiry: ChainEpoch,
-    }
-
-    #[derive(Serialize_tuple, Deserialize_tuple)]
     #[serde(transparent)]
     pub struct BatchActivateDealsParams {
-        pub sectors: Vec<ActivateDealsParams>,
+        pub sectors: Vec<SectorDeals>,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone)]

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -21,7 +21,7 @@ pub mod market {
     use super::*;
 
     pub const VERIFY_DEALS_FOR_ACTIVATION_METHOD: u64 = 5;
-    pub const ACTIVATE_DEALS_METHOD: u64 = 6;
+    pub const BATCH_ACTIVATE_DEALS_METHOD: u64 = 6;
     pub const ON_MINER_SECTORS_TERMINATE_METHOD: u64 = 7;
     pub const COMPUTE_DATA_COMMITMENT_METHOD: u64 = 8;
 
@@ -36,6 +36,12 @@ pub mod market {
     pub struct ActivateDealsParams {
         pub deal_ids: Vec<DealID>,
         pub sector_expiry: ChainEpoch,
+    }
+
+    #[derive(Serialize_tuple, Deserialize_tuple)]
+    #[serde(transparent)]
+    pub struct BatchActivateDealsParams {
+        pub sectors: Vec<ActivateDealsParams>,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
@@ -62,6 +68,12 @@ pub mod market {
         #[serde(with = "bigint_ser")]
         pub nonverified_deal_space: BigInt,
         pub verified_infos: Vec<VerifiedDealInfo>,
+    }
+
+    #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+    #[serde(transparent)]
+    pub struct BatchActivateDealsResult {
+        pub sectors: Vec<Option<ActivateDealsResult>>,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone, Default)]

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -225,10 +225,8 @@ pub mod verifreg {
     }
 
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-    #[serde(transparent)]
     pub struct ClaimAllocationsReturn {
-        /// claim_results is parallel to ClaimAllocationsParams.allocations with failed allocations
-        /// being represented by claimed_space == BigInt::zero()
-        pub claim_results: Vec<SectorAllocationClaimResult>,
+        pub claim_results: BatchReturn,
+        pub claims: Vec<SectorAllocationClaimResult>,
     }
 }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -4992,8 +4992,7 @@ fn batch_activate_deals_and_claim_allocations(
                 })?,
                 TokenAmount::zero(),
             ))?;
-            let batch_res: ext::market::BatchActivateDealsResult = deserialize_block(activate_raw)?;
-            batch_res
+            deserialize_block::<ext::market::BatchActivateDealsResult>(activate_raw)?
         }
     };
 

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1158,6 +1158,7 @@ impl Actor {
                 deal_ids: usi.update.deals.clone(),
                 sector_number: usi.update.sector_number,
                 sector_expiry: usi.sector_info.expiration,
+                sector_type: usi.sector_info.seal_proof,
             })
             .collect();
         let deals_spaces = batch_activate_deals_and_claim_allocations(rt, &activation_infos)?;
@@ -3595,6 +3596,7 @@ pub struct DealsActivationInfo {
     pub deal_ids: Vec<DealID>,
     pub sector_expiry: ChainEpoch,
     pub sector_number: SectorNumber,
+    pub sector_type: RegisteredSealProof,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -4806,6 +4808,7 @@ fn confirm_sector_proofs_valid_internal(
             deal_ids: pc.info.deal_ids.clone(),
             sector_expiry: pc.info.expiration,
             sector_number: pc.info.sector_number,
+            sector_type: pc.info.seal_proof,
         })
         .collect();
 
@@ -4970,9 +4973,10 @@ fn batch_activate_deals_and_claim_allocations(
     let mut sector_activation_params = Vec::new();
 
     for activation_info in activation_infos {
-        sector_activation_params.push(ext::market::ActivateDealsParams {
+        sector_activation_params.push(ext::market::SectorDeals {
             deal_ids: activation_info.deal_ids.clone(),
             sector_expiry: activation_info.sector_expiry,
+            sector_type: activation_info.sector_type,
         });
     }
 

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -4981,7 +4981,7 @@ fn batch_activate_deals_and_claim_allocations(
             let activation_results = sector_activation_params
                 .iter()
                 .map(|_| {
-                    Some(ext::market::ActivateDealsResult {
+                    Some(ext::market::DealActivation {
                         nonverified_deal_space: BigInt::default(),
                         verified_infos: Vec::default(),
                     })

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1166,7 +1166,7 @@ impl Actor {
             batch_activate_deals_and_claim_allocations(rt, &activation_infos)?;
 
         // associate the successfully activated sectors with the ReplicaUpdateInner and SectorOnChainInfo
-        let validated_updates: Vec<(UpdateAndSectorInfo, ext::market::DealSpaces)> =
+        let validated_updates: Vec<(&UpdateAndSectorInfo, ext::market::DealSpaces)> =
             batch_return.successes(&update_sector_infos).into_iter().zip(deals_spaces).collect();
 
         if validated_updates.is_empty() {

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1123,20 +1123,22 @@ impl ActorHarness {
             }
         }
 
-        rt.expect_send_simple(
-            STORAGE_MARKET_ACTOR_ADDR,
-            MarketMethod::BatchActivateDeals as u64,
-            IpldBlock::serialize_cbor(&BatchActivateDealsParams {
-                sectors: sector_activation_params,
-            })
-            .unwrap(),
-            TokenAmount::zero(),
-            IpldBlock::serialize_cbor(&BatchActivateDealsResult {
-                sectors: sector_activation_results,
-            })
-            .unwrap(),
-            ExitCode::OK,
-        );
+        if !sector_activation_params.iter().all(|p| p.deal_ids.is_empty()) {
+            rt.expect_send_simple(
+                STORAGE_MARKET_ACTOR_ADDR,
+                MarketMethod::BatchActivateDeals as u64,
+                IpldBlock::serialize_cbor(&BatchActivateDealsParams {
+                    sectors: sector_activation_params,
+                })
+                .unwrap(),
+                TokenAmount::zero(),
+                IpldBlock::serialize_cbor(&BatchActivateDealsResult {
+                    sectors: sector_activation_results,
+                })
+                .unwrap(),
+                ExitCode::OK,
+            );
+        }
 
         if !sectors_claims.is_empty() {
             let claim_allocation_params = ClaimAllocationsParams {

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -44,7 +44,7 @@ use fil_actor_miner::ext::verifreg::{
 };
 
 use fil_actors_runtime::runtime::{DomainSeparationTag, Policy, Runtime, RuntimePolicy};
-use fil_actors_runtime::{test_utils::*, BatchReturnGen};
+use fil_actors_runtime::{test_utils::*, BatchReturn, BatchReturnGen};
 use fil_actors_runtime::{
     ActorDowncast, ActorError, Array, DealWeight, MessageAccumulator, BURNT_FUNDS_ACTOR_ADDR,
     INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
@@ -1156,12 +1156,12 @@ impl ActorHarness {
 
             // TODO handle failures of claim allocations
             // use exit code map for claim allocations in config
-
             let claim_allocs_ret = ClaimAllocationsReturn {
-                claim_results: sectors_claims
+                claims: sectors_claims
                     .iter()
                     .map(|claim| SectorAllocationClaimResult { claimed_space: claim.size.0.into() })
                     .collect(),
+                claim_results: BatchReturn::ok(sectors_claims.len() as u32),
             };
             rt.expect_send_simple(
                 VERIFIED_REGISTRY_ACTOR_ADDR,

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1111,6 +1111,14 @@ impl ActorHarness {
                 }
             } else {
                 // empty deal ids
+                sector_activation_params.push(ActivateDealsParams {
+                    deal_ids: vec![],
+                    sector_expiry: pc.info.expiration,
+                });
+                sector_activation_results.push(Some(ActivateDealsResult {
+                    nonverified_deal_space: BigInt::zero(),
+                    verified_infos: vec![],
+                }));
                 valid_pcs.push(pc);
             }
         }

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2,8 +2,8 @@
 
 use fil_actor_account::Method as AccountMethod;
 use fil_actor_market::{
-    ActivateDealsParams, BatchActivateDealsParams, BatchActivateDealsResult, DealActivation,
-    DealSpaces, Method as MarketMethod, OnMinerSectorsTerminateParams, SectorDealData, SectorDeals,
+    BatchActivateDealsParams, BatchActivateDealsResult, DealActivation, DealSpaces,
+    Method as MarketMethod, OnMinerSectorsTerminateParams, SectorDealData, SectorDeals,
     VerifiedDealInfo, VerifyDealsForActivationParams, VerifyDealsForActivationReturn,
 };
 use fil_actor_miner::ext::market::ON_MINER_SECTORS_TERMINATE_METHOD;
@@ -1059,15 +1059,16 @@ impl ActorHarness {
         let mut sectors_claims: Vec<SectorAllocationClaim> = Vec::new();
 
         // build expectations per sector
-        let mut sector_activation_params: Vec<ActivateDealsParams> = Vec::new();
+        let mut sector_activation_params: Vec<SectorDeals> = Vec::new();
         let mut sector_activation_results: Vec<Option<DealActivation>> = Vec::new();
 
         for pc in pcs {
             if !pc.info.deal_ids.is_empty() {
                 let deal_spaces = cfg.deal_spaces(&pc.info.sector_number);
-                let activate_params = ActivateDealsParams {
+                let activate_params = SectorDeals {
                     deal_ids: pc.info.deal_ids.clone(),
                     sector_expiry: pc.info.expiration,
+                    sector_type: pc.info.seal_proof,
                 };
                 sector_activation_params.push(activate_params);
 
@@ -1111,9 +1112,10 @@ impl ActorHarness {
                 }
             } else {
                 // empty deal ids
-                sector_activation_params.push(ActivateDealsParams {
+                sector_activation_params.push(SectorDeals {
                     deal_ids: vec![],
                     sector_expiry: pc.info.expiration,
+                    sector_type: RegisteredSealProof::StackedDRG8MiBV1,
                 });
                 sector_activation_results.push(Some(DealActivation {
                     nonverified_deal_space: BigInt::zero(),

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -2,7 +2,7 @@
 
 use fil_actor_account::Method as AccountMethod;
 use fil_actor_market::{
-    ActivateDealsParams, ActivateDealsResult, BatchActivateDealsParams, BatchActivateDealsResult,
+    ActivateDealsParams, BatchActivateDealsParams, BatchActivateDealsResult, DealActivation,
     DealSpaces, Method as MarketMethod, OnMinerSectorsTerminateParams, SectorDealData, SectorDeals,
     VerifiedDealInfo, VerifyDealsForActivationParams, VerifyDealsForActivationReturn,
 };
@@ -1060,7 +1060,7 @@ impl ActorHarness {
 
         // build expectations per sector
         let mut sector_activation_params: Vec<ActivateDealsParams> = Vec::new();
-        let mut sector_activation_results: Vec<Option<ActivateDealsResult>> = Vec::new();
+        let mut sector_activation_results: Vec<Option<DealActivation>> = Vec::new();
 
         for pc in pcs {
             if !pc.info.deal_ids.is_empty() {
@@ -1071,7 +1071,7 @@ impl ActorHarness {
                 };
                 sector_activation_params.push(activate_params);
 
-                let ret = ActivateDealsResult {
+                let ret = DealActivation {
                     nonverified_deal_space: deal_spaces.deal_space,
                     verified_infos: cfg
                         .verified_deal_infos
@@ -1115,7 +1115,7 @@ impl ActorHarness {
                     deal_ids: vec![],
                     sector_expiry: pc.info.expiration,
                 });
-                sector_activation_results.push(Some(ActivateDealsResult {
+                sector_activation_results.push(Some(DealActivation {
                     nonverified_deal_space: BigInt::zero(),
                     verified_infos: vec![],
                 }));

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1084,7 +1084,7 @@ impl ActorHarness {
 
                 rt.expect_send_simple(
                     STORAGE_MARKET_ACTOR_ADDR,
-                    MarketMethod::ActivateDeals as u64,
+                    MarketMethod::BatchActivateDeals as u64,
                     IpldBlock::serialize_cbor(&activate_params).unwrap(),
                     TokenAmount::zero(),
                     IpldBlock::serialize_cbor(&ret).unwrap(),

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -456,18 +456,19 @@ impl Actor {
             Ok(())
         })
         .context("state transaction failed")?;
-        if params.all_or_nothing && sector_claims.iter().any(|c| c.claimed_space.is_zero()) {
+        let batch_info = ret_gen.gen();
+        if params.all_or_nothing && !batch_info.all_ok() {
             return Err(actor_error!(
                 illegal_argument,
-                "all or nothing call contained failures: {:?}",
-                sector_claims
+                "all or nothing call contained failures: {}",
+                batch_info.to_string()
             ));
         }
 
         // Burn the datacap tokens from verified registry's own balance.
         burn(rt, &total_datacap_claimed)?;
 
-        Ok(ClaimAllocationsReturn { claim_results: ret_gen.gen(), claims: sector_claims })
+        Ok(ClaimAllocationsReturn { claim_results: batch_info, claims: sector_claims })
     }
 
     // get claims for a provider

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -144,11 +144,9 @@ pub struct SectorAllocationClaimResult {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-#[serde(transparent)]
 pub struct ClaimAllocationsReturn {
-    /// claim_results is parallel to ClaimAllocationsParams.allocations with failed allocations
-    /// being represented by claimed_space == BigInt::zero()
-    pub claim_results: Vec<SectorAllocationClaimResult>,
+    pub claim_results: BatchReturn,
+    pub claims: Vec<SectorAllocationClaimResult>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -31,7 +31,7 @@ mod util {
     // Gets the total claimed_power_across sectors for a claim_allocation
     pub fn total_claimed_space(claim_allocations_ret: &ClaimAllocationsReturn) -> BigInt {
         claim_allocations_ret
-            .claim_results
+            .claims
             .iter()
             .fold(BigInt::zero(), |acc, claim_result| acc + claim_result.claimed_space.clone())
     }
@@ -653,7 +653,8 @@ mod allocs_claims {
                 make_claim_req(2, &alloc2, sector, expiry),
             ];
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, size * 2, false).unwrap();
-            assert_eq!(ret.claim_results.len(), 2);
+
+            assert_eq!(ret.claim_results.codes(), vec![ExitCode::OK, ExitCode::OK]);
             assert_eq!(total_claimed_space(&ret), BigInt::from(2 * size));
             assert_alloc_claimed(&rt, CLIENT1, PROVIDER1, 1, &alloc1, 0, sector);
             assert_alloc_claimed(&rt, CLIENT2, PROVIDER1, 2, &alloc2, 0, sector);
@@ -668,9 +669,7 @@ mod allocs_claims {
             ];
             reqs[1].client = CLIENT1;
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, size, false).unwrap();
-            assert_eq!(ret.claim_results.len(), 2);
-            assert!(!ret.claim_results[0].claimed_space.is_zero());
-            assert!(ret.claim_results[1].claimed_space.is_zero());
+            assert_eq!(ret.claim_results.codes(), vec![ExitCode::OK, ExitCode::USR_NOT_FOUND]);
             assert_eq!(total_claimed_space(&ret), BigInt::from(size));
             assert_alloc_claimed(&rt, CLIENT1, PROVIDER1, 1, &alloc1, 0, sector);
             assert_allocation(&rt, CLIENT2, 2, &alloc2);
@@ -684,9 +683,7 @@ mod allocs_claims {
                 make_claim_req(3, &alloc3, sector, expiry), // Different provider
             ];
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, size, false).unwrap();
-            assert_eq!(ret.claim_results.len(), 2);
-            assert!(!ret.claim_results[0].claimed_space.is_zero());
-            assert!(ret.claim_results[1].claimed_space.is_zero());
+            assert_eq!(ret.claim_results.codes(), vec![ExitCode::OK, ExitCode::USR_FORBIDDEN]);
             assert_eq!(total_claimed_space(&ret), BigInt::from(size));
             assert_alloc_claimed(&rt, CLIENT1, PROVIDER1, 2, &alloc2, 0, sector);
             assert_allocation(&rt, CLIENT1, 3, &alloc3);
@@ -704,9 +701,10 @@ mod allocs_claims {
                     .unwrap();
             reqs[1].size = PaddedPieceSize(size + 1);
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
-            assert_eq!(ret.claim_results.len(), 2);
-            assert!(ret.claim_results[0].claimed_space.is_zero());
-            assert!(ret.claim_results[1].claimed_space.is_zero());
+            assert_eq!(
+                ret.claim_results.codes(),
+                vec![ExitCode::USR_FORBIDDEN, ExitCode::USR_FORBIDDEN]
+            );
             assert_eq!(total_claimed_space(&ret), BigInt::zero());
             h.check_state(&rt);
         }
@@ -716,7 +714,7 @@ mod allocs_claims {
             let reqs = vec![make_claim_req(1, &alloc1, sector, expiry)];
             rt.set_epoch(alloc1.expiration + 1);
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
-            assert_eq!(ret.claim_results.len(), 1);
+            assert_eq!(ret.claim_results.codes(), vec![ExitCode::USR_FORBIDDEN]);
             assert_eq!(total_claimed_space(&ret), BigInt::zero());
             h.check_state(&rt);
         }
@@ -725,13 +723,11 @@ mod allocs_claims {
             rt.replace_state(&prior_state);
             let reqs = vec![make_claim_req(1, &alloc1, sector, alloc1.term_min - 1)];
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
-            assert_eq!(ret.claim_results.len(), 1);
-            assert_eq!(total_claimed_space(&ret), BigInt::zero());
-
+            assert_eq!(ret.claim_results.codes(), vec![ExitCode::USR_FORBIDDEN]);
             // Sector expiration too late
             let reqs = vec![make_claim_req(1, &alloc1, sector, alloc1.term_max + 1)];
             let ret = h.claim_allocations(&rt, PROVIDER1, reqs, 0, false).unwrap();
-            assert_eq!(ret.claim_results.len(), 1);
+            assert_eq!(ret.claim_results.codes(), vec![ExitCode::USR_FORBIDDEN]);
             assert_eq!(total_claimed_space(&ret), BigInt::zero());
             h.check_state(&rt);
         }

--- a/runtime/src/util/batch_return.rs
+++ b/runtime/src/util/batch_return.rs
@@ -51,7 +51,7 @@ impl BatchReturn {
 
     /// Returns a subset of items corresponding to the successful indices.
     /// Panics if `items` is not the same length as this batch return.
-    pub fn successes<T: Clone>(&self, items: &[T]) -> Vec<T> {
+    pub fn successes<'i, T>(&self, items: &'i [T]) -> Vec<&'i T> {
         if items.len() != self.size() {
             panic!("items length {} does not match batch size {}", items.len(), self.size());
         }
@@ -61,7 +61,7 @@ impl BatchReturn {
             if fail_idx < self.fail_codes.len() && idx == self.fail_codes[fail_idx].idx as usize {
                 fail_idx += 1;
             } else {
-                ret.push(item.clone())
+                ret.push(item)
             }
         }
         ret

--- a/runtime/src/util/batch_return.rs
+++ b/runtime/src/util/batch_return.rs
@@ -33,7 +33,7 @@ impl BatchReturn {
         self.fail_codes.is_empty()
     }
 
-    // Returns a vector of exit codes for each item (including successes).
+    /// Returns a vector of exit codes for each item (including successes).
     pub fn codes(&self) -> Vec<ExitCode> {
         let mut ret = Vec::new();
 
@@ -49,9 +49,9 @@ impl BatchReturn {
         ret
     }
 
-    // Returns a subset of items corresponding to the successful indices.
-    // Panics if `items` is not the same length as this batch return.
-    pub fn successes<T: Copy>(&self, items: &[T]) -> Vec<T> {
+    /// Returns a subset of items corresponding to the successful indices.
+    /// Panics if `items` is not the same length as this batch return.
+    pub fn successes<T: Clone>(&self, items: &[T]) -> Vec<T> {
         if items.len() != self.size() {
             panic!("items length {} does not match batch size {}", items.len(), self.size());
         }
@@ -61,7 +61,7 @@ impl BatchReturn {
             if fail_idx < self.fail_codes.len() && idx == self.fail_codes[fail_idx].idx as usize {
                 fail_idx += 1;
             } else {
-                ret.push(*item)
+                ret.push(item.clone())
             }
         }
         ret

--- a/runtime/tests/batch_return_test.rs
+++ b/runtime/tests/batch_return_test.rs
@@ -25,7 +25,7 @@ fn batch_generation() {
     );
 
     let ret_vals = vec!["first", "second", "third", "fourth", "fifth"];
-    assert_eq!(vec!["first", "fourth"], br.successes(&ret_vals));
+    assert_eq!(vec![&"first", &"fourth"], br.successes(&ret_vals));
 }
 
 #[test]
@@ -35,14 +35,14 @@ fn batch_generation_constants() {
     assert!(br.all_ok());
     assert_eq!(vec![ExitCode::OK, ExitCode::OK, ExitCode::OK], br.codes());
     let ret_vals = vec!["first", "second", "third"];
-    assert_eq!(ret_vals, br.successes(&ret_vals));
+    assert_eq!(ret_vals.iter().collect::<Vec<&&str>>(), br.successes(&ret_vals));
 
     let br = BatchReturn::empty();
     assert_eq!(0, br.size());
     assert!(br.all_ok());
     assert_eq!(Vec::<ExitCode>::new(), br.codes());
     let empty_successes = Vec::<u64>::new();
-    assert_eq!(empty_successes, br.successes(&empty_successes));
+    assert_eq!(empty_successes.iter().collect::<Vec<&u64>>(), br.successes(&empty_successes));
 }
 
 #[test]

--- a/test_vm/src/expects.rs
+++ b/test_vm/src/expects.rs
@@ -47,7 +47,7 @@ impl Expect {
         ExpectInvocation {
             from,
             to: STORAGE_MARKET_ACTOR_ADDR,
-            method: fil_actor_market::Method::ActivateDeals as u64,
+            method: fil_actor_market::Method::BatchActivateDeals as u64,
             params: Some(params),
             value: Some(TokenAmount::zero()),
             subinvocs: Some(vec![]),

--- a/test_vm/src/expects.rs
+++ b/test_vm/src/expects.rs
@@ -13,7 +13,8 @@ use num_traits::Zero;
 use fil_actor_account::types::AuthenticateMessageParams;
 use fil_actor_datacap::BalanceParams;
 use fil_actor_market::{
-    ActivateDealsParams, OnMinerSectorsTerminateParams, SectorDeals, VerifyDealsForActivationParams,
+    ActivateDealsParams, BatchActivateDealsParams, OnMinerSectorsTerminateParams, SectorDeals,
+    VerifyDealsForActivationParams,
 };
 use fil_actor_miner::ext::verifreg::ClaimID;
 use fil_actor_miner::{IsControllingAddressParam, PowerPair};
@@ -41,9 +42,10 @@ impl Expect {
         deals: Vec<DealID>,
         sector_expiry: ChainEpoch,
     ) -> ExpectInvocation {
-        let params =
-            IpldBlock::serialize_cbor(&ActivateDealsParams { deal_ids: deals, sector_expiry })
-                .unwrap();
+        let params = IpldBlock::serialize_cbor(&BatchActivateDealsParams {
+            sectors: vec![ActivateDealsParams { deal_ids: deals, sector_expiry }],
+        })
+        .unwrap();
         ExpectInvocation {
             from,
             to: STORAGE_MARKET_ACTOR_ADDR,

--- a/test_vm/src/expects.rs
+++ b/test_vm/src/expects.rs
@@ -7,13 +7,14 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
+use fvm_shared::sector::RegisteredSealProof;
 use fvm_shared::{ActorID, METHOD_SEND};
 use num_traits::Zero;
 
 use fil_actor_account::types::AuthenticateMessageParams;
 use fil_actor_datacap::BalanceParams;
 use fil_actor_market::{
-    ActivateDealsParams, BatchActivateDealsParams, OnMinerSectorsTerminateParams, SectorDeals,
+    BatchActivateDealsParams, OnMinerSectorsTerminateParams, SectorDeals,
     VerifyDealsForActivationParams,
 };
 use fil_actor_miner::ext::verifreg::ClaimID;
@@ -41,9 +42,10 @@ impl Expect {
         from: Address,
         deals: Vec<DealID>,
         sector_expiry: ChainEpoch,
+        sector_type: RegisteredSealProof,
     ) -> ExpectInvocation {
         let params = IpldBlock::serialize_cbor(&BatchActivateDealsParams {
-            sectors: vec![ActivateDealsParams { deal_ids: deals, sector_expiry }],
+            sectors: vec![SectorDeals { deal_ids: deals, sector_expiry, sector_type }],
         })
         .unwrap();
         ExpectInvocation {

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -452,6 +452,7 @@ fn extend_updated_sector_with_claim() {
                 miner_id,
                 deal_ids.clone(),
                 initial_sector_info.expiration,
+                initial_sector_info.seal_proof,
             ),
             ExpectInvocation {
                 from: miner_id,

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -1204,7 +1204,12 @@ fn replica_update_verified_deal_test<BS: Blockstore>(v: &dyn VM<BS>) {
         to: maddr,
         method: MinerMethod::ProveReplicaUpdates2 as u64,
         subinvocs: Some(vec![
-            Expect::market_activate_deals(maddr, deal_ids.clone(), old_sector_info.expiration),
+            Expect::market_activate_deals(
+                maddr,
+                deal_ids.clone(),
+                old_sector_info.expiration,
+                old_sector_info.seal_proof,
+            ),
             ExpectInvocation {
                 from: maddr,
                 to: VERIFIED_REGISTRY_ACTOR_ADDR,


### PR DESCRIPTION
Addressing #1278 

A small tidying refactor and reduction of messaging overhead costs is seen here. Gas savings are not as significant as https://github.com/filecoin-project/builtin-actors/pull/1304 since the costliness of the state updates themselves have not been reduced per se. 

Design caveats:
- ActivateDeals is modified in place to become BatchActivateDeals (which implicitly assumes batches by sector)
- In order to more easily preserve a parallel mapping between params and results, callers (miner actor) of BatchActivateDeals no longer check for sectors with zero deals. Instead, these are handled gracefully (though through a shortcut path) in the market actor. 

TODOs
- [x] Improve parameter and result documentation
- [x] Optimise handling of sectors with zero deals
- [x] Use `map` to enforce parallel return structure