### PR TITLE
Update VM trait

### DIFF
--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 
 use anyhow::bail;
-use bimap::BiBTreeMap;
 use cid::Cid;
 use fil_actor_account::State as AccountState;
 use fil_actor_cron::State as CronState;
@@ -144,7 +143,7 @@ pub fn check_state_invariants<BS: Blockstore>(
         }
         total_fil += &actor.balance;
 
-        match manifest.get_by_left(&actor.code) {
+        match manifest.get(&actor.code) {
             Some(Type::System) => (),
             Some(Type::Init) => {
                 let state = get_state!(tree, actor, InitState);

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::fmt::Debug;
 
@@ -114,7 +115,7 @@ macro_rules! get_state {
 // It could be replaced with a custom mapping trait (while Rust doesn't support
 // abstract collection traits).
 pub fn check_state_invariants<BS: Blockstore>(
-    manifest: &BiBTreeMap<Cid, Type>,
+    manifest: &BTreeMap<Cid, Type>,
     policy: &Policy,
     tree: Tree<'_, BS>,
     expected_balance_total: &TokenAmount,

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -36,7 +36,6 @@ use fil_builtin_actors_state::check::Tree;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::CborStore;
 use fvm_ipld_hamt::{BytesKey, Hamt, Sha256};
 use fvm_shared::address::Address;
@@ -68,8 +67,6 @@ use serde::de::DeserializeOwned;
 use serde::{ser, Serialize};
 use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
-use std::error::Error;
-use std::fmt;
 use std::ops::Add;
 use trace::InvocationTrace;
 
@@ -82,57 +79,8 @@ pub mod fakes;
 pub mod trace;
 pub mod util;
 
-/// An abstract VM that is injected into integration tests
-pub trait VM {
-    /// Returns the underlying blockstore of the VM
-    fn blockstore(&self) -> &dyn Blockstore;
-
-    /// Get the state root of the specified actor
-    fn actor_root(&self, address: &Address) -> Option<Cid>;
-
-    /// Get the current chain epoch
-    fn epoch(&self) -> ChainEpoch;
-
-    /// Get the balance of the specified actor
-    fn balance(&self, address: &Address) -> TokenAmount;
-
-    /// Get the ID for the specified address
-    fn resolve_id_address(&self, address: &Address) -> Option<Address>;
-
-    /// Send a message between the two specified actors
-    fn execute_message(
-        &self,
-        from: &Address,
-        to: &Address,
-        value: &TokenAmount,
-        method: MethodNum,
-        params: Option<IpldBlock>,
-    ) -> Result<MessageResult, TestVMError>;
-
-    /// Sets the epoch to the specified value
-    fn set_epoch(&self, epoch: ChainEpoch);
-
-    /// Take all the invocations that have been made since the last call to this method
-    fn take_invocations(&self) -> Vec<InvocationTrace>;
-
-    /// Get information about an actor
-    fn actor(&self, address: &Address) -> Option<Actor>;
-
-    /// Build a map of all actors in the system and their type
-    fn actor_manifest(&self) -> BiBTreeMap<Cid, Type>;
-
-    /// Provides access to VM primitives
-    fn primitives(&self) -> &dyn Primitives;
-
-    /// Get the current runtime policy
-    fn policy(&self) -> Policy;
-
-    /// Get the root Cid of the state tree
-    fn state_root(&self) -> Cid;
-
-    /// Get the total amount of FIL in circulation
-    fn total_fil(&self) -> TokenAmount;
-}
+mod vm;
+pub use vm::*;
 
 /// An in-memory rust-execution VM for testing that yields sensible stack traces and debug info
 pub struct TestVM<'bs, BS>
@@ -144,7 +92,7 @@ where
     pub state_root: RefCell<Cid>,
     total_fil: TokenAmount,
     actors_dirty: RefCell<bool>,
-    actors_cache: RefCell<HashMap<Address, Actor>>,
+    actors_cache: RefCell<HashMap<Address, ActorState>>,
     network_version: NetworkVersion,
     curr_epoch: RefCell<ChainEpoch>,
     invocations: RefCell<Vec<InvocationTrace>>,
@@ -205,11 +153,11 @@ where
         value: &TokenAmount,
         method: MethodNum,
         params: Option<IpldBlock>,
-    ) -> Result<MessageResult, TestVMError> {
+    ) -> Result<MessageResult, VMError> {
         let from_id = &self.resolve_id_address(from).unwrap();
         let mut a = self.get_actor(from_id).unwrap();
-        let call_seq = a.call_seq_num;
-        a.call_seq_num = call_seq + 1;
+        let call_seq = a.call_seq;
+        a.call_seq = call_seq + 1;
         // EthAccount abstractions turns Placeholders into EthAccounts
         if a.code == *PLACEHOLDER_ACTOR_CODE_ID {
             a.code = *ETHACCOUNT_ACTOR_CODE_ID;
@@ -260,12 +208,16 @@ where
         }
     }
 
-    fn actor_root(&self, address: &Address) -> Option<Cid> {
-        let a_opt = self.get_actor(address);
-        let a = a_opt.as_ref()?;
-        Some(a.head)
+    fn execute_message_implicit(
+        &self,
+        from: &Address,
+        to: &Address,
+        value: &TokenAmount,
+        method: MethodNum,
+        params: Option<IpldBlock>,
+    ) -> Result<MessageResult, VMError> {
+        self.execute_message(from, to, value, method, params)
     }
-
     fn resolve_id_address(&self, address: &Address) -> Option<Address> {
         let st: InitState = get_state(self, &INIT_ACTOR_ADDR).unwrap();
         st.resolve_address::<BS>(self.store, address).unwrap()
@@ -284,46 +236,22 @@ where
         self.invocations.take()
     }
 
-    fn actor(&self, address: &Address) -> Option<Actor> {
+    fn actor(&self, address: &Address) -> Option<ActorState> {
         // check for inclusion in cache of changed actors
         if let Some(act) = self.actors_cache.borrow().get(address) {
             return Some(act.clone());
         }
         // go to persisted map
-        let actors =
-            Hamt::<&'bs BS, Actor, BytesKey, Sha256>::load(&self.state_root.borrow(), self.store)
-                .unwrap();
+        let actors = Hamt::<&'bs BS, ActorState, BytesKey, Sha256>::load(
+            &self.state_root.borrow(),
+            self.store,
+        )
+        .unwrap();
         let actor = actors.get(&address.to_bytes()).unwrap().cloned();
         actor.iter().for_each(|a| {
             self.actors_cache.borrow_mut().insert(*address, a.clone());
         });
         actor
-    }
-
-    fn actor_manifest(&self) -> BiBTreeMap<Cid, Type> {
-        let actors =
-            Hamt::<&'bs BS, Actor, BytesKey, Sha256>::load(&self.state_root.borrow(), self.store)
-                .unwrap();
-        let mut manifest = BiBTreeMap::new();
-        actors
-            .for_each(|_, actor| {
-                manifest.insert(actor.code, ACTOR_TYPES.get(&actor.code).unwrap().to_owned());
-                Ok(())
-            })
-            .unwrap();
-        manifest
-    }
-
-    fn policy(&self) -> Policy {
-        Policy::default()
-    }
-
-    fn state_root(&self) -> Cid {
-        *self.state_root.borrow()
-    }
-
-    fn total_fil(&self) -> TokenAmount {
-        self.total_fil.clone()
     }
 
     fn primitives(&self) -> &dyn Primitives {
@@ -336,7 +264,7 @@ where
     BS: Blockstore,
 {
     pub fn new(store: &'bs MemoryBlockstore) -> TestVM<'bs, MemoryBlockstore> {
-        let mut actors = Hamt::<&'bs MemoryBlockstore, Actor, BytesKey, Sha256>::new(store);
+        let mut actors = Hamt::<&'bs MemoryBlockstore, ActorState, BytesKey, Sha256>::new(store);
         TestVM {
             primitives: FakePrimitives {},
             store,
@@ -520,15 +448,17 @@ where
         self.store.put_cbor(obj, Code::Blake2b256).unwrap()
     }
 
-    pub fn get_actor(&self, addr: &Address) -> Option<Actor> {
+    pub fn get_actor(&self, addr: &Address) -> Option<ActorState> {
         // check for inclusion in cache of changed actors
         if let Some(act) = self.actors_cache.borrow().get(addr) {
             return Some(act.clone());
         }
         // go to persisted map
-        let actors =
-            Hamt::<&'bs BS, Actor, BytesKey, Sha256>::load(&self.state_root.borrow(), self.store)
-                .unwrap();
+        let actors = Hamt::<&'bs BS, ActorState, BytesKey, Sha256>::load(
+            &self.state_root.borrow(),
+            self.store,
+        )
+        .unwrap();
         let actor = actors.get(&addr.to_bytes()).unwrap().cloned();
         actor.iter().for_each(|a| {
             self.actors_cache.borrow_mut().insert(*addr, a.clone());
@@ -537,16 +467,18 @@ where
     }
 
     // blindly overwrite the actor at this address whether it previously existed or not
-    pub fn set_actor(&self, key: &Address, a: Actor) {
+    pub fn set_actor(&self, key: &Address, a: ActorState) {
         self.actors_cache.borrow_mut().insert(*key, a);
         self.actors_dirty.replace(true);
     }
 
     pub fn checkpoint(&self) -> Cid {
         // persist cache on top of latest checkpoint and clear
-        let mut actors =
-            Hamt::<&'bs BS, Actor, BytesKey, Sha256>::load(&self.state_root.borrow(), self.store)
-                .unwrap();
+        let mut actors = Hamt::<&'bs BS, ActorState, BytesKey, Sha256>::load(
+            &self.state_root.borrow(),
+            self.store,
+        )
+        .unwrap();
         for (addr, act) in self.actors_cache.borrow().iter() {
             actors.set(addr.to_bytes().into(), act.clone()).unwrap();
         }
@@ -568,9 +500,9 @@ where
         F: FnOnce(&mut S),
     {
         let mut a = self.get_actor(addr).unwrap();
-        let mut st = self.store.get_cbor::<S>(&a.head).unwrap().unwrap();
+        let mut st = self.store.get_cbor::<S>(&a.state).unwrap().unwrap();
         f(&mut st);
-        a.head = self.store.put_cbor(&st, Code::Blake2b256).unwrap();
+        a.state = self.store.put_cbor(&st, Code::Blake2b256).unwrap();
         self.set_actor(addr, a);
     }
 
@@ -586,6 +518,34 @@ where
             Ok(())
         })?;
         Ok(total)
+    }
+
+    fn actor_manifest(&self) -> BiBTreeMap<Cid, Type> {
+        let actors = Hamt::<&'bs BS, ActorState, BytesKey, Sha256>::load(
+            &self.state_root.borrow(),
+            self.store,
+        )
+        .unwrap();
+        let mut manifest = BiBTreeMap::new();
+        actors
+            .for_each(|_, actor| {
+                manifest.insert(actor.code, ACTOR_TYPES.get(&actor.code).unwrap().to_owned());
+                Ok(())
+            })
+            .unwrap();
+        manifest
+    }
+
+    fn policy(&self) -> Policy {
+        Policy::default()
+    }
+
+    fn state_root(&self) -> Cid {
+        *self.state_root.borrow()
+    }
+
+    fn total_fil(&self) -> TokenAmount {
+        self.total_fil.clone()
     }
 }
 
@@ -654,7 +614,10 @@ impl<'invocation, 'bs, BS> InvocationCtx<'invocation, 'bs, BS>
 where
     BS: Blockstore,
 {
-    fn resolve_target(&'invocation self, target: &Address) -> Result<(Actor, Address), ActorError> {
+    fn resolve_target(
+        &'invocation self,
+        target: &Address,
+    ) -> Result<(ActorState, Address), ActorError> {
         if let Some(a) = self.v.resolve_id_address(target) {
             if let Some(act) = self.v.get_actor(&a) {
                 return Ok((act, a));
@@ -692,7 +655,7 @@ where
         assert!(!existing, "should never have existing actor when no f4 address is specified");
         let target_id_addr = Address::new_id(target_id);
         let mut init_actor = self.v.get_actor(&INIT_ACTOR_ADDR).unwrap();
-        init_actor.head = self.v.store.put_cbor(&st, Code::Blake2b256).unwrap();
+        init_actor.state = self.v.store.put_cbor(&st, Code::Blake2b256).unwrap();
         self.v.set_actor(&INIT_ACTOR_ADDR, init_actor);
 
         let new_actor_msg = InternalMessage {
@@ -1078,7 +1041,7 @@ where
     }
 
     fn get_state_root(&self) -> Result<Cid, ActorError> {
-        Ok(self.v.get_actor(&self.to()).unwrap().head)
+        Ok(self.v.get_actor(&self.to()).unwrap().state)
     }
 
     fn set_state_root(&self, root: &Cid) -> Result<(), ActorError> {
@@ -1089,7 +1052,7 @@ where
                 "actor does not exist".to_string(),
             )),
             Some(mut act) if !self.read_only() => {
-                act.head = *root;
+                act.state = *root;
                 self.v.set_actor(&self.to(), act);
                 Ok(())
             }
@@ -1111,7 +1074,7 @@ where
         self.allow_side_effects.replace(true);
         let ret = result?;
         let mut act = self.v.get_actor(&self.to()).unwrap();
-        act.head = self.v.store.put_cbor(&st, Code::Blake2b256).unwrap();
+        act.state = self.v.store.put_cbor(&st, Code::Blake2b256).unwrap();
 
         if self.read_only {
             return Err(ActorError::unchecked(
@@ -1278,50 +1241,4 @@ pub struct MessageResult {
     pub code: ExitCode,
     pub message: String,
     pub ret: Option<IpldBlock>,
-}
-
-#[derive(Serialize_tuple, Deserialize_tuple, Clone, PartialEq, Eq, Debug)]
-pub struct Actor {
-    pub code: Cid,
-    pub head: Cid,
-    pub call_seq_num: u64,
-    pub balance: TokenAmount,
-    pub predictable_address: Option<Address>,
-}
-
-pub fn actor(
-    code: Cid,
-    head: Cid,
-    call_seq_num: u64,
-    balance: TokenAmount,
-    predictable_address: Option<Address>,
-) -> Actor {
-    Actor { code, head, call_seq_num, balance, predictable_address }
-}
-
-#[derive(Debug)]
-pub struct TestVMError {
-    msg: String,
-}
-
-impl fmt::Display for TestVMError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.msg)
-    }
-}
-
-impl Error for TestVMError {
-    fn description(&self) -> &str {
-        &self.msg
-    }
-}
-
-impl From<fvm_ipld_hamt::Error> for TestVMError {
-    fn from(h_err: fvm_ipld_hamt::Error) -> Self {
-        vm_err(h_err.to_string().as_str())
-    }
-}
-
-pub fn vm_err(msg: &str) -> TestVMError {
-    TestVMError { msg: msg.to_string() }
 }

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -536,7 +536,7 @@ where
         manifest
     }
 
-    fn policy(&self) -> Policy {
+    pub fn policy(&self) -> Policy {
         Policy::default()
     }
 

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -536,7 +536,7 @@ where
         manifest
     }
 
-    pub fn policy(&self) -> Policy {
+    fn policy(&self) -> Policy {
         Policy::default()
     }
 

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -258,19 +258,7 @@ where
     }
 
     fn actor_manifest(&self) -> BTreeMap<Cid, Type> {
-        let actors = Hamt::<&'bs BS, ActorState, BytesKey, Sha256>::load(
-            &self.state_root.borrow(),
-            self.store,
-        )
-        .unwrap();
-        let mut manifest = BTreeMap::new();
-        actors
-            .for_each(|_, actor| {
-                manifest.insert(actor.code, ACTOR_TYPES.get(&actor.code).unwrap().to_owned());
-                Ok(())
-            })
-            .unwrap();
-        manifest
+        ACTOR_TYPES.clone()
     }
 
     fn state_root(&self) -> Cid {

--- a/test_vm/src/util/mod.rs
+++ b/test_vm/src/util/mod.rs
@@ -620,7 +620,7 @@ where
 }
 
 pub fn get_state<T: DeserializeOwned>(v: &dyn VM, a: &Address) -> Option<T> {
-    let cid = v.actor_root(a).unwrap();
+    let cid = v.actor(a).unwrap().state;
     v.blockstore().get(&cid).unwrap().map(|slice| fvm_ipld_encoding::from_slice(&slice).unwrap())
 }
 
@@ -783,7 +783,7 @@ pub fn change_beneficiary(
     );
 }
 
-pub fn check_invariants(vm: &dyn VM) -> anyhow::Result<MessageAccumulator> {
+pub fn check_invariants<BS: Blockstore>(vm: &TestVM<'_, BS>) -> anyhow::Result<MessageAccumulator> {
     check_state_invariants(
         &vm.actor_manifest(),
         &vm.policy(),
@@ -793,11 +793,11 @@ pub fn check_invariants(vm: &dyn VM) -> anyhow::Result<MessageAccumulator> {
     )
 }
 
-pub fn assert_invariants(vm: &dyn VM) {
+pub fn assert_invariants<BS: Blockstore>(vm: &TestVM<'_, BS>) {
     check_invariants(vm).unwrap().assert_empty()
 }
 
-pub fn expect_invariants(vm: &dyn VM, expected_patterns: &[Regex]) {
+pub fn expect_invariants<BS: Blockstore>(vm: &TestVM<'_, BS>, expected_patterns: &[Regex]) {
     check_invariants(vm).unwrap().assert_expected(expected_patterns)
 }
 

--- a/test_vm/src/util/mod.rs
+++ b/test_vm/src/util/mod.rs
@@ -783,22 +783,22 @@ pub fn change_beneficiary(
     );
 }
 
-pub fn check_invariants<BS: Blockstore>(vm: &TestVM<'_, BS>) -> anyhow::Result<MessageAccumulator> {
+pub fn check_invariants(vm: &dyn VM, policy: &Policy) -> anyhow::Result<MessageAccumulator> {
     check_state_invariants(
         &vm.actor_manifest(),
-        &vm.policy(),
+        policy,
         Tree::load(&DynBlockstore::wrap(vm.blockstore()), &vm.state_root()).unwrap(),
-        &vm.total_fil(),
+        &vm.circulating_supply(),
         vm.epoch() - 1,
     )
 }
 
-pub fn assert_invariants<BS: Blockstore>(vm: &TestVM<'_, BS>) {
-    check_invariants(vm).unwrap().assert_empty()
+pub fn assert_invariants(vm: &dyn VM, policy: &Policy) {
+    check_invariants(vm, policy).unwrap().assert_empty()
 }
 
-pub fn expect_invariants<BS: Blockstore>(vm: &TestVM<'_, BS>, expected_patterns: &[Regex]) {
-    check_invariants(vm).unwrap().assert_expected(expected_patterns)
+pub fn expect_invariants(vm: &dyn VM, policy: &Policy, expected_patterns: &[Regex]) {
+    check_invariants(vm, policy).unwrap().assert_expected(expected_patterns)
 }
 
 pub fn get_network_stats(vm: &dyn VM) -> NetworkStats {

--- a/test_vm/src/util/mod.rs
+++ b/test_vm/src/util/mod.rs
@@ -793,12 +793,12 @@ pub fn check_invariants(vm: &dyn VM, policy: &Policy) -> anyhow::Result<MessageA
     )
 }
 
-pub fn assert_invariants(vm: &dyn VM, policy: &Policy) {
-    check_invariants(vm, policy).unwrap().assert_empty()
+pub fn assert_invariants(v: &dyn VM, policy: &Policy) {
+    check_invariants(v, policy).unwrap().assert_empty()
 }
 
-pub fn expect_invariants(vm: &dyn VM, policy: &Policy, expected_patterns: &[Regex]) {
-    check_invariants(vm, policy).unwrap().assert_expected(expected_patterns)
+pub fn expect_invariants(v: &dyn VM, policy: &Policy, expected_patterns: &[Regex]) {
+    check_invariants(v, policy).unwrap().assert_expected(expected_patterns)
 }
 
 pub fn get_network_stats(vm: &dyn VM) -> NetworkStats {

--- a/test_vm/src/vm.rs
+++ b/test_vm/src/vm.rs
@@ -63,7 +63,8 @@ pub trait VM {
     /// Take all the invocations that have been made since the last call to this method
     fn take_invocations(&self) -> Vec<InvocationTrace>;
 
-    // TODO: set circulating supply
+    fn set_circulating_supply(&self, supply: TokenAmount);
+
     fn circulating_supply(&self) -> TokenAmount;
 
     /// Provides access to VM primitives

--- a/test_vm/src/vm.rs
+++ b/test_vm/src/vm.rs
@@ -1,0 +1,114 @@
+/*!
+ * The VM module is replicated in this code tree temporarily. This is the high-level abstract interface
+ * for a virtual-machine that can execute Filecoin WASM actors. It defines the high-level virtual-machine
+ * interface, associated error and trace types and an interface to inject/override the behaviour of
+ * certain primitives for the purpose of running tests.
+ *
+ * TODO(alexytsu): It should eventually be moved to an external location so that it can be shared
+ * with the anorth/fvm-workbench implementation
+ */
+use std::{error::Error, fmt};
+
+use cid::Cid;
+use fil_actors_runtime::runtime::Primitives;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::{
+    ipld_block::IpldBlock,
+    tuple::{serde_tuple, Deserialize_tuple, Serialize_tuple},
+};
+use fvm_shared::{address::Address, clock::ChainEpoch, econ::TokenAmount, MethodNum};
+
+use crate::{trace::InvocationTrace, MessageResult};
+
+/// An abstract VM that is injected into integration tests
+pub trait VM {
+    /// Returns the underlying blockstore of the VM
+    fn blockstore(&self) -> &dyn Blockstore;
+
+    /// Get the current chain epoch
+    fn epoch(&self) -> ChainEpoch;
+
+    /// Get the balance of the specified actor
+    fn balance(&self, address: &Address) -> TokenAmount;
+
+    /// Get the ID for the specified address
+    fn resolve_id_address(&self, address: &Address) -> Option<Address>;
+
+    /// Send a message between the two specified actors
+    fn execute_message(
+        &self,
+        from: &Address,
+        to: &Address,
+        value: &TokenAmount,
+        method: MethodNum,
+        params: Option<IpldBlock>,
+    ) -> Result<MessageResult, VMError>;
+
+    /// Send a message without charging gas
+    fn execute_message_implicit(
+        &self,
+        from: &Address,
+        to: &Address,
+        value: &TokenAmount,
+        method: MethodNum,
+        params: Option<IpldBlock>,
+    ) -> Result<MessageResult, VMError>;
+
+    /// Sets the epoch to the specified value
+    fn set_epoch(&self, epoch: ChainEpoch);
+
+    /// Take all the invocations that have been made since the last call to this method
+    fn take_invocations(&self) -> Vec<InvocationTrace>;
+
+    /// Get information about an actor
+    fn actor(&self, address: &Address) -> Option<ActorState>;
+
+    /// Provides access to VM primitives
+    fn primitives(&self) -> &dyn Primitives;
+}
+
+#[derive(Debug)]
+pub struct VMError {
+    msg: String,
+}
+
+impl fmt::Display for VMError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+impl Error for VMError {
+    fn description(&self) -> &str {
+        &self.msg
+    }
+}
+
+impl From<fvm_ipld_hamt::Error> for VMError {
+    fn from(h_err: fvm_ipld_hamt::Error) -> Self {
+        vm_err(h_err.to_string().as_str())
+    }
+}
+
+pub fn vm_err(msg: &str) -> VMError {
+    VMError { msg: msg.to_string() }
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, PartialEq, Eq, Debug)]
+pub struct ActorState {
+    pub code: Cid,
+    pub state: Cid,
+    pub call_seq: u64,
+    pub balance: TokenAmount,
+    pub predictable_address: Option<Address>,
+}
+
+pub fn actor(
+    code: Cid,
+    head: Cid,
+    call_seq_num: u64,
+    balance: TokenAmount,
+    predictable_address: Option<Address>,
+) -> ActorState {
+    ActorState { code, state: head, call_seq: call_seq_num, balance, predictable_address }
+}

--- a/test_vm/src/vm.rs
+++ b/test_vm/src/vm.rs
@@ -7,10 +7,10 @@
  * TODO(alexytsu): It should eventually be moved to an external location so that it can be shared
  * with the anorth/fvm-workbench implementation
  */
-use std::{error::Error, fmt};
+use std::{collections::BTreeMap, error::Error, fmt};
 
 use cid::Cid;
-use fil_actors_runtime::runtime::Primitives;
+use fil_actors_runtime::runtime::{builtins::Type, Primitives};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{
     ipld_block::IpldBlock,
@@ -27,6 +27,12 @@ pub trait VM {
 
     /// Get the current chain epoch
     fn epoch(&self) -> ChainEpoch;
+
+    /// Sets the epoch to the specified value
+    fn set_epoch(&self, epoch: ChainEpoch);
+
+    /// Get information about an actor
+    fn actor(&self, address: &Address) -> Option<ActorState>;
 
     /// Get the balance of the specified actor
     fn balance(&self, address: &Address) -> TokenAmount;
@@ -54,17 +60,18 @@ pub trait VM {
         params: Option<IpldBlock>,
     ) -> Result<MessageResult, VMError>;
 
-    /// Sets the epoch to the specified value
-    fn set_epoch(&self, epoch: ChainEpoch);
-
     /// Take all the invocations that have been made since the last call to this method
     fn take_invocations(&self) -> Vec<InvocationTrace>;
 
-    /// Get information about an actor
-    fn actor(&self, address: &Address) -> Option<ActorState>;
+    // TODO: set circulating supply
+    fn circulating_supply(&self) -> TokenAmount;
 
     /// Provides access to VM primitives
     fn primitives(&self) -> &dyn Primitives;
+
+    fn actor_manifest(&self) -> BTreeMap<Cid, Type>;
+
+    fn state_root(&self) -> Cid;
 }
 
 #[derive(Debug)]

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -54,6 +54,8 @@ fn batch_onboarding(v2: bool) {
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     batch_onboarding_test(&v, v2);
+
+    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
@@ -166,6 +168,4 @@ pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
         BigInt::from(sector_size * proven_count as u64)
     );
     assert!(network_stats.total_pledge_collateral.is_positive());
-
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -6,6 +6,7 @@ use fil_actors_runtime::runtime::policy::policy_constants::PRE_COMMIT_CHALLENGE_
 use fil_actors_runtime::runtime::policy_constants::{
     MAX_AGGREGATED_SECTORS, PRE_COMMIT_SECTOR_BATCH_MAX_SIZE,
 };
+use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::CRON_ACTOR_ADDR;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
@@ -167,5 +168,9 @@ pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
     );
     assert!(network_stats.total_pledge_collateral.is_positive());
 
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -54,8 +54,6 @@ fn batch_onboarding(v2: bool) {
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     batch_onboarding_test(&v, v2);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
@@ -168,4 +166,6 @@ pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
         BigInt::from(sector_size * proven_count as u64)
     );
     assert!(network_stats.total_pledge_collateral.is_positive());
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/change_beneficiary_test.rs
+++ b/test_vm/tests/change_beneficiary_test.rs
@@ -17,8 +17,6 @@ fn change_beneficiary_success() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     change_beneficiary_success_test(&v);
-
-    assert_invariants(&v);
 }
 
 fn change_beneficiary_success_test(v: &dyn VM) {
@@ -73,6 +71,7 @@ fn change_beneficiary_success_test(v: &dyn VM) {
     get_beneficiary_return = get_beneficiary(v, &query_addr, &miner_id);
     assert!(get_beneficiary_return.proposed.is_none());
     assert_active(&change_another_beneificiary_proposal, &get_beneficiary_return.active);
+    assert_invariants(v);
 }
 
 #[test]
@@ -137,8 +136,6 @@ fn change_beneficiary_fail() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     change_beneficiary_fail_test(&v);
-
-    assert_invariants(&v)
 }
 
 fn change_beneficiary_fail_test(v: &dyn VM) {
@@ -237,6 +234,8 @@ fn change_beneficiary_fail_test(v: &dyn VM) {
     let back_owner_proposal = ChangeBeneficiaryParams::new(owner, TokenAmount::zero(), 0);
     change_beneficiary(v, &owner, &miner_id, &back_owner_proposal);
     change_beneficiary(v, &beneficiary, &miner_id, &back_owner_proposal);
+
+    assert_invariants(v)
 }
 
 fn assert_pending(

--- a/test_vm/tests/change_beneficiary_test.rs
+++ b/test_vm/tests/change_beneficiary_test.rs
@@ -17,6 +17,8 @@ fn change_beneficiary_success() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     change_beneficiary_success_test(&v);
+
+    assert_invariants(&v);
 }
 
 fn change_beneficiary_success_test(v: &dyn VM) {
@@ -71,7 +73,6 @@ fn change_beneficiary_success_test(v: &dyn VM) {
     get_beneficiary_return = get_beneficiary(v, &query_addr, &miner_id);
     assert!(get_beneficiary_return.proposed.is_none());
     assert_active(&change_another_beneificiary_proposal, &get_beneficiary_return.active);
-    assert_invariants(v);
 }
 
 #[test]
@@ -136,6 +137,8 @@ fn change_beneficiary_fail() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     change_beneficiary_fail_test(&v);
+
+    assert_invariants(&v)
 }
 
 fn change_beneficiary_fail_test(v: &dyn VM) {
@@ -234,8 +237,6 @@ fn change_beneficiary_fail_test(v: &dyn VM) {
     let back_owner_proposal = ChangeBeneficiaryParams::new(owner, TokenAmount::zero(), 0);
     change_beneficiary(v, &owner, &miner_id, &back_owner_proposal);
     change_beneficiary(v, &beneficiary, &miner_id, &back_owner_proposal);
-
-    assert_invariants(v)
 }
 
 fn assert_pending(

--- a/test_vm/tests/change_beneficiary_test.rs
+++ b/test_vm/tests/change_beneficiary_test.rs
@@ -1,6 +1,7 @@
 use fil_actor_miner::{
     ActiveBeneficiary, ChangeBeneficiaryParams, Method as MinerMethod, PendingBeneficiaryChange,
 };
+use fil_actors_runtime::runtime::Policy;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
@@ -71,7 +72,7 @@ fn change_beneficiary_success_test(v: &dyn VM) {
     get_beneficiary_return = get_beneficiary(v, &query_addr, &miner_id);
     assert!(get_beneficiary_return.proposed.is_none());
     assert_active(&change_another_beneificiary_proposal, &get_beneficiary_return.active);
-    assert_invariants(v);
+    assert_invariants(v, &Policy::default());
 }
 
 #[test]
@@ -235,7 +236,7 @@ fn change_beneficiary_fail_test(v: &dyn VM) {
     change_beneficiary(v, &owner, &miner_id, &back_owner_proposal);
     change_beneficiary(v, &beneficiary, &miner_id, &back_owner_proposal);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 fn assert_pending(

--- a/test_vm/tests/change_owner_test.rs
+++ b/test_vm/tests/change_owner_test.rs
@@ -1,4 +1,5 @@
 use fil_actor_miner::{ChangeBeneficiaryParams, Method as MinerMethod};
+use fil_actors_runtime::runtime::Policy;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
@@ -48,7 +49,7 @@ fn change_owner_success_test(v: &dyn VM) {
     assert_eq!(new_owner, minfo.owner);
     assert_eq!(new_owner, minfo.beneficiary);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -94,7 +95,7 @@ fn keep_beneficiary_when_owner_changed_test(v: &dyn VM) {
     assert_eq!(new_owner, minfo.owner);
     assert_eq!(beneficiary, minfo.beneficiary);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -171,5 +172,5 @@ fn change_owner_fail_test(v: &dyn VM) {
     assert_eq!(addr, minfo.owner);
     assert_eq!(addr, minfo.beneficiary);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }

--- a/test_vm/tests/change_owner_test.rs
+++ b/test_vm/tests/change_owner_test.rs
@@ -15,8 +15,6 @@ fn change_owner_success() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     change_owner_success_test(&v);
-
-    assert_invariants(&v)
 }
 
 fn change_owner_success_test(v: &dyn VM) {
@@ -49,6 +47,8 @@ fn change_owner_success_test(v: &dyn VM) {
     assert!(minfo.pending_owner_address.is_none());
     assert_eq!(new_owner, minfo.owner);
     assert_eq!(new_owner, minfo.beneficiary);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -56,8 +56,6 @@ fn keep_beneficiary_when_owner_changed() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     keep_beneficiary_when_owner_changed_test(&v);
-
-    assert_invariants(&v)
 }
 
 fn keep_beneficiary_when_owner_changed_test(v: &dyn VM) {
@@ -95,6 +93,8 @@ fn keep_beneficiary_when_owner_changed_test(v: &dyn VM) {
     assert!(minfo.pending_owner_address.is_none());
     assert_eq!(new_owner, minfo.owner);
     assert_eq!(beneficiary, minfo.beneficiary);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -102,8 +102,6 @@ fn change_owner_fail() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     change_owner_fail_test(&v);
-
-    assert_invariants(&v)
 }
 
 fn change_owner_fail_test(v: &dyn VM) {
@@ -172,4 +170,6 @@ fn change_owner_fail_test(v: &dyn VM) {
     assert!(minfo.pending_owner_address.is_none());
     assert_eq!(addr, minfo.owner);
     assert_eq!(addr, minfo.beneficiary);
+
+    assert_invariants(v)
 }

--- a/test_vm/tests/change_owner_test.rs
+++ b/test_vm/tests/change_owner_test.rs
@@ -15,6 +15,8 @@ fn change_owner_success() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     change_owner_success_test(&v);
+
+    assert_invariants(&v)
 }
 
 fn change_owner_success_test(v: &dyn VM) {
@@ -47,8 +49,6 @@ fn change_owner_success_test(v: &dyn VM) {
     assert!(minfo.pending_owner_address.is_none());
     assert_eq!(new_owner, minfo.owner);
     assert_eq!(new_owner, minfo.beneficiary);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -56,6 +56,8 @@ fn keep_beneficiary_when_owner_changed() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     keep_beneficiary_when_owner_changed_test(&v);
+
+    assert_invariants(&v)
 }
 
 fn keep_beneficiary_when_owner_changed_test(v: &dyn VM) {
@@ -93,8 +95,6 @@ fn keep_beneficiary_when_owner_changed_test(v: &dyn VM) {
     assert!(minfo.pending_owner_address.is_none());
     assert_eq!(new_owner, minfo.owner);
     assert_eq!(beneficiary, minfo.beneficiary);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -102,6 +102,8 @@ fn change_owner_fail() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     change_owner_fail_test(&v);
+
+    assert_invariants(&v)
 }
 
 fn change_owner_fail_test(v: &dyn VM) {
@@ -170,6 +172,4 @@ fn change_owner_fail_test(v: &dyn VM) {
     assert!(minfo.pending_owner_address.is_none());
     assert_eq!(addr, minfo.owner);
     assert_eq!(addr, minfo.beneficiary);
-
-    assert_invariants(v)
 }

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -160,8 +160,6 @@ fn submit_post_succeeds() {
     let store = MemoryBlockstore::new();
     let (v, miner_info, sector_info) = setup(&store);
     submit_post_succeeds_test(&v, miner_info, sector_info);
-
-    assert_invariants(&v);
 }
 
 fn submit_post_succeeds_test(v: &dyn VM, miner_info: MinerInfo, sector_info: SectorInfo) {
@@ -182,6 +180,8 @@ fn submit_post_succeeds_test(v: &dyn VM, miner_info: MinerInfo, sector_info: Sec
     assert!(balances.initial_pledge.is_positive());
     let p_st: PowerState = get_state(v, &STORAGE_POWER_ACTOR_ADDR).unwrap();
     assert_eq!(sector_power.raw, p_st.total_bytes_committed);
+
+    assert_invariants(v);
 }
 
 #[test]
@@ -189,8 +189,6 @@ fn skip_sector() {
     let store = MemoryBlockstore::new();
     let (v, miner_info, sector_info) = setup(&store);
     skip_sector_test(&v, sector_info, miner_info);
-
-    assert_invariants(&v)
 }
 
 fn skip_sector_test(v: &dyn VM, sector_info: SectorInfo, miner_info: MinerInfo) {
@@ -228,6 +226,7 @@ fn skip_sector_test(v: &dyn VM, sector_info: SectorInfo, miner_info: MinerInfo) 
     let network_stats = get_network_stats(v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
+    assert_invariants(v)
 }
 
 #[test]
@@ -236,8 +235,6 @@ fn missed_first_post_deadline() {
     let (v, miner_info, sector_info) = setup(&store);
 
     missed_first_post_deadline_test(&v, sector_info, miner_info);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn missed_first_post_deadline_test(v: &dyn VM, sector_info: SectorInfo, miner_info: MinerInfo) {
@@ -291,6 +288,8 @@ fn missed_first_post_deadline_test(v: &dyn VM, sector_info: SectorInfo, miner_in
     let network_stats = get_network_stats(v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -299,8 +298,6 @@ fn overdue_precommit() {
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     overdue_precommit_test(&v);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn overdue_precommit_test(v: &dyn VM) {
@@ -399,6 +396,8 @@ fn overdue_precommit_test(v: &dyn VM) {
     assert!(network_stats.total_pledge_collateral.is_zero());
     assert!(network_stats.total_raw_byte_power.is_zero());
     assert!(network_stats.total_quality_adj_power.is_zero());
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -406,8 +405,6 @@ fn aggregate_bad_sector_number() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     aggregate_bad_sector_number_test(&v);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn aggregate_bad_sector_number_test(v: &dyn VM) {
@@ -473,6 +470,7 @@ fn aggregate_bad_sector_number_test(v: &dyn VM) {
         Some(params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -480,8 +478,6 @@ fn aggregate_size_limits() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     aggregate_size_limits_test(&v);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn aggregate_size_limits_test(v: &dyn VM) {
@@ -578,6 +574,8 @@ fn aggregate_size_limits_test(v: &dyn VM) {
         Some(params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -585,8 +583,6 @@ fn aggregate_bad_sender() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     aggregate_bad_sender_test(&v);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn aggregate_bad_sender_test(v: &dyn VM) {
@@ -648,6 +644,7 @@ fn aggregate_bad_sender_test(v: &dyn VM) {
         Some(params),
         ExitCode::USR_FORBIDDEN,
     );
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -655,8 +652,6 @@ fn aggregate_one_precommit_expires() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     aggregate_one_precommit_expires_test(&v);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn aggregate_one_precommit_expires_test(v: &dyn VM) {
@@ -767,4 +762,6 @@ fn aggregate_one_precommit_expires_test(v: &dyn VM) {
     let balances = miner_balance(v, &id_addr);
     assert!(balances.initial_pledge.is_positive());
     assert!(balances.pre_commit_deposit.is_positive());
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -181,7 +181,7 @@ fn submit_post_succeeds_test(v: &dyn VM, miner_info: MinerInfo, sector_info: Sec
     let p_st: PowerState = get_state(v, &STORAGE_POWER_ACTOR_ADDR).unwrap();
     assert_eq!(sector_power.raw, p_st.total_bytes_committed);
 
-    assert_invariants(v);
+    assert_invariants(v, &Policy::default());
 }
 
 #[test]
@@ -226,7 +226,7 @@ fn skip_sector_test(v: &dyn VM, sector_info: SectorInfo, miner_info: MinerInfo) 
     let network_stats = get_network_stats(v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -289,7 +289,11 @@ fn missed_first_post_deadline_test(v: &dyn VM, sector_info: SectorInfo, miner_in
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
 
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -397,7 +401,11 @@ fn overdue_precommit_test(v: &dyn VM) {
     assert!(network_stats.total_raw_byte_power.is_zero());
     assert!(network_stats.total_quality_adj_power.is_zero());
 
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -470,7 +478,11 @@ fn aggregate_bad_sector_number_test(v: &dyn VM) {
         Some(params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -575,7 +587,11 @@ fn aggregate_size_limits_test(v: &dyn VM) {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -644,7 +660,11 @@ fn aggregate_bad_sender_test(v: &dyn VM) {
         Some(params),
         ExitCode::USR_FORBIDDEN,
     );
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -763,5 +783,9 @@ fn aggregate_one_precommit_expires_test(v: &dyn VM) {
     assert!(balances.initial_pledge.is_positive());
     assert!(balances.pre_commit_deposit.is_positive());
 
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }

--- a/test_vm/tests/commit_post_test.rs
+++ b/test_vm/tests/commit_post_test.rs
@@ -160,6 +160,8 @@ fn submit_post_succeeds() {
     let store = MemoryBlockstore::new();
     let (v, miner_info, sector_info) = setup(&store);
     submit_post_succeeds_test(&v, miner_info, sector_info);
+
+    assert_invariants(&v);
 }
 
 fn submit_post_succeeds_test(v: &dyn VM, miner_info: MinerInfo, sector_info: SectorInfo) {
@@ -180,8 +182,6 @@ fn submit_post_succeeds_test(v: &dyn VM, miner_info: MinerInfo, sector_info: Sec
     assert!(balances.initial_pledge.is_positive());
     let p_st: PowerState = get_state(v, &STORAGE_POWER_ACTOR_ADDR).unwrap();
     assert_eq!(sector_power.raw, p_st.total_bytes_committed);
-
-    assert_invariants(v);
 }
 
 #[test]
@@ -189,6 +189,8 @@ fn skip_sector() {
     let store = MemoryBlockstore::new();
     let (v, miner_info, sector_info) = setup(&store);
     skip_sector_test(&v, sector_info, miner_info);
+
+    assert_invariants(&v)
 }
 
 fn skip_sector_test(v: &dyn VM, sector_info: SectorInfo, miner_info: MinerInfo) {
@@ -226,7 +228,6 @@ fn skip_sector_test(v: &dyn VM, sector_info: SectorInfo, miner_info: MinerInfo) 
     let network_stats = get_network_stats(v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
-    assert_invariants(v)
 }
 
 #[test]
@@ -235,6 +236,8 @@ fn missed_first_post_deadline() {
     let (v, miner_info, sector_info) = setup(&store);
 
     missed_first_post_deadline_test(&v, sector_info, miner_info);
+
+    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn missed_first_post_deadline_test(v: &dyn VM, sector_info: SectorInfo, miner_info: MinerInfo) {
@@ -288,8 +291,6 @@ fn missed_first_post_deadline_test(v: &dyn VM, sector_info: SectorInfo, miner_in
     let network_stats = get_network_stats(v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
-
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -298,6 +299,8 @@ fn overdue_precommit() {
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     overdue_precommit_test(&v);
+
+    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn overdue_precommit_test(v: &dyn VM) {
@@ -396,8 +399,6 @@ fn overdue_precommit_test(v: &dyn VM) {
     assert!(network_stats.total_pledge_collateral.is_zero());
     assert!(network_stats.total_raw_byte_power.is_zero());
     assert!(network_stats.total_quality_adj_power.is_zero());
-
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -405,6 +406,8 @@ fn aggregate_bad_sector_number() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     aggregate_bad_sector_number_test(&v);
+
+    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn aggregate_bad_sector_number_test(v: &dyn VM) {
@@ -470,7 +473,6 @@ fn aggregate_bad_sector_number_test(v: &dyn VM) {
         Some(params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -478,6 +480,8 @@ fn aggregate_size_limits() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     aggregate_size_limits_test(&v);
+
+    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn aggregate_size_limits_test(v: &dyn VM) {
@@ -574,8 +578,6 @@ fn aggregate_size_limits_test(v: &dyn VM) {
         Some(params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -583,6 +585,8 @@ fn aggregate_bad_sender() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     aggregate_bad_sender_test(&v);
+
+    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn aggregate_bad_sender_test(v: &dyn VM) {
@@ -644,7 +648,6 @@ fn aggregate_bad_sender_test(v: &dyn VM) {
         Some(params),
         ExitCode::USR_FORBIDDEN,
     );
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -652,6 +655,8 @@ fn aggregate_one_precommit_expires() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     aggregate_one_precommit_expires_test(&v);
+
+    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn aggregate_one_precommit_expires_test(v: &dyn VM) {
@@ -762,6 +767,4 @@ fn aggregate_one_precommit_expires_test(v: &dyn VM) {
     let balances = miner_balance(v, &id_addr);
     assert!(balances.initial_pledge.is_positive());
     assert!(balances.pre_commit_deposit.is_positive());
-
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -333,7 +333,11 @@ fn extend_legacy_sector_with_deals_inner<BS: Blockstore>(
     // 1/2 * 2/3 -> 1/3
     assert_eq!(initial_verified_deal_weight / 3, sector_info.verified_deal_weight);
 
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -37,6 +37,8 @@ fn extend_legacy_sector_with_deals() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     extend_legacy_sector_with_deals_inner(&v, false, &v);
+
+    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -44,6 +46,8 @@ fn extend2_legacy_sector_with_deals() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     extend_legacy_sector_with_deals_inner(&v, true, &v);
+
+    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -332,8 +336,6 @@ fn extend_legacy_sector_with_deals_inner<BS: Blockstore>(
     assert_eq!(initial_deal_weight, sector_info.deal_weight);
     // 1/2 * 2/3 -> 1/3
     assert_eq!(initial_verified_deal_weight / 3, sector_info.verified_deal_weight);
-
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -37,8 +37,6 @@ fn extend_legacy_sector_with_deals() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     extend_legacy_sector_with_deals_inner(&v, false, &v);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -46,8 +44,6 @@ fn extend2_legacy_sector_with_deals() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     extend_legacy_sector_with_deals_inner(&v, true, &v);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -336,6 +332,8 @@ fn extend_legacy_sector_with_deals_inner<BS: Blockstore>(
     assert_eq!(initial_deal_weight, sector_info.deal_weight);
     // 1/2 * 2/3 -> 1/3
     assert_eq!(initial_verified_deal_weight / 3, sector_info.verified_deal_weight);
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]

--- a/test_vm/tests/init_test.rs
+++ b/test_vm/tests/init_test.rs
@@ -12,7 +12,7 @@ use test_vm::{actor, util::serialize_ok, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUC
 
 fn assert_placeholder_actor(exp_bal: TokenAmount, v: &dyn VM, addr: Address) {
     let act = v.actor(&addr).unwrap();
-    assert_eq!(EMPTY_ARR_CID, act.head);
+    assert_eq!(EMPTY_ARR_CID, act.state);
     assert_eq!(*PLACEHOLDER_ACTOR_CODE_ID, act.code);
     assert_eq!(exp_bal, act.balance);
 }

--- a/test_vm/tests/init_test.rs
+++ b/test_vm/tests/init_test.rs
@@ -12,7 +12,7 @@ use test_vm::{actor, util::serialize_ok, TestVM, FIRST_TEST_USER_ADDR, TEST_FAUC
 
 fn assert_placeholder_actor(exp_bal: TokenAmount, v: &dyn VM, addr: Address) {
     let act = v.actor(&addr).unwrap();
-    assert_eq!(EMPTY_ARR_CID, act.state);
+    assert_eq!(EMPTY_ARR_CID, act.head);
     assert_eq!(*PLACEHOLDER_ACTOR_CODE_ID, act.code);
     assert_eq!(exp_bal, act.balance);
 }

--- a/test_vm/tests/market_miner_withdrawal_test.rs
+++ b/test_vm/tests/market_miner_withdrawal_test.rs
@@ -14,7 +14,7 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::sector::RegisteredPoStProof;
 use fvm_shared::METHOD_SEND;
 use test_vm::util::{apply_code, apply_ok, create_accounts, create_miner};
-use test_vm::Actor;
+use test_vm::ActorState;
 use test_vm::TestVM;
 use test_vm::VM;
 
@@ -254,7 +254,7 @@ fn assert_add_collateral_and_withdraw(
     assert_eq!(caller_initial_balance, c.balance);
 }
 
-fn require_actor(v: &dyn VM, addr: Address) -> Actor {
+fn require_actor(v: &dyn VM, addr: Address) -> ActorState {
     v.actor(&addr).unwrap()
 }
 

--- a/test_vm/tests/multisig_test.rs
+++ b/test_vm/tests/multisig_test.rs
@@ -189,8 +189,6 @@ fn swap_self_1_of_2() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     swap_self_1_of_2_test(&v);
-
-    assert_invariants(&v);
 }
 
 fn swap_self_1_of_2_test(v: &dyn VM) {
@@ -215,6 +213,7 @@ fn swap_self_1_of_2_test(v: &dyn VM) {
     );
     let st: MsigState = get_state(v, &msig_addr).unwrap();
     assert_eq!(vec![bob, chuck], st.signers);
+    assert_invariants(v);
 }
 
 #[test]
@@ -222,8 +221,6 @@ fn swap_self_2_of_3() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     swap_self_2_of_3_test(&v);
-
-    assert_invariants(&v)
 }
 
 fn swap_self_2_of_3_test(v: &dyn VM) {
@@ -293,6 +290,8 @@ fn swap_self_2_of_3_test(v: &dyn VM) {
     );
     let st: MsigState = get_state(v, &msig_addr).unwrap();
     assert_eq!(vec![bob, chuck, alice], st.signers);
+
+    assert_invariants(v)
 }
 
 fn create_msig(v: &dyn VM, signers: &[Address], threshold: u64) -> Address {

--- a/test_vm/tests/multisig_test.rs
+++ b/test_vm/tests/multisig_test.rs
@@ -189,6 +189,8 @@ fn swap_self_1_of_2() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     swap_self_1_of_2_test(&v);
+
+    assert_invariants(&v);
 }
 
 fn swap_self_1_of_2_test(v: &dyn VM) {
@@ -213,7 +215,6 @@ fn swap_self_1_of_2_test(v: &dyn VM) {
     );
     let st: MsigState = get_state(v, &msig_addr).unwrap();
     assert_eq!(vec![bob, chuck], st.signers);
-    assert_invariants(v);
 }
 
 #[test]
@@ -221,6 +222,8 @@ fn swap_self_2_of_3() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     swap_self_2_of_3_test(&v);
+
+    assert_invariants(&v)
 }
 
 fn swap_self_2_of_3_test(v: &dyn VM) {
@@ -290,8 +293,6 @@ fn swap_self_2_of_3_test(v: &dyn VM) {
     );
     let st: MsigState = get_state(v, &msig_addr).unwrap();
     assert_eq!(vec![bob, chuck, alice], st.signers);
-
-    assert_invariants(v)
 }
 
 fn create_msig(v: &dyn VM, signers: &[Address], threshold: u64) -> Address {

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -30,6 +30,8 @@ fn power_create_miner() {
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     power_create_miner_test(&v);
+
+    assert_invariants(&v);
 }
 
 fn power_create_miner_test(v: &dyn VM) {
@@ -102,7 +104,6 @@ fn power_create_miner_test(v: &dyn VM) {
     };
 
     expect.matches(v.take_invocations().last().unwrap());
-    assert_invariants(v);
 }
 
 #[test]

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -30,8 +30,6 @@ fn power_create_miner() {
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
     power_create_miner_test(&v);
-
-    assert_invariants(&v);
 }
 
 fn power_create_miner_test(v: &dyn VM) {
@@ -104,6 +102,7 @@ fn power_create_miner_test(v: &dyn VM) {
     };
 
     expect.matches(v.take_invocations().last().unwrap());
+    assert_invariants(v);
 }
 
 #[test]

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -102,7 +102,7 @@ fn power_create_miner_test(v: &dyn VM) {
     };
 
     expect.matches(v.take_invocations().last().unwrap());
-    assert_invariants(v);
+    assert_invariants(v, &Policy::default());
 }
 
 #[test]
@@ -215,5 +215,9 @@ fn test_cron_tick() {
     }
     .matches(v.take_invocations().first().unwrap());
 
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        &v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -145,7 +145,7 @@ fn psd_mismatched_provider_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 2], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -173,7 +173,7 @@ fn psd_bad_piece_size_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -195,7 +195,7 @@ fn psd_start_time_in_past_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -216,7 +216,7 @@ fn psd_client_address_cannot_be_resolved_test(v: &dyn VM, a: Addrs, deal_start: 
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -236,7 +236,7 @@ fn psd_no_client_lockup_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -272,7 +272,7 @@ fn psd_not_enough_client_lockup_for_batch_test(v: &dyn VM, a: Addrs, deal_start:
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -314,7 +314,7 @@ fn psd_not_enough_provider_lockup_for_batch_test(v: &dyn VM, deal_start: i64, a:
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -346,7 +346,7 @@ fn psd_duplicate_deal_in_batch_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 4], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -376,7 +376,7 @@ fn psd_duplicate_deal_in_state_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let good_inputs2 = bf_all(deal_ret2.valid_deals);
     assert_eq!(vec![1], good_inputs2);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -408,7 +408,7 @@ fn psd_verified_deal_fails_getting_datacap_test(v: &dyn VM, a: Addrs, deal_start
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -471,7 +471,7 @@ fn psd_random_assortment_of_failures_test(v: &dyn VM, a: Addrs, deal_start: i64)
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 2, 8], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -501,7 +501,7 @@ fn psd_all_deals_are_bad_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     );
 
     batcher.publish_fail(a.worker);
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -579,7 +579,7 @@ fn psd_bad_sig_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     }
     .matches(v.take_invocations().last().unwrap());
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -604,7 +604,7 @@ fn all_deals_are_good_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 2, 3, 4], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -635,7 +635,7 @@ fn psd_valid_deals_with_ones_longer_than_540_test(v: &dyn VM, a: Addrs, deal_sta
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 2], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -668,5 +668,5 @@ fn psd_deal_duration_too_long_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1], good_inputs);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -128,6 +128,8 @@ fn psd_mismatched_provider() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_mismatched_provider_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_mismatched_provider_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -144,8 +146,6 @@ fn psd_mismatched_provider_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 2], good_inputs);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -154,6 +154,8 @@ fn psd_bad_piece_size() {
     let (v, a, deal_start) = setup(&store);
 
     psd_bad_piece_size_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_bad_piece_size_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -172,8 +174,6 @@ fn psd_bad_piece_size_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -181,6 +181,8 @@ fn psd_start_time_in_past() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_start_time_in_past_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_start_time_in_past_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -194,8 +196,6 @@ fn psd_start_time_in_past_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -203,6 +203,8 @@ fn psd_client_address_cannot_be_resolved() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_client_address_cannot_be_resolved_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_client_address_cannot_be_resolved_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -215,8 +217,6 @@ fn psd_client_address_cannot_be_resolved_test(v: &dyn VM, a: Addrs, deal_start: 
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -224,6 +224,8 @@ fn psd_no_client_lockup() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_no_client_lockup_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_no_client_lockup_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -235,8 +237,6 @@ fn psd_no_client_lockup_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -245,6 +245,8 @@ fn psd_not_enough_client_lockup_for_batch() {
     let (v, a, deal_start) = setup(&store);
 
     psd_not_enough_client_lockup_for_batch_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_not_enough_client_lockup_for_batch_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -271,8 +273,6 @@ fn psd_not_enough_client_lockup_for_batch_test(v: &dyn VM, a: Addrs, deal_start:
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -281,6 +281,8 @@ fn psd_not_enough_provider_lockup_for_batch() {
     let (v, a, deal_start) = setup(&store);
 
     psd_not_enough_provider_lockup_for_batch_test(&v, deal_start, a);
+
+    assert_invariants(&v)
 }
 
 fn psd_not_enough_provider_lockup_for_batch_test(v: &dyn VM, deal_start: i64, a: Addrs) {
@@ -313,8 +315,6 @@ fn psd_not_enough_provider_lockup_for_batch_test(v: &dyn VM, deal_start: i64, a:
     let deal_ret = batcher.publish_ok(cheap_worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -322,6 +322,8 @@ fn psd_duplicate_deal_in_batch() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_duplicate_deal_in_batch_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_duplicate_deal_in_batch_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -345,8 +347,6 @@ fn psd_duplicate_deal_in_batch_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 4], good_inputs);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -354,6 +354,8 @@ fn psd_duplicate_deal_in_state() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_duplicate_deal_in_state_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_duplicate_deal_in_state_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -375,8 +377,6 @@ fn psd_duplicate_deal_in_state_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret2 = batcher.publish_ok(a.worker);
     let good_inputs2 = bf_all(deal_ret2.valid_deals);
     assert_eq!(vec![1], good_inputs2);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -384,6 +384,8 @@ fn psd_verified_deal_fails_getting_datacap() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_verified_deal_fails_getting_datacap_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_verified_deal_fails_getting_datacap_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -407,8 +409,6 @@ fn psd_verified_deal_fails_getting_datacap_test(v: &dyn VM, a: Addrs, deal_start
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1], good_inputs);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -416,6 +416,8 @@ fn psd_random_assortment_of_failures() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_random_assortment_of_failures_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_random_assortment_of_failures_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -470,8 +472,6 @@ fn psd_random_assortment_of_failures_test(v: &dyn VM, a: Addrs, deal_start: i64)
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 2, 8], good_inputs);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -479,6 +479,8 @@ fn psd_all_deals_are_bad() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_all_deals_are_bad_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_all_deals_are_bad_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -501,7 +503,6 @@ fn psd_all_deals_are_bad_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     );
 
     batcher.publish_fail(a.worker);
-    assert_invariants(v)
 }
 
 #[test]
@@ -509,6 +510,8 @@ fn psd_bad_sig() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_bad_sig_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_bad_sig_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -578,8 +581,6 @@ fn psd_bad_sig_test(v: &dyn VM, a: Addrs, deal_start: i64) {
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -587,6 +588,8 @@ fn psd_all_deals_are_good() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     all_deals_are_good_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn all_deals_are_good_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -603,8 +606,6 @@ fn all_deals_are_good_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 2, 3, 4], good_inputs);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -612,6 +613,8 @@ fn psd_valid_deals_with_ones_longer_than_540() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_valid_deals_with_ones_longer_than_540_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_valid_deals_with_ones_longer_than_540_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -634,8 +637,6 @@ fn psd_valid_deals_with_ones_longer_than_540_test(v: &dyn VM, a: Addrs, deal_sta
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 2], good_inputs);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -643,6 +644,8 @@ fn psd_deal_duration_too_long() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_deal_duration_too_long_test(&v, a, deal_start);
+
+    assert_invariants(&v)
 }
 
 fn psd_deal_duration_too_long_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -667,6 +670,4 @@ fn psd_deal_duration_too_long_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1], good_inputs);
-
-    assert_invariants(v)
 }

--- a/test_vm/tests/publish_deals_test.rs
+++ b/test_vm/tests/publish_deals_test.rs
@@ -128,8 +128,6 @@ fn psd_mismatched_provider() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_mismatched_provider_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_mismatched_provider_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -146,6 +144,8 @@ fn psd_mismatched_provider_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 2], good_inputs);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -154,8 +154,6 @@ fn psd_bad_piece_size() {
     let (v, a, deal_start) = setup(&store);
 
     psd_bad_piece_size_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_bad_piece_size_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -174,6 +172,8 @@ fn psd_bad_piece_size_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -181,8 +181,6 @@ fn psd_start_time_in_past() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_start_time_in_past_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_start_time_in_past_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -196,6 +194,8 @@ fn psd_start_time_in_past_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -203,8 +203,6 @@ fn psd_client_address_cannot_be_resolved() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_client_address_cannot_be_resolved_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_client_address_cannot_be_resolved_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -217,6 +215,8 @@ fn psd_client_address_cannot_be_resolved_test(v: &dyn VM, a: Addrs, deal_start: 
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -224,8 +224,6 @@ fn psd_no_client_lockup() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_no_client_lockup_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_no_client_lockup_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -237,6 +235,8 @@ fn psd_no_client_lockup_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -245,8 +245,6 @@ fn psd_not_enough_client_lockup_for_batch() {
     let (v, a, deal_start) = setup(&store);
 
     psd_not_enough_client_lockup_for_batch_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_not_enough_client_lockup_for_batch_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -273,6 +271,8 @@ fn psd_not_enough_client_lockup_for_batch_test(v: &dyn VM, a: Addrs, deal_start:
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -281,8 +281,6 @@ fn psd_not_enough_provider_lockup_for_batch() {
     let (v, a, deal_start) = setup(&store);
 
     psd_not_enough_provider_lockup_for_batch_test(&v, deal_start, a);
-
-    assert_invariants(&v)
 }
 
 fn psd_not_enough_provider_lockup_for_batch_test(v: &dyn VM, deal_start: i64, a: Addrs) {
@@ -315,6 +313,8 @@ fn psd_not_enough_provider_lockup_for_batch_test(v: &dyn VM, deal_start: i64, a:
     let deal_ret = batcher.publish_ok(cheap_worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -322,8 +322,6 @@ fn psd_duplicate_deal_in_batch() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_duplicate_deal_in_batch_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_duplicate_deal_in_batch_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -347,6 +345,8 @@ fn psd_duplicate_deal_in_batch_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 4], good_inputs);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -354,8 +354,6 @@ fn psd_duplicate_deal_in_state() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_duplicate_deal_in_state_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_duplicate_deal_in_state_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -377,6 +375,8 @@ fn psd_duplicate_deal_in_state_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret2 = batcher.publish_ok(a.worker);
     let good_inputs2 = bf_all(deal_ret2.valid_deals);
     assert_eq!(vec![1], good_inputs2);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -384,8 +384,6 @@ fn psd_verified_deal_fails_getting_datacap() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_verified_deal_fails_getting_datacap_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_verified_deal_fails_getting_datacap_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -409,6 +407,8 @@ fn psd_verified_deal_fails_getting_datacap_test(v: &dyn VM, a: Addrs, deal_start
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1], good_inputs);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -416,8 +416,6 @@ fn psd_random_assortment_of_failures() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_random_assortment_of_failures_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_random_assortment_of_failures_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -472,6 +470,8 @@ fn psd_random_assortment_of_failures_test(v: &dyn VM, a: Addrs, deal_start: i64)
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 2, 8], good_inputs);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -479,8 +479,6 @@ fn psd_all_deals_are_bad() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_all_deals_are_bad_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_all_deals_are_bad_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -503,6 +501,7 @@ fn psd_all_deals_are_bad_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     );
 
     batcher.publish_fail(a.worker);
+    assert_invariants(v)
 }
 
 #[test]
@@ -510,8 +509,6 @@ fn psd_bad_sig() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_bad_sig_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_bad_sig_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -581,6 +578,8 @@ fn psd_bad_sig_test(v: &dyn VM, a: Addrs, deal_start: i64) {
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -588,8 +587,6 @@ fn psd_all_deals_are_good() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     all_deals_are_good_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn all_deals_are_good_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -606,6 +603,8 @@ fn all_deals_are_good_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 2, 3, 4], good_inputs);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -613,8 +612,6 @@ fn psd_valid_deals_with_ones_longer_than_540() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_valid_deals_with_ones_longer_than_540_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_valid_deals_with_ones_longer_than_540_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -637,6 +634,8 @@ fn psd_valid_deals_with_ones_longer_than_540_test(v: &dyn VM, a: Addrs, deal_sta
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 2], good_inputs);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -644,8 +643,6 @@ fn psd_deal_duration_too_long() {
     let store = MemoryBlockstore::new();
     let (v, a, deal_start) = setup(&store);
     psd_deal_duration_too_long_test(&v, a, deal_start);
-
-    assert_invariants(&v)
 }
 
 fn psd_deal_duration_too_long_test(v: &dyn VM, a: Addrs, deal_start: i64) {
@@ -670,4 +667,6 @@ fn psd_deal_duration_too_long_test(v: &dyn VM, a: Addrs, deal_start: i64) {
     let deal_ret = batcher.publish_ok(a.worker);
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1], good_inputs);
+
+    assert_invariants(v)
 }

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -69,8 +69,6 @@ fn replica_update_full_path_success(v2: bool) {
         policy,
         sector_size,
     );
-
-    assert_invariants(&v)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -127,6 +125,8 @@ fn replica_update_full_path_success_test(
     assert!(check_sector_active(v, &miner_id, sector_number));
     assert!(!check_sector_faulty(v, &miner_id, deadline_index, partition_index, sector_number));
     assert_eq!(miner_power(v, &miner_id).raw, BigInt::from(sector_size as i64));
+
+    assert_invariants(v)
 }
 
 #[test_case(false; "v1")]
@@ -145,8 +145,6 @@ fn upgrade_and_miss_post(v2: bool) {
         partition_index,
         sector_size,
     );
-
-    assert_invariants(&v)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -201,6 +199,8 @@ fn upgrade_and_miss_post_test(
     assert!(check_sector_active(v, &miner_id, sector_number));
     assert!(!check_sector_faulty(v, &miner_id, deadline_index, partition_index, sector_number));
     assert_eq!(miner_power(v, &miner_id).raw, BigInt::from(sector_size as i64));
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -208,8 +208,6 @@ fn prove_replica_update_multi_dline() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     prove_replica_update_multi_dline_test(&v);
-
-    assert_invariants(&v);
 }
 
 fn prove_replica_update_multi_dline_test(v: &dyn VM) {
@@ -344,6 +342,8 @@ fn prove_replica_update_multi_dline_test(v: &dyn VM) {
     assert_eq!(1, new_sector_info_p2.deal_ids.len());
     assert_eq!(old_sector_commr_p2, new_sector_info_p2.sector_key_cid.unwrap());
     assert_eq!(new_sealed_cid2, new_sector_info_p2.sealed_cid);
+
+    assert_invariants(v);
 }
 
 // ---- Failure cases ----
@@ -354,8 +354,6 @@ fn immutable_deadline_failure() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     immutable_deadline_failure_test(&v);
-
-    assert_invariants(&v)
 }
 
 fn immutable_deadline_failure_test(v: &dyn VM) {
@@ -402,6 +400,8 @@ fn immutable_deadline_failure_test(v: &dyn VM) {
         Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -409,8 +409,6 @@ fn unhealthy_sector_failure() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     unhealthy_sector_failure_test(&v);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn unhealthy_sector_failure_test(v: &dyn VM) {
@@ -461,6 +459,8 @@ fn unhealthy_sector_failure_test(v: &dyn VM) {
         Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -468,8 +468,6 @@ fn terminated_sector_failure() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     terminated_sector_failure_test(&v);
-
-    assert_invariants(&v)
 }
 
 fn terminated_sector_failure_test(v: &dyn VM) {
@@ -531,6 +529,8 @@ fn terminated_sector_failure_test(v: &dyn VM) {
         Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -538,8 +538,6 @@ fn bad_batch_size_failure() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     bad_batch_size_failure_test(&v);
-
-    assert_invariants(&v)
 }
 
 fn bad_batch_size_failure_test(v: &dyn VM) {
@@ -589,6 +587,8 @@ fn bad_batch_size_failure_test(v: &dyn VM) {
         Some(ProveReplicaUpdatesParams { updates }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -598,8 +598,6 @@ fn no_dispute_after_upgrade() {
         create_miner_and_upgrade_sector(store, false);
 
     nodispute_after_upgrade_test(&v, deadline_index, worker, miner_id);
-
-    assert_invariants(&v)
 }
 
 fn nodispute_after_upgrade_test(
@@ -618,6 +616,8 @@ fn nodispute_after_upgrade_test(
         Some(dispute_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -634,8 +634,6 @@ fn upgrade_bad_post_dispute() {
         partition_index,
         deadline_index,
     );
-
-    assert_invariants(&v)
 }
 
 fn upgrade_bad_post_dispute_test(
@@ -663,6 +661,8 @@ fn upgrade_bad_post_dispute_test(
         MinerMethod::DisputeWindowedPoSt as u64,
         Some(dispute_params),
     );
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -670,8 +670,6 @@ fn bad_post_upgrade_dispute() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     bad_post_upgrade_dispute_test(&v);
-
-    assert_invariants(&v)
 }
 
 fn bad_post_upgrade_dispute_test(v: &dyn VM) {
@@ -745,6 +743,8 @@ fn bad_post_upgrade_dispute_test(v: &dyn VM) {
         MinerMethod::DisputeWindowedPoSt as u64,
         Some(dispute_params),
     );
+
+    assert_invariants(v)
 }
 
 // Tests that an active CC sector can be correctly upgraded, and then the sector can be terminated
@@ -761,8 +761,6 @@ fn terminate_after_upgrade() {
         deadline_index,
         partition_index,
     );
-
-    assert_invariants(&v);
 }
 
 fn terminate_after_upgrade_test(
@@ -804,6 +802,8 @@ fn terminate_after_upgrade_test(
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_qa_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_zero());
+
+    assert_invariants(v);
 }
 
 // Tests that an active CC sector can be correctly upgraded, and then the sector can be extended
@@ -832,8 +832,6 @@ fn extend_after_upgrade() {
         partition_index,
         sector_number,
     );
-
-    assert_invariants(&v)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -872,6 +870,8 @@ fn extend_after_upgrade_test(
         policy.max_sector_expiration_extension - 1,
         final_sector_info.expiration - extension_epoch,
     );
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -880,8 +880,6 @@ fn wrong_deadline_index_failure() {
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
 
     wrong_deadline_index_failure_test(&v);
-
-    assert_invariants(&v)
 }
 
 fn wrong_deadline_index_failure_test(v: &dyn VM) {
@@ -935,6 +933,8 @@ fn wrong_deadline_index_failure_test(v: &dyn VM) {
 
     let new_sector_info = sector_info(v, &maddr, sector_number);
     assert_eq!(old_sector_info, new_sector_info);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -943,8 +943,6 @@ fn wrong_partition_index_failure() {
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
 
     wrong_partition_index_failure_test(&v);
-
-    assert_invariants(&v)
 }
 
 fn wrong_partition_index_failure_test(v: &dyn VM) {
@@ -998,6 +996,8 @@ fn wrong_partition_index_failure_test(v: &dyn VM) {
 
     let new_sector_info = sector_info(v, &maddr, sector_number);
     assert_eq!(old_sector_info, new_sector_info);
+
+    assert_invariants(v)
 }
 
 #[test]
@@ -1126,6 +1126,8 @@ fn deal_included_in_multiple_sectors_failure_test(v: &dyn VM) {
     let new_sector_info_p2 = sector_info(v, &maddr, first_sector_number + 1);
     assert!(new_sector_info_p2.deal_ids.len().is_zero());
     assert_ne!(new_sealed_cid2, new_sector_info_p2.sealed_cid);
+
+    assert_invariants(v)
 }
 
 #[test]

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -48,7 +48,10 @@ use test_vm::TestVM;
 #[test_case(false; "v1")]
 #[test_case(true; "v2")]
 fn replica_update_simple_path_success(v2: bool) {
-    assert_invariants(&create_miner_and_upgrade_sector(&MemoryBlockstore::new(), v2).0);
+    assert_invariants(
+        &create_miner_and_upgrade_sector(&MemoryBlockstore::new(), v2).0,
+        &Policy::default(),
+    );
 }
 
 // Tests a successful upgrade, followed by the sector going faulty and recovering
@@ -126,7 +129,7 @@ fn replica_update_full_path_success_test(
     assert!(!check_sector_faulty(v, &miner_id, deadline_index, partition_index, sector_number));
     assert_eq!(miner_power(v, &miner_id).raw, BigInt::from(sector_size as i64));
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test_case(false; "v1")]
@@ -200,7 +203,7 @@ fn upgrade_and_miss_post_test(
     assert!(!check_sector_faulty(v, &miner_id, deadline_index, partition_index, sector_number));
     assert_eq!(miner_power(v, &miner_id).raw, BigInt::from(sector_size as i64));
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -343,7 +346,7 @@ fn prove_replica_update_multi_dline_test(v: &dyn VM) {
     assert_eq!(old_sector_commr_p2, new_sector_info_p2.sector_key_cid.unwrap());
     assert_eq!(new_sealed_cid2, new_sector_info_p2.sealed_cid);
 
-    assert_invariants(v);
+    assert_invariants(v, &Policy::default());
 }
 
 // ---- Failure cases ----
@@ -401,7 +404,7 @@ fn immutable_deadline_failure_test(v: &dyn VM) {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -460,7 +463,11 @@ fn unhealthy_sector_failure_test(v: &dyn VM) {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -530,7 +537,7 @@ fn terminated_sector_failure_test(v: &dyn VM) {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -588,7 +595,7 @@ fn bad_batch_size_failure_test(v: &dyn VM) {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -617,7 +624,7 @@ fn nodispute_after_upgrade_test(
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -662,7 +669,7 @@ fn upgrade_bad_post_dispute_test(
         Some(dispute_params),
     );
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -744,7 +751,7 @@ fn bad_post_upgrade_dispute_test(v: &dyn VM) {
         Some(dispute_params),
     );
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 // Tests that an active CC sector can be correctly upgraded, and then the sector can be terminated
@@ -803,7 +810,7 @@ fn terminate_after_upgrade_test(
     assert!(network_stats.total_qa_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_zero());
 
-    assert_invariants(v);
+    assert_invariants(v, &Policy::default());
 }
 
 // Tests that an active CC sector can be correctly upgraded, and then the sector can be extended
@@ -871,7 +878,7 @@ fn extend_after_upgrade_test(
         final_sector_info.expiration - extension_epoch,
     );
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -934,7 +941,7 @@ fn wrong_deadline_index_failure_test(v: &dyn VM) {
     let new_sector_info = sector_info(v, &maddr, sector_number);
     assert_eq!(old_sector_info, new_sector_info);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -997,7 +1004,7 @@ fn wrong_partition_index_failure_test(v: &dyn VM) {
     let new_sector_info = sector_info(v, &maddr, sector_number);
     assert_eq!(old_sector_info, new_sector_info);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -1127,7 +1134,7 @@ fn deal_included_in_multiple_sectors_failure_test(v: &dyn VM) {
     assert!(new_sector_info_p2.deal_ids.len().is_zero());
     assert_ne!(new_sealed_cid2, new_sector_info_p2.sealed_cid);
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -69,6 +69,8 @@ fn replica_update_full_path_success(v2: bool) {
         policy,
         sector_size,
     );
+
+    assert_invariants(&v)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -125,8 +127,6 @@ fn replica_update_full_path_success_test(
     assert!(check_sector_active(v, &miner_id, sector_number));
     assert!(!check_sector_faulty(v, &miner_id, deadline_index, partition_index, sector_number));
     assert_eq!(miner_power(v, &miner_id).raw, BigInt::from(sector_size as i64));
-
-    assert_invariants(v)
 }
 
 #[test_case(false; "v1")]
@@ -145,6 +145,8 @@ fn upgrade_and_miss_post(v2: bool) {
         partition_index,
         sector_size,
     );
+
+    assert_invariants(&v)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -199,8 +201,6 @@ fn upgrade_and_miss_post_test(
     assert!(check_sector_active(v, &miner_id, sector_number));
     assert!(!check_sector_faulty(v, &miner_id, deadline_index, partition_index, sector_number));
     assert_eq!(miner_power(v, &miner_id).raw, BigInt::from(sector_size as i64));
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -208,6 +208,8 @@ fn prove_replica_update_multi_dline() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     prove_replica_update_multi_dline_test(&v);
+
+    assert_invariants(&v);
 }
 
 fn prove_replica_update_multi_dline_test(v: &dyn VM) {
@@ -342,8 +344,6 @@ fn prove_replica_update_multi_dline_test(v: &dyn VM) {
     assert_eq!(1, new_sector_info_p2.deal_ids.len());
     assert_eq!(old_sector_commr_p2, new_sector_info_p2.sector_key_cid.unwrap());
     assert_eq!(new_sealed_cid2, new_sector_info_p2.sealed_cid);
-
-    assert_invariants(v);
 }
 
 // ---- Failure cases ----
@@ -354,6 +354,8 @@ fn immutable_deadline_failure() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     immutable_deadline_failure_test(&v);
+
+    assert_invariants(&v)
 }
 
 fn immutable_deadline_failure_test(v: &dyn VM) {
@@ -400,8 +402,6 @@ fn immutable_deadline_failure_test(v: &dyn VM) {
         Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -409,6 +409,8 @@ fn unhealthy_sector_failure() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     unhealthy_sector_failure_test(&v);
+
+    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn unhealthy_sector_failure_test(v: &dyn VM) {
@@ -459,8 +461,6 @@ fn unhealthy_sector_failure_test(v: &dyn VM) {
         Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -468,6 +468,8 @@ fn terminated_sector_failure() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     terminated_sector_failure_test(&v);
+
+    assert_invariants(&v)
 }
 
 fn terminated_sector_failure_test(v: &dyn VM) {
@@ -529,8 +531,6 @@ fn terminated_sector_failure_test(v: &dyn VM) {
         Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -538,6 +538,8 @@ fn bad_batch_size_failure() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     bad_batch_size_failure_test(&v);
+
+    assert_invariants(&v)
 }
 
 fn bad_batch_size_failure_test(v: &dyn VM) {
@@ -587,8 +589,6 @@ fn bad_batch_size_failure_test(v: &dyn VM) {
         Some(ProveReplicaUpdatesParams { updates }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -598,6 +598,8 @@ fn no_dispute_after_upgrade() {
         create_miner_and_upgrade_sector(store, false);
 
     nodispute_after_upgrade_test(&v, deadline_index, worker, miner_id);
+
+    assert_invariants(&v)
 }
 
 fn nodispute_after_upgrade_test(
@@ -616,8 +618,6 @@ fn nodispute_after_upgrade_test(
         Some(dispute_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -634,6 +634,8 @@ fn upgrade_bad_post_dispute() {
         partition_index,
         deadline_index,
     );
+
+    assert_invariants(&v)
 }
 
 fn upgrade_bad_post_dispute_test(
@@ -661,8 +663,6 @@ fn upgrade_bad_post_dispute_test(
         MinerMethod::DisputeWindowedPoSt as u64,
         Some(dispute_params),
     );
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -670,6 +670,8 @@ fn bad_post_upgrade_dispute() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
     bad_post_upgrade_dispute_test(&v);
+
+    assert_invariants(&v)
 }
 
 fn bad_post_upgrade_dispute_test(v: &dyn VM) {
@@ -743,8 +745,6 @@ fn bad_post_upgrade_dispute_test(v: &dyn VM) {
         MinerMethod::DisputeWindowedPoSt as u64,
         Some(dispute_params),
     );
-
-    assert_invariants(v)
 }
 
 // Tests that an active CC sector can be correctly upgraded, and then the sector can be terminated
@@ -761,6 +761,8 @@ fn terminate_after_upgrade() {
         deadline_index,
         partition_index,
     );
+
+    assert_invariants(&v);
 }
 
 fn terminate_after_upgrade_test(
@@ -802,8 +804,6 @@ fn terminate_after_upgrade_test(
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_qa_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_zero());
-
-    assert_invariants(v);
 }
 
 // Tests that an active CC sector can be correctly upgraded, and then the sector can be extended
@@ -832,6 +832,8 @@ fn extend_after_upgrade() {
         partition_index,
         sector_number,
     );
+
+    assert_invariants(&v)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -870,8 +872,6 @@ fn extend_after_upgrade_test(
         policy.max_sector_expiration_extension - 1,
         final_sector_info.expiration - extension_epoch,
     );
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -880,6 +880,8 @@ fn wrong_deadline_index_failure() {
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
 
     wrong_deadline_index_failure_test(&v);
+
+    assert_invariants(&v)
 }
 
 fn wrong_deadline_index_failure_test(v: &dyn VM) {
@@ -933,8 +935,6 @@ fn wrong_deadline_index_failure_test(v: &dyn VM) {
 
     let new_sector_info = sector_info(v, &maddr, sector_number);
     assert_eq!(old_sector_info, new_sector_info);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -943,6 +943,8 @@ fn wrong_partition_index_failure() {
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
 
     wrong_partition_index_failure_test(&v);
+
+    assert_invariants(&v)
 }
 
 fn wrong_partition_index_failure_test(v: &dyn VM) {
@@ -996,8 +998,6 @@ fn wrong_partition_index_failure_test(v: &dyn VM) {
 
     let new_sector_info = sector_info(v, &maddr, sector_number);
     assert_eq!(old_sector_info, new_sector_info);
-
-    assert_invariants(v)
 }
 
 #[test]
@@ -1126,8 +1126,6 @@ fn deal_included_in_multiple_sectors_failure_test(v: &dyn VM) {
     let new_sector_info_p2 = sector_info(v, &maddr, first_sector_number + 1);
     assert!(new_sector_info_p2.deal_ids.len().is_zero());
     assert_ne!(new_sealed_cid2, new_sector_info_p2.sealed_cid);
-
-    assert_invariants(v)
 }
 
 #[test]

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -37,8 +37,6 @@ fn terminate_sectors() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     terminate_sectors_test(&v);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn terminate_sectors_test(v: &dyn VM) {
@@ -353,4 +351,6 @@ fn terminate_sectors_test(v: &dyn VM) {
     // before the slash and should be << 1 FIL. Actual amount withdrawn should be between 58 and 59 FIL.
     assert!(TokenAmount::from_whole(58) < value_withdrawn);
     assert!(TokenAmount::from_whole(59) > value_withdrawn);
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -37,6 +37,8 @@ fn terminate_sectors() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     terminate_sectors_test(&v);
+
+    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn terminate_sectors_test(v: &dyn VM) {
@@ -351,6 +353,4 @@ fn terminate_sectors_test(v: &dyn VM) {
     // before the slash and should be << 1 FIL. Actual amount withdrawn should be between 58 and 59 FIL.
     assert!(TokenAmount::from_whole(58) < value_withdrawn);
     assert!(TokenAmount::from_whole(59) > value_withdrawn);
-
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -352,5 +352,9 @@ fn terminate_sectors_test(v: &dyn VM) {
     assert!(TokenAmount::from_whole(58) < value_withdrawn);
     assert!(TokenAmount::from_whole(59) > value_withdrawn);
 
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }

--- a/test_vm/tests/test_vm_test.rs
+++ b/test_vm/tests/test_vm_test.rs
@@ -1,4 +1,5 @@
 use fil_actor_account::State as AccountState;
+use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::test_utils::{
     make_identity_cid, ACCOUNT_ACTOR_CODE_ID, PAYCH_ACTOR_CODE_ID,
 };
@@ -47,7 +48,7 @@ fn state_control() {
     assert_eq!(None, v.get_actor(&addr2));
     assert_eq!(v.get_actor(&addr1).unwrap(), a1);
 
-    let invariants_check = check_invariants(&v);
+    let invariants_check = check_invariants(&v, &Policy::default());
     assert!(invariants_check.is_err());
     assert!(invariants_check.unwrap_err().to_string().contains("AccountState is empty"));
 }
@@ -115,7 +116,7 @@ fn test_sent() {
     assert_account_actor(3, TokenAmount::from_atto(42u8), addr1, &v, expect_id_addr1);
     assert_account_actor(2, TokenAmount::zero(), addr2, &v, expect_id_addr2);
 
-    assert_invariants(&v)
+    assert_invariants(&v, &Policy::default())
 }
 
 #[test]

--- a/test_vm/tests/test_vm_test.rs
+++ b/test_vm/tests/test_vm_test.rs
@@ -61,7 +61,7 @@ fn assert_account_actor<BS: Blockstore>(
 ) {
     let act = v.get_actor(&addr).unwrap();
     let st: AccountState = get_state(v, &addr).unwrap();
-    assert_eq!(exp_call_seq, act.call_seq_num);
+    assert_eq!(exp_call_seq, act.call_seq);
     assert_eq!(*ACCOUNT_ACTOR_CODE_ID, act.code);
     assert_eq!(exp_bal, act.balance);
     assert_eq!(exp_pk_addr, st.address);

--- a/test_vm/tests/verified_claim_test.rs
+++ b/test_vm/tests/verified_claim_test.rs
@@ -362,7 +362,11 @@ fn verified_claim_scenario_test(v: &dyn VM) {
     assert_eq!(vec![claim_id], ret.considered);
     assert!(ret.results.all_ok(), "results had failures {}", ret.results);
 
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -456,7 +460,11 @@ fn expired_allocations_test(v: &dyn VM) {
     // Client has original datacap balance
     assert_eq!(TokenAmount::from_whole(datacap), datacap_get_balance(v, &verified_client));
 
-    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
+    expect_invariants(
+        v,
+        &Policy::default(),
+        &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+    );
 }
 
 #[test]
@@ -491,7 +499,7 @@ fn deal_passes_claim_fails_test(v: &dyn VM) {
     market_add_balance(v, &worker, &miner_id, &TokenAmount::from_whole(64));
 
     // Publish verified deal
-    let deal_start = v.epoch() + v.policy().maximum_verified_allocation_expiration + 1;
+    let deal_start = v.epoch() + Policy::default().maximum_verified_allocation_expiration + 1;
     let sector_start = deal_start;
     let deal_term_min = 180 * EPOCHS_IN_DAY;
     let deal_size = (32u64 << 30) / 2;
@@ -591,5 +599,5 @@ fn deal_passes_claim_fails_test(v: &dyn VM) {
     assert_eq!(None, sector_info_a);
 
     // run check before last change and confirm that we hit the expected broken state error
-    assert_invariants(v);
+    assert_invariants(v, &Policy::default());
 }

--- a/test_vm/tests/verified_claim_test.rs
+++ b/test_vm/tests/verified_claim_test.rs
@@ -46,8 +46,6 @@ fn verified_claim_scenario() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     verified_claim_scenario_test(&v);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn verified_claim_scenario_test(v: &dyn VM) {
@@ -363,6 +361,8 @@ fn verified_claim_scenario_test(v: &dyn VM) {
     let ret: RemoveExpiredClaimsReturn = deserialize(&ret_raw, "balance of return value").unwrap();
     assert_eq!(vec![claim_id], ret.considered);
     assert!(ret.results.all_ok(), "results had failures {}", ret.results);
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
@@ -370,8 +370,6 @@ fn expired_allocations() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     expired_allocations_test(&v);
-
-    expect_invariants(&v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 fn expired_allocations_test(v: &dyn VM) {
@@ -457,20 +455,18 @@ fn expired_allocations_test(v: &dyn VM) {
 
     // Client has original datacap balance
     assert_eq!(TokenAmount::from_whole(datacap), datacap_get_balance(v, &verified_client));
+
+    expect_invariants(v, &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()]);
 }
 
 #[test]
 fn deal_passes_claim_fails() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
-    let maximum_verified_allocation_expiration = v.policy().maximum_verified_allocation_expiration;
-    deal_passes_claim_fails_test(&v, maximum_verified_allocation_expiration);
-
-    // run check before last change and confirm that we hit the expected broken state error
-    assert_invariants(&v);
+    deal_passes_claim_fails_test(&v);
 }
 
-fn deal_passes_claim_fails_test(v: &dyn VM, maximum_verified_allocation_expiration: i64) {
+fn deal_passes_claim_fails_test(v: &dyn VM) {
     let addrs = create_accounts(v, 3, &TokenAmount::from_whole(10_000));
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let (owner, worker, verifier, verified_client) = (addrs[0], addrs[0], addrs[1], addrs[2]);
@@ -495,7 +491,7 @@ fn deal_passes_claim_fails_test(v: &dyn VM, maximum_verified_allocation_expirati
     market_add_balance(v, &worker, &miner_id, &TokenAmount::from_whole(64));
 
     // Publish verified deal
-    let deal_start = v.epoch() + maximum_verified_allocation_expiration + 1;
+    let deal_start = v.epoch() + v.policy().maximum_verified_allocation_expiration + 1;
     let sector_start = deal_start;
     let deal_term_min = 180 * EPOCHS_IN_DAY;
     let deal_size = (32u64 << 30) / 2;
@@ -593,4 +589,7 @@ fn deal_passes_claim_fails_test(v: &dyn VM, maximum_verified_allocation_expirati
     let sector_info_a =
         miner_state.get_sector(&DynBlockstore::wrap(v.blockstore()), sector_number_a).unwrap();
     assert_eq!(None, sector_info_a);
+
+    // run check before last change and confirm that we hit the expected broken state error
+    assert_invariants(v);
 }

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -38,6 +38,8 @@ fn remove_datacap_simple_successful_path() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     remove_datacap_simple_successful_path_test(&v);
+
+    assert_invariants(&v)
 }
 
 fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
@@ -298,7 +300,6 @@ fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
         .unwrap();
 
     assert_eq!(2u64, verifier2_proposal_id.id);
-    assert_invariants(v)
 }
 
 #[test]
@@ -359,8 +360,6 @@ fn remove_datacap_fails_on_verifreg_test(v: &dyn VM) {
         Some(remove_datacap_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-
-    assert_invariants(v)
 }
 
 fn expect_remove_datacap(

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -38,8 +38,6 @@ fn remove_datacap_simple_successful_path() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     remove_datacap_simple_successful_path_test(&v);
-
-    assert_invariants(&v)
 }
 
 fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
@@ -300,6 +298,7 @@ fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
         .unwrap();
 
     assert_eq!(2u64, verifier2_proposal_id.id);
+    assert_invariants(v)
 }
 
 #[test]
@@ -360,6 +359,8 @@ fn remove_datacap_fails_on_verifreg_test(v: &dyn VM) {
         Some(remove_datacap_params),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
+
+    assert_invariants(v)
 }
 
 fn expect_remove_datacap(

--- a/test_vm/tests/verifreg_remove_datacap_test.rs
+++ b/test_vm/tests/verifreg_remove_datacap_test.rs
@@ -1,3 +1,4 @@
+use fil_actors_runtime::runtime::Policy;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::{to_vec, RawBytes};
 use fvm_shared::bigint::bigint_ser::BigIntDe;
@@ -298,7 +299,7 @@ fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
         .unwrap();
 
     assert_eq!(2u64, verifier2_proposal_id.id);
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 #[test]
@@ -360,7 +361,7 @@ fn remove_datacap_fails_on_verifreg_test(v: &dyn VM) {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    assert_invariants(v)
+    assert_invariants(v, &Policy::default())
 }
 
 fn expect_remove_datacap(


### PR DESCRIPTION
- update VM trait to align with anorth/fvm-workbench

Some methods that were previously on the abstract VM are deemed specific to the implementation of the TestVM in builtin-actors. To ease alignment with VM implementations in other contexts such as https://github.com/anorth/fvm-workbench, certain methods have been removed from the trait such as those relating to builtin-actors' notion of `Policy` and actor manifest. 

