### PR TITLE
fix new_deadline_info_from_offset_and_epoch

### DIFF
--- a/actors/miner/src/deadlines.rs
+++ b/actors/miner/src/deadlines.rs
@@ -138,8 +138,7 @@ pub fn new_deadline_info_from_offset_and_epoch(
 ) -> DeadlineInfo {
     let q = QuantSpec { unit: policy.wpost_proving_period, offset: period_start_seed };
     let current_period_start = q.quantize_down(current_epoch);
-    let current_deadline_idx = ((current_epoch - current_period_start)
-        / policy.wpost_deadline_window) as u64
-        % policy.wpost_period_deadlines;
+    let current_deadline_idx =
+        ((current_epoch - current_period_start) / policy.wpost_deadline_window) as u64;
     new_deadline_info(policy, current_period_start, current_deadline_idx, current_epoch)
 }

--- a/actors/miner/src/deadlines.rs
+++ b/actors/miner/src/deadlines.rs
@@ -139,7 +139,7 @@ pub fn new_deadline_info_from_offset_and_epoch(
     let q = QuantSpec { unit: policy.wpost_proving_period, offset: period_start_seed };
     let current_period_start = q.quantize_down(current_epoch);
     let current_deadline_idx = ((current_epoch - current_period_start)
-        / policy.wpost_challenge_window) as u64
+        / policy.wpost_deadline_window) as u64
         % policy.wpost_period_deadlines;
     new_deadline_info(policy, current_period_start, current_deadline_idx, current_epoch)
 }

--- a/actors/miner/src/deadlines.rs
+++ b/actors/miner/src/deadlines.rs
@@ -139,6 +139,6 @@ pub fn new_deadline_info_from_offset_and_epoch(
     let q = QuantSpec { unit: policy.wpost_proving_period, offset: period_start_seed };
     let current_period_start = q.quantize_down(current_epoch);
     let current_deadline_idx =
-        ((current_epoch - current_period_start) / policy.wpost_deadline_window) as u64;
+        ((current_epoch - current_period_start) / policy.wpost_challenge_window) as u64;
     new_deadline_info(policy, current_period_start, current_deadline_idx, current_epoch)
 }

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -33,9 +33,8 @@ pub struct Policy {
 
     /// The period over which all a miner's active sectors will be challenged.
     pub wpost_proving_period: ChainEpoch,
-    // The duration of a deadline's proving window.
-    pub wpost_deadline_window: ChainEpoch,
     /// The duration of a deadline's challenge window, the period before a deadline when the challenge is available.
+    /// Notice that the challenge window is assumed to have the same duration as a deadline itself both in FIP and implementation.
     pub wpost_challenge_window: ChainEpoch,
     /// The number of non-overlapping PoSt deadlines in each proving period.
     pub wpost_period_deadlines: u64,
@@ -180,8 +179,6 @@ impl Default for Policy {
             expired_pre_commit_clean_up_delay: policy_constants::EXPIRED_PRE_COMMIT_CLEAN_UP_DELAY,
             wpost_proving_period: policy_constants::WPOST_PROVING_PERIOD,
             wpost_challenge_window: policy_constants::WPOST_CHALLENGE_WINDOW,
-            wpost_deadline_window: policy_constants::WPOST_PROVING_PERIOD
-                / policy_constants::WPOST_PERIOD_DEADLINES as i64,
             wpost_period_deadlines: policy_constants::WPOST_PERIOD_DEADLINES,
             wpost_max_chain_commit_age: policy_constants::WPOST_MAX_CHAIN_COMMIT_AGE,
             wpost_dispute_window: policy_constants::WPOST_DISPUTE_WINDOW,

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -33,6 +33,8 @@ pub struct Policy {
 
     /// The period over which all a miner's active sectors will be challenged.
     pub wpost_proving_period: ChainEpoch,
+    // The duration of a deadline's proving window.
+    pub wpost_deadline_window: ChainEpoch,
     /// The duration of a deadline's challenge window, the period before a deadline when the challenge is available.
     pub wpost_challenge_window: ChainEpoch,
     /// The number of non-overlapping PoSt deadlines in each proving period.
@@ -178,6 +180,8 @@ impl Default for Policy {
             expired_pre_commit_clean_up_delay: policy_constants::EXPIRED_PRE_COMMIT_CLEAN_UP_DELAY,
             wpost_proving_period: policy_constants::WPOST_PROVING_PERIOD,
             wpost_challenge_window: policy_constants::WPOST_CHALLENGE_WINDOW,
+            wpost_deadline_window: policy_constants::WPOST_PROVING_PERIOD
+                / policy_constants::WPOST_PERIOD_DEADLINES as i64,
             wpost_period_deadlines: policy_constants::WPOST_PERIOD_DEADLINES,
             wpost_max_chain_commit_age: policy_constants::WPOST_MAX_CHAIN_COMMIT_AGE,
             wpost_dispute_window: policy_constants::WPOST_DISPUTE_WINDOW,


### PR DESCRIPTION
This PR introduces a new field `wpost_deadline_window` to the `Policy` struct. Previously there was a [bug](https://github.com/filecoin-project/builtin-actors/blob/b712d1ed4ad6f6da57916caaed8af209daaf4db4/actors/miner/src/deadlines.rs#L142) but it happens that `wpost_challenge_window` and `wpost_deadline_window` are equal but they don't have to be.

`% policy.wpost_period_deadlines` is unnecessary since `current_epoch - current_period_start` is in range [0, wpost_proving_period), so `((current_epoch - current_period_start) / policy.wpost_deadline_window)` is in range [0, wpost_period_deadlines) 
