### PR TITLE
chore: switch to workspace deps common deps & workspace packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,47 +29,13 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
-dependencies = [
- "cfg-if",
- "cipher 0.3.0",
- "cpufeatures",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aes"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
 ]
 
 [[package]]
@@ -499,51 +465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
-dependencies = [
- "borsh-derive",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
-dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,28 +487,6 @@ name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "byteorder"
@@ -706,15 +605,6 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
-dependencies = [
- "generic-array 0.14.7",
-]
-
-[[package]]
-name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
@@ -773,7 +663,7 @@ dependencies = [
  "coins-core",
  "digest 0.10.7",
  "getrandom",
- "hmac 0.12.1",
+ "hmac",
  "k256",
  "lazy_static",
  "serde",
@@ -791,8 +681,8 @@ dependencies = [
  "coins-bip32",
  "getrandom",
  "hex",
- "hmac 0.12.1",
- "pbkdf2 0.11.0",
+ "hmac",
+ "pbkdf2",
  "rand",
  "sha2 0.10.7",
  "thiserror",
@@ -845,12 +735,6 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
-
-[[package]]
-name = "convert_case"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
 
 [[package]]
 name = "convert_case"
@@ -917,16 +801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array 0.14.7",
- "subtle",
-]
-
-[[package]]
 name = "cs_serde_bytes"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,20 +811,11 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
-dependencies = [
- "cipher 0.3.0",
-]
-
-[[package]]
-name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -1190,63 +1055,24 @@ dependencies = [
 
 [[package]]
 name = "eth-keystore"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f65b750ac950f2f825b36d08bef4cda4112e19a7b1a68f6e2bb499413e12440"
-dependencies = [
- "aes 0.7.5",
- "ctr 0.8.0",
- "digest 0.10.7",
- "hex",
- "hmac 0.12.1",
- "pbkdf2 0.11.0",
- "rand",
- "scrypt 0.8.1",
- "serde",
- "serde_json",
- "sha2 0.10.7",
- "sha3",
- "thiserror",
- "uuid 0.8.2",
-]
-
-[[package]]
-name = "eth-keystore"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
 dependencies = [
- "aes 0.8.3",
- "ctr 0.9.2",
+ "aes",
+ "ctr",
  "digest 0.10.7",
  "hex",
- "hmac 0.12.1",
- "pbkdf2 0.11.0",
+ "hmac",
+ "pbkdf2",
  "rand",
- "scrypt 0.10.0",
+ "scrypt",
  "serde",
  "serde_json",
  "sha2 0.10.7",
  "sha3",
  "thiserror",
- "uuid 0.8.2",
-]
-
-[[package]]
-name = "ethabi"
-version = "17.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4966fba78396ff92db3b817ee71143eccd98acf0f876b8d600e585a670c5d1b"
-dependencies = [
- "ethereum-types 0.13.1",
- "hex",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3",
- "thiserror",
- "uint",
+ "uuid",
 ]
 
 [[package]]
@@ -1255,7 +1081,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
 dependencies = [
- "ethereum-types 0.14.1",
+ "ethereum-types",
  "hex",
  "once_cell",
  "regex",
@@ -1264,19 +1090,6 @@ dependencies = [
  "sha3",
  "thiserror",
  "uint",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
-dependencies = [
- "crunchy",
- "fixed-hash 0.7.0",
- "impl-rlp",
- "impl-serde 0.3.2",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -1286,26 +1099,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde 0.4.0",
+ "impl-serde",
  "scale-info",
  "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
-dependencies = [
- "ethbloom 0.12.1",
- "fixed-hash 0.7.0",
- "impl-rlp",
- "impl-serde 0.3.2",
- "primitive-types 0.11.1",
- "uint",
 ]
 
 [[package]]
@@ -1314,29 +1113,14 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
- "ethbloom 0.13.0",
- "fixed-hash 0.8.0",
+ "ethbloom",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde 0.4.0",
- "primitive-types 0.12.1",
+ "impl-serde",
+ "primitive-types",
  "scale-info",
  "uint",
-]
-
-[[package]]
-name = "ethers"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16142eeb3155cfa5aec6be3f828a28513a28bd995534f945fa70e7d608f16c10"
-dependencies = [
- "ethers-addressbook 0.17.0",
- "ethers-contract 0.17.0",
- "ethers-core 0.17.0",
- "ethers-etherscan 0.17.0",
- "ethers-middleware 0.17.0",
- "ethers-providers 0.17.0",
- "ethers-signers 0.17.0",
 ]
 
 [[package]]
@@ -1345,25 +1129,13 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f26f9d8d80da18ca72aca51804c65eb2153093af3bec74fd5ce32aa0c1f665"
 dependencies = [
- "ethers-addressbook 1.0.2",
- "ethers-contract 1.0.2",
- "ethers-core 1.0.2",
- "ethers-etherscan 1.0.2",
- "ethers-middleware 1.0.2",
- "ethers-providers 1.0.2",
- "ethers-signers 1.0.2",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23f8992ecf45ea9dd2983696aabc566c108723585f07f5dc8c9efb24e52d3db"
-dependencies = [
- "ethers-core 0.17.0",
- "once_cell",
- "serde",
- "serde_json",
+ "ethers-addressbook",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-middleware",
+ "ethers-providers",
+ "ethers-signers",
 ]
 
 [[package]]
@@ -1372,29 +1144,10 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4be54dd2260945d784e06ccdeb5ad573e8f1541838cee13a1ab885485eaa0b"
 dependencies = [
- "ethers-core 1.0.2",
+ "ethers-core",
  "once_cell",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "ethers-contract"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0010fffc97c5abcf75a30fd75676b1ed917b2b82beb8270391333618e2847d"
-dependencies = [
- "ethers-contract-abigen 0.17.0",
- "ethers-contract-derive 0.17.0",
- "ethers-core 0.17.0",
- "ethers-providers 0.17.0",
- "futures-util",
- "hex",
- "once_cell",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -1403,10 +1156,10 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c3c3e119a89f0a9a1e539e7faecea815f74ddcf7c90d0b00d1f524db2fdc9c"
 dependencies = [
- "ethers-contract-abigen 1.0.2",
- "ethers-contract-derive 1.0.2",
- "ethers-core 1.0.2",
- "ethers-providers 1.0.2",
+ "ethers-contract-abigen",
+ "ethers-contract-derive",
+ "ethers-core",
+ "ethers-providers",
  "futures-util",
  "hex",
  "once_cell",
@@ -1414,29 +1167,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "ethers-contract-abigen"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda76ce804d524f693a898dc5857d08f4db443f3da64d0c36237fa05c0ecef30"
-dependencies = [
- "Inflector",
- "cfg-if",
- "dunce",
- "ethers-core 0.17.0",
- "eyre",
- "getrandom",
- "hex",
- "proc-macro2",
- "quote",
- "reqwest",
- "serde",
- "serde_json",
- "syn 1.0.109",
- "url",
- "walkdir",
 ]
 
 [[package]]
@@ -1448,7 +1178,7 @@ dependencies = [
  "Inflector",
  "cfg-if",
  "dunce",
- "ethers-core 1.0.2",
+ "ethers-core",
  "eyre",
  "getrandom",
  "hex",
@@ -1466,64 +1196,17 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41170ccb5950f559cba5a052158a28ec2d224af3a7d5b266b3278b929538ef55"
-dependencies = [
- "ethers-contract-abigen 0.17.0",
- "ethers-core 0.17.0",
- "hex",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ethers-contract-derive"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f192e8e4cf2b038318aae01e94e7644e0659a76219e94bcd3203df744341d61f"
 dependencies = [
- "ethers-contract-abigen 1.0.2",
- "ethers-core 1.0.2",
+ "ethers-contract-abigen",
+ "ethers-core",
  "hex",
  "proc-macro2",
  "quote",
  "serde_json",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "ethers-core"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebdd63c828f58aa067f40f9adcbea5e114fb1f90144b3a1e2858e0c9b1ff4e8"
-dependencies = [
- "arrayvec",
- "bytes",
- "cargo_metadata",
- "chrono",
- "convert_case 0.5.0",
- "elliptic-curve",
- "ethabi 17.2.0",
- "fastrlp",
- "generic-array 0.14.7",
- "hex",
- "k256",
- "once_cell",
- "proc-macro2",
- "rand",
- "rlp",
- "rlp-derive",
- "rust_decimal",
- "serde",
- "serde_json",
- "strum",
- "syn 1.0.109",
- "thiserror",
- "tiny-keccak",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1536,9 +1219,9 @@ dependencies = [
  "bytes",
  "cargo_metadata",
  "chrono",
- "convert_case 0.6.0",
+ "convert_case",
  "elliptic-curve",
- "ethabi 18.0.0",
+ "ethabi",
  "generic-array 0.14.7",
  "hex",
  "k256",
@@ -1559,61 +1242,19 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b279a3d00bd219caa2f9a34451b4accbfa9a1eaafc26dcda9d572591528435f0"
-dependencies = [
- "ethers-core 0.17.0",
- "getrandom",
- "reqwest",
- "semver",
- "serde",
- "serde-aux 3.1.0",
- "serde_json",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "ethers-etherscan"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9713f525348e5dde025d09b0a4217429f8074e8ff22c886263cc191e87d8216"
 dependencies = [
- "ethers-core 1.0.2",
+ "ethers-core",
  "getrandom",
  "reqwest",
  "semver",
  "serde",
- "serde-aux 4.2.0",
+ "serde-aux",
  "serde_json",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "ethers-middleware"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e7e8632d28175352b9454bbcb604643b6ca1de4d36dc99b3f86860d75c132b"
-dependencies = [
- "async-trait",
- "ethers-contract 0.17.0",
- "ethers-core 0.17.0",
- "ethers-etherscan 0.17.0",
- "ethers-providers 0.17.0",
- "ethers-signers 0.17.0",
- "futures-locks",
- "futures-util",
- "instant",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
- "url",
 ]
 
 [[package]]
@@ -1624,11 +1265,11 @@ checksum = "e71df7391b0a9a51208ffb5c7f2d068900e99d6b3128d3a4849d138f194778b7"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
- "ethers-contract 1.0.2",
- "ethers-core 1.0.2",
- "ethers-etherscan 1.0.2",
- "ethers-providers 1.0.2",
- "ethers-signers 1.0.2",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-providers",
+ "ethers-signers",
  "futures-locks",
  "futures-util",
  "instant",
@@ -1640,41 +1281,6 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "url",
-]
-
-[[package]]
-name = "ethers-providers"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46482e4d1e79b20c338fd9db9e166184eb387f0a4e7c05c5b5c0aa2e8c8900c"
-dependencies = [
- "async-trait",
- "auto_impl 1.1.0",
- "base64 0.13.1",
- "ethers-core 0.17.0",
- "futures-core",
- "futures-timer",
- "futures-util",
- "getrandom",
- "hashers",
- "hex",
- "http",
- "once_cell",
- "parking_lot",
- "pin-project",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-timer",
- "web-sys",
- "ws_stream_wasm",
 ]
 
 [[package]]
@@ -1686,7 +1292,7 @@ dependencies = [
  "async-trait",
  "auto_impl 1.1.0",
  "base64 0.13.1",
- "ethers-core 1.0.2",
+ "ethers-core",
  "futures-core",
  "futures-timer",
  "futures-util",
@@ -1710,24 +1316,6 @@ dependencies = [
  "wasm-timer",
  "web-sys",
  "ws_stream_wasm",
-]
-
-[[package]]
-name = "ethers-signers"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a72ecad124e8ccd18d6a43624208cab0199e59621b1f0fa6b776b2e0529107"
-dependencies = [
- "async-trait",
- "coins-bip32",
- "coins-bip39",
- "elliptic-curve",
- "eth-keystore 0.4.2",
- "ethers-core 0.17.0",
- "hex",
- "rand",
- "sha2 0.10.7",
- "thiserror",
 ]
 
 [[package]]
@@ -1740,8 +1328,8 @@ dependencies = [
  "coins-bip32",
  "coins-bip39",
  "elliptic-curve",
- "eth-keystore 0.5.0",
- "ethers-core 1.0.2",
+ "eth-keystore",
+ "ethers-core",
  "hex",
  "rand",
  "sha2 0.10.7",
@@ -1792,31 +1380,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "fastrlp"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089263294bb1c38ac73649a6ad563dd9a5142c8dc0482be15b8b9acb22a1611e"
-dependencies = [
- "arrayvec",
- "auto_impl 1.1.0",
- "bytes",
- "ethereum-types 0.13.1",
- "fastrlp-derive",
-]
-
-[[package]]
-name = "fastrlp-derive"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0f9d074ab623d1b388c12544bfeed759c7df36dc5c300cda053df9ba1232075"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1917,7 +1480,6 @@ dependencies = [
  "num-traits",
  "rlp",
  "serde",
- "serde_tuple",
 ]
 
 [[package]]
@@ -1941,7 +1503,7 @@ version = "12.0.0"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
- "ethers 1.0.2",
+ "ethers",
  "etk-asm",
  "fil_actors_evm_shared",
  "fil_actors_runtime",
@@ -1961,7 +1523,6 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "serde_tuple",
  "substrate-bn",
 ]
 
@@ -2268,18 +1829,6 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder",
- "rand",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
-name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
@@ -2453,7 +2002,6 @@ checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
 dependencies = [
  "futures-channel",
  "futures-task",
- "tokio",
 ]
 
 [[package]]
@@ -2793,18 +2341,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.6",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.3",
-]
 
 [[package]]
 name = "hashers"
@@ -2853,32 +2389,11 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hmac"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.7",
- "hmac 0.8.1",
 ]
 
 [[package]]
@@ -2998,15 +2513,6 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
@@ -3038,7 +2544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
  "serde",
 ]
 
@@ -3208,14 +2714,12 @@ dependencies = [
  "arrayref",
  "base64 0.13.1",
  "digest 0.9.0",
- "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand",
  "serde",
  "sha2 0.9.9",
- "typenum",
 ]
 
 [[package]]
@@ -3358,7 +2862,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3502,7 +3006,7 @@ dependencies = [
  "arrayvec",
  "auto_impl 1.1.0",
  "bytes",
- "ethereum-types 0.14.1",
+ "ethereum-types",
  "open-fastrlp-derive",
 ]
 
@@ -3544,7 +3048,7 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d884d78fcf214d70b1e239fcd1c6e5e95aa3be1881918da2e488cc946c7a476"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3583,17 +3087,6 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "password-hash"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
@@ -3611,22 +3104,13 @@ checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
 
 [[package]]
 name = "pbkdf2"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
- "hmac 0.12.1",
- "password-hash 0.4.2",
+ "hmac",
+ "password-hash",
  "sha2 0.10.7",
 ]
 
@@ -3766,38 +3250,16 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
-dependencies = [
- "fixed-hash 0.7.0",
- "impl-codec",
- "impl-rlp",
- "impl-serde 0.3.2",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde 0.4.0",
+ "impl-serde",
  "scale-info",
  "uint",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
 ]
 
 [[package]]
@@ -3841,26 +3303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3959,15 +3401,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
 
 [[package]]
-name = "rend"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4013,7 +3446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint",
- "hmac 0.12.1",
+ "hmac",
  "zeroize",
 ]
 
@@ -4042,34 +3475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
-dependencies = [
- "bitvec 1.0.1",
- "bytecheck",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid 1.4.0",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4088,24 +3493,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0446843641c69436765a35a5a77088e28c2e6a12da93e84aa3ab1cd4aa5a042"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytecheck",
- "byteorder",
- "bytes",
- "num-traits",
- "rand",
- "rkyv",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4188,20 +3575,11 @@ checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "salsa20"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0fbb5f676da676c260ba276a8f43a8dc67cf02d1438423aeb1c677a7212686"
-dependencies = [
- "cipher 0.3.0",
-]
-
-[[package]]
-name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -4231,7 +3609,7 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4245,26 +3623,13 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73d6d7c6311ebdbd9184ad6c4447b2f36337e327bda107d3ba9e3c374f9d325"
-dependencies = [
- "hmac 0.12.1",
- "password-hash 0.3.2",
- "pbkdf2 0.10.1",
- "salsa20 0.9.0",
- "sha2 0.10.7",
-]
-
-[[package]]
-name = "scrypt"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
 dependencies = [
- "hmac 0.12.1",
- "pbkdf2 0.11.0",
- "salsa20 0.10.2",
+ "hmac",
+ "pbkdf2",
+ "salsa20",
  "sha2 0.10.7",
 ]
 
@@ -4277,12 +3642,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -4320,16 +3679,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7daf513456463b42aa1d94cff7e0c24d682b429f020b9afa4f5ba5c40a22b237"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-aux"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a77223b653fa95f3f9864f3eb25b93e4ed170687eb42d85b6b98af21d5e1de"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4505,12 +3854,6 @@ dependencies = [
  "digest 0.10.7",
  "rand_core",
 ]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "slab"
@@ -4707,7 +4050,7 @@ dependencies = [
  "bimap",
  "blake2b_simd",
  "cid 0.10.1",
- "ethers 0.17.0",
+ "ethers",
  "fil_actor_account",
  "fil_actor_cron",
  "fil_actor_datacap",
@@ -4995,12 +4338,6 @@ dependencies = [
  "getrandom",
  "serde",
 ]
-
-[[package]]
-name = "uuid"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
 
 [[package]]
 name = "value-bag"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,7 +2035,6 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "log",
- "multihash 0.16.3",
  "multihash 0.18.1",
  "num-derive",
  "num-traits",
@@ -2525,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_amt"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36fc2a2fd536e8fdf93644218b683ca153de352e8db7345aaf1c6c91e591762"
+checksum = "7c0b0ee51ca8defa9717a72e1d35c8cbb85bd8320a835911410b63b9a63dffec"
 dependencies = [
  "anyhow",
  "cid 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ fil_actor_verifreg = { version = "12.0.0", path = "./actors/verifreg", features 
 
 [build-dependencies]
 fil_actor_bundler = "5.0.0"
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
+cid = { workspace = true }
 fil_actors_runtime = { version = "12.0.0", path = "runtime" }
 num-traits = "0.2.15"
 
@@ -57,6 +57,26 @@ members = [
      "runtime",
      "test_vm",
 ]
+
+[workspace.dependencies]
+serde = { version = "1.0.136", features = ["derive"] }
+anyhow = "1.0.65"
+
+cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
+multihash = { version = "0.18.1", default-features = false }
+
+fvm_actor_utils = "7.0.0"
+frc42_dispatch = "3.3.0"
+frc46_token = "7.0.0"
+
+fvm_sdk = "~3.3.0"
+fvm_shared = "~3.4.0"
+fvm_ipld_encoding = "0.4.0"
+fvm_ipld_blockstore = "0.2.0"
+fvm_ipld_hamt = "0.7.0"
+fvm_ipld_kamt = "0.3.0"
+fvm_ipld_amt = { version = "0.6.1", features = ["go-interop"] }
+fvm_ipld_bitfield = "0.5.4"
 
 [patch.crates-io]
 #fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,27 +13,27 @@ exclude = ["examples", ".github"]
 publish = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fil_actor_account = { version = "12.0.0", path = "./actors/account", features = ["fil-actor"] }
-fil_actor_cron = { version = "12.0.0", path = "./actors/cron", features = ["fil-actor"] }
-fil_actor_datacap = { version = "12.0.0", path = "./actors/datacap", features = ["fil-actor"] }
-fil_actor_ethaccount = { version = "12.0.0", path = "actors/ethaccount", features = ["fil-actor"] }
-fil_actor_eam = { version = "12.0.0", path = "./actors/eam", features = ["fil-actor"] }
-fil_actor_evm = { version = "12.0.0", path = "./actors/evm", features = ["fil-actor"] }
-fil_actor_init = { version = "12.0.0", path = "./actors/init", features = ["fil-actor"] }
-fil_actor_market = { version = "12.0.0", path = "./actors/market", features = ["fil-actor"] }
-fil_actor_miner = { version = "12.0.0", path = "./actors/miner", features = ["fil-actor"] }
-fil_actor_multisig = { version = "12.0.0", path = "./actors/multisig", features = ["fil-actor"] }
-fil_actor_paych = { version = "12.0.0", path = "./actors/paych", features = ["fil-actor"] }
-fil_actor_placeholder = { version = "12.0.0", path = "./actors/placeholder", features = ["fil-actor"] }
-fil_actor_power = { version = "12.0.0", path = "./actors/power", features = ["fil-actor"] }
-fil_actor_reward = { version = "12.0.0", path = "./actors/reward", features = ["fil-actor"] }
-fil_actor_system = { version = "12.0.0", path = "./actors/system", features = ["fil-actor"] }
-fil_actor_verifreg = { version = "12.0.0", path = "./actors/verifreg", features = ["fil-actor"] }
+fil_actor_account = { workspace = true, features = ["fil-actor"] }
+fil_actor_cron = { workspace = true, features = ["fil-actor"] }
+fil_actor_datacap = { workspace = true, features = ["fil-actor"] }
+fil_actor_ethaccount = { workspace = true, features = ["fil-actor"] }
+fil_actor_eam = { workspace = true, features = ["fil-actor"] }
+fil_actor_evm = { workspace = true, features = ["fil-actor"] }
+fil_actor_init = { workspace = true, features = ["fil-actor"] }
+fil_actor_market = { workspace = true, features = ["fil-actor"] }
+fil_actor_miner = { workspace = true, features = ["fil-actor"] }
+fil_actor_multisig = { workspace = true, features = ["fil-actor"] }
+fil_actor_paych = { workspace = true, features = ["fil-actor"] }
+fil_actor_placeholder = { workspace = true, features = ["fil-actor"] }
+fil_actor_power = { workspace = true, features = ["fil-actor"] }
+fil_actor_reward = { workspace = true, features = ["fil-actor"] }
+fil_actor_system = { workspace = true, features = ["fil-actor"] }
+fil_actor_verifreg = { workspace = true, features = ["fil-actor"] }
 
 [build-dependencies]
 fil_actor_bundler = "5.0.0"
 cid = { workspace = true }
-fil_actors_runtime = { version = "12.0.0", path = "runtime" }
+fil_actors_runtime = { workspace = true }
 num-traits = "0.2.15"
 
 [dependencies]
@@ -77,6 +77,27 @@ fvm_ipld_hamt = "0.7.0"
 fvm_ipld_kamt = "0.3.0"
 fvm_ipld_amt = { version = "0.6.1", features = ["go-interop"] }
 fvm_ipld_bitfield = "0.5.4"
+
+# 
+fil_actor_account = { version = "12.0.0", path = "actors/account" }
+fil_actor_cron = { version = "12.0.0", path = "actors/cron" }
+fil_actor_datacap = { version = "12.0.0", path = "actors/datacap" }
+fil_actor_eam = { version = "12.0.0", path = "actors/eam" }
+fil_actor_ethaccount = { version = "12.0.0", path = "actors/ethaccount" }
+fil_actor_evm = { version = "12.0.0", path = "actors/evm" }
+fil_actor_init = { version = "12.0.0", path = "actors/init" }
+fil_actor_market = { version = "12.0.0", path = "actors/market" }
+fil_actor_miner = { version = "12.0.0", path = "actors/miner" }
+fil_actor_multisig = { version = "12.0.0", path = "actors/multisig" }
+fil_actor_paych = { version = "12.0.0", path = "actors/paych" }
+fil_actor_placeholder = { version = "12.0.0", path = "actors/placeholder" }
+fil_actor_power = { version = "12.0.0", path = "actors/power" }
+fil_actor_reward = { version = "12.0.0", path = "actors/reward" }
+fil_actor_system = { version = "12.0.0", path = "actors/system" }
+fil_actor_verifreg = { version = "12.0.0", path = "actors/verifreg" }
+fil_actors_evm_shared = { version = "12.0.0", path = "actors/evm/shared" }
+fil_actors_runtime = { version = "12.0.0", path = "runtime" }
+fil_builtin_actors_state = { version = "12.0.0", path = "state"}
 
 [patch.crates-io]
 #fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ fil_actor_verifreg = { workspace = true, features = ["fil-actor"] }
 fil_actor_bundler = "5.0.0"
 cid = { workspace = true }
 fil_actors_runtime = { workspace = true }
-num-traits = "0.2.15"
+num-traits = { workspace = true }
 
 [dependencies]
 clap = { version = "3.2.3", features = ["derive"] }
@@ -59,16 +59,58 @@ members = [
 ]
 
 [workspace.dependencies]
+# Common
 serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.65"
+num = { version = "0.4", features = ["serde"] }
+num-derive = "0.3.3"
+num-traits = "0.2.14"
+lazy_static = "1.4.0"
+log = { version = "0.4.14", features = ["std"] }
+byteorder = "1.4.3"
+itertools = "0.10.3"
+indexmap = { version = "1.8.0", features = ["serde-1"] }
+derive_builder = "0.10.2"
+once_cell = "1.17.0"
+rand = { version = "0.8.5", default-features = false }
+hex = "0.4.3"
+hex-literal = "0.3.4"
+serde_json = "1.0"
+regex = "1"
+test-case = "2.2.1"
+bimap = "0.6.2"
+castaway = "0.2.2"
+paste = "1.0.9"
+thiserror = "1.0.30"
+pretty_env_logger = "0.4.0"
+serde_repr = "0.1.8"
+unsigned-varint = "0.7.1"
+rand_chacha = "0.3.1"
 
+# Crypto
+libsecp256k1 = { version = "0.7.1", default-features = false }
+blake2b_simd = "1.0"
+sha2 = "0.10"
+
+# EVM
+ethers = { version = "1.0.2", features = ["abigen"] }
+uint = { version = "0.9.3", default-features = false }
+etk-asm = "^0.2.1"
+rlp = { version = "0.5.1", default-features = false }
+substrate-bn = { version = "0.6.0", default-features = false }
+
+# IPLD/Encoding
 cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
 multihash = { version = "0.18.1", default-features = false }
+libipld-core = { version = "0.13.1", features = ["serde-codec"] }
+integer-encoding = { version = "3.0.3", default-features = false }
 
+# helix-onchain
 fvm_actor_utils = "7.0.0"
 frc42_dispatch = "3.3.0"
 frc46_token = "7.0.0"
 
+# FVM
 fvm_sdk = "~3.3.0"
 fvm_shared = "~3.4.0"
 fvm_ipld_encoding = "0.4.0"
@@ -78,7 +120,7 @@ fvm_ipld_kamt = "0.3.0"
 fvm_ipld_amt = { version = "0.6.1", features = ["go-interop"] }
 fvm_ipld_bitfield = "0.5.4"
 
-# 
+# workspace
 fil_actor_account = { version = "12.0.0", path = "actors/account" }
 fil_actor_cron = { version = "12.0.0", path = "actors/cron" }
 fil_actor_datacap = { version = "12.0.0", path = "actors/datacap" }

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -18,8 +18,8 @@ frc42_dispatch = { workspace = true }
 fvm_actor_utils = { workspace = true }
 fvm_shared = { workspace = true }
 serde = { workspace = true }
-num-traits = "0.2.14"
-num-derive = "0.3.3"
+num-traits = { workspace = true }
+num-derive = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 anyhow = { workspace = true }

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -14,15 +14,15 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
-frc42_dispatch = "3.3.0"
-fvm_actor_utils = "7.0.0"
-fvm_shared = { version = "3.4.0", default-features = false }
-serde = { version = "1.0.136", features = ["derive"] }
+frc42_dispatch = { workspace = true }
+fvm_actor_utils = { workspace = true }
+fvm_shared = { workspace = true }
+serde = { workspace = true }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
-anyhow = "1.0.65"
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+anyhow = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
+fil_actors_runtime = { workspace = true }
 frc42_dispatch = { workspace = true }
 fvm_actor_utils = { workspace = true }
 fvm_shared = { workspace = true }
@@ -25,7 +25,7 @@ fvm_ipld_encoding = { workspace = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { workspace = true }
 fvm_shared = { workspace = true }
-num-traits = "0.2.14"
-num-derive = "0.3.3"
-log = "0.4.14"
+num-traits = { workspace = true }
+num-derive = { workspace = true }
+log = { workspace = true }
 serde = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
+fil_actors_runtime = { workspace = true }
 fvm_shared = { workspace = true }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -24,7 +24,7 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -15,13 +15,13 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
-fvm_shared = { version = "3.4.0", default-features = false }
+fvm_shared = { workspace = true }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"
-serde = { version = "1.0.136", features = ["derive"] }
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
+serde = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -16,18 +16,18 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime"}
 
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.3.0"
-frc46_token = "7.0.0"
-fvm_actor_utils = "7.0.0"
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
-fvm_ipld_hamt = "0.7.0"
-fvm_shared = { version = "3.4.0", default-features = false }
+cid = { workspace = true }
+frc42_dispatch = { workspace = true }
+frc46_token = { workspace = true }
+fvm_actor_utils = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+fvm_ipld_hamt = { workspace = true }
+fvm_shared = { workspace = true }
 lazy_static = "1.4.0"
 num-derive = "0.3.3"
 num-traits = "0.2.14"
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { workspace = true }
 log = "0.4.14"
 
 [dev-dependencies]

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -24,11 +24,11 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_hamt = { workspace = true }
 fvm_shared = { workspace = true }
-lazy_static = "1.4.0"
-num-derive = "0.3.3"
-num-traits = "0.2.14"
+lazy_static = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
 serde = { workspace = true }
-log = "0.4.14"
+log = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime"}
+fil_actors_runtime = { workspace = true}
 
 cid = { workspace = true }
 frc42_dispatch = { workspace = true }
@@ -31,7 +31,7 @@ serde = { workspace = true }
 log = "0.4.14"
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]
 

--- a/actors/eam/Cargo.toml
+++ b/actors/eam/Cargo.toml
@@ -15,16 +15,16 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { workspace = true }
 serde_tuple = "0.5"
 rlp = { version = "0.5.1", default-features = false }
-anyhow = "1.0.65"
+anyhow = { workspace = true }
 log = "0.4.14"
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
-multihash = { version = "0.18.1", default-features = false }
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
-fvm_shared = { version = "3.4.0", default-features = false }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+multihash = { workspace = true }
+cid = { workspace = true }
+fvm_shared = { workspace = true }
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 hex-literal = "0.3.4"

--- a/actors/eam/Cargo.toml
+++ b/actors/eam/Cargo.toml
@@ -14,21 +14,20 @@ keywords = ["filecoin", "web3", "wasm", "evm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { workspace = true }
-serde = { workspace = true }
-serde_tuple = "0.5"
-rlp = { version = "0.5.1", default-features = false }
 anyhow = { workspace = true }
-log = "0.4.14"
+cid = { workspace = true }
+fil_actors_evm_shared = { workspace = true }
+fil_actors_runtime = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
-multihash = { workspace = true }
-cid = { workspace = true }
 fvm_shared = { workspace = true }
-num-traits = "0.2.15"
-num-derive = "0.3.3"
-hex-literal = "0.3.4"
-fil_actors_evm_shared = { workspace = true }
+log = { workspace = true }
+multihash = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+hex-literal = { workspace = true }
+rlp = { workspace = true }
 
 [dev-dependencies]
 fil_actor_evm = { workspace = true}

--- a/actors/eam/Cargo.toml
+++ b/actors/eam/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm", "evm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
+fil_actors_runtime = { workspace = true }
 serde = { workspace = true }
 serde_tuple = "0.5"
 rlp = { version = "0.5.1", default-features = false }
@@ -28,11 +28,11 @@ fvm_shared = { workspace = true }
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 hex-literal = "0.3.4"
-fil_actors_evm_shared = { version = "12.0.0", path = "../evm/shared" }
+fil_actors_evm_shared = { workspace = true }
 
 [dev-dependencies]
-fil_actor_evm = { path = "../evm"}
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils"] }
+fil_actor_evm = { workspace = true}
+fil_actors_runtime = { workspace = true, features = ["test_utils"] }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/ethaccount/Cargo.toml
+++ b/actors/ethaccount/Cargo.toml
@@ -15,11 +15,11 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
-frc42_dispatch = "3.3.0"
-fvm_actor_utils = "7.0.0"
-serde = { version = "1.0.136", features = ["derive"] }
-fvm_ipld_encoding = "0.4.0"
-fvm_shared = { version = "3.4.0", default-features = false }
+frc42_dispatch = { workspace = true }
+fvm_actor_utils = { workspace = true }
+serde = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+fvm_shared = { workspace = true }
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 hex-literal = "0.3.4"

--- a/actors/ethaccount/Cargo.toml
+++ b/actors/ethaccount/Cargo.toml
@@ -20,9 +20,9 @@ fvm_actor_utils = { workspace = true }
 serde = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }
-num-traits = "0.2.15"
-num-derive = "0.3.3"
-hex-literal = "0.3.4"
+num-traits = { workspace = true }
+num-derive = { workspace = true }
+hex-literal = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { workspace = true, features = ["test_utils"] }

--- a/actors/ethaccount/Cargo.toml
+++ b/actors/ethaccount/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm", "evm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
+fil_actors_runtime = { workspace = true }
 frc42_dispatch = { workspace = true }
 fvm_actor_utils = { workspace = true }
 serde = { workspace = true }
@@ -25,7 +25,7 @@ num-derive = "0.3.3"
 hex-literal = "0.3.4"
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils"] }
+fil_actors_runtime = { workspace = true, features = ["test_utils"] }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["/precompile-testdata", "/tests/measurements", "/tests/contracts"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
+fil_actors_runtime = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_kamt = { workspace = true }
 serde = { workspace = true }
@@ -32,11 +32,11 @@ hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.3.4"
 substrate-bn = { version = "0.6.0", default-features = false }
 frc42_dispatch = { workspace = true }
-fil_actors_evm_shared = { version = "12.0.0", path = "shared" }
+fil_actors_evm_shared = { workspace = true }
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 etk-asm = "^0.2.1"
 ethers = { version = "1.0.2", features = ["abigen"] }
 serde_json = "1.0"

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -19,29 +19,29 @@ fil_actors_runtime = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_kamt = { workspace = true }
 serde = { workspace = true }
-serde_tuple = "0.5"
-num-traits = "0.2.14"
-num-derive = "0.3.3"
+num-traits = { workspace = true }
+num-derive = { workspace = true }
 cid = { workspace = true }
 anyhow = { workspace = true }
-log = "0.4.14"
+log = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 multihash = { workspace = true }
-hex = { version = "0.4.3", features = ["serde"] }
-hex-literal = "0.3.4"
-substrate-bn = { version = "0.6.0", default-features = false }
 frc42_dispatch = { workspace = true }
 fil_actors_evm_shared = { workspace = true }
+hex = { workspace = true }
+hex-literal = { workspace = true }
+substrate-bn = { workspace = true }
 
 [dev-dependencies]
-lazy_static = "1.4.0"
+hex = { workspace = true, features = ["serde"] }
+lazy_static = { workspace = true }
 fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
-etk-asm = "^0.2.1"
-ethers = { version = "1.0.2", features = ["abigen"] }
-serde_json = "1.0"
-rand = "0.8.5"
-once_cell = "1.17.0"
+etk-asm = { workspace = true }
+ethers = { workspace = true }
+serde_json = { workspace = true }
+rand = { workspace = true }
+once_cell = { workspace = true }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -16,22 +16,22 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
-fvm_shared = { version = "3.4.0", default-features = false }
-fvm_ipld_kamt = { version = "0.3.0" }
-serde = { version = "1.0.136", features = ["derive"] }
+fvm_shared = { workspace = true }
+fvm_ipld_kamt = { workspace = true }
+serde = { workspace = true }
 serde_tuple = "0.5"
 num-traits = "0.2.14"
 num-derive = "0.3.3"
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
-anyhow = "1.0.65"
+cid = { workspace = true }
+anyhow = { workspace = true }
 log = "0.4.14"
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
-multihash = { version = "0.18.1", default-features = false }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+multihash = { workspace = true }
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.3.4"
 substrate-bn = { version = "0.6.0", default-features = false }
-frc42_dispatch = "3.3.0"
+frc42_dispatch = { workspace = true }
 fil_actors_evm_shared = { version = "12.0.0", path = "shared" }
 
 [dev-dependencies]

--- a/actors/evm/shared/Cargo.toml
+++ b/actors/evm/shared/Cargo.toml
@@ -13,5 +13,5 @@ serde = { workspace = true }
 fvm_shared = { workspace = true }
 fil_actors_runtime = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
-uint = { version = "0.9.3", default-features = false }
-hex = "0.4.3"
+uint = { workspace = true }
+hex = { workspace = true }

--- a/actors/evm/shared/Cargo.toml
+++ b/actors/evm/shared/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm", "evm"]
 
 [dependencies]
-serde = { version = "1.0.136", features = ["derive"] }
-fvm_shared = { version = "3.4.0", default-features = false }
+serde = { workspace = true }
+fvm_shared = { workspace = true }
 fil_actors_runtime = { version = "12.0.0", path = "../../../runtime" }
-fvm_ipld_encoding = "0.4.0"
+fvm_ipld_encoding = { workspace = true }
 uint = { version = "0.9.3", default-features = false }
 hex = "0.4.3"

--- a/actors/evm/shared/Cargo.toml
+++ b/actors/evm/shared/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["filecoin", "web3", "wasm", "evm"]
 [dependencies]
 serde = { workspace = true }
 fvm_shared = { workspace = true }
-fil_actors_runtime = { version = "12.0.0", path = "../../../runtime" }
+fil_actors_runtime = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 uint = { version = "0.9.3", default-features = false }
 hex = "0.4.3"

--- a/actors/evm/src/state.rs
+++ b/actors/evm/src/state.rs
@@ -7,7 +7,6 @@ use cid::Cid;
 use fvm_ipld_encoding::strict_bytes;
 use fvm_ipld_encoding::tuple::*;
 use serde::{Deserialize, Serialize};
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 /// A tombstone indicating that the contract has been self-destructed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize_tuple, Deserialize_tuple)]

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -19,11 +19,11 @@ frc42_dispatch = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_hamt = { workspace = true }
 serde = { workspace = true }
-num-traits = "0.2.14"
-num-derive = "0.3.3"
+num-traits = { workspace = true }
+num-derive = { workspace = true }
 cid = { workspace = true }
 anyhow = { workspace = true }
-log = "0.4.14"
+log = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
+fil_actors_runtime = { workspace = true }
 frc42_dispatch = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_hamt = { workspace = true }
@@ -28,7 +28,7 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -15,17 +15,17 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
-frc42_dispatch = "3.3.0"
-fvm_shared = { version = "3.4.0", default-features = false }
-fvm_ipld_hamt = "0.7.0"
-serde = { version = "1.0.136", features = ["derive"] }
+frc42_dispatch = { workspace = true }
+fvm_shared = { workspace = true }
+fvm_ipld_hamt = { workspace = true }
+serde = { workspace = true }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
-anyhow = "1.0.65"
+cid = { workspace = true }
+anyhow = { workspace = true }
 log = "0.4.14"
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime"}
+fil_actors_runtime = { workspace = true}
 
 anyhow = { workspace = true }
 cid = { workspace = true }
@@ -33,10 +33,10 @@ num-traits = "0.2.14"
 serde = { workspace = true }
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
-fil_actor_power = { path = "../power" }
-fil_actor_reward = { path = "../reward" }
-fil_actor_verifreg = { path = "../verifreg" }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
+fil_actor_power = { workspace = true }
+fil_actor_reward = { workspace = true }
+fil_actor_verifreg = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 multihash = { workspace = true }
 regex = "1"

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -25,11 +25,11 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_hamt = { workspace = true }
 fvm_shared = { workspace = true }
-integer-encoding = { version = "3.0.3", default-features = false }
-libipld-core = { version = "0.13.1", features = ["serde-codec"] }
-log = "0.4.14"
-num-derive = "0.3.3"
-num-traits = "0.2.14"
+integer-encoding = { workspace = true }
+libipld-core = { workspace = true }
+log = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
@@ -39,9 +39,9 @@ fil_actor_reward = { workspace = true }
 fil_actor_verifreg = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 multihash = { workspace = true }
-regex = "1"
-itertools = "0.10"
-lazy_static = "1.4.0"
+regex = { workspace = true }
+itertools = { workspace = true }
+lazy_static = { workspace = true }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -16,29 +16,29 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime"}
 
-anyhow = "1.0.65"
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.3.0"
-frc46_token = "7.0.0"
-fvm_ipld_bitfield = "0.5.4"
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
-fvm_ipld_hamt = "0.7.0"
-fvm_shared = { version = "3.4.0", default-features = false }
+anyhow = { workspace = true }
+cid = { workspace = true }
+frc42_dispatch = { workspace = true }
+frc46_token = { workspace = true }
+fvm_ipld_bitfield = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+fvm_ipld_hamt = { workspace = true }
+fvm_shared = { workspace = true }
 integer-encoding = { version = "3.0.3", default-features = false }
 libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 log = "0.4.14"
 num-derive = "0.3.3"
 num-traits = "0.2.14"
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
 fil_actor_power = { path = "../power" }
 fil_actor_reward = { path = "../reward" }
 fil_actor_verifreg = { path = "../verifreg" }
-fvm_ipld_amt = { version = "0.6.0", features = ["go-interop"] }
-multihash = { version = "0.18.1", default-features = false }
+fvm_ipld_amt = { workspace = true }
+multihash = { workspace = true }
 regex = "1"
 itertools = "0.10"
 lazy_static = "1.4.0"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
+fil_actors_runtime = { workspace = true }
 frc42_dispatch = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_bitfield = { workspace = true }
@@ -34,11 +34,11 @@ byteorder = "1.4.3"
 itertools = "0.10.3"
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
-fil_actor_account = { path = "../account" }
-fil_actor_reward = { path = "../reward" }
-fil_actor_power = { path = "../power" }
-fil_actor_market = { path = "../market" }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
+fil_actor_account = { workspace = true }
+fil_actor_reward = { workspace = true }
+fil_actor_power = { workspace = true }
+fil_actor_market = { workspace = true }
 rand = "0.8.5"
 test-case = "2.2.1"
 

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -26,12 +26,12 @@ serde = { workspace = true }
 cid = { workspace = true }
 anyhow = { workspace = true }
 multihash = { workspace = true }
-num-traits = "0.2.14"
-num-derive = "0.3.3"
-lazy_static = "1.4.0"
-log = "0.4.14"
-byteorder = "1.4.3"
-itertools = "0.10.3"
+num-traits = { workspace = true }
+num-derive = { workspace = true }
+lazy_static = { workspace = true }
+log = { workspace = true }
+byteorder = { workspace = true }
+itertools = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
@@ -39,8 +39,8 @@ fil_actor_account = { workspace = true }
 fil_actor_reward = { workspace = true }
 fil_actor_power = { workspace = true }
 fil_actor_market = { workspace = true }
-rand = "0.8.5"
-test-case = "2.2.1"
+rand = { workspace = true }
+test-case = { workspace = true }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -15,23 +15,23 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
-frc42_dispatch = "3.3.0"
-fvm_shared = { version = "3.4.0", default-features = false }
-fvm_ipld_bitfield = "0.5.4"
-fvm_ipld_amt = { version = "0.6.0", features = ["go-interop"] }
-fvm_ipld_hamt = "0.7.0"
-serde = { version = "1.0.136", features = ["derive"] }
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
+frc42_dispatch = { workspace = true }
+fvm_shared = { workspace = true }
+fvm_ipld_bitfield = { workspace = true }
+fvm_ipld_amt = { workspace = true }
+fvm_ipld_hamt = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+serde = { workspace = true }
+cid = { workspace = true }
+anyhow = { workspace = true }
+multihash = { workspace = true }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 lazy_static = "1.4.0"
 log = "0.4.14"
 byteorder = "1.4.3"
-anyhow = "1.0.65"
 itertools = "0.10.3"
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
-multihash = { version = "0.16.2", default-features = false }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
@@ -40,8 +40,6 @@ fil_actor_reward = { path = "../reward" }
 fil_actor_power = { path = "../power" }
 fil_actor_market = { path = "../market" }
 rand = "0.8.5"
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
-multihash = { version = "0.18.1", default-features = false }
 test-case = "2.2.1"
 
 [features]

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -16,19 +16,19 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime"}
 
-anyhow = "1.0.65"
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.3.0"
-fvm_actor_utils = "7.0.0"
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
-fvm_ipld_hamt = "0.7.0"
-fvm_shared = { version = "3.4.0", default-features = false }
+anyhow = { workspace = true }
+cid = { workspace = true }
+frc42_dispatch = { workspace = true }
+fvm_actor_utils = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+fvm_ipld_hamt = { workspace = true }
+fvm_shared = { workspace = true }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 num-derive = "0.3.3"
 num-traits = "0.2.14"
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -24,15 +24,15 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_hamt = { workspace = true }
 fvm_shared = { workspace = true }
-indexmap = { version = "1.8.0", features = ["serde-1"] }
-integer-encoding = { version = "3.0.3", default-features = false }
-num-derive = "0.3.3"
-num-traits = "0.2.14"
+indexmap = { workspace = true }
+integer-encoding = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
-lazy_static = "1.4.0"
+lazy_static = { workspace = true }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime"}
+fil_actors_runtime = { workspace = true}
 
 anyhow = { workspace = true }
 cid = { workspace = true }
@@ -31,7 +31,7 @@ num-traits = "0.2.14"
 serde = { workspace = true }
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 lazy_static = "1.4.0"
 
 [features]

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
+fil_actors_runtime = { workspace = true }
 frc42_dispatch = { workspace = true }
 fvm_shared = { workspace = true }
 num-traits = "0.2.14"
@@ -26,7 +26,7 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { workspace = true }
 derive_builder = "0.10.2"
 lazy_static = "1.4.0"

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -15,19 +15,19 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
-frc42_dispatch = "3.3.0"
-fvm_shared = { version = "3.4.0", default-features = false }
+frc42_dispatch = { workspace = true }
+fvm_shared = { workspace = true }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
-serde = { version = "1.0.136", features = ["derive"] }
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
-anyhow = "1.0.65"
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
+serde = { workspace = true }
+cid = { workspace = true }
+anyhow = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
-fvm_ipld_amt = { version = "0.6.0", features = ["go-interop"] }
+fvm_ipld_amt = { workspace = true }
 derive_builder = "0.10.2"
 lazy_static = "1.4.0"
 

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -17,8 +17,8 @@ crate-type = ["cdylib", "lib"]
 fil_actors_runtime = { workspace = true }
 frc42_dispatch = { workspace = true }
 fvm_shared = { workspace = true }
-num-traits = "0.2.14"
-num-derive = "0.3.3"
+num-traits = { workspace = true }
+num-derive = { workspace = true }
 serde = { workspace = true }
 cid = { workspace = true }
 anyhow = { workspace = true }
@@ -28,8 +28,8 @@ fvm_ipld_encoding = { workspace = true }
 [dev-dependencies]
 fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 fvm_ipld_amt = { workspace = true }
-derive_builder = "0.10.2"
-lazy_static = "1.4.0"
+derive_builder = { workspace = true }
+lazy_static = { workspace = true }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -18,13 +18,13 @@ fil_actors_runtime = { workspace = true }
 frc42_dispatch = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_hamt = { workspace = true }
-num-traits = "0.2.14"
-num-derive = "0.3.3"
-log = "0.4.14"
-indexmap = { version = "1.8.0", features = ["serde-1"] }
+num-traits = { workspace = true }
+num-derive = { workspace = true }
+log = { workspace = true }
+indexmap = { workspace = true }
 cid = { workspace = true }
-integer-encoding = { version = "3.0.3", default-features = false }
-lazy_static = "1.4.0"
+integer-encoding = { workspace = true }
+lazy_static = { workspace = true }
 serde = { workspace = true }
 anyhow = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
+fil_actors_runtime = { workspace = true }
 frc42_dispatch = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_hamt = { workspace = true }
@@ -31,8 +31,8 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
-fil_actor_reward = { path = "../reward" }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
+fil_actor_reward = { workspace = true }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -15,20 +15,20 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
-frc42_dispatch = "3.3.0"
-fvm_shared = { version = "3.4.0", default-features = false }
-fvm_ipld_hamt = "0.7.0"
+frc42_dispatch = { workspace = true }
+fvm_shared = { workspace = true }
+fvm_ipld_hamt = { workspace = true }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"
 indexmap = { version = "1.8.0", features = ["serde-1"] }
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
+cid = { workspace = true }
 integer-encoding = { version = "3.0.3", default-features = false }
 lazy_static = "1.4.0"
-serde = { version = "1.0.136", features = ["derive"] }
-anyhow = "1.0.65"
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
+serde = { workspace = true }
+anyhow = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
+fil_actors_runtime = { workspace = true }
 fvm_shared = { workspace = true }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -25,7 +25,7 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 num = "0.4.0"
 
 [features]

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -15,14 +15,14 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
-fvm_shared = { version = "3.4.0", default-features = false }
+fvm_shared = { workspace = true }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 log = "0.4.14"
 lazy_static = "1.4.0"
-serde = { version = "1.0.136", features = ["derive"] }
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
+serde = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -16,17 +16,17 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { workspace = true }
 fvm_shared = { workspace = true }
-num-traits = "0.2.14"
-num-derive = "0.3.3"
-log = "0.4.14"
-lazy_static = "1.4.0"
+num-traits = { workspace = true }
+num-derive = { workspace = true }
+log = { workspace = true }
+lazy_static = { workspace = true }
 serde = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
-num = "0.4.0"
+num = { workspace = true }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
+fil_actors_runtime = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
@@ -25,7 +25,7 @@ serde = { workspace = true }
 cid = { workspace = true }
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -18,9 +18,9 @@ fil_actors_runtime = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
-num-traits = "0.2.14"
+num-traits = { workspace = true }
 anyhow = { workspace = true }
-num-derive = "0.3.3"
+num-derive = { workspace = true }
 serde = { workspace = true }
 cid = { workspace = true }
 

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,14 +15,14 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime" }
-fvm_shared = { version = "3.4.0", default-features = false }
-fvm_ipld_encoding = "0.4.0"
-fvm_ipld_blockstore = "0.2.0"
+fvm_shared = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
 num-traits = "0.2.14"
-anyhow = "1.0.65"
+anyhow = { workspace = true }
 num-derive = "0.3.3"
-serde = { version = "1.0.136", features = ["derive"] }
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
+serde = { workspace = true }
+cid = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { version = "12.0.0", path = "../../runtime"}
+fil_actors_runtime = { workspace = true}
 
 anyhow = { workspace = true }
 cid = { workspace = true }
@@ -32,7 +32,7 @@ num-traits = "0.2.14"
 serde = { workspace = true }
 
 [dev-dependencies]
-fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }
+fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -16,20 +16,20 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { version = "12.0.0", path = "../../runtime"}
 
-anyhow = "1.0.65"
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.3.0"
-frc46_token = "7.0.0"
-fvm_actor_utils = "7.0.0"
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
-fvm_ipld_hamt = "0.7.0"
-fvm_shared = { version = "3.4.0", default-features = false }
+anyhow = { workspace = true }
+cid = { workspace = true }
+frc42_dispatch = { workspace = true }
+frc46_token = { workspace = true }
+fvm_actor_utils = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+fvm_ipld_hamt = { workspace = true }
+fvm_shared = { workspace = true }
 lazy_static = "1.4.0"
 log = "0.4.14"
 num-derive = "0.3.3"
 num-traits = "0.2.14"
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { path = "../../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -25,10 +25,10 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_hamt = { workspace = true }
 fvm_shared = { workspace = true }
-lazy_static = "1.4.0"
-log = "0.4.14"
-num-derive = "0.3.3"
-num-traits = "0.2.14"
+lazy_static = { workspace = true }
+log = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,25 +8,25 @@ edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"
 
 [dependencies]
-fvm_ipld_hamt = "0.7.0"
-fvm_ipld_amt = { version = "0.6.0", features = ["go-interop"] }
-fvm_shared = { version = "3.4.0", default-features = false }
+fvm_ipld_hamt = { workspace = true }
+fvm_ipld_amt = { workspace = true }
+fvm_shared = { workspace = true }
 num = { version = "0.4", features = ["serde"] }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { workspace = true }
 lazy_static = { version = "1.4.0", optional = true }
 unsigned-varint = "0.7.1"
 byteorder = "1.4.3"
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
+cid = { workspace = true }
 log = { version = "0.4.14", features = ["std"] }
 thiserror = "1.0.30"
-anyhow = "1.0.65"
-fvm_sdk = { version = "3.3.0", optional = true }
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_encoding = "0.4.0"
-fvm_ipld_bitfield = "0.5.4"
-multihash = { version = "0.18.1", default-features = false }
+anyhow = { workspace = true }
+fvm_sdk = { workspace = true, optional = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+fvm_ipld_bitfield = { workspace = true }
+multihash = { workspace = true }
 serde_repr = "0.1.8"
 regex = "1"
 itertools = "0.10"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,48 +11,47 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 fvm_ipld_hamt = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 fvm_shared = { workspace = true }
-num = { version = "0.4", features = ["serde"] }
-num-traits = "0.2.14"
-num-derive = "0.3.3"
+num = { workspace = true  }
+num-traits = { workspace = true }
+num-derive = { workspace = true }
 serde = { workspace = true }
-lazy_static = { version = "1.4.0", optional = true }
-unsigned-varint = "0.7.1"
-byteorder = "1.4.3"
+lazy_static = { workspace = true, optional = true }
+unsigned-varint = { workspace = true }
+byteorder = { workspace = true }
 cid = { workspace = true }
-log = { version = "0.4.14", features = ["std"] }
-thiserror = "1.0.30"
+log = { workspace = true }
+thiserror = { workspace = true }
 anyhow = { workspace = true }
 fvm_sdk = { workspace = true, optional = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_bitfield = { workspace = true }
 multihash = { workspace = true }
-serde_repr = "0.1.8"
-regex = "1"
-itertools = "0.10"
-paste = "1.0.9"
-castaway = "0.2.2"
+serde_repr = { workspace = true }
+regex = { workspace = true }
+itertools = { workspace = true }
+paste = { workspace = true }
+castaway = { workspace = true }
 
 # A fake-proofs dependency but... we can't select on that feature here because we enable it from
 # build.rs.
-sha2 = "0.10"
+sha2 = { workspace = true }
 
 # test_util
-rand = { version = "0.8.5", default-features = false, optional = true }
-hex = { version = "0.4.3", optional = true }
-blake2b_simd = { version = "1.0", optional = true }
-pretty_env_logger = {version = "0.4.0", optional = true }
+rand = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
+blake2b_simd = { workspace = true, optional = true }
+pretty_env_logger = { workspace = true, optional = true }
 
 [dependencies.libsecp256k1]
-version = "0.7.1"
-default-features = false
+workspace = true
 features = ["static-context", "std"]
 optional = true
 
 [dev-dependencies]
-derive_builder = "0.10.2"
-hex = "0.4.3"
-rand = { version = "0.8.5" }
+derive_builder = { workspace = true }
+hex = { workspace = true }
+rand = { workspace = true }
 
 [features]
 default = []

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -27,16 +27,16 @@ fil_actor_reward = { version = "12.0.0", path = "../actors/reward"}
 fil_actor_system = { version = "12.0.0", path = "../actors/system"}
 fil_actor_init = { version = "12.0.0", path = "../actors/init"}
 fil_actors_runtime = { version = "12.0.0", path = "../runtime"}
-frc46_token = "7.0.0"
-fvm_shared = { version = "3.4.0", default-features = false }
-fvm_ipld_encoding = "0.4.0"
-fvm_ipld_blockstore = "0.2.0"
+frc46_token = { workspace = true }
+fvm_shared = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
 num-traits = "0.2.14"
-anyhow = "1.0.65"
+anyhow = { workspace = true }
 bimap = { version = "0.6.2" }
 num-derive = "0.3.3"
-serde = { version = "1.0.136", features = ["derive"] }
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
+serde = { workspace = true }
+cid = { workspace = true }
 
 [dev-dependencies]
 

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -31,10 +31,10 @@ frc46_token = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
-num-traits = "0.2.14"
+num-traits = { workspace = true }
 anyhow = { workspace = true }
-bimap = { version = "0.6.2" }
-num-derive = "0.3.3"
+bimap = { workspace = true }
+num-derive = { workspace = true }
 serde = { workspace = true }
 cid = { workspace = true }
 

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -14,19 +14,19 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actor_account = { version = "12.0.0", path = "../actors/account"}
-fil_actor_verifreg = { version = "12.0.0", path = "../actors/verifreg"}
-fil_actor_datacap = { version = "12.0.0", path = "../actors/datacap"}
-fil_actor_cron = { version = "12.0.0", path = "../actors/cron"}
-fil_actor_market = { version = "12.0.0", path = "../actors/market"}
-fil_actor_multisig = { version = "12.0.0", path = "../actors/multisig"}
-fil_actor_paych = { version = "12.0.0", path = "../actors/paych"}
-fil_actor_power = { version = "12.0.0", path = "../actors/power"}
-fil_actor_miner = { version = "12.0.0", path = "../actors/miner"}
-fil_actor_reward = { version = "12.0.0", path = "../actors/reward"}
-fil_actor_system = { version = "12.0.0", path = "../actors/system"}
-fil_actor_init = { version = "12.0.0", path = "../actors/init"}
-fil_actors_runtime = { version = "12.0.0", path = "../runtime"}
+fil_actor_account = { workspace = true}
+fil_actor_verifreg = { workspace = true}
+fil_actor_datacap = { workspace = true}
+fil_actor_cron = { workspace = true}
+fil_actor_market = { workspace = true}
+fil_actor_multisig = { workspace = true}
+fil_actor_paych = { workspace = true}
+fil_actor_power = { workspace = true}
+fil_actor_miner = { workspace = true}
+fil_actor_reward = { workspace = true}
+fil_actor_system = { workspace = true}
+fil_actor_init = { workspace = true}
+fil_actors_runtime = { workspace = true}
 frc46_token = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -30,8 +30,8 @@ fil_actor_eam = { workspace = true }
 fil_actor_ethaccount = { workspace = true }
 
 anyhow = { workspace = true }
-bimap = { version = "0.6.2" }
-blake2b_simd = "1.0"
+bimap = { workspace = true }
+blake2b_simd = { workspace = true }
 cid = { workspace = true }
 frc42_dispatch = { workspace = true }
 frc46_token = { workspace = true }
@@ -41,24 +41,24 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_hamt = { workspace = true }
 fvm_shared = { workspace = true }
-indexmap = { version = "1.8.0", features = ["serde-1"] }
-integer-encoding = { version = "3.0.3", default-features = false }
-lazy_static = "1.4.0"
-log = "0.4.14"
-num-derive = "0.3.3"
-num-traits = "0.2.14"
-rand = "0.8.5"
-rand_chacha = "0.3.1"
-regex = "1"
+indexmap = { workspace = true }
+integer-encoding = { workspace = true }
+lazy_static = { workspace = true }
+log = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
+regex = { workspace = true }
 serde = { workspace = true }
-thiserror = "1.0.30"
-libsecp256k1 = { version = "0.7.1"}
+thiserror = { workspace = true }
+libsecp256k1 = { workspace = true }
 fil_actors_evm_shared = { workspace = true }
 
 [dev-dependencies]
 cid = { workspace = true }
 multihash = { workspace = true }
-test-case = "2.2.1"
-ethers = { version = "0.17.0", features = ["abigen"] }
-hex = "0.4.3"
-hex-literal = "0.3.4"
+test-case = { workspace = true }
+ethers = { workspace = true }
+hex = { workspace = true }
+hex-literal = { workspace = true }

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -29,18 +29,18 @@ fil_actor_evm = { version = "12.0.0", path = "../actors/evm" }
 fil_actor_eam = { version = "12.0.0", path = "../actors/eam" }
 fil_actor_ethaccount = { version = "12.0.0", path = "../actors/ethaccount" }
 
-anyhow = "1.0.65"
+anyhow = { workspace = true }
 bimap = { version = "0.6.2" }
 blake2b_simd = "1.0"
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
-frc42_dispatch = "3.3.0"
-frc46_token = "7.0.0"
-fvm_actor_utils = "7.0.0"
-fvm_ipld_bitfield = "0.5.4"
-fvm_ipld_blockstore = { version = "0.2.0", default-features = false }
-fvm_ipld_encoding = { version = "0.4.0", default-features = false }
-fvm_ipld_hamt = "0.7.0"
-fvm_shared = { version = "3.4.0", default-features = false }
+cid = { workspace = true }
+frc42_dispatch = { workspace = true }
+frc46_token = { workspace = true }
+fvm_actor_utils = { workspace = true }
+fvm_ipld_bitfield = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+fvm_ipld_hamt = { workspace = true }
+fvm_shared = { workspace = true }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 lazy_static = "1.4.0"
@@ -50,14 +50,14 @@ num-traits = "0.2.14"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 regex = "1"
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { workspace = true }
 thiserror = "1.0.30"
 libsecp256k1 = { version = "0.7.1"}
 fil_actors_evm_shared = { version = "12.0.0", path = "../actors/evm/shared" }
 
 [dev-dependencies]
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
-multihash = { version = "0.18.1", default-features = false }
+cid = { workspace = true }
+multihash = { workspace = true }
 test-case = "2.2.1"
 ethers = { version = "0.17.0", features = ["abigen"] }
 hex = "0.4.3"

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -11,23 +11,23 @@ publish = false
 [lib]
 
 [dependencies]
-fil_builtin_actors_state = { version = "12.0.0", path = "../state"}
-fil_actors_runtime = { version = "12.0.0", path = "../runtime", features = [ "test_utils" ] }
-fil_actor_init = { version = "12.0.0", path = "../actors/init" }
-fil_actor_cron = { version = "12.0.0", path = "../actors/cron" }
-fil_actor_system = { version = "12.0.0", path = "../actors/system" }
-fil_actor_account = { version = "12.0.0", path = "../actors/account" }
-fil_actor_multisig = { version = "12.0.0", path = "../actors/multisig" }
-fil_actor_paych = { version = "12.0.0", path = "../actors/paych" }
-fil_actor_reward = { version = "12.0.0", path = "../actors/reward" }
-fil_actor_power = { version = "12.0.0", path = "../actors/power" }
-fil_actor_market = { version = "12.0.0", path = "../actors/market" }
-fil_actor_verifreg = { version = "12.0.0", path = "../actors/verifreg" }
-fil_actor_miner = { version = "12.0.0", path = "../actors/miner" }
-fil_actor_datacap = { version = "12.0.0", path = "../actors/datacap" }
-fil_actor_evm = { version = "12.0.0", path = "../actors/evm" }
-fil_actor_eam = { version = "12.0.0", path = "../actors/eam" }
-fil_actor_ethaccount = { version = "12.0.0", path = "../actors/ethaccount" }
+fil_builtin_actors_state = { workspace = true }
+fil_actors_runtime = { workspace = true, features = [ "test_utils" ] }
+fil_actor_init = { workspace = true }
+fil_actor_cron = { workspace = true }
+fil_actor_system = { workspace = true }
+fil_actor_account = { workspace = true }
+fil_actor_multisig = { workspace = true }
+fil_actor_paych = { workspace = true }
+fil_actor_reward = { workspace = true }
+fil_actor_power = { workspace = true }
+fil_actor_market = { workspace = true }
+fil_actor_verifreg = { workspace = true }
+fil_actor_miner = { workspace = true }
+fil_actor_datacap = { workspace = true }
+fil_actor_evm = { workspace = true }
+fil_actor_eam = { workspace = true }
+fil_actor_ethaccount = { workspace = true }
 
 anyhow = { workspace = true }
 bimap = { version = "0.6.2" }
@@ -53,7 +53,7 @@ regex = "1"
 serde = { workspace = true }
 thiserror = "1.0.30"
 libsecp256k1 = { version = "0.7.1"}
-fil_actors_evm_shared = { version = "12.0.0", path = "../actors/evm/shared" }
+fil_actors_evm_shared = { workspace = true }
 
 [dev-dependencies]
 cid = { workspace = true }


### PR DESCRIPTION
This makes it easier to update them and makes dependency upgrade diffs smaller. It should reduce rebase conflicts for the same reason.