### PR TITLE
Switch to FVM next branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,8 +2073,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0b0ee51ca8defa9717a72e1d35c8cbb85bd8320a835911410b63b9a63dffec"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=next#f2ad8938cdfc7d1ca0fdbf290f93f2782c0533da"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -2089,10 +2088,9 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=next#f2ad8938cdfc7d1ca0fdbf290f93f2782c0533da"
 dependencies = [
- "fvm_ipld_encoding 0.3.3",
+ "fvm_ipld_encoding 0.4.0",
  "serde",
  "thiserror",
  "unsigned-varint",
@@ -2112,8 +2110,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417f52f6915b9f9a68de8462e1cf46f14a2c16420f484b8d2066873de2ffe420"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=next#f2ad8938cdfc7d1ca0fdbf290f93f2782c0533da"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -2155,8 +2152,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90608092e31d9a06236268c58f7c36668ab4b2a48afafe3a97e08f094ad7ae50"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=next#f2ad8938cdfc7d1ca0fdbf290f93f2782c0533da"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -2172,8 +2168,7 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c65915bd7ab95ff973bb0bb7e03e8d43a43642c8f4b15407e42e4ffcc0d98"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=next#f2ad8938cdfc7d1ca0fdbf290f93f2782c0533da"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2210,9 +2205,9 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c855aead9219cacd48450a4d9d5f57d13dbe4dbbe2d8538d350212792854f5d"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=next#f2ad8938cdfc7d1ca0fdbf290f93f2782c0533da"
 dependencies = [
+ "byteorder",
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
  "fvm_shared",
@@ -2225,8 +2220,7 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8704b912372b9640f625fef1b8af24873e27feba66dcbae3f2a49f486a26589d"
+source = "git+https://github.com/filecoin-project/ref-fvm?branch=next#f2ad8938cdfc7d1ca0fdbf290f93f2782c0533da"
 dependencies = [
  "anyhow",
  "bitflags 2.3.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,13 +142,13 @@ fil_actors_runtime = { version = "12.0.0", path = "runtime" }
 fil_builtin_actors_state = { version = "12.0.0", path = "state"}
 
 [patch.crates-io]
-#fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
-#fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }
+fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "next" }
+fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "next" }
+fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "next" }
+fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "next" }
+fvm_ipld_bitfield = { git = "https://github.com/filecoin-project/ref-fvm", branch = "next" }
+fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm", branch = "next" }
+fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm", branch = "next" }
 #fvm_actor_utils = { git = "https://github.com/helix-onchain/filecoin", branch = "alex/update-fvm-ipld" }
 #frc42_dispatch = { git = "https://github.com/helix-onchain/filecoin", branch = "alex/update-fvm-ipld" }
 #frc46_token = { git = "https://github.com/helix-onchain/filecoin", branch = "alex/update-fvm-ipld" }


### PR DESCRIPTION
Start depending on fvm next branch while we develop backwards incompatible features for FVM ascent. 

I had to bump the anyhow version dependency to be in sync with fvm as otherwise cargo could not resolve its version correctly. While doing that, it brought with it a new error `BTreeSet::<T>::new is not yet stable as a const fn` so I bumped also the rust version to be in sync with fvm rust version.