### PR TITLE
check sectors.is_empty() at the more proper position

### DIFF
--- a/actors/miner/src/deadline_state.rs
+++ b/actors/miner/src/deadline_state.rs
@@ -412,10 +412,6 @@ impl Deadline {
 
         // try filling up the last partition first.
         for partition_idx in partitions.count().saturating_sub(1).. {
-            if sectors.is_empty() {
-                break;
-            }
-
             // Get/create partition to update.
             let mut partition = match partitions.get(partition_idx)? {
                 Some(partition) => partition.clone(),
@@ -449,7 +445,11 @@ impl Deadline {
 
             // Record deadline -> partition mapping so we can later update the deadlines.
             partition_deadline_updates
-                .extend(partition_new_sectors.iter().map(|s| (s.expiration, partition_idx)))
+                .extend(partition_new_sectors.iter().map(|s| (s.expiration, partition_idx)));
+
+            if sectors.is_empty() {
+                break;
+            }
         }
 
         // Save partitions back.


### PR DESCRIPTION
`sectors.is_empty()` is already checked [at the beginning](https://github.com/filecoin-project/builtin-actors/blob/ea77289a435303aefc60a050fb4332f9728e5772/actors/miner/src/deadline_state.rs#L402), the check in the loop can be moved to the end after `sectors` have shrinked.