### PR TITLE
Update the builtin actors to expose `create` entrypoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,6 +1839,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
+ "fvm_sdk",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -1976,6 +1977,7 @@ dependencies = [
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt",
+ "fvm_sdk",
  "fvm_shared",
  "log",
  "num-derive",
@@ -2542,10 +2544,8 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
 dependencies = [
- "fvm_ipld_encoding 0.3.3",
+ "fvm_ipld_encoding 0.4.0",
  "serde",
  "thiserror",
  "unsigned-varint",
@@ -2565,8 +2565,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417f52f6915b9f9a68de8462e1cf46f14a2c16420f484b8d2066873de2ffe420"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -2608,8 +2606,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90608092e31d9a06236268c58f7c36668ab4b2a48afafe3a97e08f094ad7ae50"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -2625,8 +2621,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c65915bd7ab95ff973bb0bb7e03e8d43a43642c8f4b15407e42e4ffcc0d98"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2663,8 +2657,6 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c855aead9219cacd48450a4d9d5f57d13dbe4dbbe2d8538d350212792854f5d"
 dependencies = [
  "cid 0.10.1",
  "fvm_ipld_encoding 0.4.0",
@@ -2678,8 +2670,6 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8704b912372b9640f625fef1b8af24873e27feba66dcbae3f2a49f486a26589d"
 dependencies = [
  "anyhow",
  "bitflags 2.3.3",
@@ -5295,3 +5285,7 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[patch.unused]]
+name = "fvm_ipld_amt"
+version = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,13 +86,13 @@ members = [
 ## Assumes the ref-fvm checkout is in a sibling directory with the same name.
 ## (Valid once FVM modules are published to crates.io)
 # [patch.crates-io]
-# fvm_shared = { path = "../ref-fvm/shared" }
-# fvm_sdk = { path = "../ref-fvm/sdk" }
-# fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
-# fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
-# fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
-# fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
-# fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
+fvm_shared = { path = "../ref-fvm/shared" }
+fvm_sdk = { path = "../ref-fvm/sdk" }
+fvm_ipld_hamt = { path = "../ref-fvm/ipld/hamt" }
+fvm_ipld_amt = { path = "../ref-fvm/ipld/amt" }
+fvm_ipld_bitfield = { path = "../ref-fvm/ipld/bitfield"}
+fvm_ipld_encoding = { path = "../ref-fvm/ipld/encoding"}
+fvm_ipld_blockstore = { path = "../ref-fvm/ipld/blockstore"}
 #fvm_actor_utils = { path = "../../filecoin/fvm_actor_utils"}
 #frc42_dispatch = { path = "../../filecoin/frc42_dispatch"}
 #frc46_token = { path = "../../filecoin/frc46_token"}

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
+fvm_sdk = { version = "3.3.0" }
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
 frc42_dispatch = "3.3.0"
 fvm_actor_utils = "7.0.0"

--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -6,7 +6,7 @@ use fvm_shared::address::Protocol;
 use fvm_shared::crypto::signature::SignatureType::{Secp256k1, BLS};
 use fvm_shared::crypto::signature::{Signature, SignatureType};
 use fvm_shared::error::ExitCode;
-use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
+use fvm_shared::MethodNum;
 use num_derive::FromPrimitive;
 
 use fil_actors_runtime::builtin::singletons::SYSTEM_ACTOR_ADDR;
@@ -30,7 +30,6 @@ fil_actors_runtime::wasm_trampoline!(Actor);
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
     PubkeyAddress = 2,
     // Deprecated in v10
     // AuthenticateMessage = 3,
@@ -115,7 +114,6 @@ impl ActorCode for Actor {
     }
 
     actor_dispatch! {
-        Constructor => constructor,
         PubkeyAddress => pubkey_address,
         AuthenticateMessageExported => authenticate_message,
         _ => fallback [raw],

--- a/actors/account/tests/account_actor_test.rs
+++ b/actors/account/tests/account_actor_test.rs
@@ -24,11 +24,7 @@ fn construction() {
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
 
         if exit_code.is_success() {
-            rt.call::<AccountActor>(
-                Method::Constructor as MethodNum,
-                IpldBlock::serialize_cbor(&addr).unwrap(),
-            )
-            .unwrap();
+            rt.construct::<AccountActor>(IpldBlock::serialize_cbor(&addr).unwrap()).unwrap();
 
             let state: State = rt.get_state();
             assert_eq!(state.address, addr);
@@ -45,7 +41,7 @@ fn construction() {
         } else {
             expect_abort(
                 exit_code,
-                rt.call::<AccountActor>(1, IpldBlock::serialize_cbor(&addr).unwrap()),
+                rt.construct::<AccountActor>(IpldBlock::serialize_cbor(&addr).unwrap()),
             )
         }
         rt.verify();
@@ -67,11 +63,7 @@ fn token_receiver() {
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
 
     let param = Address::new_secp256k1(&[2; fvm_shared::address::SECP_PUB_LEN]).unwrap();
-    rt.call::<AccountActor>(
-        Method::Constructor as MethodNum,
-        IpldBlock::serialize_cbor(&param).unwrap(),
-    )
-    .unwrap();
+    rt.construct::<AccountActor>(IpldBlock::serialize_cbor(&param).unwrap()).unwrap();
 
     rt.set_caller(*EVM_ACTOR_CODE_ID, Address::new_id(1000));
     rt.expect_validate_caller_any();
@@ -95,11 +87,7 @@ fn authenticate_message() {
 
     let addr = Address::new_secp256k1(&[2; fvm_shared::address::SECP_PUB_LEN]).unwrap();
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
-    rt.call::<AccountActor>(
-        Method::Constructor as MethodNum,
-        IpldBlock::serialize_cbor(&addr).unwrap(),
-    )
-    .unwrap();
+    rt.construct::<AccountActor>(IpldBlock::serialize_cbor(&addr).unwrap()).unwrap();
 
     let state: State = rt.get_state();
     assert_eq!(state.address, addr);
@@ -166,11 +154,7 @@ fn test_fallback() {
 
     let addr = Address::new_secp256k1(&[2; fvm_shared::address::SECP_PUB_LEN]).unwrap();
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
-    rt.call::<AccountActor>(
-        Method::Constructor as MethodNum,
-        IpldBlock::serialize_cbor(&addr).unwrap(),
-    )
-    .unwrap();
+    rt.construct::<AccountActor>(IpldBlock::serialize_cbor(&addr).unwrap()).unwrap();
 
     let state: State = rt.get_state();
     assert_eq!(state.address, addr);

--- a/actors/cron/src/lib.rs
+++ b/actors/cron/src/lib.rs
@@ -2,14 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{
-    actor_dispatch, actor_error, extract_send_result, ActorError, SYSTEM_ACTOR_ADDR,
-};
+use fil_actors_runtime::{actor_dispatch, extract_send_result, ActorError, SYSTEM_ACTOR_ADDR};
 
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::econ::TokenAmount;
 
-use fvm_shared::METHOD_CONSTRUCTOR;
 use num_derive::FromPrimitive;
 use num_traits::Zero;
 
@@ -27,7 +24,6 @@ fil_actors_runtime::wasm_trampoline!(Actor);
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
     EpochTick = 2,
 }
 
@@ -84,7 +80,6 @@ impl ActorCode for Actor {
     }
 
     actor_dispatch! {
-        Constructor => constructor,
         EpochTick => epoch_tick,
     }
 }

--- a/actors/cron/tests/cron_actor_test.rs
+++ b/actors/cron/tests/cron_actor_test.rs
@@ -120,7 +120,7 @@ fn epoch_tick_with_entries() {
 fn construct_and_verify(rt: &MockRuntime, params: &ConstructorParams) {
     rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
-    let ret = rt.call::<CronActor>(1, IpldBlock::serialize_cbor(&params).unwrap()).unwrap();
+    let ret = rt.construct::<CronActor>(IpldBlock::serialize_cbor(&params).unwrap()).unwrap();
     assert!(ret.is_none());
     rt.verify();
 }

--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -14,7 +14,7 @@ use fvm_shared::bigint::BigInt;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::Response;
-use fvm_shared::{ActorID, MethodNum, METHOD_CONSTRUCTOR};
+use fvm_shared::{ActorID, MethodNum};
 use lazy_static::lazy_static;
 use log::info;
 use num_derive::FromPrimitive;
@@ -50,7 +50,6 @@ lazy_static! {
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
     // Deprecated in v10
     // Mint = 2,
     // Destroy = 3,
@@ -505,7 +504,6 @@ impl ActorCode for Actor {
     }
 
     actor_dispatch! {
-        Constructor => constructor,
         MintExported => mint,
         DestroyExported => destroy,
         NameExported => name,

--- a/actors/datacap/tests/harness/mod.rs
+++ b/actors/datacap/tests/harness/mod.rs
@@ -47,12 +47,8 @@ impl Harness {
     pub fn construct_and_verify(&self, rt: &MockRuntime, registry: &Address) {
         rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
-        let ret = rt
-            .call::<DataCapActor>(
-                Method::Constructor as MethodNum,
-                IpldBlock::serialize_cbor(registry).unwrap(),
-            )
-            .unwrap();
+        let ret =
+            rt.construct::<DataCapActor>(IpldBlock::serialize_cbor(registry).unwrap()).unwrap();
 
         assert!(ret.is_none());
         rt.verify();

--- a/actors/eam/src/lib.rs
+++ b/actors/eam/src/lib.rs
@@ -14,7 +14,7 @@ use fil_actors_runtime::{
 };
 
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_shared::{error::ExitCode, sys::SendFlags, ActorID, METHOD_CONSTRUCTOR};
+use fvm_shared::{error::ExitCode, sys::SendFlags, ActorID};
 use serde::{Deserialize, Serialize};
 
 pub mod ext;
@@ -33,7 +33,6 @@ fil_actors_runtime::wasm_trampoline!(EamActor);
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
     Create = 2,
     Create2 = 3,
     CreateExternal = 4,
@@ -296,7 +295,6 @@ impl ActorCode for EamActor {
     }
 
     actor_dispatch_unrestricted! {
-        Constructor => constructor,
         Create => create,
         Create2 => create2,
         CreateExternal => create_external,

--- a/actors/eam/tests/create.rs
+++ b/actors/eam/tests/create.rs
@@ -274,7 +274,7 @@ pub fn construct_and_verify() -> MockRuntime {
 
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
 
-    let result = rt.call::<eam::EamActor>(eam::Method::Constructor as u64, None).unwrap();
+    let result = rt.construct::<eam::EamActor>(None).unwrap();
     expect_empty(result);
     rt.verify();
     rt.reset();

--- a/actors/ethaccount/src/lib.rs
+++ b/actors/ethaccount/src/lib.rs
@@ -2,8 +2,7 @@ pub mod types;
 
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Payload;
-use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
-use num_derive::FromPrimitive;
+use fvm_shared::MethodNum;
 
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
@@ -13,13 +12,6 @@ use fil_actors_runtime::{
 
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(EthAccountActor);
-
-/// Ethereum Account actor methods.
-#[derive(FromPrimitive)]
-#[repr(u64)]
-pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
-}
 
 /// Ethereum Account actor.
 pub struct EthAccountActor;
@@ -66,14 +58,13 @@ impl EthAccountActor {
 }
 
 impl ActorCode for EthAccountActor {
-    type Methods = Method;
+    type Methods = fvm_shared::MethodNum;
 
     fn name() -> &'static str {
         "EVMAccount"
     }
 
     actor_dispatch! {
-        Constructor => constructor,
         _ => fallback [raw],
     }
 }

--- a/actors/ethaccount/tests/ethaccount_test.rs
+++ b/actors/ethaccount/tests/ethaccount_test.rs
@@ -6,9 +6,8 @@ use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 
-use fil_actor_ethaccount::{EthAccountActor, Method};
+use fil_actor_ethaccount::EthAccountActor;
 use fvm_shared::error::ExitCode;
-use fvm_shared::MethodNum;
 
 use fil_actors_runtime::test_utils::{
     expect_abort_contains_message, ACCOUNT_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID,
@@ -23,7 +22,7 @@ fn no_delegated_cant_deploy() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "receiver must have a predictable address",
-        rt.call::<EthAccountActor>(Method::Constructor as MethodNum, None),
+        rt.construct::<EthAccountActor>(None),
     );
     rt.verify();
 }

--- a/actors/ethaccount/tests/util.rs
+++ b/actors/ethaccount/tests/util.rs
@@ -1,11 +1,10 @@
 use std::cell::RefCell;
 
-use fil_actor_ethaccount::{EthAccountActor, Method};
+use fil_actor_ethaccount::EthAccountActor;
 use fil_actors_runtime::test_utils::{MockRuntime, SYSTEM_ACTOR_CODE_ID};
 use fil_actors_runtime::EAM_ACTOR_ID;
 use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
 use fvm_shared::address::Address;
-use fvm_shared::MethodNum;
 
 pub const EOA: Address = Address::new_id(1000);
 
@@ -31,7 +30,7 @@ pub fn setup() -> MockRuntime {
         )
         .unwrap(),
     );
-    rt.call::<EthAccountActor>(Method::Constructor as MethodNum, None).unwrap();
+    rt.construct::<EthAccountActor>(None).unwrap();
     rt.verify();
     rt
 }

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -15,7 +15,6 @@ use crate::interpreter::{execute, Bytecode, ExecutionState, System};
 use crate::reader::ValueReader;
 use cid::Cid;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fvm_shared::METHOD_CONSTRUCTOR;
 use num_derive::FromPrimitive;
 
 pub use types::*;
@@ -59,7 +58,6 @@ fn test_method_selector() {
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
     Resurrect = 2,
     GetBytecode = 3,
     GetBytecodeHash = 4,
@@ -410,7 +408,6 @@ impl ActorCode for EvmContractActor {
     }
 
     actor_dispatch_unrestricted! {
-        Constructor => constructor,
         InvokeContract => invoke_contract [default_params],
         GetBytecode => bytecode,
         GetBytecodeHash => bytecode_hash,

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -1179,10 +1179,7 @@ impl ContractTester {
         rt.set_delegated_address(0, Address::new_delegated(EAM_ACTOR_ID, &addr.0).unwrap());
 
         assert!(rt
-            .call::<evm::EvmContractActor>(
-                evm::Method::Constructor as u64,
-                IpldBlock::serialize_cbor(&params).unwrap(),
-            )
+            .construct::<evm::EvmContractActor>(IpldBlock::serialize_cbor(&params).unwrap(),)
             .unwrap()
             .is_none());
 

--- a/actors/evm/tests/env.rs
+++ b/actors/evm/tests/env.rs
@@ -65,10 +65,7 @@ impl TestEnv {
 
         assert!(self
             .runtime
-            .call::<evm::EvmContractActor>(
-                evm::Method::Constructor as u64,
-                IpldBlock::serialize_cbor(&params).unwrap(),
-            )
+            .construct::<evm::EvmContractActor>(IpldBlock::serialize_cbor(&params).unwrap(),)
             .unwrap()
             .is_none());
 

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -51,10 +51,7 @@ pub fn init_construct_and_verify<F: FnOnce(&MockRuntime)>(
     };
 
     assert!(rt
-        .call::<evm::EvmContractActor>(
-            evm::Method::Constructor as u64,
-            IpldBlock::serialize_cbor(&params).unwrap(),
-        )
+        .construct::<evm::EvmContractActor>(IpldBlock::serialize_cbor(&params).unwrap(),)
         .unwrap()
         .is_none());
     let evm_st: State = rt.state().unwrap();

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
+fvm_sdk = { version = "3.3.0" }
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
 frc42_dispatch = "3.3.0"
 fvm_shared = { version = "3.4.0", default-features = false }

--- a/actors/init/src/lib.rs
+++ b/actors/init/src/lib.rs
@@ -11,7 +11,7 @@ use fil_actors_runtime::{
 };
 use fvm_shared::address::Address;
 use fvm_shared::error::ExitCode;
-use fvm_shared::{ActorID, METHOD_CONSTRUCTOR};
+use fvm_shared::ActorID;
 use num_derive::FromPrimitive;
 
 pub use self::state::State;
@@ -28,7 +28,6 @@ fil_actors_runtime::wasm_trampoline!(Actor);
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
     Exec = 2,
     Exec4 = 3,
 }
@@ -92,17 +91,15 @@ impl Actor {
             ));
         }
 
-        // Create an empty actor
-        rt.create_actor(params.code_cid, id_address, None)?;
-
-        // Invoke constructor
-        extract_send_result(rt.send_simple(
-            &Address::new_id(id_address),
-            METHOD_CONSTRUCTOR,
+        // Create the actor.
+        extract_send_result(rt.create_actor(
+            params.code_cid,
+            id_address,
+            None,
             params.constructor_params.into(),
             rt.message().value_received(),
-        ))
-        .context("constructor failed")?;
+            None,
+        ))?;
 
         Ok(ExecReturn { id_address: Address::new_id(id_address), robust_address })
     }
@@ -148,17 +145,15 @@ impl Actor {
             }
         }
 
-        // Create an empty actor
-        rt.create_actor(params.code_cid, id_address, Some(delegated_address))?;
-
-        // Invoke constructor
-        extract_send_result(rt.send_simple(
-            &Address::new_id(id_address),
-            METHOD_CONSTRUCTOR,
+        // Create the actor.
+        extract_send_result(rt.create_actor(
+            params.code_cid,
+            id_address,
+            Some(delegated_address),
             params.constructor_params.into(),
             rt.message().value_received(),
-        ))
-        .context("constructor failed")?;
+            None,
+        ))?;
 
         Ok(Exec4Return { id_address: Address::new_id(id_address), robust_address })
     }
@@ -172,7 +167,6 @@ impl ActorCode for Actor {
     }
 
     actor_dispatch! {
-        Constructor => constructor,
         Exec => exec,
         Exec4 => exec4,
     }

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -20,7 +20,7 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::reward::ThisEpochRewardReturn;
 use fvm_shared::sector::{RegisteredSealProof, SectorSize, StoragePower};
-use fvm_shared::{ActorID, METHOD_CONSTRUCTOR, METHOD_SEND};
+use fvm_shared::{ActorID, METHOD_SEND};
 use integer_encoding::VarInt;
 use log::info;
 use num_derive::FromPrimitive;
@@ -69,7 +69,6 @@ pub const EX_DEAL_EXPIRED: ExitCode = ExitCode::new(FIRST_ACTOR_SPECIFIC_EXIT_CO
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
     AddBalance = 2,
     WithdrawBalance = 3,
     PublishStorageDeals = 4,
@@ -1450,7 +1449,6 @@ impl ActorCode for Actor {
     }
 
     actor_dispatch! {
-        Constructor => constructor,
         AddBalance|AddBalanceExported => add_balance,
         WithdrawBalance|WithdrawBalanceExported => withdraw_balance,
         PublishStorageDeals|PublishStorageDealsExported => publish_storage_deals,

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -44,9 +44,7 @@ use fvm_shared::reward::ThisEpochRewardReturn;
 use fvm_shared::sector::{RegisteredSealProof, StoragePower};
 use fvm_shared::smooth::FilterEstimate;
 use fvm_shared::sys::SendFlags;
-use fvm_shared::{
-    address::Address, econ::TokenAmount, error::ExitCode, ActorID, METHOD_CONSTRUCTOR, METHOD_SEND,
-};
+use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, ActorID, METHOD_SEND};
 
 // Define common set of actor ids that will be used across all tests.
 const OWNER_ID: u64 = 101;
@@ -133,7 +131,7 @@ pub fn check_state_with_expected(rt: &MockRuntime, expected_patterns: &[Regex]) 
 pub fn construct_and_verify(rt: &MockRuntime) {
     rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
-    assert!(rt.call::<MarketActor>(METHOD_CONSTRUCTOR, None).unwrap().is_none());
+    assert!(rt.construct::<MarketActor>(None).unwrap().is_none());
     rt.verify();
 }
 

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -30,7 +30,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::{RegisteredSealProof, StoragePower};
-use fvm_shared::{MethodNum, HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR, METHOD_SEND};
+use fvm_shared::{MethodNum, HAMT_BIT_WIDTH, METHOD_SEND};
 use regex::Regex;
 use std::cell::RefCell;
 use std::ops::Add;
@@ -66,7 +66,7 @@ fn simple_construction() {
     rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
 
-    assert!(rt.call::<MarketActor>(METHOD_CONSTRUCTOR, None).unwrap().is_none());
+    assert!(rt.construct::<MarketActor>(None).unwrap().is_none());
 
     rt.verify();
 

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -24,7 +24,7 @@ use fvm_shared::randomness::*;
 use fvm_shared::reward::ThisEpochRewardReturn;
 use fvm_shared::sector::*;
 use fvm_shared::smooth::FilterEstimate;
-use fvm_shared::{ActorID, METHOD_CONSTRUCTOR, METHOD_SEND};
+use fvm_shared::{ActorID, METHOD_SEND};
 use itertools::Itertools;
 use log::{error, info, warn};
 use num_derive::FromPrimitive;
@@ -96,7 +96,6 @@ mod vesting_state;
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
     ControlAddresses = 2,
     ChangeWorkerAddress = 3,
     ChangePeerID = 4,
@@ -5094,7 +5093,6 @@ impl ActorCode for Actor {
     }
 
     actor_dispatch! {
-        Constructor => constructor,
         ControlAddresses => control_addresses,
         ChangeWorkerAddress|ChangeWorkerAddressExported => change_worker_address,
         ChangePeerID|ChangePeerIDExported => change_peer_id,

--- a/actors/miner/tests/miner_actor_test_construction.rs
+++ b/actors/miner/tests/miner_actor_test_construction.rs
@@ -3,7 +3,7 @@ use fil_actors_runtime::INIT_ACTOR_ADDR;
 
 use fil_actor_account::Method as AccountMethod;
 use fil_actor_miner::{
-    Actor, Deadline, Deadlines, Method, MinerConstructorParams as ConstructorParams, State,
+    Actor, Deadline, Deadlines, MinerConstructorParams as ConstructorParams, State,
 };
 
 use fvm_ipld_encoding::{BytesDe, CborStore};
@@ -80,10 +80,7 @@ fn simple_construction() {
         ExitCode::OK,
     );
 
-    let result = env
-        .rt
-        .call::<Actor>(Method::Constructor as u64, IpldBlock::serialize_cbor(&params).unwrap())
-        .unwrap();
+    let result = env.rt.construct::<Actor>(IpldBlock::serialize_cbor(&params).unwrap()).unwrap();
     expect_empty(result);
     env.rt.verify();
 
@@ -155,10 +152,7 @@ fn control_addresses_are_resolved_during_construction() {
         ExitCode::OK,
     );
 
-    let result = env
-        .rt
-        .call::<Actor>(Method::Constructor as u64, IpldBlock::serialize_cbor(&params).unwrap())
-        .unwrap();
+    let result = env.rt.construct::<Actor>(IpldBlock::serialize_cbor(&params).unwrap()).unwrap();
     expect_empty(result);
     env.rt.verify();
 
@@ -179,10 +173,8 @@ fn test_construct_with_invalid_peer_id() {
     env.rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
     env.rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
 
-    let result = env
-        .rt
-        .call::<Actor>(Method::Constructor as u64, IpldBlock::serialize_cbor(&params).unwrap())
-        .unwrap_err();
+    let result =
+        env.rt.construct::<Actor>(IpldBlock::serialize_cbor(&params).unwrap()).unwrap_err();
     assert_eq!(result.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
     env.rt.verify();
 }
@@ -199,10 +191,8 @@ fn fails_if_control_addresses_exceeds_maximum_length() {
     env.rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
     env.rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
 
-    let result = env
-        .rt
-        .call::<Actor>(Method::Constructor as u64, IpldBlock::serialize_cbor(&params).unwrap())
-        .unwrap_err();
+    let result =
+        env.rt.construct::<Actor>(IpldBlock::serialize_cbor(&params).unwrap()).unwrap_err();
     assert_eq!(result.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
     env.rt.verify();
 }
@@ -219,10 +209,8 @@ fn test_construct_with_large_multiaddr() {
     env.rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
     env.rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
 
-    let result = env
-        .rt
-        .call::<Actor>(Method::Constructor as u64, IpldBlock::serialize_cbor(&params).unwrap())
-        .unwrap_err();
+    let result =
+        env.rt.construct::<Actor>(IpldBlock::serialize_cbor(&params).unwrap()).unwrap_err();
     assert_eq!(result.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
     env.rt.verify();
 }
@@ -238,10 +226,8 @@ fn test_construct_with_empty_multiaddr() {
     env.rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
     env.rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
 
-    let result = env
-        .rt
-        .call::<Actor>(Method::Constructor as u64, IpldBlock::serialize_cbor(&params).unwrap())
-        .unwrap_err();
+    let result =
+        env.rt.construct::<Actor>(IpldBlock::serialize_cbor(&params).unwrap()).unwrap_err();
     assert_eq!(result.exit_code(), ExitCode::USR_ILLEGAL_ARGUMENT);
     env.rt.verify();
 }

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -270,9 +270,7 @@ impl ActorHarness {
             ExitCode::OK,
         );
 
-        let result = rt
-            .call::<Actor>(Method::Constructor as u64, IpldBlock::serialize_cbor(&params).unwrap())
-            .unwrap();
+        let result = rt.construct::<Actor>(IpldBlock::serialize_cbor(&params).unwrap()).unwrap();
         expect_empty(result);
         rt.verify();
     }

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -12,7 +12,7 @@ use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::MethodNum;
-use fvm_shared::{HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR};
+use fvm_shared::HAMT_BIT_WIDTH;
 use num_derive::FromPrimitive;
 use num_traits::Zero;
 
@@ -37,7 +37,6 @@ mod types;
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
     Propose = 2,
     Approve = 3,
     Cancel = 4,
@@ -568,7 +567,6 @@ impl ActorCode for Actor {
     }
 
     actor_dispatch! {
-      Constructor => constructor,
       Propose => propose,
       Approve => approve,
       Cancel => cancel,

--- a/actors/multisig/tests/multisig_actor_test.rs
+++ b/actors/multisig/tests/multisig_actor_test.rs
@@ -80,10 +80,7 @@ mod constructor_tests {
         rt.set_received(TokenAmount::from_atto(100u8));
         rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
-        let ret = rt.call::<MultisigActor>(
-            Method::Constructor as u64,
-            IpldBlock::serialize_cbor(&params).unwrap(),
-        );
+        let ret = rt.construct::<MultisigActor>(IpldBlock::serialize_cbor(&params).unwrap());
         assert!(ret.unwrap().is_none());
         rt.verify();
 
@@ -116,12 +113,8 @@ mod constructor_tests {
 
         rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
-        let ret = rt
-            .call::<MultisigActor>(
-                Method::Constructor as u64,
-                IpldBlock::serialize_cbor(&params).unwrap(),
-            )
-            .unwrap();
+        let ret =
+            rt.construct::<MultisigActor>(IpldBlock::serialize_cbor(&params).unwrap()).unwrap();
         assert!(ret.is_none());
         check_state(&rt);
     }
@@ -140,10 +133,7 @@ mod constructor_tests {
         rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
         assert!(rt
-            .call::<MultisigActor>(
-                Method::Constructor as u64,
-                IpldBlock::serialize_cbor(&params).unwrap(),
-            )
+            .construct::<MultisigActor>(IpldBlock::serialize_cbor(&params).unwrap())
             .unwrap()
             .is_none());
 
@@ -171,10 +161,7 @@ mod constructor_tests {
 
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            rt.call::<MultisigActor>(
-                Method::Constructor as u64,
-                IpldBlock::serialize_cbor(&zero_signer_params).unwrap(),
-            ),
+            rt.construct::<MultisigActor>(IpldBlock::serialize_cbor(&zero_signer_params).unwrap()),
         );
         rt.verify();
     }
@@ -198,8 +185,7 @@ mod constructor_tests {
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            rt.call::<MultisigActor>(
-                Method::Constructor as u64,
+            rt.construct::<MultisigActor>(
                 IpldBlock::serialize_cbor(&over_max_signers_params).unwrap(),
             ),
         );
@@ -219,10 +205,7 @@ mod constructor_tests {
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            rt.call::<MultisigActor>(
-                Method::Constructor as u64,
-                IpldBlock::serialize_cbor(&params).unwrap(),
-            ),
+            rt.construct::<MultisigActor>(IpldBlock::serialize_cbor(&params).unwrap()),
         );
         rt.verify();
     }
@@ -250,10 +233,7 @@ mod constructor_tests {
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            rt.call::<MultisigActor>(
-                Method::Constructor as u64,
-                IpldBlock::serialize_cbor(&params).unwrap(),
-            ),
+            rt.construct::<MultisigActor>(IpldBlock::serialize_cbor(&params).unwrap()),
         );
         rt.verify();
     }
@@ -271,10 +251,7 @@ mod constructor_tests {
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            rt.call::<MultisigActor>(
-                Method::Constructor as u64,
-                IpldBlock::serialize_cbor(&params).unwrap(),
-            ),
+            rt.construct::<MultisigActor>(IpldBlock::serialize_cbor(&params).unwrap()),
         );
         rt.verify();
     }
@@ -294,10 +271,7 @@ mod constructor_tests {
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            rt.call::<MultisigActor>(
-                Method::Constructor as u64,
-                IpldBlock::serialize_cbor(&params).unwrap(),
-            ),
+            rt.construct::<MultisigActor>(IpldBlock::serialize_cbor(&params).unwrap()),
         );
         rt.verify();
     }

--- a/actors/multisig/tests/util.rs
+++ b/actors/multisig/tests/util.rs
@@ -41,9 +41,7 @@ impl ActorHarness {
         };
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
         rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
-        let result = rt
-            .call::<Actor>(Method::Constructor as u64, IpldBlock::serialize_cbor(&params).unwrap())
-            .unwrap();
+        let result = rt.construct::<Actor>(IpldBlock::serialize_cbor(&params).unwrap()).unwrap();
         assert!(result.is_none());
         rt.verify();
     }

--- a/actors/paych/src/lib.rs
+++ b/actors/paych/src/lib.rs
@@ -15,7 +15,7 @@ use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sys::SendFlags;
-use fvm_shared::{METHOD_CONSTRUCTOR, METHOD_SEND};
+use fvm_shared::METHOD_SEND;
 use num_derive::FromPrimitive;
 use num_traits::Zero;
 
@@ -36,7 +36,6 @@ mod types;
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
     UpdateChannelState = 2,
     Settle = 3,
     Collect = 4,
@@ -325,7 +324,6 @@ impl ActorCode for Actor {
     }
 
     actor_dispatch! {
-        Constructor => constructor,
         UpdateChannelState => update_channel_state,
         Settle => settle,
         Collect => collect,

--- a/actors/power/src/ext.rs
+++ b/actors/power/src/ext.rs
@@ -6,7 +6,6 @@ use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, StoragePower};
 use fvm_shared::smooth::FilterEstimate;
-use fvm_shared::METHOD_CONSTRUCTOR;
 use num_derive::FromPrimitive;
 
 pub mod init {
@@ -75,7 +74,6 @@ pub mod reward {
     #[derive(FromPrimitive)]
     #[repr(u64)]
     pub enum Method {
-        Constructor = METHOD_CONSTRUCTOR,
         AwardBlockReward = 2,
         ThisEpochReward = 3,
         UpdateNetworkKPI = 4,

--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -21,7 +21,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::reward::ThisEpochRewardReturn;
 use fvm_shared::sector::SealVerifyInfo;
-use fvm_shared::{MethodNum, HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR};
+use fvm_shared::{MethodNum, HAMT_BIT_WIDTH};
 use log::{debug, error};
 use num_derive::FromPrimitive;
 use num_traits::Zero;
@@ -53,7 +53,6 @@ pub mod detail {
 #[repr(u64)]
 pub enum Method {
     /// Constructor for Storage Power Actor
-    Constructor = METHOD_CONSTRUCTOR,
     CreateMiner = 2,
     UpdateClaimedPower = 3,
     EnrollCronEvent = 4,
@@ -683,7 +682,6 @@ impl ActorCode for Actor {
     }
 
     actor_dispatch! {
-        Constructor => constructor,
         CreateMiner|CreateMinerExported => create_miner,
         UpdateClaimedPower => update_claimed_power            ,
         EnrollCronEvent => enroll_cron_event,

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -105,7 +105,7 @@ impl Harness {
     pub fn construct(&self, rt: &MockRuntime) {
         rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
-        rt.call::<PowerActor>(Method::Constructor as MethodNum, None).unwrap();
+        rt.construct::<PowerActor>(None).unwrap();
         rt.verify()
     }
 

--- a/actors/reward/src/lib.rs
+++ b/actors/reward/src/lib.rs
@@ -10,7 +10,7 @@ use fil_actors_runtime::{
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::{METHOD_CONSTRUCTOR, METHOD_SEND};
+use fvm_shared::METHOD_SEND;
 use log::{error, warn};
 use num_derive::FromPrimitive;
 
@@ -40,7 +40,6 @@ pub const PENALTY_MULTIPLIER: u64 = 3;
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
     AwardBlockReward = 2,
     ThisEpochReward = 3,
     UpdateNetworkKPI = 4,
@@ -223,7 +222,6 @@ impl ActorCode for Actor {
     }
 
     actor_dispatch! {
-        Constructor => constructor,
         AwardBlockReward => award_block_reward,
         ThisEpochReward => this_epoch_reward,
         UpdateNetworkKPI => update_network_kpi,

--- a/actors/reward/tests/reward_actor_test.rs
+++ b/actors/reward/tests/reward_actor_test.rs
@@ -20,7 +20,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::StoragePower;
-use fvm_shared::{METHOD_CONSTRUCTOR, METHOD_SEND};
+use fvm_shared::METHOD_SEND;
 use lazy_static::lazy_static;
 use num_traits::FromPrimitive;
 
@@ -335,10 +335,7 @@ fn construct_and_verify(curr_power: &StoragePower) -> MockRuntime {
     rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
     rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
     let ret = rt
-        .call::<RewardActor>(
-            METHOD_CONSTRUCTOR,
-            IpldBlock::serialize_cbor(&(BigIntSer(curr_power))).unwrap(),
-        )
+        .construct::<RewardActor>(IpldBlock::serialize_cbor(&(BigIntSer(curr_power))).unwrap())
         .unwrap();
 
     assert!(ret.is_none());

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -14,7 +14,7 @@ use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::{ActorID, HAMT_BIT_WIDTH, METHOD_CONSTRUCTOR};
+use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
 use log::info;
 use num_derive::FromPrimitive;
 use num_traits::{Signed, Zero};
@@ -52,7 +52,6 @@ pub mod types;
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
-    Constructor = METHOD_CONSTRUCTOR,
     AddVerifier = 2,
     RemoveVerifier = 3,
     AddVerifiedClient = 4,
@@ -1084,7 +1083,6 @@ impl ActorCode for Actor {
     }
 
     actor_dispatch! {
-        Constructor => constructor,
         AddVerifier => add_verifier,
         RemoveVerifier => remove_verifier,
         AddVerifiedClient|AddVerifiedClientExported => add_verified_client,

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -88,12 +88,8 @@ impl Harness {
     pub fn construct_and_verify(&self, rt: &MockRuntime, root_param: &Address) {
         rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
-        let ret = rt
-            .call::<VerifregActor>(
-                Method::Constructor as MethodNum,
-                IpldBlock::serialize_cbor(root_param).unwrap(),
-            )
-            .unwrap();
+        let ret =
+            rt.construct::<VerifregActor>(IpldBlock::serialize_cbor(root_param).unwrap()).unwrap();
 
         assert!(ret.is_none());
         rt.verify();

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -40,9 +40,8 @@ mod util {
 mod construction {
     use fvm_shared::address::{Address, BLS_PUB_LEN};
     use fvm_shared::error::ExitCode;
-    use fvm_shared::MethodNum;
 
-    use fil_actor_verifreg::{Actor as VerifregActor, Method};
+    use fil_actor_verifreg::Actor as VerifregActor;
     use fil_actors_runtime::test_utils::*;
     use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
     use fvm_ipld_encoding::ipld_block::IpldBlock;
@@ -77,10 +76,7 @@ mod construction {
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
         expect_abort(
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            rt.call::<VerifregActor>(
-                Method::Constructor as MethodNum,
-                IpldBlock::serialize_cbor(&root_pubkey).unwrap(),
-            ),
+            rt.construct::<VerifregActor>(IpldBlock::serialize_cbor(&root_pubkey).unwrap()),
         );
     }
 }

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -141,9 +141,12 @@ impl Display for SendError {
     }
 }
 
-pub fn extract_send_result(
-    res: Result<fvm_shared::Response, SendError>,
-) -> Result<Option<IpldBlock>, ActorError> {
+pub fn extract_send_result<E>(
+    res: Result<fvm_shared::Response, E>,
+) -> Result<Option<IpldBlock>, ActorError>
+where
+    ActorError: From<E>,
+{
     let ret = res?;
     if ret.exit_code.is_success() {
         Ok(ret.return_data)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -39,8 +39,19 @@ pub mod test_utils;
 macro_rules! wasm_trampoline {
     ($target:ty) => {
         #[no_mangle]
+        pub extern "C" fn create(param: u32) -> u32 {
+            $crate::runtime::fvm::trampoline::<$target>(
+                param,
+                $crate::runtime::fvm::Entrypoint::Create,
+            )
+        }
+
+        #[no_mangle]
         pub extern "C" fn invoke(param: u32) -> u32 {
-            $crate::runtime::fvm::trampoline::<$target>(param)
+            $crate::runtime::fvm::trampoline::<$target>(
+                param,
+                $crate::runtime::fvm::Entrypoint::Invoke,
+            )
         }
     };
 }
@@ -135,3 +146,6 @@ impl Keyer for &str {
         BytesKey(self.as_bytes().to_owned())
     }
 }
+
+/// A type which can never be constructed.
+pub enum Never {}

--- a/runtime/src/runtime/actor_code.rs
+++ b/runtime/src/runtime/actor_code.rs
@@ -10,11 +10,22 @@ use crate::{ActorError, Runtime};
 /// Interface for invoking methods on an Actor
 pub trait ActorCode {
     type Methods;
+
     /// A name for the actor type, used in debugging.
     fn name() -> &'static str;
+
+    /// The actor constructor. Called once, when the actor is first created.
+    fn create<RT>(rt: &RT, params: Option<IpldBlock>) -> Result<Option<IpldBlock>, ActorError>
+    where
+        // TODO: remove the clone requirement on the blockstore when we fix "replica update" to not
+        // hold onto state between transactions.
+        // https://github.com/filecoin-project/builtin-actors/issues/133
+        RT: Runtime,
+        RT::Blockstore: Blockstore + Clone;
+
     /// Invokes method with runtime on the actor's code. Method number will match one
     /// defined by the Actor, and parameters will be serialized and used in execution
-    fn invoke_method<RT>(
+    fn invoke<RT>(
         rt: &RT,
         method: MethodNum,
         params: Option<IpldBlock>,

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -209,7 +209,10 @@ pub trait Runtime: Primitives + Verifier + RuntimePolicy {
         code_id: Cid,
         actor_id: ActorID,
         predictable_address: Option<Address>,
-    ) -> Result<(), ActorError>;
+        params: Option<IpldBlock>,
+        value: TokenAmount,
+        gas_limit: Option<u64>,
+    ) -> Result<Response, ActorError>;
 
     /// Deletes the executing actor from the state tree, transferring any balance to beneficiary.
     /// Aborts if the beneficiary does not exist.

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -802,24 +802,24 @@ where
         let params = self.msg.params.clone();
         let mut res = match ACTOR_TYPES.get(&to_actor.code).expect("Target actor is not a builtin")
         {
-            Type::Account => AccountActor::invoke_method(self, self.msg.method, params),
-            Type::Cron => CronActor::invoke_method(self, self.msg.method, params),
-            Type::Init => InitActor::invoke_method(self, self.msg.method, params),
-            Type::Market => MarketActor::invoke_method(self, self.msg.method, params),
-            Type::Miner => MinerActor::invoke_method(self, self.msg.method, params),
-            Type::Multisig => MultisigActor::invoke_method(self, self.msg.method, params),
-            Type::System => SystemActor::invoke_method(self, self.msg.method, params),
-            Type::Reward => RewardActor::invoke_method(self, self.msg.method, params),
-            Type::Power => PowerActor::invoke_method(self, self.msg.method, params),
-            Type::PaymentChannel => PaychActor::invoke_method(self, self.msg.method, params),
-            Type::VerifiedRegistry => VerifregActor::invoke_method(self, self.msg.method, params),
-            Type::DataCap => DataCapActor::invoke_method(self, self.msg.method, params),
+            Type::Account => AccountActor::invoke(self, self.msg.method, params),
+            Type::Cron => CronActor::invoke(self, self.msg.method, params),
+            Type::Init => InitActor::invoke(self, self.msg.method, params),
+            Type::Market => MarketActor::invoke(self, self.msg.method, params),
+            Type::Miner => MinerActor::invoke(self, self.msg.method, params),
+            Type::Multisig => MultisigActor::invoke(self, self.msg.method, params),
+            Type::System => SystemActor::invoke(self, self.msg.method, params),
+            Type::Reward => RewardActor::invoke(self, self.msg.method, params),
+            Type::Power => PowerActor::invoke(self, self.msg.method, params),
+            Type::PaymentChannel => PaychActor::invoke(self, self.msg.method, params),
+            Type::VerifiedRegistry => VerifregActor::invoke(self, self.msg.method, params),
+            Type::DataCap => DataCapActor::invoke(self, self.msg.method, params),
             Type::Placeholder => {
                 Err(ActorError::unhandled_message("placeholder actors only handle method 0".into()))
             }
-            Type::EVM => EvmContractActor::invoke_method(self, self.msg.method, params),
-            Type::EAM => EamActor::invoke_method(self, self.msg.method, params),
-            Type::EthAccount => EthAccountActor::invoke_method(self, self.msg.method, params),
+            Type::EVM => EvmContractActor::invoke(self, self.msg.method, params),
+            Type::EAM => EamActor::invoke(self, self.msg.method, params),
+            Type::EthAccount => EthAccountActor::invoke(self, self.msg.method, params),
         };
         if res.is_ok() && !*self.caller_validated.borrow() {
             res = Err(actor_error!(assertion_failed, "failed to validate caller"));


### PR DESCRIPTION
WASM module level `create` functions were added in https://github.com/filecoin-project/ref-fvm/pull/1821, and this PR adds support for them in the builtin actors. Only the unit tests for each individual test are passing, as well as the integration tests in the `ref-fvm` repo. I'll update all of the other tests once I get some general approval on the approach taken in this PR and https://github.com/filecoin-project/ref-fvm/pull/1821.