### PR TITLE
Draft: Avoid redundant VerifyDealsForActivation call in ProveReplicaUpdates

### DIFF
--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -589,9 +589,9 @@ impl Actor {
                 // This construction could be replaced with a single "update deal state"
                 // state method, possibly batched over all deal ids at once.
                 let update_result: Result<(), ActorError> =
-                    proposals.into_iter().try_for_each(|(deal_id, proposal)| {
+                    proposals.iter().try_for_each(|(deal_id, proposal)| {
                         let s = st
-                            .find_deal_state(rt.store(), deal_id)
+                            .find_deal_state(rt.store(), *deal_id)
                             .context(format!("error looking up deal state for {}", deal_id))?;
 
                         if s.is_some() {
@@ -602,7 +602,7 @@ impl Actor {
                             ));
                         }
 
-                        let propc = rt_deal_cid(rt, &proposal)?;
+                        let propc = rt_deal_cid(rt, proposal)?;
 
                         // Confirm the deal is in the pending proposals queue.
                         // It will be removed from this queue later, during cron.
@@ -618,7 +618,7 @@ impl Actor {
 
                         // Extract and remove any verified allocation ID for the pending deal.
                         let allocation = st
-                            .remove_pending_deal_allocation_id(rt.store(), &deal_id_key(deal_id))
+                            .remove_pending_deal_allocation_id(rt.store(), &deal_id_key(*deal_id))
                             .context(format!(
                                 "failed to remove pending deal allocation id {}",
                                 deal_id
@@ -636,7 +636,7 @@ impl Actor {
                         }
 
                         deal_states.push((
-                            deal_id,
+                            *deal_id,
                             DealState {
                                 sector_start_epoch: curr_epoch,
                                 last_updated_epoch: EPOCH_UNDEFINED,
@@ -644,15 +644,17 @@ impl Actor {
                                 verified_claim: allocation,
                             },
                         ));
-                        activated_deals.insert(deal_id);
+                        activated_deals.insert(*deal_id);
                         Ok(())
                     });
 
                 match update_result {
                     Ok(_) => {
+                        let commd = compute_data_commitment(rt, &proposals, p.sector_type)?;
                         activations.push(DealActivation {
                             nonverified_deal_space: deal_spaces.deal_space,
                             verified_infos,
+                            commd: Some(commd),
                         });
                         batch_gen.add_success();
                     }

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -116,6 +116,7 @@ pub struct DealActivation {
     #[serde(with = "bigint_ser")]
     pub nonverified_deal_space: BigInt,
     pub verified_infos: Vec<VerifiedDealInfo>,
+    pub commd: Option<Cid>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -62,6 +62,7 @@ pub mod market {
         #[serde(with = "bigint_ser")]
         pub nonverified_deal_space: BigInt,
         pub verified_infos: Vec<VerifiedDealInfo>,
+        pub commd: Option<Cid>,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
@@ -70,13 +71,6 @@ pub mod market {
         pub activations: Vec<DealActivation>,
     }
 
-    #[derive(Serialize_tuple, Deserialize_tuple, Clone, Default)]
-    pub struct DealSpaces {
-        #[serde(with = "bigint_ser")]
-        pub deal_space: BigInt,
-        #[serde(with = "bigint_ser")]
-        pub verified_deal_space: BigInt,
-    }
     #[derive(Serialize_tuple)]
     pub struct ComputeDataCommitmentParamsRef<'a> {
         pub inputs: &'a [SectorDataSpec],

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1080,6 +1080,7 @@ impl ActorHarness {
                         .get(&pc.info.sector_number)
                         .cloned()
                         .unwrap_or_default(),
+                    commd: None,
                 };
 
                 let mut activate_deals_exit = ExitCode::OK;
@@ -1124,6 +1125,7 @@ impl ActorHarness {
                 sector_activations.push(DealActivation {
                     nonverified_deal_space: BigInt::zero(),
                     verified_infos: vec![],
+                    commd: None,
                 });
                 sector_activation_results.add_success();
                 valid_pcs.push(pc);


### PR DESCRIPTION
Closes #1308 

TODO: 

- [ ] Update test utilities to allow different RegisteredSealProof types to be specified
- [ ] Run benchmarks to check gas-savings (also check PCA path doesn't get much more expensive)


