### PR TITLE
Have VM trait expose a dyn blockstore

### DIFF
--- a/test_vm/src/deals.rs
+++ b/test_vm/src/deals.rs
@@ -45,21 +45,15 @@ impl Default for DealOptions {
 // A helper for staging and publishing deals.
 // Note that this doesn't check trace expectations,
 // see https://github.com/filecoin-project/builtin-actors/issues/1302.
-pub struct DealBatcher<'vm, BS>
-where
-    BS: Blockstore,
-{
-    v: &'vm dyn VM<BS>,
+pub struct DealBatcher<'vm> {
+    v: &'vm dyn VM,
     deals: Vec<DealProposal>,
     default_options: DealOptions,
     published: bool,
 }
 
-impl<'vm, BS> DealBatcher<'vm, BS>
-where
-    BS: Blockstore,
-{
-    pub fn new(v: &'vm dyn VM<BS>, opts: DealOptions) -> Self {
+impl<'vm> DealBatcher<'vm> {
+    pub fn new(v: &'vm dyn VM, opts: DealOptions) -> Self {
         DealBatcher { v, deals: vec![], default_options: opts, published: false }
     }
 

--- a/test_vm/src/deals.rs
+++ b/test_vm/src/deals.rs
@@ -8,7 +8,6 @@ use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::test_utils::make_piece_cid;
 use fil_actors_runtime::STORAGE_MARKET_ACTOR_ADDR;
-use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::{Signature, SignatureType};

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -122,7 +122,7 @@ pub trait VM {
     fn actor_manifest(&self) -> BiBTreeMap<Cid, Type>;
 
     /// Provides access to VM primitives
-    fn primitives(&self) -> &FakePrimitives;
+    fn primitives(&self) -> &dyn Primitives;
 
     /// Get the current runtime policy
     fn policy(&self) -> Policy;
@@ -326,7 +326,7 @@ where
         self.total_fil.clone()
     }
 
-    fn primitives(&self) -> &FakePrimitives {
+    fn primitives(&self) -> &dyn Primitives {
         &self.primitives
     }
 }

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -190,8 +190,8 @@ impl<'bs, BS> VM for TestVM<'bs, BS>
 where
     BS: Blockstore,
 {
-    fn blockstore(&self) -> Box<&BS> {
-        Box::new(self.store)
+    fn blockstore(&self) -> &dyn Blockstore {
+        self.store
     }
 
     fn epoch(&self) -> ChainEpoch {

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -83,9 +83,9 @@ pub mod trace;
 pub mod util;
 
 /// An abstract VM that is injected into integration tests
-pub trait VM<BS: Blockstore> {
+pub trait VM {
     /// Returns the underlying blockstore of the VM
-    fn blockstore(&self) -> Box<&BS>;
+    fn blockstore(&self) -> &dyn Blockstore;
 
     /// Get the state root of the specified actor
     fn actor_root(&self, address: &Address) -> Option<Cid>;
@@ -186,7 +186,7 @@ pub const FAUCET_ROOT_KEY: &[u8] = &[153; fvm_shared::address::BLS_PUB_LEN];
 pub const TEST_FAUCET_ADDR: Address = Address::new_id(FIRST_NON_SINGLETON_ADDR + 2);
 pub const FIRST_TEST_USER_ADDR: ActorID = FIRST_NON_SINGLETON_ADDR + 3;
 
-impl<'bs, BS> VM<BS> for TestVM<'bs, BS>
+impl<'bs, BS> VM for TestVM<'bs, BS>
 where
     BS: Blockstore,
 {

--- a/test_vm/src/util.rs
+++ b/test_vm/src/util.rs
@@ -74,16 +74,12 @@ fn new_bls_from_rng(rng: &mut ChaCha8Rng) -> Address {
 
 const ACCOUNT_SEED: u64 = 93837778;
 
-pub fn create_accounts<BS: Blockstore>(
-    v: &dyn VM<BS>,
-    count: u64,
-    balance: &TokenAmount,
-) -> Vec<Address> {
+pub fn create_accounts(v: &dyn VM, count: u64, balance: &TokenAmount) -> Vec<Address> {
     create_accounts_seeded(v, count, balance, ACCOUNT_SEED)
 }
 
-pub fn create_accounts_seeded<BS: Blockstore>(
-    v: &dyn VM<BS>,
+pub fn create_accounts_seeded(
+    v: &dyn VM,
     count: u64,
     balance: &TokenAmount,
     seed: u64,
@@ -97,8 +93,8 @@ pub fn create_accounts_seeded<BS: Blockstore>(
     pk_addrs.iter().map(|pk_addr| v.resolve_id_address(pk_addr).unwrap()).collect()
 }
 
-pub fn apply_ok<S: Serialize, BS: Blockstore>(
-    v: &dyn VM<BS>,
+pub fn apply_ok<S: Serialize>(
+    v: &dyn VM,
     from: &Address,
     to: &Address,
     value: &TokenAmount,
@@ -108,8 +104,8 @@ pub fn apply_ok<S: Serialize, BS: Blockstore>(
     apply_code(v, from, to, value, method, params, ExitCode::OK)
 }
 
-pub fn apply_code<S: Serialize, BS: Blockstore>(
-    v: &dyn VM<BS>,
+pub fn apply_code<S: Serialize>(
+    v: &dyn VM,
     from: &Address,
     to: &Address,
     value: &TokenAmount,
@@ -128,7 +124,7 @@ pub fn serialize_ok<S: Serialize>(s: &S) -> IpldBlock {
     IpldBlock::serialize_cbor(s).unwrap().unwrap()
 }
 
-pub fn cron_tick<BS: Blockstore>(v: &dyn VM<BS>) {
+pub fn cron_tick<BS: Blockstore>(v: &dyn VM) {
     apply_ok(
         v,
         &SYSTEM_ACTOR_ADDR,
@@ -140,7 +136,7 @@ pub fn cron_tick<BS: Blockstore>(v: &dyn VM<BS>) {
 }
 
 pub fn create_miner<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     owner: &Address,
     worker: &Address,
     post_proof_type: RegisteredPoStProof,
@@ -174,7 +170,7 @@ pub fn create_miner<BS: Blockstore>(
 }
 
 pub fn miner_precommit_sector<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     worker: &Address,
     miner_id: &Address,
     seal_proof: RegisteredSealProof,
@@ -211,7 +207,7 @@ pub fn miner_precommit_sector<BS: Blockstore>(
 }
 
 pub fn miner_prove_sector<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     worker: &Address,
     miner_id: &Address,
     sector_number: SectorNumber,
@@ -248,7 +244,7 @@ pub struct PrecommitMetadata {
 
 #[allow(clippy::too_many_arguments)]
 pub fn precommit_sectors_v2<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     count: usize,
     batch_size: usize,
     metadata: Vec<PrecommitMetadata>, // Per-sector deal metadata, or empty vector for no deals.
@@ -419,7 +415,7 @@ pub fn precommit_sectors_v2<BS: Blockstore>(
 
 #[allow(clippy::too_many_arguments)]
 pub fn precommit_sectors<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     count: usize,
     batch_size: usize,
     worker: &Address,
@@ -445,7 +441,7 @@ pub fn precommit_sectors<BS: Blockstore>(
 }
 
 pub fn prove_commit_sectors<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     worker: &Address,
     maddr: &Address,
     precommits: Vec<SectorPreCommitOnChainInfo>,
@@ -496,7 +492,7 @@ pub fn prove_commit_sectors<BS: Blockstore>(
 
 #[allow(clippy::too_many_arguments)]
 pub fn miner_extend_sector_expiration2<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     worker: &Address,
     miner: &Address,
     deadline: u64,
@@ -552,7 +548,7 @@ pub fn miner_extend_sector_expiration2<BS: Blockstore>(
 }
 
 pub fn advance_by_deadline_to_epoch<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     maddr: &Address,
     e: ChainEpoch,
 ) -> DeadlineInfo {
@@ -564,7 +560,7 @@ pub fn advance_by_deadline_to_epoch<BS: Blockstore>(
 }
 
 pub fn advance_by_deadline_to_index<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     maddr: &Address,
     i: u64,
 ) -> DeadlineInfo {
@@ -572,7 +568,7 @@ pub fn advance_by_deadline_to_index<BS: Blockstore>(
 }
 
 pub fn advance_by_deadline_to_epoch_while_proving<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     maddr: &Address,
     worker: &Address,
     s: SectorNumber,
@@ -596,7 +592,7 @@ pub fn advance_by_deadline_to_epoch_while_proving<BS: Blockstore>(
 }
 
 pub fn advance_to_proving_deadline<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     maddr: &Address,
     s: SectorNumber,
 ) -> (DeadlineInfo, u64) {
@@ -606,7 +602,7 @@ pub fn advance_to_proving_deadline<BS: Blockstore>(
     (dline_info, p)
 }
 
-fn advance_by_deadline<BS: Blockstore, F>(v: &dyn VM<BS>, maddr: &Address, more: F) -> DeadlineInfo
+fn advance_by_deadline<BS: Blockstore, F>(v: &dyn VM, maddr: &Address, more: F) -> DeadlineInfo
 where
     F: Fn(DeadlineInfo) -> bool,
 {
@@ -622,12 +618,12 @@ where
     }
 }
 
-pub fn get_state<T: DeserializeOwned, BS: Blockstore>(v: &dyn VM<BS>, a: &Address) -> Option<T> {
+pub fn get_state<T: DeserializeOwned, BS: Blockstore>(v: &dyn VM, a: &Address) -> Option<T> {
     let cid = v.actor_root(a).unwrap();
     v.blockstore().get(&cid).unwrap().map(|slice| fvm_ipld_encoding::from_slice(&slice).unwrap())
 }
 
-pub fn miner_balance<BS: Blockstore>(v: &dyn VM<BS>, m: &Address) -> MinerBalances {
+pub fn miner_balance<BS: Blockstore>(v: &dyn VM, m: &Address) -> MinerBalances {
     let st: MinerState = get_state(v, m).unwrap();
     MinerBalances {
         available_balance: st.get_available_balance(&v.balance(m)).unwrap(),
@@ -637,29 +633,29 @@ pub fn miner_balance<BS: Blockstore>(v: &dyn VM<BS>, m: &Address) -> MinerBalanc
     }
 }
 
-pub fn miner_info<BS: Blockstore>(v: &dyn VM<BS>, m: &Address) -> MinerInfo {
+pub fn miner_info<BS: Blockstore>(v: &dyn VM, m: &Address) -> MinerInfo {
     let st: MinerState = get_state(v, m).unwrap();
     v.blockstore().get_cbor(&st.info).unwrap().unwrap()
 }
 
-pub fn miner_dline_info<BS: Blockstore>(v: &dyn VM<BS>, m: &Address) -> DeadlineInfo {
+pub fn miner_dline_info<BS: Blockstore>(v: &dyn VM, m: &Address) -> DeadlineInfo {
     let st: MinerState = get_state(v, m).unwrap();
     new_deadline_info_from_offset_and_epoch(&Policy::default(), st.proving_period_start, v.epoch())
 }
 
-pub fn sector_deadline<BS: Blockstore>(v: &dyn VM<BS>, m: &Address, s: SectorNumber) -> (u64, u64) {
+pub fn sector_deadline<BS: Blockstore>(v: &dyn VM, m: &Address, s: SectorNumber) -> (u64, u64) {
     let st: MinerState = get_state(v, m).unwrap();
     st.find_sector(&Policy::default(), *v.blockstore(), s).unwrap()
 }
 
-pub fn check_sector_active<BS: Blockstore>(v: &dyn VM<BS>, m: &Address, s: SectorNumber) -> bool {
+pub fn check_sector_active<BS: Blockstore>(v: &dyn VM, m: &Address, s: SectorNumber) -> bool {
     let (d_idx, p_idx) = sector_deadline(v, m, s);
     let st: MinerState = get_state(v, m).unwrap();
     st.check_sector_active(&Policy::default(), *v.blockstore(), d_idx, p_idx, s, true).unwrap()
 }
 
 pub fn check_sector_faulty<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     m: &Address,
     d_idx: u64,
     p_idx: u64,
@@ -673,30 +669,26 @@ pub fn check_sector_faulty<BS: Blockstore>(
     partition.faults.get(s)
 }
 
-pub fn deadline_state<BS: Blockstore>(v: &dyn VM<BS>, m: &Address, d_idx: u64) -> Deadline {
+pub fn deadline_state<BS: Blockstore>(v: &dyn VM, m: &Address, d_idx: u64) -> Deadline {
     let st: MinerState = get_state(v, m).unwrap();
     let bs = *v.blockstore();
     let deadlines = st.load_deadlines(bs).unwrap();
     deadlines.load_deadline(&Policy::default(), bs, d_idx).unwrap()
 }
 
-pub fn sector_info<BS: Blockstore>(
-    v: &dyn VM<BS>,
-    m: &Address,
-    s: SectorNumber,
-) -> SectorOnChainInfo {
+pub fn sector_info<BS: Blockstore>(v: &dyn VM, m: &Address, s: SectorNumber) -> SectorOnChainInfo {
     let st: MinerState = get_state(v, m).unwrap();
     st.get_sector(*v.blockstore(), s).unwrap().unwrap()
 }
 
-pub fn miner_power<BS: Blockstore>(v: &dyn VM<BS>, m: &Address) -> PowerPair {
+pub fn miner_power<BS: Blockstore>(v: &dyn VM, m: &Address) -> PowerPair {
     let st: PowerState = get_state(v, &STORAGE_POWER_ACTOR_ADDR).unwrap();
     let claim = st.get_claim(*v.blockstore(), m).unwrap().unwrap();
     PowerPair::new(claim.raw_byte_power, claim.quality_adj_power)
 }
 
 pub fn declare_recovery<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     worker: &Address,
     maddr: &Address,
     deadline: u64,
@@ -722,7 +714,7 @@ pub fn declare_recovery<BS: Blockstore>(
 }
 
 pub fn submit_windowed_post<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     worker: &Address,
     maddr: &Address,
     dline_info: DeadlineInfo,
@@ -767,7 +759,7 @@ pub fn submit_windowed_post<BS: Blockstore>(
 }
 
 pub fn change_beneficiary<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     from: &Address,
     maddr: &Address,
     beneficiary_change_proposal: &ChangeBeneficiaryParams,
@@ -782,7 +774,7 @@ pub fn change_beneficiary<BS: Blockstore>(
     );
 }
 
-pub fn check_invariants<BS: Blockstore>(vm: &dyn VM<BS>) -> anyhow::Result<MessageAccumulator> {
+pub fn check_invariants<BS: Blockstore>(vm: &dyn VM) -> anyhow::Result<MessageAccumulator> {
     check_state_invariants(
         &vm.actor_manifest(),
         &vm.policy(),
@@ -792,15 +784,15 @@ pub fn check_invariants<BS: Blockstore>(vm: &dyn VM<BS>) -> anyhow::Result<Messa
     )
 }
 
-pub fn assert_invariants<BS: Blockstore>(vm: &dyn VM<BS>) {
+pub fn assert_invariants<BS: Blockstore>(vm: &dyn VM) {
     check_invariants(vm).unwrap().assert_empty()
 }
 
-pub fn expect_invariants<BS: Blockstore>(vm: &dyn VM<BS>, expected_patterns: &[Regex]) {
+pub fn expect_invariants<BS: Blockstore>(vm: &dyn VM, expected_patterns: &[Regex]) {
     check_invariants(vm).unwrap().assert_expected(expected_patterns)
 }
 
-pub fn get_network_stats<BS: Blockstore>(vm: &dyn VM<BS>) -> NetworkStats {
+pub fn get_network_stats<BS: Blockstore>(vm: &dyn VM) -> NetworkStats {
     let power_state: PowerState = get_state(vm, &STORAGE_POWER_ACTOR_ADDR).unwrap();
     let reward_state: RewardState = get_state(vm, &REWARD_ACTOR_ADDR).unwrap();
     let market_state: MarketState = get_state(vm, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
@@ -827,7 +819,7 @@ pub fn get_network_stats<BS: Blockstore>(vm: &dyn VM<BS>) -> NetworkStats {
 }
 
 pub fn get_beneficiary<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     from: &Address,
     m_addr: &Address,
 ) -> GetBeneficiaryReturn {
@@ -844,7 +836,7 @@ pub fn get_beneficiary<BS: Blockstore>(
 }
 
 pub fn change_owner_address<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     from: &Address,
     m_addr: &Address,
     new_miner_addr: &Address,
@@ -860,7 +852,7 @@ pub fn change_owner_address<BS: Blockstore>(
 }
 
 pub fn withdraw_balance<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     from: &Address,
     m_addr: &Address,
     to_withdraw_amount: &TokenAmount,
@@ -898,7 +890,7 @@ pub fn withdraw_balance<BS: Blockstore>(
 }
 
 pub fn submit_invalid_post<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     worker: &Address,
     maddr: &Address,
     dline_info: DeadlineInfo,
@@ -925,7 +917,7 @@ pub fn submit_invalid_post<BS: Blockstore>(
 }
 
 pub fn verifreg_add_verifier<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     verifier: &Address,
     data_cap: StoragePower,
 ) {
@@ -968,7 +960,7 @@ pub fn verifreg_add_verifier<BS: Blockstore>(
 }
 
 pub fn verifreg_add_client<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     verifier: &Address,
     client: &Address,
     allowance: StoragePower,
@@ -1017,7 +1009,7 @@ pub fn verifreg_add_client<BS: Blockstore>(
 }
 
 pub fn verifreg_extend_claim_terms<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     client: &Address,
     provider: &Address,
     claim: ClaimID,
@@ -1041,7 +1033,7 @@ pub fn verifreg_extend_claim_terms<BS: Blockstore>(
 }
 
 pub fn verifreg_remove_expired_allocations<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     caller: &Address,
     client: &Address,
     ids: Vec<AllocationID>,
@@ -1089,7 +1081,7 @@ pub fn verifreg_remove_expired_allocations<BS: Blockstore>(
     .matches(v.take_invocations().last().unwrap());
 }
 
-pub fn datacap_get_balance<BS: Blockstore>(v: &dyn VM<BS>, address: &Address) -> TokenAmount {
+pub fn datacap_get_balance<BS: Blockstore>(v: &dyn VM, address: &Address) -> TokenAmount {
     let ret = apply_ok(
         v,
         address,
@@ -1102,7 +1094,7 @@ pub fn datacap_get_balance<BS: Blockstore>(v: &dyn VM<BS>, address: &Address) ->
 }
 
 pub fn datacap_extend_claim<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     client: &Address,
     provider: &Address,
     claim: ClaimID,
@@ -1173,7 +1165,7 @@ pub fn datacap_extend_claim<BS: Blockstore>(
 }
 
 pub fn market_add_balance<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     sender: &Address,
     beneficiary: &Address,
     amount: &TokenAmount,
@@ -1190,7 +1182,7 @@ pub fn market_add_balance<BS: Blockstore>(
 
 #[allow(clippy::too_many_arguments)]
 pub fn market_publish_deal<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     worker: &Address,
     deal_client: &Address,
     miner_id: &Address,

--- a/test_vm/src/util/blockstore.rs
+++ b/test_vm/src/util/blockstore.rs
@@ -1,0 +1,22 @@
+use cid::Cid;
+use fvm_ipld_blockstore::Blockstore;
+
+/// A DynBlockstore is used to make the blockstore trait object consumable by functions that
+/// accept a generic BS: Blockstore parameter rather than a dyn Blockstore
+pub struct DynBlockstore<'bs>(&'bs dyn Blockstore);
+
+impl<'bs> Blockstore for DynBlockstore<'bs> {
+    fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
+        self.0.get(k)
+    }
+
+    fn put_keyed(&self, k: &Cid, block: &[u8]) -> anyhow::Result<()> {
+        self.0.put_keyed(k, block)
+    }
+}
+
+impl<'bs> DynBlockstore<'bs> {
+    pub fn wrap(blockstore: &'bs dyn Blockstore) -> Self {
+        Self(blockstore)
+    }
+}

--- a/test_vm/tests/authenticate_message_test.rs
+++ b/test_vm/tests/authenticate_message_test.rs
@@ -1,6 +1,6 @@
 use fil_actor_account::types::AuthenticateMessageParams;
 use fil_actor_account::Method::AuthenticateMessageExported;
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
@@ -19,7 +19,7 @@ fn account_authenticate_message() {
 /// Using a deal proposal as a serialized message, we confirm that:
 /// - calls to Account::authenticate_message with valid signatures succeed
 /// - calls to Account::authenticate_message with invalid signatures fail
-pub fn account_authenticate_message_test<BS: Blockstore>(v: &dyn VM) {
+pub fn account_authenticate_message_test(v: &dyn VM) {
     let addr = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
 
     let proposal =

--- a/test_vm/tests/authenticate_message_test.rs
+++ b/test_vm/tests/authenticate_message_test.rs
@@ -19,7 +19,7 @@ fn account_authenticate_message() {
 /// Using a deal proposal as a serialized message, we confirm that:
 /// - calls to Account::authenticate_message with valid signatures succeed
 /// - calls to Account::authenticate_message with invalid signatures fail
-pub fn account_authenticate_message_test<BS: Blockstore>(v: &dyn VM<BS>) {
+pub fn account_authenticate_message_test<BS: Blockstore>(v: &dyn VM) {
     let addr = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
 
     let proposal =

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -7,7 +7,7 @@ use fil_actors_runtime::runtime::policy_constants::{
     MAX_AGGREGATED_SECTORS, PRE_COMMIT_SECTOR_BATCH_MAX_SIZE,
 };
 use fil_actors_runtime::CRON_ACTOR_ADDR;
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::bigint::{BigInt, Zero};
 use fvm_shared::econ::TokenAmount;
@@ -16,7 +16,7 @@ use test_case::test_case;
 use test_vm::util::{
     advance_to_proving_deadline, apply_ok, create_accounts, create_miner, expect_invariants,
     get_network_stats, get_state, invariant_failure_patterns, miner_balance, precommit_sectors_v2,
-    prove_commit_sectors, submit_windowed_post,
+    prove_commit_sectors, submit_windowed_post, DynBlockstore,
 };
 use test_vm::{TestVM, VM};
 
@@ -56,7 +56,7 @@ fn batch_onboarding(v2: bool) {
     batch_onboarding_test(&v, v2);
 }
 
-pub fn batch_onboarding_test<BS: Blockstore>(v: &dyn VM, v2: bool) {
+pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
     let seal_proof = &RegisteredSealProof::StackedDRG32GiBV1P1;
 
     let mut proven_count = 0;
@@ -132,7 +132,7 @@ pub fn batch_onboarding_test<BS: Blockstore>(v: &dyn VM, v2: bool) {
 
     // submit post
     let st: MinerState = get_state(v, &id_addr).unwrap();
-    let sector = st.get_sector(*v.blockstore(), 0).unwrap().unwrap();
+    let sector = st.get_sector(&DynBlockstore::wrap(v.blockstore()), 0).unwrap().unwrap();
     let mut new_power = power_for_sector(seal_proof.sector_size().unwrap(), &sector);
     new_power.raw *= proven_count;
     new_power.qa *= proven_count;

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -56,7 +56,7 @@ fn batch_onboarding(v2: bool) {
     batch_onboarding_test(&v, v2);
 }
 
-pub fn batch_onboarding_test<BS: Blockstore>(v: &dyn VM<BS>, v2: bool) {
+pub fn batch_onboarding_test<BS: Blockstore>(v: &dyn VM, v2: bool) {
     let seal_proof = &RegisteredSealProof::StackedDRG32GiBV1P1;
 
     let mut proven_count = 0;

--- a/test_vm/tests/batch_onboarding_deals_test.rs
+++ b/test_vm/tests/batch_onboarding_deals_test.rs
@@ -39,7 +39,7 @@ fn batch_onboarding_deals() {
 }
 
 // Tests batch onboarding of sectors with verified deals.
-pub fn batch_onboarding_deals_test<BS: Blockstore>(v: &dyn VM<BS>) {
+pub fn batch_onboarding_deals_test<BS: Blockstore>(v: &dyn VM) {
     let deal_duration: ChainEpoch = Policy::default().min_sector_expiration;
     let sector_duration: ChainEpoch =
         deal_duration + Policy::default().market_default_allocation_term_buffer;
@@ -140,7 +140,7 @@ pub fn batch_onboarding_deals_test<BS: Blockstore>(v: &dyn VM<BS>) {
 }
 
 fn publish_deals<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     client: Address,
     provider: Address,
     worker: Address,
@@ -167,7 +167,7 @@ fn publish_deals<BS: Blockstore>(
 // the information necessary to check expectations of deal activation and FIL+ claims.
 // https://github.com/filecoin-project/builtin-actors/issues/1302
 pub fn prove_commit_aggregate<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     worker: &Address,
     maddr: &Address,
     precommits: Vec<SectorPreCommitOnChainInfo>,

--- a/test_vm/tests/batch_onboarding_deals_test.rs
+++ b/test_vm/tests/batch_onboarding_deals_test.rs
@@ -16,7 +16,7 @@ use fil_actor_miner::{
 };
 use fil_actor_miner::{Method as MinerMethod, ProveCommitAggregateParams};
 use fil_actors_runtime::runtime::policy::policy_constants::PRE_COMMIT_CHALLENGE_DELAY;
-use fil_actors_runtime::runtime::{Policy, Primitives};
+use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::STORAGE_MARKET_ACTOR_ADDR;
 use test_vm::deals::{DealBatcher, DealOptions};
 use test_vm::util::{

--- a/test_vm/tests/change_beneficiary_test.rs
+++ b/test_vm/tests/change_beneficiary_test.rs
@@ -19,7 +19,7 @@ fn change_beneficiary_success() {
     change_beneficiary_success_test(&v);
 }
 
-fn change_beneficiary_success_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn change_beneficiary_success_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, another_beneficiary, query_addr) =
@@ -81,7 +81,7 @@ fn change_beneficiary_back_owner_success() {
     change_beneficiary_back_owner_success_test(&v);
 }
 
-fn change_beneficiary_back_owner_success_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn change_beneficiary_back_owner_success_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, query_addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -138,7 +138,7 @@ fn change_beneficiary_fail() {
     change_beneficiary_fail_test(&v);
 }
 
-fn change_beneficiary_fail_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn change_beneficiary_fail_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/change_beneficiary_test.rs
+++ b/test_vm/tests/change_beneficiary_test.rs
@@ -1,7 +1,7 @@
 use fil_actor_miner::{
     ActiveBeneficiary, ChangeBeneficiaryParams, Method as MinerMethod, PendingBeneficiaryChange,
 };
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -19,7 +19,7 @@ fn change_beneficiary_success() {
     change_beneficiary_success_test(&v);
 }
 
-fn change_beneficiary_success_test<BS: Blockstore>(v: &dyn VM) {
+fn change_beneficiary_success_test(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, another_beneficiary, query_addr) =
@@ -81,7 +81,7 @@ fn change_beneficiary_back_owner_success() {
     change_beneficiary_back_owner_success_test(&v);
 }
 
-fn change_beneficiary_back_owner_success_test<BS: Blockstore>(v: &dyn VM) {
+fn change_beneficiary_back_owner_success_test(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, query_addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -138,7 +138,7 @@ fn change_beneficiary_fail() {
     change_beneficiary_fail_test(&v);
 }
 
-fn change_beneficiary_fail_test<BS: Blockstore>(v: &dyn VM) {
+fn change_beneficiary_fail_test(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/change_owner_test.rs
+++ b/test_vm/tests/change_owner_test.rs
@@ -1,5 +1,5 @@
 use fil_actor_miner::{ChangeBeneficiaryParams, Method as MinerMethod};
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -17,7 +17,7 @@ fn change_owner_success() {
     change_owner_success_test(&v);
 }
 
-fn change_owner_success_test<BS: Blockstore>(v: &dyn VM) {
+fn change_owner_success_test(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -58,7 +58,7 @@ fn keep_beneficiary_when_owner_changed() {
     keep_beneficiary_when_owner_changed_test(&v);
 }
 
-fn keep_beneficiary_when_owner_changed_test<BS: Blockstore>(v: &dyn VM) {
+fn keep_beneficiary_when_owner_changed_test(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -104,7 +104,7 @@ fn change_owner_fail() {
     change_owner_fail_test(&v);
 }
 
-fn change_owner_fail_test<BS: Blockstore>(v: &dyn VM) {
+fn change_owner_fail_test(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/change_owner_test.rs
+++ b/test_vm/tests/change_owner_test.rs
@@ -17,7 +17,7 @@ fn change_owner_success() {
     change_owner_success_test(&v);
 }
 
-fn change_owner_success_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn change_owner_success_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -58,7 +58,7 @@ fn keep_beneficiary_when_owner_changed() {
     keep_beneficiary_when_owner_changed_test(&v);
 }
 
-fn keep_beneficiary_when_owner_changed_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn keep_beneficiary_when_owner_changed_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, beneficiary) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -104,7 +104,7 @@ fn change_owner_fail() {
     change_owner_fail_test(&v);
 }
 
-fn change_owner_fail_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn change_owner_fail_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, new_owner, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -162,7 +162,7 @@ fn submit_post_succeeds() {
 }
 
 fn submit_post_succeeds_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     miner_info: MinerInfo,
     sector_info: SectorInfo,
 ) {
@@ -193,11 +193,7 @@ fn skip_sector() {
     skip_sector_test(&v, sector_info, miner_info);
 }
 
-fn skip_sector_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
-    sector_info: SectorInfo,
-    miner_info: MinerInfo,
-) {
+fn skip_sector_test<BS: Blockstore>(v: &dyn VM, sector_info: SectorInfo, miner_info: MinerInfo) {
     // submit post, but skip the only sector in it
     let params = SubmitWindowedPoStParams {
         deadline: sector_info.deadline_info.index,
@@ -244,7 +240,7 @@ fn missed_first_post_deadline() {
 }
 
 fn missed_first_post_deadline_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     sector_info: SectorInfo,
     miner_info: MinerInfo,
 ) {
@@ -310,7 +306,7 @@ fn overdue_precommit() {
     overdue_precommit_test(&v);
 }
 
-fn overdue_precommit_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn overdue_precommit_test<BS: Blockstore>(v: &dyn VM) {
     let policy = &Policy::default();
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -417,7 +413,7 @@ fn aggregate_bad_sector_number() {
     aggregate_bad_sector_number_test(&v);
 }
 
-fn aggregate_bad_sector_number_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn aggregate_bad_sector_number_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -490,7 +486,7 @@ fn aggregate_size_limits() {
     aggregate_size_limits_test(&v);
 }
 
-fn aggregate_size_limits_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn aggregate_size_limits_test<BS: Blockstore>(v: &dyn VM) {
     let oversized_batch = 820;
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -595,7 +591,7 @@ fn aggregate_bad_sender() {
     aggregate_bad_sender_test(&v);
 }
 
-fn aggregate_bad_sender_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn aggregate_bad_sender_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 2, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);
@@ -664,7 +660,7 @@ fn aggregate_one_precommit_expires() {
     aggregate_one_precommit_expires_test(&v);
 }
 
-fn aggregate_one_precommit_expires_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn aggregate_one_precommit_expires_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker) = (addrs[0], addrs[0]);

--- a/test_vm/tests/datacap_tests.rs
+++ b/test_vm/tests/datacap_tests.rs
@@ -27,7 +27,7 @@ fn datacap_transfer() {
     datacap_transfer_test(&v);
 }
 
-fn datacap_transfer_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn datacap_transfer_test<BS: Blockstore>(v: &dyn VM) {
     let policy = Policy::default();
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let (client, operator, owner) = (addrs[0], addrs[1], addrs[2]);
@@ -213,7 +213,7 @@ fn call_name_symbol() {
     call_name_symbol_test(&v);
 }
 
-fn call_name_symbol_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn call_name_symbol_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(10_000));
     let sender = addrs[0];
 

--- a/test_vm/tests/datacap_tests.rs
+++ b/test_vm/tests/datacap_tests.rs
@@ -1,4 +1,4 @@
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PaddedPieceSize;
@@ -27,7 +27,7 @@ fn datacap_transfer() {
     datacap_transfer_test(&v);
 }
 
-fn datacap_transfer_test<BS: Blockstore>(v: &dyn VM) {
+fn datacap_transfer_test(v: &dyn VM) {
     let policy = Policy::default();
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let (client, operator, owner) = (addrs[0], addrs[1], addrs[2]);
@@ -213,7 +213,7 @@ fn call_name_symbol() {
     call_name_symbol_test(&v);
 }
 
-fn call_name_symbol_test<BS: Blockstore>(v: &dyn VM) {
+fn call_name_symbol_test(v: &dyn VM) {
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(10_000));
     let sender = addrs[0];
 

--- a/test_vm/tests/evm_test.rs
+++ b/test_vm/tests/evm_test.rs
@@ -8,7 +8,7 @@ use fil_actors_runtime::{
     test_utils::ETHACCOUNT_ACTOR_CODE_ID, test_utils::EVM_ACTOR_CODE_ID, EAM_ACTOR_ADDR,
     EAM_ACTOR_ID,
 };
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::{strict_bytes, BytesDe, RawBytes};
 use fvm_shared::{address::Address, econ::TokenAmount};
@@ -46,7 +46,7 @@ fn evm_call() {
     evm_call_test(&v);
 }
 
-fn evm_call_test<BS: Blockstore>(v: &dyn VM) {
+fn evm_call_test(v: &dyn VM) {
     let account = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
     let address = id_to_eth(account.id().unwrap());
     let (client, _mock) = Provider::mocked();
@@ -102,7 +102,7 @@ fn evm_create() {
     evm_create_test(&v);
 }
 
-fn evm_create_test<BS: Blockstore>(v: &dyn VM) {
+fn evm_create_test(v: &dyn VM) {
     let account = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
 
     let address = id_to_eth(account.id().unwrap());
@@ -251,10 +251,7 @@ fn evm_eth_create_external() {
 
 // Concrete use of TestVM is required here to run `set_actor`
 // Removing it will depend on https://github.com/filecoin-project/builtin-actors/issues/1297
-fn evm_eth_create_external_test<BS: Blockstore>(
-    v: &dyn VM,
-    _v_concrete: &TestVM<MemoryBlockstore>,
-) {
+fn evm_eth_create_external_test(v: &dyn VM, _v_concrete: &TestVM<MemoryBlockstore>) {
     // create the EthAccount
     let eth_bits = hex_literal::hex!("FEEDFACECAFEBEEF000000000000000000000000");
     let eth_addr = Address::new_delegated(EAM_ACTOR_ID, &eth_bits).unwrap();
@@ -318,7 +315,7 @@ fn evm_empty_initcode() {
     evm_empty_initcode_test(&v);
 }
 
-fn evm_empty_initcode_test<BS: Blockstore>(v: &dyn VM) {
+fn evm_empty_initcode_test(v: &dyn VM) {
     let account = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
     let create_result = v
         .execute_message(
@@ -346,7 +343,7 @@ fn evm_staticcall() {
 }
 
 #[allow(non_snake_case)]
-fn evm_staticcall_test<BS: Blockstore>(v: &dyn VM) {
+fn evm_staticcall_test(v: &dyn VM) {
     // test scenarios:
     // one hop:
     // A -> staticcall -> B (read) OK
@@ -503,7 +500,7 @@ fn evm_delegatecall() {
 }
 
 #[allow(non_snake_case)]
-fn evm_delegatecall_test<BS: Blockstore>(v: &dyn VM) {
+fn evm_delegatecall_test(v: &dyn VM) {
     // test scenarios:
     // one hop:
     // A -> delegatecall -> B (read) OK
@@ -644,7 +641,7 @@ fn evm_staticcall_delegatecall() {
 }
 
 #[allow(non_snake_case)]
-fn evm_staticcall_delegatecall_test<BS: Blockstore>(v: &dyn VM) {
+fn evm_staticcall_delegatecall_test(v: &dyn VM) {
     // test scenarios:
     // one hop:
     // A -> delegatecall -> B (read) OK
@@ -752,7 +749,7 @@ fn evm_init_revert_data() {
     evm_init_revert_data_test(&v);
 }
 
-fn evm_init_revert_data_test<BS: Blockstore>(v: &dyn VM) {
+fn evm_init_revert_data_test(v: &dyn VM) {
     let account = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
     let create_result = v
         .execute_message(

--- a/test_vm/tests/evm_test.rs
+++ b/test_vm/tests/evm_test.rs
@@ -46,7 +46,7 @@ fn evm_call() {
     evm_call_test(&v);
 }
 
-fn evm_call_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn evm_call_test<BS: Blockstore>(v: &dyn VM) {
     let account = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
     let address = id_to_eth(account.id().unwrap());
     let (client, _mock) = Provider::mocked();
@@ -102,7 +102,7 @@ fn evm_create() {
     evm_create_test(&v);
 }
 
-fn evm_create_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn evm_create_test<BS: Blockstore>(v: &dyn VM) {
     let account = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
 
     let address = id_to_eth(account.id().unwrap());
@@ -252,7 +252,7 @@ fn evm_eth_create_external() {
 // Concrete use of TestVM is required here to run `set_actor`
 // Removing it will depend on https://github.com/filecoin-project/builtin-actors/issues/1297
 fn evm_eth_create_external_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     _v_concrete: &TestVM<MemoryBlockstore>,
 ) {
     // create the EthAccount
@@ -318,7 +318,7 @@ fn evm_empty_initcode() {
     evm_empty_initcode_test(&v);
 }
 
-fn evm_empty_initcode_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn evm_empty_initcode_test<BS: Blockstore>(v: &dyn VM) {
     let account = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
     let create_result = v
         .execute_message(
@@ -346,7 +346,7 @@ fn evm_staticcall() {
 }
 
 #[allow(non_snake_case)]
-fn evm_staticcall_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn evm_staticcall_test<BS: Blockstore>(v: &dyn VM) {
     // test scenarios:
     // one hop:
     // A -> staticcall -> B (read) OK
@@ -503,7 +503,7 @@ fn evm_delegatecall() {
 }
 
 #[allow(non_snake_case)]
-fn evm_delegatecall_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn evm_delegatecall_test<BS: Blockstore>(v: &dyn VM) {
     // test scenarios:
     // one hop:
     // A -> delegatecall -> B (read) OK
@@ -644,7 +644,7 @@ fn evm_staticcall_delegatecall() {
 }
 
 #[allow(non_snake_case)]
-fn evm_staticcall_delegatecall_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn evm_staticcall_delegatecall_test<BS: Blockstore>(v: &dyn VM) {
     // test scenarios:
     // one hop:
     // A -> delegatecall -> B (read) OK
@@ -752,7 +752,7 @@ fn evm_init_revert_data() {
     evm_init_revert_data_test(&v);
 }
 
-fn evm_init_revert_data_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn evm_init_revert_data_test<BS: Blockstore>(v: &dyn VM) {
     let account = create_accounts(v, 1, &TokenAmount::from_whole(10_000))[0];
     let create_result = v
         .execute_message(

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -47,7 +47,7 @@ fn extend2_legacy_sector_with_deals() {
 
 #[allow(clippy::too_many_arguments)]
 fn extend<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     worker: Address,
     maddr: Address,
     deadline_index: u64,
@@ -122,7 +122,7 @@ fn extend<BS: Blockstore>(
 // TODO: remove usage of _v_concrete which is currently required by mutate_state
 // https://github.com/filecoin-project/builtin-actors/issues/1297
 fn extend_legacy_sector_with_deals_inner<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     do_extend2: bool,
     _v_concrete: &TestVM<BS>,
 ) {
@@ -638,7 +638,7 @@ fn commit_sector_with_max_duration_deal() {
     commit_sector_with_max_duration_deal_test(&v);
 }
 
-fn commit_sector_with_max_duration_deal_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn commit_sector_with_max_duration_deal_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/init_test.rs
+++ b/test_vm/tests/init_test.rs
@@ -5,12 +5,12 @@ use fil_actors_runtime::{
     test_utils::{EAM_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID, PLACEHOLDER_ACTOR_CODE_ID},
     EAM_ACTOR_ADDR, EAM_ACTOR_ID, INIT_ACTOR_ADDR,
 };
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, METHOD_SEND};
 use num_traits::Zero;
 use test_vm::{actor, util::serialize_ok, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
 
-fn assert_placeholder_actor<BS: Blockstore>(exp_bal: TokenAmount, v: &dyn VM, addr: Address) {
+fn assert_placeholder_actor(exp_bal: TokenAmount, v: &dyn VM, addr: Address) {
     let act = v.actor(&addr).unwrap();
     assert_eq!(EMPTY_ARR_CID, act.head);
     assert_eq!(*PLACEHOLDER_ACTOR_CODE_ID, act.code);

--- a/test_vm/tests/init_test.rs
+++ b/test_vm/tests/init_test.rs
@@ -10,7 +10,7 @@ use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, METHOD_SE
 use num_traits::Zero;
 use test_vm::{actor, util::serialize_ok, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUCET_ADDR, VM};
 
-fn assert_placeholder_actor<BS: Blockstore>(exp_bal: TokenAmount, v: &dyn VM<BS>, addr: Address) {
+fn assert_placeholder_actor<BS: Blockstore>(exp_bal: TokenAmount, v: &dyn VM, addr: Address) {
     let act = v.actor(&addr).unwrap();
     assert_eq!(EMPTY_ARR_CID, act.head);
     assert_eq!(*PLACEHOLDER_ACTOR_CODE_ID, act.code);

--- a/test_vm/tests/multisig_test.rs
+++ b/test_vm/tests/multisig_test.rs
@@ -6,7 +6,7 @@ use fil_actor_multisig::{
 use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::test_utils::*;
 use fil_actors_runtime::{make_map_with_root, INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR};
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
@@ -18,7 +18,9 @@ use std::collections::HashSet;
 use std::iter::FromIterator;
 use test_vm::expects::Expect;
 use test_vm::trace::ExpectInvocation;
-use test_vm::util::{apply_code, apply_ok, assert_invariants, create_accounts, get_state};
+use test_vm::util::{
+    apply_code, apply_ok, assert_invariants, create_accounts, get_state, DynBlockstore,
+};
 use test_vm::{TestVM, VM};
 
 #[test]
@@ -32,7 +34,7 @@ fn proposal_hash() {
     assert_invariants(&v)
 }
 
-fn proposal_hash_test<BS: Blockstore>(v: &dyn VM, addrs: &[Address]) -> TokenAmount {
+fn proposal_hash_test(v: &dyn VM, addrs: &[Address]) -> TokenAmount {
     let alice = addrs[0];
     let bob = addrs[1];
     let msig_addr = create_msig(v, addrs, 2);
@@ -61,7 +63,9 @@ fn proposal_hash_test<BS: Blockstore>(v: &dyn VM, addrs: &[Address]) -> TokenAmo
         approved: vec![alice],
         params: RawBytes::default(),
     };
-    let wrong_hash = compute_proposal_hash(&wrong_tx, &MockRuntime::new(*v.blockstore())).unwrap();
+    let wrong_hash =
+        compute_proposal_hash(&wrong_tx, &MockRuntime::new(&DynBlockstore::wrap(v.blockstore())))
+            .unwrap();
     let wrong_approval_params = TxnIDParams { id: TxnID(0), proposal_hash: wrong_hash.to_vec() };
     apply_code(
         v,
@@ -81,7 +85,8 @@ fn proposal_hash_test<BS: Blockstore>(v: &dyn VM, addrs: &[Address]) -> TokenAmo
         params: RawBytes::default(),
     };
     let correct_hash =
-        compute_proposal_hash(&correct_tx, &MockRuntime::new(*v.blockstore())).unwrap();
+        compute_proposal_hash(&correct_tx, &MockRuntime::new(&DynBlockstore::wrap(v.blockstore())))
+            .unwrap();
     let correct_approval_params =
         TxnIDParams { id: TxnID(0), proposal_hash: correct_hash.to_vec() };
     apply_ok(
@@ -186,7 +191,7 @@ fn swap_self_1_of_2() {
     swap_self_1_of_2_test(&v);
 }
 
-fn swap_self_1_of_2_test<BS: Blockstore>(v: &dyn VM) {
+fn swap_self_1_of_2_test(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let (alice, bob, chuck) = (addrs[0], addrs[1], addrs[2]);
     let msig_addr = create_msig(v, &[alice, bob], 1);
@@ -218,7 +223,7 @@ fn swap_self_2_of_3() {
     swap_self_2_of_3_test(&v);
 }
 
-fn swap_self_2_of_3_test<BS: Blockstore>(v: &dyn VM) {
+fn swap_self_2_of_3_test(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let (alice, bob, chuck, dinesh) = (addrs[0], addrs[1], addrs[2], addrs[3]);
 
@@ -289,7 +294,7 @@ fn swap_self_2_of_3_test<BS: Blockstore>(v: &dyn VM) {
     assert_invariants(v)
 }
 
-fn create_msig<BS: Blockstore>(v: &dyn VM, signers: &[Address], threshold: u64) -> Address {
+fn create_msig(v: &dyn VM, signers: &[Address], threshold: u64) -> Address {
     assert!(!signers.is_empty());
     let msig_ctor_params = serialize(
         &fil_actor_multisig::ConstructorParams {
@@ -317,13 +322,10 @@ fn create_msig<BS: Blockstore>(v: &dyn VM, signers: &[Address], threshold: u64) 
     msig_ctor_ret.id_address
 }
 
-fn check_txs<BS: Blockstore>(
-    v: &dyn VM,
-    msig_addr: Address,
-    mut expect_txns: Vec<(TxnID, Transaction)>,
-) {
+fn check_txs(v: &dyn VM, msig_addr: Address, mut expect_txns: Vec<(TxnID, Transaction)>) {
     let st: MsigState = get_state(v, &msig_addr).unwrap();
-    let ptx = make_map_with_root::<_, Transaction>(&st.pending_txs, *v.blockstore()).unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    let ptx = make_map_with_root::<_, Transaction>(&st.pending_txs, &store).unwrap();
     let mut actual_txns = Vec::new();
     ptx.for_each(|k, txn: &Transaction| {
         let id = i64::decode_var(k).unwrap().0;

--- a/test_vm/tests/multisig_test.rs
+++ b/test_vm/tests/multisig_test.rs
@@ -32,7 +32,7 @@ fn proposal_hash() {
     assert_invariants(&v)
 }
 
-fn proposal_hash_test<BS: Blockstore>(v: &dyn VM<BS>, addrs: &[Address]) -> TokenAmount {
+fn proposal_hash_test<BS: Blockstore>(v: &dyn VM, addrs: &[Address]) -> TokenAmount {
     let alice = addrs[0];
     let bob = addrs[1];
     let msig_addr = create_msig(v, addrs, 2);
@@ -186,7 +186,7 @@ fn swap_self_1_of_2() {
     swap_self_1_of_2_test(&v);
 }
 
-fn swap_self_1_of_2_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn swap_self_1_of_2_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let (alice, bob, chuck) = (addrs[0], addrs[1], addrs[2]);
     let msig_addr = create_msig(v, &[alice, bob], 1);
@@ -218,7 +218,7 @@ fn swap_self_2_of_3() {
     swap_self_2_of_3_test(&v);
 }
 
-fn swap_self_2_of_3_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn swap_self_2_of_3_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let (alice, bob, chuck, dinesh) = (addrs[0], addrs[1], addrs[2], addrs[3]);
 
@@ -289,7 +289,7 @@ fn swap_self_2_of_3_test<BS: Blockstore>(v: &dyn VM<BS>) {
     assert_invariants(v)
 }
 
-fn create_msig<BS: Blockstore>(v: &dyn VM<BS>, signers: &[Address], threshold: u64) -> Address {
+fn create_msig<BS: Blockstore>(v: &dyn VM, signers: &[Address], threshold: u64) -> Address {
     assert!(!signers.is_empty());
     let msig_ctor_params = serialize(
         &fil_actor_multisig::ConstructorParams {
@@ -318,7 +318,7 @@ fn create_msig<BS: Blockstore>(v: &dyn VM<BS>, signers: &[Address], threshold: u
 }
 
 fn check_txs<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     msig_addr: Address,
     mut expect_txns: Vec<(TxnID, Transaction)>,
 ) {

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -7,7 +7,7 @@ use fil_actor_power::{CreateMinerParams, Method as PowerMethod};
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::test_utils::make_sealed_cid;
 use fil_actors_runtime::{CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR};
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::{BytesDe, RawBytes};
 use fvm_shared::address::Address;
 
@@ -32,7 +32,7 @@ fn power_create_miner() {
     power_create_miner_test(&v);
 }
 
-fn power_create_miner_test<BS: Blockstore>(v: &dyn VM) {
+fn power_create_miner_test(v: &dyn VM) {
     let owner = Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();
     v.execute_message(
         &TEST_FAUCET_ADDR,

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -32,7 +32,7 @@ fn power_create_miner() {
     power_create_miner_test(&v);
 }
 
-fn power_create_miner_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn power_create_miner_test<BS: Blockstore>(v: &dyn VM) {
     let owner = Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();
     v.execute_message(
         &TEST_FAUCET_ADDR,

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -1,4 +1,3 @@
-use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
@@ -131,7 +130,7 @@ fn psd_mismatched_provider() {
     psd_mismatched_provider_test(&v, a, deal_start);
 }
 
-fn psd_mismatched_provider_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
+fn psd_mismatched_provider_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts);
 
@@ -157,7 +156,7 @@ fn psd_bad_piece_size() {
     psd_bad_piece_size_test(&v, a, deal_start);
 }
 
-fn psd_bad_piece_size_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
+fn psd_bad_piece_size_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
 
@@ -184,7 +183,7 @@ fn psd_start_time_in_past() {
     psd_start_time_in_past_test(&v, a, deal_start);
 }
 
-fn psd_start_time_in_past_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
+fn psd_start_time_in_past_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
 
@@ -206,11 +205,7 @@ fn psd_client_address_cannot_be_resolved() {
     psd_client_address_cannot_be_resolved_test(&v, a, deal_start);
 }
 
-fn psd_client_address_cannot_be_resolved_test<BS: Blockstore>(
-    v: &dyn VM,
-    a: Addrs,
-    deal_start: i64,
-) {
+fn psd_client_address_cannot_be_resolved_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts);
     let bad_client = Address::new_id(5_000_000);
@@ -231,7 +226,7 @@ fn psd_no_client_lockup() {
     psd_no_client_lockup_test(&v, a, deal_start);
 }
 
-fn psd_no_client_lockup_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
+fn psd_no_client_lockup_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts);
     batcher.stage(a.cheap_client, a.maddr);
@@ -252,11 +247,7 @@ fn psd_not_enough_client_lockup_for_batch() {
     psd_not_enough_client_lockup_for_batch_test(&v, a, deal_start);
 }
 
-fn psd_not_enough_client_lockup_for_batch_test<BS: Blockstore>(
-    v: &dyn VM,
-    a: Addrs,
-    deal_start: i64,
-) {
+fn psd_not_enough_client_lockup_for_batch_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
 
@@ -292,11 +283,7 @@ fn psd_not_enough_provider_lockup_for_batch() {
     psd_not_enough_provider_lockup_for_batch_test(&v, deal_start, a);
 }
 
-fn psd_not_enough_provider_lockup_for_batch_test<BS: Blockstore>(
-    v: &dyn VM,
-    deal_start: i64,
-    a: Addrs,
-) {
+fn psd_not_enough_provider_lockup_for_batch_test(v: &dyn VM, deal_start: i64, a: Addrs) {
     // note different seed, different address
     let cheap_worker = create_accounts_seeded(v, 1, &TokenAmount::from_whole(10_000), 444)[0];
     let cheap_maddr = create_miner(
@@ -337,7 +324,7 @@ fn psd_duplicate_deal_in_batch() {
     psd_duplicate_deal_in_batch_test(&v, a, deal_start);
 }
 
-fn psd_duplicate_deal_in_batch_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
+fn psd_duplicate_deal_in_batch_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts);
 
@@ -369,7 +356,7 @@ fn psd_duplicate_deal_in_state() {
     psd_duplicate_deal_in_state_test(&v, a, deal_start);
 }
 
-fn psd_duplicate_deal_in_state_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
+fn psd_duplicate_deal_in_state_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
 
@@ -399,11 +386,7 @@ fn psd_verified_deal_fails_getting_datacap() {
     psd_verified_deal_fails_getting_datacap_test(&v, a, deal_start);
 }
 
-fn psd_verified_deal_fails_getting_datacap_test<BS: Blockstore>(
-    v: &dyn VM,
-    a: Addrs,
-    deal_start: i64,
-) {
+fn psd_verified_deal_fails_getting_datacap_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
 
@@ -435,7 +418,7 @@ fn psd_random_assortment_of_failures() {
     psd_random_assortment_of_failures_test(&v, a, deal_start);
 }
 
-fn psd_random_assortment_of_failures_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
+fn psd_random_assortment_of_failures_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
     // Add one lifetime cost to cheap_client's market balance but attempt to make 3 deals
@@ -498,7 +481,7 @@ fn psd_all_deals_are_bad() {
     psd_all_deals_are_bad_test(&v, a, deal_start);
 }
 
-fn psd_all_deals_are_bad_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
+fn psd_all_deals_are_bad_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
     let bad_client = Address::new_id(1000);
@@ -528,7 +511,7 @@ fn psd_bad_sig() {
     psd_bad_sig_test(&v, a, deal_start);
 }
 
-fn psd_bad_sig_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
+fn psd_bad_sig_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let DealOptions { price_per_epoch, provider_collateral, client_collateral, .. } =
         DealOptions::default();
     let deal_label = "deal0".to_string();
@@ -606,7 +589,7 @@ fn psd_all_deals_are_good() {
     all_deals_are_good_test(&v, a, deal_start);
 }
 
-fn all_deals_are_good_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
+fn all_deals_are_good_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts);
 
@@ -631,11 +614,7 @@ fn psd_valid_deals_with_ones_longer_than_540() {
     psd_valid_deals_with_ones_longer_than_540_test(&v, a, deal_start);
 }
 
-fn psd_valid_deals_with_ones_longer_than_540_test<BS: Blockstore>(
-    v: &dyn VM,
-    a: Addrs,
-    deal_start: i64,
-) {
+fn psd_valid_deals_with_ones_longer_than_540_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
 
@@ -666,7 +645,7 @@ fn psd_deal_duration_too_long() {
     psd_deal_duration_too_long_test(&v, a, deal_start);
 }
 
-fn psd_deal_duration_too_long_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
+fn psd_deal_duration_too_long_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
 

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -131,7 +131,7 @@ fn psd_mismatched_provider() {
     psd_mismatched_provider_test(&v, a, deal_start);
 }
 
-fn psd_mismatched_provider_test<BS: Blockstore>(v: &dyn VM<BS>, a: Addrs, deal_start: i64) {
+fn psd_mismatched_provider_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts);
 
@@ -157,7 +157,7 @@ fn psd_bad_piece_size() {
     psd_bad_piece_size_test(&v, a, deal_start);
 }
 
-fn psd_bad_piece_size_test<BS: Blockstore>(v: &dyn VM<BS>, a: Addrs, deal_start: i64) {
+fn psd_bad_piece_size_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
 
@@ -184,7 +184,7 @@ fn psd_start_time_in_past() {
     psd_start_time_in_past_test(&v, a, deal_start);
 }
 
-fn psd_start_time_in_past_test<BS: Blockstore>(v: &dyn VM<BS>, a: Addrs, deal_start: i64) {
+fn psd_start_time_in_past_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
 
@@ -207,7 +207,7 @@ fn psd_client_address_cannot_be_resolved() {
 }
 
 fn psd_client_address_cannot_be_resolved_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     a: Addrs,
     deal_start: i64,
 ) {
@@ -231,7 +231,7 @@ fn psd_no_client_lockup() {
     psd_no_client_lockup_test(&v, a, deal_start);
 }
 
-fn psd_no_client_lockup_test<BS: Blockstore>(v: &dyn VM<BS>, a: Addrs, deal_start: i64) {
+fn psd_no_client_lockup_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts);
     batcher.stage(a.cheap_client, a.maddr);
@@ -253,7 +253,7 @@ fn psd_not_enough_client_lockup_for_batch() {
 }
 
 fn psd_not_enough_client_lockup_for_batch_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     a: Addrs,
     deal_start: i64,
 ) {
@@ -293,7 +293,7 @@ fn psd_not_enough_provider_lockup_for_batch() {
 }
 
 fn psd_not_enough_provider_lockup_for_batch_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     deal_start: i64,
     a: Addrs,
 ) {
@@ -337,7 +337,7 @@ fn psd_duplicate_deal_in_batch() {
     psd_duplicate_deal_in_batch_test(&v, a, deal_start);
 }
 
-fn psd_duplicate_deal_in_batch_test<BS: Blockstore>(v: &dyn VM<BS>, a: Addrs, deal_start: i64) {
+fn psd_duplicate_deal_in_batch_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts);
 
@@ -369,7 +369,7 @@ fn psd_duplicate_deal_in_state() {
     psd_duplicate_deal_in_state_test(&v, a, deal_start);
 }
 
-fn psd_duplicate_deal_in_state_test<BS: Blockstore>(v: &dyn VM<BS>, a: Addrs, deal_start: i64) {
+fn psd_duplicate_deal_in_state_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
 
@@ -400,7 +400,7 @@ fn psd_verified_deal_fails_getting_datacap() {
 }
 
 fn psd_verified_deal_fails_getting_datacap_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     a: Addrs,
     deal_start: i64,
 ) {
@@ -435,11 +435,7 @@ fn psd_random_assortment_of_failures() {
     psd_random_assortment_of_failures_test(&v, a, deal_start);
 }
 
-fn psd_random_assortment_of_failures_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
-    a: Addrs,
-    deal_start: i64,
-) {
+fn psd_random_assortment_of_failures_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
     // Add one lifetime cost to cheap_client's market balance but attempt to make 3 deals
@@ -502,7 +498,7 @@ fn psd_all_deals_are_bad() {
     psd_all_deals_are_bad_test(&v, a, deal_start);
 }
 
-fn psd_all_deals_are_bad_test<BS: Blockstore>(v: &dyn VM<BS>, a: Addrs, deal_start: i64) {
+fn psd_all_deals_are_bad_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
     let bad_client = Address::new_id(1000);
@@ -532,7 +528,7 @@ fn psd_bad_sig() {
     psd_bad_sig_test(&v, a, deal_start);
 }
 
-fn psd_bad_sig_test<BS: Blockstore>(v: &dyn VM<BS>, a: Addrs, deal_start: i64) {
+fn psd_bad_sig_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
     let DealOptions { price_per_epoch, provider_collateral, client_collateral, .. } =
         DealOptions::default();
     let deal_label = "deal0".to_string();
@@ -610,7 +606,7 @@ fn psd_all_deals_are_good() {
     all_deals_are_good_test(&v, a, deal_start);
 }
 
-fn all_deals_are_good_test<BS: Blockstore>(v: &dyn VM<BS>, a: Addrs, deal_start: i64) {
+fn all_deals_are_good_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts);
 
@@ -636,7 +632,7 @@ fn psd_valid_deals_with_ones_longer_than_540() {
 }
 
 fn psd_valid_deals_with_ones_longer_than_540_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     a: Addrs,
     deal_start: i64,
 ) {
@@ -670,7 +666,7 @@ fn psd_deal_duration_too_long() {
     psd_deal_duration_too_long_test(&v, a, deal_start);
 }
 
-fn psd_deal_duration_too_long_test<BS: Blockstore>(v: &dyn VM<BS>, a: Addrs, deal_start: i64) {
+fn psd_deal_duration_too_long_test<BS: Blockstore>(v: &dyn VM, a: Addrs, deal_start: i64) {
     let opts = DealOptions { deal_start, ..DealOptions::default() };
     let mut batcher = DealBatcher::new(v, opts.clone());
 

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -72,7 +72,7 @@ fn replica_update_full_path_success(v2: bool) {
 
 #[allow(clippy::too_many_arguments)]
 fn replica_update_full_path_success_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     sector_info: SectorOnChainInfo,
     miner_id: Address,
     worker: Address,
@@ -148,7 +148,7 @@ fn upgrade_and_miss_post(v2: bool) {
 
 #[allow(clippy::too_many_arguments)]
 fn upgrade_and_miss_post_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     sector_info: SectorOnChainInfo,
     miner_id: Address,
     deadline_index: u64,
@@ -209,7 +209,7 @@ fn prove_replica_update_multi_dline() {
     prove_replica_update_multi_dline_test(&v);
 }
 
-fn prove_replica_update_multi_dline_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn prove_replica_update_multi_dline_test<BS: Blockstore>(v: &dyn VM) {
     let policy = Policy::default();
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(1_000_000));
     let (worker, owner) = (addrs[0], addrs[0]);
@@ -355,7 +355,7 @@ fn immutable_deadline_failure() {
     immutable_deadline_failure_test(&v);
 }
 
-fn immutable_deadline_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn immutable_deadline_failure_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -410,7 +410,7 @@ fn unhealthy_sector_failure() {
     unhealthy_sector_failure_test(&v);
 }
 
-fn unhealthy_sector_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn unhealthy_sector_failure_test<BS: Blockstore>(v: &dyn VM) {
     let policy = Policy::default();
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
@@ -469,7 +469,7 @@ fn terminated_sector_failure() {
     terminated_sector_failure_test(&v);
 }
 
-fn terminated_sector_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn terminated_sector_failure_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -539,7 +539,7 @@ fn bad_batch_size_failure() {
     bad_batch_size_failure_test(&v);
 }
 
-fn bad_batch_size_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn bad_batch_size_failure_test<BS: Blockstore>(v: &dyn VM) {
     let policy = Policy::default();
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
@@ -600,7 +600,7 @@ fn no_dispute_after_upgrade() {
 }
 
 fn nodispute_after_upgrade_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     deadline_index: u64,
     worker: Address,
     miner_id: Address,
@@ -636,7 +636,7 @@ fn upgrade_bad_post_dispute() {
 }
 
 fn upgrade_bad_post_dispute_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     sector_info: SectorOnChainInfo,
     miner_id: Address,
     worker: Address,
@@ -671,7 +671,7 @@ fn bad_post_upgrade_dispute() {
     bad_post_upgrade_dispute_test(&v);
 }
 
-fn bad_post_upgrade_dispute_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn bad_post_upgrade_dispute_test<BS: Blockstore>(v: &dyn VM) {
     let policy = Policy::default();
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
@@ -763,7 +763,7 @@ fn terminate_after_upgrade() {
 }
 
 fn terminate_after_upgrade_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     sector_info: SectorOnChainInfo,
     worker: Address,
     miner_id: Address,
@@ -835,7 +835,7 @@ fn extend_after_upgrade() {
 
 #[allow(clippy::too_many_arguments)]
 fn extend_after_upgrade_test<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     miner_id: Address,
     store: &MemoryBlockstore,
     worker: Address,
@@ -881,7 +881,7 @@ fn wrong_deadline_index_failure() {
     wrong_deadline_index_failure_test(&v);
 }
 
-fn wrong_deadline_index_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn wrong_deadline_index_failure_test<BS: Blockstore>(v: &dyn VM) {
     let policy = Policy::default();
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
@@ -944,7 +944,7 @@ fn wrong_partition_index_failure() {
     wrong_partition_index_failure_test(&v);
 }
 
-fn wrong_partition_index_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn wrong_partition_index_failure_test<BS: Blockstore>(v: &dyn VM) {
     let policy = Policy::default();
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
@@ -1006,7 +1006,7 @@ fn deal_included_in_multiple_sectors_failure() {
     deal_included_in_multiple_sectors_failure_test(&v);
 }
 
-fn deal_included_in_multiple_sectors_failure_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn deal_included_in_multiple_sectors_failure_test<BS: Blockstore>(v: &dyn VM) {
     let policy = Policy::default();
     let addrs = create_accounts(v, 1, &TokenAmount::from_whole(100_000));
     let (worker, owner) = (addrs[0], addrs[0]);
@@ -1137,7 +1137,7 @@ fn replica_update_verified_deal() {
     replica_update_verified_deal_test(&v);
 }
 
-fn replica_update_verified_deal_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn replica_update_verified_deal_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(100_000));
     let (worker, owner, client, verifier) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1252,7 +1252,7 @@ fn replica_update_verified_deal_max_term_violated() {
     replica_update_verified_deal_max_term_violated_test(&v);
 }
 
-fn replica_update_verified_deal_max_term_violated_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn replica_update_verified_deal_max_term_violated_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(100_000));
     let (worker, owner, client, verifier) = (addrs[0], addrs[0], addrs[1], addrs[2]);
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
@@ -1397,7 +1397,7 @@ fn create_miner_and_upgrade_sector(
 // - fastforwarding out of the proving period into a new deadline
 // This method assumes that this is a miners first and only sector
 fn create_sector<BS: Blockstore>(
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     worker: Address,
     maddr: Address,
     sector_number: SectorNumber,
@@ -1460,7 +1460,7 @@ fn create_sector<BS: Blockstore>(
 }
 fn create_deals<BS: Blockstore>(
     num_deals: u32,
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     client: Address,
     worker: Address,
     maddr: Address,
@@ -1470,7 +1470,7 @@ fn create_deals<BS: Blockstore>(
 
 fn create_verified_deals<BS: Blockstore>(
     num_deals: u32,
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     client: Address,
     worker: Address,
     maddr: Address,
@@ -1482,7 +1482,7 @@ fn create_verified_deals<BS: Blockstore>(
 #[allow(clippy::too_many_arguments)]
 fn create_deals_frac<BS: Blockstore>(
     num_deals: u32,
-    v: &dyn VM<BS>,
+    v: &dyn VM,
     client: Address,
     worker: Address,
     maddr: Address,

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -14,7 +14,7 @@ use fil_actors_runtime::{
     test_utils::*, CRON_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
     SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -28,7 +28,7 @@ use test_vm::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
     advance_to_proving_deadline, apply_ok, create_accounts, create_miner, expect_invariants,
     get_state, invariant_failure_patterns, make_bitfield, market_publish_deal, miner_balance,
-    submit_windowed_post, verifreg_add_verifier,
+    submit_windowed_post, verifreg_add_verifier, DynBlockstore,
 };
 use test_vm::{TestVM, VM};
 
@@ -39,7 +39,7 @@ fn terminate_sectors() {
     terminate_sectors_test(&v);
 }
 
-fn terminate_sectors_test<BS: Blockstore>(v: &dyn VM) {
+fn terminate_sectors_test(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let (owner, verifier, unverified_client, verified_client) =
         (addrs[0], addrs[1], addrs[2], addrs[3]);
@@ -160,7 +160,8 @@ fn terminate_sectors_test<BS: Blockstore>(v: &dyn VM) {
         .unwrap();
     assert_eq!(ExitCode::OK, res.code);
     let st: MarketState = get_state(v, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
-    let deal_states = DealMetaArray::load(&st.states, *v.blockstore()).unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    let deal_states = DealMetaArray::load(&st.states, &store).unwrap();
     for id in deal_ids.iter() {
         // deals are pending and don't yet have deal states
         let state = deal_states.get(*id).unwrap();
@@ -209,7 +210,8 @@ fn terminate_sectors_test<BS: Blockstore>(v: &dyn VM) {
     let (dline_info, p_idx) = advance_to_proving_deadline(v, &miner_id_addr, sector_number);
     let d_idx = dline_info.index;
     let st: MinerState = get_state(v, &miner_id_addr).unwrap();
-    let sector = st.get_sector(*v.blockstore(), sector_number).unwrap().unwrap();
+    let sector =
+        st.get_sector(&DynBlockstore::wrap(v.blockstore()), sector_number).unwrap().unwrap();
     let sector_power = power_for_sector(seal_proof.sector_size().unwrap(), &sector);
     submit_windowed_post(v, &worker, &miner_id_addr, dline_info, p_idx, Some(sector_power.clone()));
     v.set_epoch(dline_info.last());
@@ -238,7 +240,8 @@ fn terminate_sectors_test<BS: Blockstore>(v: &dyn VM) {
 
     // market cron updates deal states indication deals are no longer pending
     let st: MarketState = get_state(v, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
-    let deal_states = DealMetaArray::load(&st.states, *v.blockstore()).unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    let deal_states = DealMetaArray::load(&st.states, &store).unwrap();
     for id in deal_ids.iter() {
         let state = deal_states.get(*id).unwrap().unwrap();
         assert!(state.last_updated_epoch > 0);
@@ -292,7 +295,8 @@ fn terminate_sectors_test<BS: Blockstore>(v: &dyn VM) {
     // termination slashes deals in market state
     let termination_epoch = v.epoch();
     let st: MarketState = get_state(v, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
-    let deal_states = DealMetaArray::load(&st.states, *v.blockstore()).unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    let deal_states = DealMetaArray::load(&st.states, &store).unwrap();
     for id in deal_ids.iter() {
         let state = deal_states.get(*id).unwrap().unwrap();
         assert!(state.last_updated_epoch > 0);

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -39,7 +39,7 @@ fn terminate_sectors() {
     terminate_sectors_test(&v);
 }
 
-fn terminate_sectors_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn terminate_sectors_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let (owner, verifier, unverified_client, verified_client) =
         (addrs[0], addrs[1], addrs[2], addrs[3]);

--- a/test_vm/tests/verified_claim_test.rs
+++ b/test_vm/tests/verified_claim_test.rs
@@ -47,7 +47,7 @@ fn verified_claim_scenario() {
     verified_claim_scenario_test(&v);
 }
 
-fn verified_claim_scenario_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn verified_claim_scenario_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client, verified_client2) =
@@ -344,7 +344,7 @@ fn expired_allocations() {
     expired_allocations_test(&v);
 }
 
-fn expired_allocations_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn expired_allocations_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -436,7 +436,7 @@ fn deal_passes_claim_fails() {
     deal_passes_claim_fails_test(&v);
 }
 
-fn deal_passes_claim_fails_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn deal_passes_claim_fails_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/verified_claim_test.rs
+++ b/test_vm/tests/verified_claim_test.rs
@@ -1,4 +1,4 @@
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PaddedPieceSize;
@@ -34,6 +34,7 @@ use test_vm::util::{
     market_publish_deal, miner_extend_sector_expiration2, miner_precommit_sector,
     miner_prove_sector, sector_deadline, submit_windowed_post, verifreg_add_client,
     verifreg_add_verifier, verifreg_extend_claim_terms, verifreg_remove_expired_allocations,
+    DynBlockstore,
 };
 use test_vm::{TestVM, VM};
 
@@ -47,7 +48,7 @@ fn verified_claim_scenario() {
     verified_claim_scenario_test(&v);
 }
 
-fn verified_claim_scenario_test<BS: Blockstore>(v: &dyn VM) {
+fn verified_claim_scenario_test(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client, verified_client2) =
@@ -114,7 +115,10 @@ fn verified_claim_scenario_test<BS: Blockstore>(v: &dyn VM) {
 
     // Verify sector info
     let miner_state: MinerState = get_state(v, &miner_id).unwrap();
-    let sector_info = miner_state.get_sector(*v.blockstore(), sector_number).unwrap().unwrap();
+    let sector_info = miner_state
+        .get_sector(&DynBlockstore::wrap(v.blockstore()), sector_number)
+        .unwrap()
+        .unwrap();
     assert_eq!(sector_term, sector_info.expiration - sector_info.activation);
     assert_eq!(DealWeight::zero(), sector_info.deal_weight);
     // Verified weight is sector term * 32 GiB, using simple QAP
@@ -123,7 +127,8 @@ fn verified_claim_scenario_test<BS: Blockstore>(v: &dyn VM) {
 
     // Verify deal state.
     let market_state: MarketState = get_state(v, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
-    let deal_states = DealMetaArray::load(&market_state.states, *v.blockstore()).unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    let deal_states = DealMetaArray::load(&market_state.states, &store).unwrap();
     let deal_state = deal_states.get(deals[0]).unwrap().unwrap();
     let claim_id = deal_state.verified_claim;
     assert_ne!(0, claim_id);
@@ -132,17 +137,26 @@ fn verified_claim_scenario_test<BS: Blockstore>(v: &dyn VM) {
     let datacap_state: DatacapState = get_state(v, &DATACAP_TOKEN_ACTOR_ADDR).unwrap();
     assert_eq!(
         TokenAmount::from_whole(datacap.clone()) - TokenAmount::from_whole(deal_size), // Spent deal size
-        datacap_state.token.get_balance(*v.blockstore(), verified_client.id().unwrap()).unwrap()
+        datacap_state
+            .token
+            .get_balance(&DynBlockstore::wrap(v.blockstore()), verified_client.id().unwrap())
+            .unwrap()
     );
     assert_eq!(
         TokenAmount::from_whole(datacap.clone()), // Nothing spent
-        datacap_state.token.get_balance(*v.blockstore(), verified_client2.id().unwrap()).unwrap()
+        datacap_state
+            .token
+            .get_balance(&DynBlockstore::wrap(v.blockstore()), verified_client2.id().unwrap())
+            .unwrap()
     );
     assert_eq!(
         TokenAmount::zero(), // Burnt when the allocation was claimed
         datacap_state
             .token
-            .get_balance(*v.blockstore(), VERIFIED_REGISTRY_ACTOR_ADDR.id().unwrap())
+            .get_balance(
+                &DynBlockstore::wrap(v.blockstore()),
+                VERIFIED_REGISTRY_ACTOR_ADDR.id().unwrap()
+            )
             .unwrap()
     );
     assert_eq!(
@@ -152,7 +166,8 @@ fn verified_claim_scenario_test<BS: Blockstore>(v: &dyn VM) {
 
     // Verify claim state
     let verifreg_state: VerifregState = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
-    let mut claims = verifreg_state.load_claims(*v.blockstore()).unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    let mut claims = verifreg_state.load_claims(&store).unwrap();
     let claim = claims.get(miner_id.id().unwrap(), claim_id).unwrap().unwrap();
     assert_eq!(sector_number, claim.sector);
     assert_eq!(
@@ -185,7 +200,8 @@ fn verified_claim_scenario_test<BS: Blockstore>(v: &dyn VM) {
 
     // Verify miner power
     let power_state: PowerState = get_state(v, &STORAGE_POWER_ACTOR_ADDR).unwrap();
-    let power_claim = power_state.get_claim(*v.blockstore(), &miner_id).unwrap().unwrap();
+    let power_claim =
+        power_state.get_claim(&DynBlockstore::wrap(v.blockstore()), &miner_id).unwrap().unwrap();
     assert_eq!(power_claim.raw_byte_power, expected_power.raw);
     assert_eq!(power_claim.quality_adj_power, expected_power.qa);
 
@@ -280,7 +296,10 @@ fn verified_claim_scenario_test<BS: Blockstore>(v: &dyn VM) {
 
     // Verify sector info
     let miner_state: MinerState = get_state(v, &miner_id).unwrap();
-    let sector_info = miner_state.get_sector(*v.blockstore(), sector_number).unwrap().unwrap();
+    let sector_info = miner_state
+        .get_sector(&DynBlockstore::wrap(v.blockstore()), sector_number)
+        .unwrap()
+        .unwrap();
     assert_eq!(extended_expiration_2, sector_info.expiration);
     assert_eq!(DealWeight::zero(), sector_info.deal_weight);
     assert_eq!(DealWeight::zero(), sector_info.verified_deal_weight);
@@ -290,17 +309,26 @@ fn verified_claim_scenario_test<BS: Blockstore>(v: &dyn VM) {
     let datacap_state: DatacapState = get_state(v, &DATACAP_TOKEN_ACTOR_ADDR).unwrap();
     assert_eq!(
         TokenAmount::from_whole(datacap.clone()) - TokenAmount::from_whole(deal_size), // Spent deal size
-        datacap_state.token.get_balance(*v.blockstore(), verified_client.id().unwrap()).unwrap()
+        datacap_state
+            .token
+            .get_balance(&DynBlockstore::wrap(v.blockstore()), verified_client.id().unwrap())
+            .unwrap()
     );
     assert_eq!(
         TokenAmount::from_whole(datacap.clone()) - TokenAmount::from_whole(deal_size), // Also spent deal size
-        datacap_state.token.get_balance(*v.blockstore(), verified_client2.id().unwrap()).unwrap()
+        datacap_state
+            .token
+            .get_balance(&DynBlockstore::wrap(v.blockstore()), verified_client2.id().unwrap())
+            .unwrap()
     );
     assert_eq!(
         TokenAmount::zero(), // All burnt
         datacap_state
             .token
-            .get_balance(*v.blockstore(), VERIFIED_REGISTRY_ACTOR_ADDR.id().unwrap())
+            .get_balance(
+                &DynBlockstore::wrap(v.blockstore()),
+                VERIFIED_REGISTRY_ACTOR_ADDR.id().unwrap()
+            )
             .unwrap()
     );
     assert_eq!(
@@ -344,7 +372,7 @@ fn expired_allocations() {
     expired_allocations_test(&v);
 }
 
-fn expired_allocations_test<BS: Blockstore>(v: &dyn VM) {
+fn expired_allocations_test(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -399,12 +427,12 @@ fn expired_allocations_test<BS: Blockstore>(v: &dyn VM) {
 
     // Deal has expired and cleaned up.
     let market_state: MarketState = get_state(v, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
-    let proposals: DealArray<BS> =
-        DealArray::load(&market_state.proposals, *v.blockstore()).unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    let proposals = DealArray::load(&market_state.proposals, &store).unwrap();
     assert!(proposals.get(deal1).unwrap().is_none());
-    let pending_deal_allocs: Map<BS, AllocationID> = make_map_with_root_and_bitwidth(
+    let pending_deal_allocs: Map<_, AllocationID> = make_map_with_root_and_bitwidth(
         &market_state.pending_deal_allocation_ids,
-        *v.blockstore(),
+        &store,
         HAMT_BIT_WIDTH,
     )
     .unwrap();
@@ -413,14 +441,16 @@ fn expired_allocations_test<BS: Blockstore>(v: &dyn VM) {
     // Allocation still exists until explicit cleanup
     let alloc_id = 1;
     let verifreg_state: VerifregState = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
-    let mut allocs = verifreg_state.load_allocs(*v.blockstore()).unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    let mut allocs = verifreg_state.load_allocs(&store).unwrap();
     assert!(allocs.get(verified_client.id().unwrap(), alloc_id).unwrap().is_some());
 
     verifreg_remove_expired_allocations(v, &worker, &verified_client, vec![], deal_size);
 
     // Allocation is gone
     let verifreg_state: VerifregState = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
-    let mut allocs = verifreg_state.load_allocs(*v.blockstore()).unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    let mut allocs = verifreg_state.load_allocs(&store).unwrap();
     assert!(allocs.get(verified_client.id().unwrap(), alloc_id).unwrap().is_none());
 
     // Client has original datacap balance
@@ -436,7 +466,7 @@ fn deal_passes_claim_fails() {
     deal_passes_claim_fails_test(&v);
 }
 
-fn deal_passes_claim_fails_test<BS: Blockstore>(v: &dyn VM) {
+fn deal_passes_claim_fails_test(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -540,7 +570,8 @@ fn deal_passes_claim_fails_test<BS: Blockstore>(v: &dyn VM) {
 
     // Verify deal state.
     let market_state: MarketState = get_state(v, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
-    let deal_states = DealMetaArray::load(&market_state.states, *v.blockstore()).unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    let deal_states = DealMetaArray::load(&market_state.states, &store).unwrap();
     // bad deal sector can't be confirmed for commit so bad deal must not be included
     let bad_deal_state = deal_states.get(bad_deal).unwrap();
     assert_eq!(None, bad_deal_state);
@@ -551,10 +582,12 @@ fn deal_passes_claim_fails_test<BS: Blockstore>(v: &dyn VM) {
     // Verify sector info
     let miner_state: MinerState = get_state(v, &miner_id).unwrap();
     // bad deal sector can't be confirmed for commit because alloc can't be claimed
-    let sector_info_b = miner_state.get_sector(*v.blockstore(), sector_number_b).unwrap();
+    let sector_info_b =
+        miner_state.get_sector(&DynBlockstore::wrap(v.blockstore()), sector_number_b).unwrap();
     assert_eq!(None, sector_info_b);
     // deal sector fails because confirm for commit is now all or nothing
-    let sector_info_a = miner_state.get_sector(*v.blockstore(), sector_number_a).unwrap();
+    let sector_info_a =
+        miner_state.get_sector(&DynBlockstore::wrap(v.blockstore()), sector_number_a).unwrap();
     assert_eq!(None, sector_info_a);
 
     // run check before last change and confirm that we hit the expected broken state error

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -1,4 +1,4 @@
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::{to_vec, RawBytes};
 use fvm_shared::bigint::bigint_ser::BigIntDe;
 use fvm_shared::bigint::{BigInt, Zero};
@@ -29,6 +29,7 @@ use test_vm::expects::Expect;
 use test_vm::trace::ExpectInvocation;
 use test_vm::util::{
     apply_code, apply_ok, assert_invariants, create_accounts, get_state, verifreg_add_verifier,
+    DynBlockstore,
 };
 use test_vm::{TestVM, TEST_VERIFREG_ROOT_ADDR, VM};
 
@@ -39,7 +40,7 @@ fn remove_datacap_simple_successful_path() {
     remove_datacap_simple_successful_path_test(&v);
 }
 
-fn remove_datacap_simple_successful_path_test<BS: Blockstore>(v: &dyn VM) {
+fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let (verifier1, verifier2, verified_client) = (addrs[0], addrs[1], addrs[2]);
 
@@ -89,12 +90,10 @@ fn remove_datacap_simple_successful_path_test<BS: Blockstore>(v: &dyn VM) {
 
     // state checks on the 2 verifiers and the client
     let v_st: VerifregState = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
-    let verifiers = make_map_with_root_and_bitwidth::<_, BigIntDe>(
-        &v_st.verifiers,
-        *v.blockstore(),
-        HAMT_BIT_WIDTH,
-    )
-    .unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    let verifiers =
+        make_map_with_root_and_bitwidth::<_, BigIntDe>(&v_st.verifiers, &store, HAMT_BIT_WIDTH)
+            .unwrap();
 
     let BigIntDe(verifier1_data_cap) =
         verifiers.get(&verifier1_id_addr.to_bytes()).unwrap().unwrap();
@@ -105,12 +104,15 @@ fn remove_datacap_simple_successful_path_test<BS: Blockstore>(v: &dyn VM) {
     assert_eq!(verifier_allowance, *verifier2_data_cap);
 
     let token_st: DataCapState = get_state(v, &DATACAP_TOKEN_ACTOR_ADDR).unwrap();
-    let balance = token_st.balance(*v.blockstore(), verified_client_id_addr.id().unwrap()).unwrap();
+    let balance = token_st
+        .balance(&DynBlockstore::wrap(v.blockstore()), verified_client_id_addr.id().unwrap())
+        .unwrap();
     assert_eq!(balance, TokenAmount::from_whole(verifier_allowance.to_i64().unwrap()));
 
+    let store = DynBlockstore::wrap(v.blockstore());
     let mut proposal_ids = make_map_with_root_and_bitwidth::<_, RemoveDataCapProposalID>(
         &v_st.remove_data_cap_proposal_ids,
-        *v.blockstore(),
+        &store,
         HAMT_BIT_WIDTH,
     )
     .unwrap();
@@ -183,7 +185,9 @@ fn remove_datacap_simple_successful_path_test<BS: Blockstore>(v: &dyn VM) {
 
     // confirm client's allowance has fallen by half
     let token_st: DataCapState = get_state(v, &DATACAP_TOKEN_ACTOR_ADDR).unwrap();
-    let balance = token_st.balance(*v.blockstore(), verified_client_id_addr.id().unwrap()).unwrap();
+    let balance = token_st
+        .balance(&DynBlockstore::wrap(v.blockstore()), verified_client_id_addr.id().unwrap())
+        .unwrap();
     assert_eq!(
         balance,
         TokenAmount::from_whole(verifier_allowance.sub(&allowance_to_remove).to_i64().unwrap())
@@ -191,12 +195,10 @@ fn remove_datacap_simple_successful_path_test<BS: Blockstore>(v: &dyn VM) {
 
     let v_st: VerifregState = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
     // confirm proposalIds has changed as expected
-    proposal_ids = make_map_with_root_and_bitwidth(
-        &v_st.remove_data_cap_proposal_ids,
-        *v.blockstore(),
-        HAMT_BIT_WIDTH,
-    )
-    .unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    proposal_ids =
+        make_map_with_root_and_bitwidth(&v_st.remove_data_cap_proposal_ids, &store, HAMT_BIT_WIDTH)
+            .unwrap();
 
     let verifier1_proposal_id: &RemoveDataCapProposalID = proposal_ids
         .get(&AddrPairKey::new(verifier1_id_addr, verified_client_id_addr).to_bytes())
@@ -271,17 +273,17 @@ fn remove_datacap_simple_successful_path_test<BS: Blockstore>(v: &dyn VM) {
 
     // confirm client has no balance
     let token_st: DataCapState = get_state(v, &DATACAP_TOKEN_ACTOR_ADDR).unwrap();
-    let balance = token_st.balance(*v.blockstore(), verified_client_id_addr.id().unwrap()).unwrap();
+    let balance = token_st
+        .balance(&DynBlockstore::wrap(v.blockstore()), verified_client_id_addr.id().unwrap())
+        .unwrap();
     assert_eq!(balance, TokenAmount::zero());
 
     // confirm proposalIds has changed as expected
     let v_st: VerifregState = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
-    proposal_ids = make_map_with_root_and_bitwidth(
-        &v_st.remove_data_cap_proposal_ids,
-        *v.blockstore(),
-        HAMT_BIT_WIDTH,
-    )
-    .unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    proposal_ids =
+        make_map_with_root_and_bitwidth(&v_st.remove_data_cap_proposal_ids, &store, HAMT_BIT_WIDTH)
+            .unwrap();
 
     let verifier1_proposal_id: &RemoveDataCapProposalID = proposal_ids
         .get(&AddrPairKey::new(verifier1_id_addr, verified_client_id_addr).to_bytes())
@@ -306,7 +308,7 @@ fn remove_datacap_fails_on_verifreg() {
     remove_datacap_fails_on_verifreg_test(&v);
 }
 
-fn remove_datacap_fails_on_verifreg_test<BS: Blockstore>(v: &dyn VM) {
+fn remove_datacap_fails_on_verifreg_test(v: &dyn VM) {
     let addrs = create_accounts(v, 2, &TokenAmount::from_whole(10_000));
     let (verifier1, verifier2) = (addrs[0], addrs[1]);
 

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -39,7 +39,7 @@ fn remove_datacap_simple_successful_path() {
     remove_datacap_simple_successful_path_test(&v);
 }
 
-fn remove_datacap_simple_successful_path_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn remove_datacap_simple_successful_path_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let (verifier1, verifier2, verified_client) = (addrs[0], addrs[1], addrs[2]);
 
@@ -306,7 +306,7 @@ fn remove_datacap_fails_on_verifreg() {
     remove_datacap_fails_on_verifreg_test(&v);
 }
 
-fn remove_datacap_fails_on_verifreg_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn remove_datacap_fails_on_verifreg_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 2, &TokenAmount::from_whole(10_000));
     let (verifier1, verifier2) = (addrs[0], addrs[1]);
 

--- a/test_vm/tests/withdraw_balance_test.rs
+++ b/test_vm/tests/withdraw_balance_test.rs
@@ -1,5 +1,5 @@
 use fil_actor_miner::{ChangeBeneficiaryParams, Method as MinerMethod, WithdrawBalanceParams};
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
@@ -16,7 +16,7 @@ fn withdraw_balance_success() {
     withdraw_balance_success_test(&v);
 }
 
-fn withdraw_balance_success_test<BS: Blockstore>(v: &dyn VM) {
+fn withdraw_balance_success_test(v: &dyn VM) {
     let addrs = create_accounts(v, 2, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary) = (addrs[0], addrs[0], addrs[1]);
@@ -59,10 +59,10 @@ fn withdraw_balance_success_test<BS: Blockstore>(v: &dyn VM) {
 fn withdraw_balance_fail() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    withdraw_balance_fail_test::<MemoryBlockstore>(&v);
+    withdraw_balance_fail_test(&v);
 }
 
-fn withdraw_balance_fail_test<BS: Blockstore>(v: &dyn VM) {
+fn withdraw_balance_fail_test(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);

--- a/test_vm/tests/withdraw_balance_test.rs
+++ b/test_vm/tests/withdraw_balance_test.rs
@@ -16,7 +16,7 @@ fn withdraw_balance_success() {
     withdraw_balance_success_test(&v);
 }
 
-fn withdraw_balance_success_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn withdraw_balance_success_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 2, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary) = (addrs[0], addrs[0], addrs[1]);
@@ -62,7 +62,7 @@ fn withdraw_balance_fail() {
     withdraw_balance_fail_test::<MemoryBlockstore>(&v);
 }
 
-fn withdraw_balance_fail_test<BS: Blockstore>(v: &dyn VM<BS>) {
+fn withdraw_balance_fail_test<BS: Blockstore>(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, beneficiary, addr) = (addrs[0], addrs[0], addrs[1], addrs[2]);


### PR DESCRIPTION
A trait that returns a dyn Blockstore is more flexible than returning a generic BS: Blockstore. 

At call sites requiring a concrete type, the dyn Blockstore can be wrapped. 