### PR TITLE
Updates dependencies and tests for Synthetic PoRep support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,8 +693,7 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+source = "git+https://github.com/multiformats/rust-cid?rev=v0.10.1#1df4e3fe0f6bcb8845655d2ccefd9da5ef81a1cd"
 dependencies = [
  "core2",
  "multibase",
@@ -1837,8 +1836,8 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -1848,17 +1847,16 @@ dependencies = [
 [[package]]
 name = "fil_actor_bundler"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3138c84b845e64c6ad0c50ef299f954d979bd265c8b74509a22b9d1b8107e0"
+source = "git+https://github.com/filecoin-project/builtin-actors-bundler?branch=synthetic-porep#df3d90d4bd9e70ab3abd11dd480695593a796abf"
 dependencies = [
  "anyhow",
  "async-std",
- "cid 0.8.6",
+ "cid 0.10.1",
  "clap",
  "futures",
- "fvm_ipld_blockstore 0.1.2",
+ "fvm_ipld_blockstore",
  "fvm_ipld_car",
- "fvm_ipld_encoding 0.3.3",
+ "fvm_ipld_encoding",
  "serde",
  "serde_ipld_dagcbor 0.2.2",
  "serde_json",
@@ -1869,8 +1867,8 @@ name = "fil_actor_cron"
 version = "12.0.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "log",
  "num-derive",
@@ -1887,8 +1885,8 @@ dependencies = [
  "frc42_dispatch",
  "frc46_token",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
  "lazy_static",
@@ -1907,8 +1905,8 @@ dependencies = [
  "fil_actor_evm",
  "fil_actors_evm_shared",
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "hex-literal",
  "log",
@@ -1927,7 +1925,7 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "hex-literal",
  "num-derive",
@@ -1946,8 +1944,8 @@ dependencies = [
  "fil_actors_evm_shared",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_ipld_kamt",
  "fvm_shared",
  "hex",
@@ -1973,8 +1971,8 @@ dependencies = [
  "cid 0.10.1",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
  "log",
@@ -1997,8 +1995,8 @@ dependencies = [
  "frc46_token",
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
  "integer-encoding",
@@ -2028,8 +2026,8 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
  "itertools 0.10.5",
@@ -2053,8 +2051,8 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
  "indexmap",
@@ -2075,8 +2073,8 @@ dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_amt",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "lazy_static",
  "num-derive",
@@ -2097,8 +2095,8 @@ dependencies = [
  "fil_actor_reward",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
  "indexmap",
@@ -2115,8 +2113,8 @@ name = "fil_actor_reward"
 version = "12.0.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "lazy_static",
  "log",
@@ -2133,8 +2131,8 @@ dependencies = [
  "anyhow",
  "cid 0.10.1",
  "fil_actors_runtime",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -2151,8 +2149,8 @@ dependencies = [
  "frc42_dispatch",
  "frc46_token",
  "fvm_actor_utils",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
  "lazy_static",
@@ -2167,7 +2165,7 @@ name = "fil_actors_evm_shared"
 version = "12.0.0"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "hex",
  "serde",
@@ -2186,8 +2184,8 @@ dependencies = [
  "derive_builder",
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_sdk",
  "fvm_shared",
@@ -2259,8 +2257,8 @@ dependencies = [
  "fil_actor_verifreg",
  "fil_actors_runtime",
  "frc46_token",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -2319,12 +2317,11 @@ dependencies = [
 [[package]]
 name = "frc42_dispatch"
 version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b74f15b21f4938a7c160ff18312d284d5eb8c94b95d48e3183cdc3a083c6f96"
+source = "git+https://github.com/cryptonemo/filecoin?branch=synthetic-porep#3b63d07c7b35b9f72b49bcf71cb58a0a70b933f3"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_encoding",
  "fvm_sdk",
  "fvm_shared",
  "thiserror",
@@ -2333,8 +2330,7 @@ dependencies = [
 [[package]]
 name = "frc42_hasher"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f72dabfe1b958b3588138f9d15ade5f485b79aca6f1e8f307f5dd09d0694d350"
+source = "git+https://github.com/cryptonemo/filecoin?branch=synthetic-porep#3b63d07c7b35b9f72b49bcf71cb58a0a70b933f3"
 dependencies = [
  "fvm_sdk",
  "fvm_shared",
@@ -2344,8 +2340,7 @@ dependencies = [
 [[package]]
 name = "frc42_macros"
 version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9581d30bf75a1e5637a93eaf6605ebcf617f75e882a790248c5cc49d6b6de5b"
+source = "git+https://github.com/cryptonemo/filecoin?branch=synthetic-porep#3b63d07c7b35b9f72b49bcf71cb58a0a70b933f3"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
@@ -2357,16 +2352,15 @@ dependencies = [
 [[package]]
 name = "frc46_token"
 version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462ee03466de3e94fda83742df339bbe2acb72847cef40baed4c7a8c92525354"
+source = "git+https://github.com/cryptonemo/filecoin?branch=synthetic-porep#3b63d07c7b35b9f72b49bcf71cb58a0a70b933f3"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_amt",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_sdk",
  "fvm_shared",
@@ -2507,14 +2501,13 @@ dependencies = [
 [[package]]
 name = "fvm_actor_utils"
 version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab9226c2760276fab371869a021e0b8b6cf0fd001d1d42321941f0da7dd63d8"
+source = "git+https://github.com/cryptonemo/filecoin?branch=synthetic-porep#3b63d07c7b35b9f72b49bcf71cb58a0a70b933f3"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
  "frc42_dispatch",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_sdk",
  "fvm_shared",
  "num-traits",
@@ -2531,8 +2524,8 @@ checksum = "b36fc2a2fd536e8fdf93644218b683ca153de352e8db7345aaf1c6c91e591762"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "itertools 0.11.0",
  "once_cell",
  "serde",
@@ -2542,10 +2535,9 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=synthetic-porep#eb90e48da43e2ba0ca58b0b2d4be866f1c8cc0e6"
 dependencies = [
- "fvm_ipld_encoding 0.3.3",
+ "fvm_ipld_encoding",
  "serde",
  "thiserror",
  "unsigned-varint",
@@ -2553,20 +2545,8 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_blockstore"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee8c75be2b58943e1a9755802d34d4c3934f6ea151b6be192ff98f644e515bd"
-dependencies = [
- "anyhow",
- "cid 0.8.6",
- "multihash 0.16.3",
-]
-
-[[package]]
-name = "fvm_ipld_blockstore"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417f52f6915b9f9a68de8462e1cf46f14a2c16420f484b8d2066873de2ffe420"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=synthetic-porep#eb90e48da43e2ba0ca58b0b2d4be866f1c8cc0e6"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -2575,14 +2555,13 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_car"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60423568393a284de6d7c342cd664690611f27d223eb78629fa568ddd4e7951"
+version = "0.7.0"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=synthetic-porep#eb90e48da43e2ba0ca58b0b2d4be866f1c8cc0e6"
 dependencies = [
- "cid 0.8.6",
+ "cid 0.10.1",
  "futures",
- "fvm_ipld_blockstore 0.1.2",
- "fvm_ipld_encoding 0.3.3",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "integer-encoding",
  "serde",
  "thiserror",
@@ -2590,30 +2569,12 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_encoding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0816a2a6df4853de08a723d261110d56a121aa313bc570fe9d248f0a4bc5288"
-dependencies = [
- "anyhow",
- "cid 0.8.6",
- "fvm_ipld_blockstore 0.1.2",
- "multihash 0.16.3",
- "serde",
- "serde_ipld_dagcbor 0.2.2",
- "serde_repr",
- "serde_tuple",
- "thiserror",
-]
-
-[[package]]
-name = "fvm_ipld_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90608092e31d9a06236268c58f7c36668ab4b2a48afafe3a97e08f094ad7ae50"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=synthetic-porep#eb90e48da43e2ba0ca58b0b2d4be866f1c8cc0e6"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
- "fvm_ipld_blockstore 0.2.0",
+ "fvm_ipld_blockstore",
  "multihash 0.18.1",
  "serde",
  "serde_ipld_dagcbor 0.4.0",
@@ -2632,8 +2593,8 @@ dependencies = [
  "byteorder",
  "cid 0.10.1",
  "forest_hash_utils",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "libipld-core 0.16.0",
  "multihash 0.18.1",
  "once_cell",
@@ -2652,8 +2613,8 @@ dependencies = [
  "byteorder",
  "cid 0.10.1",
  "forest_hash_utils",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "multihash 0.18.1",
  "once_cell",
  "serde",
@@ -2663,11 +2624,10 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c855aead9219cacd48450a4d9d5f57d13dbe4dbbe2d8538d350212792854f5d"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=synthetic-porep#eb90e48da43e2ba0ca58b0b2d4be866f1c8cc0e6"
 dependencies = [
  "cid 0.10.1",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_encoding",
  "fvm_shared",
  "lazy_static",
  "log",
@@ -2678,8 +2638,7 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8704b912372b9640f625fef1b8af24873e27feba66dcbae3f2a49f486a26589d"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=synthetic-porep#eb90e48da43e2ba0ca58b0b2d4be866f1c8cc0e6"
 dependencies = [
  "anyhow",
  "bitflags 2.3.3",
@@ -2687,7 +2646,7 @@ dependencies = [
  "cid 0.10.1",
  "data-encoding",
  "data-encoding-macro",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_encoding",
  "lazy_static",
  "multihash 0.18.1",
  "num-bigint",
@@ -3322,29 +3281,24 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "blake3",
  "core2",
- "digest 0.10.7",
- "multihash-derive",
+ "multihash-derive 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde-big-array",
- "sha2 0.10.7",
- "sha3",
  "unsigned-varint",
 ]
 
 [[package]]
 name = "multihash"
 version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
+source = "git+https://github.com/multiformats/rust-multihash?rev=v0.18.1#02c5c664a7e59f6ecf84e81276c4eb8bb65693d5"
 dependencies = [
  "blake2b_simd",
+ "blake2s_simd",
+ "blake3",
  "core2",
  "digest 0.10.7",
- "multihash-derive",
+ "multihash-derive 0.8.1 (git+https://github.com/multiformats/rust-multihash?rev=v0.18.1)",
  "ripemd",
  "serde",
  "serde-big-array",
@@ -3358,6 +3312,19 @@ name = "multihash-derive"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
+dependencies = [
+ "proc-macro-crate 1.1.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.8.1"
+source = "git+https://github.com/multiformats/rust-multihash?rev=v0.18.1#02c5c664a7e59f6ecf84e81276c4eb8bb65693d5"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro-error",
@@ -4731,8 +4698,8 @@ dependencies = [
  "frc46_token",
  "fvm_actor_utils",
  "fvm_ipld_bitfield",
- "fvm_ipld_blockstore 0.2.0",
- "fvm_ipld_encoding 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
  "hex",
@@ -4915,9 +4882,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "uint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,17 @@ members = [
 ]
 
 [patch.crates-io]
+cid = { version = "0.10.1", git = "https://github.com/multiformats/rust-cid", rev = "v0.10.1" }
+multihash = { version = "0.18.1", git = "https://github.com/multiformats/rust-multihash", rev = "v0.18.1" }
+fil_actor_bundler = { git = "https://github.com/filecoin-project/builtin-actors-bundler", branch = "synthetic-porep" }
+fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "synthetic-porep" }
+fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "synthetic-porep" }
+fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm", branch = "synthetic-porep" }
+fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm", branch = "synthetic-porep" }
+fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm", branch = "synthetic-porep" }
+frc42_dispatch = { git = "https://github.com/cryptonemo/filecoin", branch = "synthetic-porep" }
+frc46_token = { git = "https://github.com/cryptonemo/filecoin", branch = "synthetic-porep" }
+fvm_actor_utils = { git = "https://github.com/cryptonemo/filecoin", branch = "synthetic-porep" }
 #fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
 #fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
 #fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }

--- a/actors/miner/src/commd.rs
+++ b/actors/miner/src/commd.rs
@@ -1,8 +1,8 @@
-use cid::multihash::Multihash;
 use cid::{Cid, Version};
 use fil_actors_runtime::{actor_error, ActorError};
 use fvm_shared::commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED};
 use fvm_shared::sector::RegisteredSealProof;
+use cid::multihash::Multihash;
 use serde::{Deserialize, Serialize};
 
 /// CompactCommD represents a Cid with compact representation of context dependant zero value
@@ -68,11 +68,16 @@ fn zero_commd(seal_proof: RegisteredSealProof) -> Result<Cid, ActorError> {
     let mut seal_proof = seal_proof;
     seal_proof.update_to_v1();
     let i = match seal_proof {
-        RegisteredSealProof::StackedDRG2KiBV1P1 => 0,
-        RegisteredSealProof::StackedDRG512MiBV1P1 => 1,
-        RegisteredSealProof::StackedDRG8MiBV1P1 => 2,
-        RegisteredSealProof::StackedDRG32GiBV1P1 => 3,
-        RegisteredSealProof::StackedDRG64GiBV1P1 => 4,
+        RegisteredSealProof::StackedDRG2KiBV1P1
+        | RegisteredSealProof::StackedDRG2KiBV1P1_Feat_SyntheticPoRep => 0,
+        RegisteredSealProof::StackedDRG512MiBV1P1
+        | RegisteredSealProof::StackedDRG512MiBV1P1_Feat_SyntheticPoRep => 1,
+        RegisteredSealProof::StackedDRG8MiBV1P1
+        | RegisteredSealProof::StackedDRG8MiBV1P1_Feat_SyntheticPoRep => 2,
+        RegisteredSealProof::StackedDRG32GiBV1P1
+        | RegisteredSealProof::StackedDRG32GiBV1P1_Feat_SyntheticPoRep => 3,
+        RegisteredSealProof::StackedDRG64GiBV1P1
+        | RegisteredSealProof::StackedDRG64GiBV1P1_Feat_SyntheticPoRep => 4,
         _ => {
             return Err(actor_error!(illegal_argument, "unknown SealProof"));
         }

--- a/actors/miner/src/commd.rs
+++ b/actors/miner/src/commd.rs
@@ -1,8 +1,8 @@
+use cid::multihash::Multihash;
 use cid::{Cid, Version};
 use fil_actors_runtime::{actor_error, ActorError};
 use fvm_shared::commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED};
 use fvm_shared::sector::RegisteredSealProof;
-use cid::multihash::Multihash;
 use serde::{Deserialize, Serialize};
 
 /// CompactCommD represents a Cid with compact representation of context dependant zero value

--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -104,8 +104,18 @@ pub fn max_prove_commit_duration(
     match proof {
         StackedDRG32GiBV1 | StackedDRG2KiBV1 | StackedDRG8MiBV1 | StackedDRG512MiBV1
         | StackedDRG64GiBV1 => Some(EPOCHS_IN_DAY + policy.pre_commit_challenge_delay),
-        StackedDRG32GiBV1P1 | StackedDRG64GiBV1P1 | StackedDRG512MiBV1P1 | StackedDRG8MiBV1P1
-        | StackedDRG2KiBV1P1 => Some(30 * EPOCHS_IN_DAY + policy.pre_commit_challenge_delay),
+        StackedDRG32GiBV1P1
+        | StackedDRG64GiBV1P1
+        | StackedDRG512MiBV1P1
+        | StackedDRG8MiBV1P1
+        | StackedDRG2KiBV1P1
+        | StackedDRG32GiBV1P1_Feat_SyntheticPoRep
+        | StackedDRG64GiBV1P1_Feat_SyntheticPoRep
+        | StackedDRG512MiBV1P1_Feat_SyntheticPoRep
+        | StackedDRG8MiBV1P1_Feat_SyntheticPoRep
+        | StackedDRG2KiBV1P1_Feat_SyntheticPoRep => {
+            Some(30 * EPOCHS_IN_DAY + policy.pre_commit_challenge_delay)
+        }
         _ => None,
     }
 }
@@ -117,8 +127,16 @@ pub fn seal_proof_sector_maximum_lifetime(proof: RegisteredSealProof) -> Option<
     match proof {
         StackedDRG32GiBV1 | StackedDRG2KiBV1 | StackedDRG8MiBV1 | StackedDRG512MiBV1
         | StackedDRG64GiBV1 => Some(EPOCHS_IN_DAY * 540),
-        StackedDRG32GiBV1P1 | StackedDRG2KiBV1P1 | StackedDRG8MiBV1P1 | StackedDRG512MiBV1P1
-        | StackedDRG64GiBV1P1 => Some(EPOCHS_IN_YEAR * 5),
+        StackedDRG32GiBV1P1
+        | StackedDRG2KiBV1P1
+        | StackedDRG8MiBV1P1
+        | StackedDRG512MiBV1P1
+        | StackedDRG64GiBV1P1
+        | StackedDRG32GiBV1P1_Feat_SyntheticPoRep
+        | StackedDRG2KiBV1P1_Feat_SyntheticPoRep
+        | StackedDRG8MiBV1P1_Feat_SyntheticPoRep
+        | StackedDRG512MiBV1P1_Feat_SyntheticPoRep
+        | StackedDRG64GiBV1P1_Feat_SyntheticPoRep => Some(EPOCHS_IN_YEAR * 5),
         _ => None,
     }
 }

--- a/actors/miner/tests/miner_actor_test_commitment.rs
+++ b/actors/miner/tests/miner_actor_test_commitment.rs
@@ -429,8 +429,11 @@ mod miner_actor_test_commitment {
         let sector_number: SectorNumber = 100;
         let deal_limits = [
             (RegisteredSealProof::StackedDRG2KiBV1P1, 256),
+            (RegisteredSealProof::StackedDRG2KiBV1P1_Feat_SyntheticPoRep, 256),
             (RegisteredSealProof::StackedDRG32GiBV1P1, 256),
+            (RegisteredSealProof::StackedDRG32GiBV1P1_Feat_SyntheticPoRep, 256),
             (RegisteredSealProof::StackedDRG64GiBV1P1, 512),
+            (RegisteredSealProof::StackedDRG64GiBV1P1_Feat_SyntheticPoRep, 512),
         ];
 
         for (proof, limit) in deal_limits {
@@ -502,7 +505,8 @@ mod miner_actor_test_commitment {
                 ),
             );
             rt.reset();
-            precommit_params.seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
+            precommit_params.seal_proof =
+                RegisteredSealProof::StackedDRG32GiBV1P1_Feat_SyntheticPoRep;
             h.pre_commit_sector_and_get(
                 &rt,
                 precommit_params,

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -78,11 +78,11 @@ use fvm_shared::sector::{
 use fvm_shared::smooth::FilterEstimate;
 use fvm_shared::{MethodNum, HAMT_BIT_WIDTH, METHOD_SEND};
 
-use cid::multihash::MultihashDigest;
 use cid::Cid;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use multihash::derive::Multihash;
+use multihash::MultihashDigest;
 
 use fil_actor_miner::testing::{
     check_deadline_state_invariants, check_state_invariants, DeadlineStateSummary,
@@ -177,7 +177,7 @@ impl ActorHarness {
         let receiver = Address::new_id(RECEIVER_ID);
         let rwd = TokenAmount::from_whole(10);
         let pwr = StoragePower::from(1i128 << 50);
-        let proof_type = RegisteredSealProof::StackedDRG32GiBV1P1;
+        let proof_type = RegisteredSealProof::StackedDRG32GiBV1P1_Feat_SyntheticPoRep;
 
         ActorHarness {
             receiver,

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -360,7 +360,7 @@ pub mod policy_constants {
     pub const REGISTERED_POST_PROOF_VARIANTS: usize = 15;
 
     /// The number of total possible types (enum variants) of RegisteredSealProof
-    pub const REGISTERED_SEAL_PROOF_VARIANTS: usize = 10;
+    pub const REGISTERED_SEAL_PROOF_VARIANTS: usize = 15;
 
     #[cfg(not(feature = "small-deals"))]
     pub const MINIMUM_VERIFIED_ALLOCATION_SIZE: i32 = 1 << 20;
@@ -446,22 +446,34 @@ impl ProofSet {
         #[cfg(feature = "sector-2k")]
         {
             proofs[i64::from(RegisteredSealProof::StackedDRG2KiBV1P1) as usize] = true;
+            proofs
+                [i64::from(RegisteredSealProof::StackedDRG2KiBV1P1_Feat_SyntheticPoRep) as usize] =
+                true;
         }
         #[cfg(feature = "sector-8m")]
         {
             proofs[i64::from(RegisteredSealProof::StackedDRG8MiBV1P1) as usize] = true;
+            proofs
+                [i64::from(RegisteredSealProof::StackedDRG8MiBV1P1_Feat_SyntheticPoRep) as usize] =
+                true;
         }
         #[cfg(feature = "sector-512m")]
         {
             proofs[i64::from(RegisteredSealProof::StackedDRG512MiBV1P1) as usize] = true;
+            proofs[i64::from(RegisteredSealProof::StackedDRG512MiBV1P1_Feat_SyntheticPoRep)
+                as usize] = true;
         }
         #[cfg(feature = "sector-32g")]
         {
             proofs[i64::from(RegisteredSealProof::StackedDRG32GiBV1P1) as usize] = true;
+            proofs[i64::from(RegisteredSealProof::StackedDRG32GiBV1P1_Feat_SyntheticPoRep)
+                as usize] = true;
         }
         #[cfg(feature = "sector-64g")]
         {
             proofs[i64::from(RegisteredSealProof::StackedDRG64GiBV1P1) as usize] = true;
+            proofs[i64::from(RegisteredSealProof::StackedDRG64GiBV1P1_Feat_SyntheticPoRep)
+                as usize] = true;
         }
         ProofSet(proofs)
     }

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -47,7 +47,7 @@ struct MinerInfo {
 fn setup(store: &'_ MemoryBlockstore) -> (TestVM<MemoryBlockstore>, MinerInfo, SectorInfo) {
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     let addrs = create_accounts(&v, 1, &TokenAmount::from_whole(10_000));
-    let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
+    let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1_Feat_SyntheticPoRep;
     let (owner, worker) = (addrs[0], addrs[0]);
     let (id_addr, robust_addr) = create_miner(
         &v,


### PR DESCRIPTION
~~Unfortunately, I had a similar version working, but hardcoded the dependencies everywhere (very invasive) and trying to resolve the issues by using the patch mechanism at the top-level is not working.  Any eyes/assistance on this is appreciated.  tl;dr -- this is broken due to the deps/build system.~~

~~EDIT: Not yet resolved, sorry was on the wrong branch~~

Another oddity is that since SyntheticPoRep is a new proof type, but is *optional*, it wasn't clear how to handle in the tests.  In the future, it looks like maybe they should be re-factored to take the proof type as an arg so that we can iterate through several(?)  I'm not familiar enough with this repo to know if that's a valid test/use-case.