### PR TITLE
Implement sector->deal mapping in built-in market actor

### DIFF
--- a/actors/market/src/deal.rs
+++ b/actors/market/src/deal.rs
@@ -11,6 +11,7 @@ use fvm_shared::commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED};
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PaddedPieceSize;
+use fvm_shared::sector::SectorNumber;
 use libipld_core::ipld::Ipld;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::{TryFrom, TryInto};
@@ -136,6 +137,8 @@ pub struct ClientDealProposal {
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy, Serialize_tuple, Deserialize_tuple)]
 pub struct DealState {
+    // 0 if not yet included in proven sector (0 is also a valid sector number)
+    pub sector_number: SectorNumber,
     // -1 if not yet included in proven sector
     pub sector_start_epoch: ChainEpoch,
     // -1 if deal state never updated

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -6,10 +6,11 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use cid::multihash::{Code, MultihashDigest, MultihashGeneric};
 use cid::Cid;
-use fil_actors_runtime::{extract_send_result, BatchReturnGen, FIRST_ACTOR_SPECIFIC_EXIT_CODE};
 use frc46_token::token::types::{BalanceReturn, TransferFromParams, TransferFromReturn};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
@@ -19,14 +20,14 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::reward::ThisEpochRewardReturn;
-use fvm_shared::sector::{RegisteredSealProof, SectorSize, StoragePower};
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber, SectorSize, StoragePower};
+use fvm_shared::sys::SendFlags;
 use fvm_shared::{ActorID, METHOD_CONSTRUCTOR, METHOD_SEND};
 use integer_encoding::VarInt;
 use log::info;
 use num_derive::FromPrimitive;
 use num_traits::Zero;
 
-use crate::balance_table::BalanceTable;
 use fil_actors_runtime::cbor::{deserialize, serialize};
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Policy, Runtime};
@@ -35,10 +36,9 @@ use fil_actors_runtime::{
     AsActorError, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR, DATACAP_TOKEN_ACTOR_ADDR,
     REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
-use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
-use fvm_shared::sys::SendFlags;
+use fil_actors_runtime::{extract_send_result, BatchReturnGen, FIRST_ACTOR_SPECIFIC_EXIT_CODE};
 
+use crate::balance_table::BalanceTable;
 use crate::ext::verifreg::{AllocationID, AllocationRequest};
 
 pub use self::deal::*;
@@ -547,6 +547,7 @@ impl Actor {
             let mut batch_gen = BatchReturnGen::new(params.sectors.len());
             let mut activations: Vec<SectorDealActivation> = vec![];
             let mut activated_deals: HashSet<DealID> = HashSet::new();
+            let mut sector_deals: Vec<(SectorNumber, SectorDealIDs)> = vec![];
 
             for p in params.sectors {
                 let proposal_array = st.get_proposal_array(rt.store())?;
@@ -583,6 +584,11 @@ impl Actor {
                         continue;
                     }
                 };
+
+                sector_deals.push((
+                    p.sector_number,
+                    SectorDealIDs { sector_expiration: p.sector_expiry, deals: p.deal_ids.clone() },
+                ));
 
                 // Update deal states
                 let mut verified_infos = Vec::new();
@@ -639,6 +645,7 @@ impl Actor {
                         deal_states.push((
                             deal_id,
                             DealState {
+                                sector_number: p.sector_number,
                                 sector_start_epoch: curr_epoch,
                                 last_updated_epoch: EPOCH_UNDEFINED,
                                 slash_epoch: EPOCH_UNDEFINED,
@@ -664,8 +671,8 @@ impl Actor {
                 }
             }
 
+            st.put_sector_deal_ids(rt.store(), &miner_addr, &sector_deals)?;
             st.put_deal_states(rt.store(), &deal_states)?;
-
             Ok((activations, batch_gen.gen()))
         })?;
 
@@ -683,10 +690,18 @@ impl Actor {
         let miner_addr = rt.message().caller();
 
         rt.transaction(|st: &mut State, rt| {
-            let mut deal_states: Vec<(DealID, DealState)> = vec![];
+            // The sector deals mapping is removed all at once.
+            // Other deal clean-up is deferred to cron.
+            let sector_deals =
+                st.pop_sector_deal_ids(rt.store(), &miner_addr, params.sectors.iter())?;
+            let all_deal_ids = sector_deals
+                .iter()
+                .flat_map(|(_, deal_ids)| deal_ids.deals.iter())
+                .collect::<Vec<_>>();
 
-            for id in params.deal_ids {
-                let deal = st.find_proposal(rt.store(), id)?;
+            let mut deal_states: Vec<(DealID, DealState)> = vec![];
+            for id in all_deal_ids {
+                let deal = st.find_proposal(rt.store(), *id)?;
                 // The deal may have expired and been deleted before the sector is terminated.
                 // Nothing to do, but continue execution for the other deals.
                 if deal.is_none() {
@@ -712,7 +727,7 @@ impl Actor {
                 }
 
                 let mut state: DealState = st
-                    .find_deal_state(rt.store(), id)?
+                    .find_deal_state(rt.store(), *id)?
                     // A deal with a proposal but no state is not activated, but then it should not be
                     // part of a sector that is terminating.
                     .ok_or_else(|| actor_error!(illegal_argument, "no state for deal {}", id))?;
@@ -727,7 +742,7 @@ impl Actor {
                 // and slashing of provider collateral happens in cron_tick.
                 state.slash_epoch = params.epoch;
 
-                deal_states.push((id, state));
+                deal_states.push((*id, state));
             }
 
             st.put_deal_states(rt.store(), &deal_states)?;
@@ -762,6 +777,10 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             let last_cron = st.last_cron;
+            let mut provider_deals_to_remove: BTreeMap<
+                Address,
+                BTreeMap<SectorNumber, Vec<DealID>>,
+            > = BTreeMap::new();
             let mut new_updates_scheduled: BTreeMap<ChainEpoch, Vec<DealID>> = BTreeMap::new();
             let mut epochs_completed: Vec<ChainEpoch> = vec![];
 
@@ -846,7 +865,14 @@ impl Actor {
 
                         // Delete proposal and state simultaneously.
                         let deleted = st.remove_deal_state(rt.store(), deal_id)?;
-                        if deleted.is_none() {
+                        if let Some(deleted) = deleted {
+                            provider_deals_to_remove
+                                .entry(deal.provider)
+                                .or_default()
+                                .entry(deleted.sector_number)
+                                .or_default()
+                                .push(deal_id);
+                        } else {
                             return Err(actor_error!(
                                 illegal_state,
                                 "failed to delete deal state: does not exist"
@@ -886,7 +912,9 @@ impl Actor {
                 }
                 epochs_completed.push(i);
             }
-
+            // Remove the provider->sector->deal mappings.
+            // The sectors may still have other deals, so we can't remove the sector altogether.
+            st.remove_sector_deal_ids(rt.store(), &provider_deals_to_remove)?;
             st.remove_deals_by_epoch(rt.store(), &epochs_completed)?;
             st.put_batch_deals_by_epoch(rt.store(), &new_updates_scheduled)?;
             st.last_cron = rt.curr_epoch();
@@ -1438,6 +1466,11 @@ fn request_current_network_power(
 }
 
 pub fn deal_id_key(k: DealID) -> BytesKey {
+    let bz = k.encode_var_vec();
+    bz.into()
+}
+
+pub fn sector_number_key(k: SectorNumber) -> BytesKey {
     let bz = k.encode_var_vec();
     bz.into()
 }

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -585,10 +585,7 @@ impl Actor {
                     }
                 };
 
-                sector_deals.push((
-                    p.sector_number,
-                    SectorDealIDs { sector_expiration: p.sector_expiry, deals: p.deal_ids.clone() },
-                ));
+                sector_deals.push((p.sector_number, SectorDealIDs { deals: p.deal_ids.clone() }));
 
                 // Update deal states
                 let mut verified_infos = Vec::new();

--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -3,10 +3,11 @@
 
 use crate::balance_table::BalanceTable;
 use crate::ext::verifreg::AllocationID;
+use crate::sector_number_key;
 use cid::Cid;
 use fil_actors_runtime::{
     actor_error, make_empty_map, make_map_with_root_and_bitwidth, ActorError, Array, AsActorError,
-    Set, SetMultimap,
+    Map, Set, SetMultimap,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
@@ -16,6 +17,7 @@ use fvm_shared::clock::{ChainEpoch, EPOCH_UNDEFINED};
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
+use fvm_shared::sector::SectorNumber;
 use fvm_shared::HAMT_BIT_WIDTH;
 use num_traits::Zero;
 use std::collections::BTreeMap;
@@ -71,7 +73,23 @@ pub struct State {
     pub total_client_storage_fee: TokenAmount,
 
     /// Verified registry allocation IDs for deals that are not yet activated.
-    pub pending_deal_allocation_ids: Cid, // HAMT[DealID]AllocationID
+    // HAMT[DealID]AllocationID
+    pub pending_deal_allocation_ids: Cid,
+
+    /// Maps providers to their sector IDs to deal IDs.
+    /// This supports finding affected deals when a sector is terminated early
+    /// or has data replaced.
+    /// Grouping by provider limits the cost of operations in the expected use case
+    /// of multiple sectors all belonging to the same provider.
+    /// HAMT[Address]HAMT[SectorNumber]SectorDealIDs
+    pub provider_sectors: Cid,
+}
+
+/// IDs of deals associated with a single sector.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct SectorDealIDs {
+    pub sector_expiration: ChainEpoch,
+    pub deals: Vec<DealID>,
 }
 
 impl State {
@@ -81,33 +99,38 @@ impl State {
                 .flush()
                 .context_code(
                     ExitCode::USR_ILLEGAL_STATE,
-                    "Failed to create empty proposals array",
+                    "failed to create empty proposals array",
                 )?;
 
         let empty_states_array = Array::<(), BS>::new_with_bit_width(store, STATES_AMT_BITWIDTH)
             .flush()
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "Failed to create empty states array")?;
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to create empty states array")?;
 
         let empty_pending_proposals_map =
             make_empty_map::<_, ()>(store, HAMT_BIT_WIDTH).flush().context_code(
                 ExitCode::USR_ILLEGAL_STATE,
-                "Failed to create empty pending proposals map state",
+                "failed to create empty pending proposals map state",
             )?;
 
         let empty_balance_table = BalanceTable::new(store).root().context_code(
             ExitCode::USR_ILLEGAL_STATE,
-            "Failed to create empty balance table map",
+            "failed to create empty balance table map",
         )?;
 
         let empty_deal_ops_hamt = SetMultimap::new(store)
             .root()
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "Failed to create empty multiset")?;
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to create empty multiset")?;
 
         let empty_pending_deal_allocation_map =
             make_empty_map::<_, AllocationID>(store, HAMT_BIT_WIDTH).flush().context_code(
                 ExitCode::USR_ILLEGAL_STATE,
-                "Failed to create empty pending deal allocation map",
+                "failed to create empty pending deal allocation map",
             )?;
+
+        // XXX Tune the width parameter
+        let empty_sector_deals_hamt = make_empty_map::<_, Cid>(store, HAMT_BIT_WIDTH)
+            .flush()
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to create empty sector deals map")?;
 
         Ok(Self {
             proposals: empty_proposals_array,
@@ -123,6 +146,7 @@ impl State {
             total_provider_locked_collateral: TokenAmount::default(),
             total_client_storage_fee: TokenAmount::default(),
             pending_deal_allocation_ids: empty_pending_deal_allocation_map,
+            provider_sectors: empty_sector_deals_hamt,
         })
     }
 
@@ -600,6 +624,165 @@ impl State {
     }
 
     ////////////////////////////////////////////////////////////////////////////////
+    // Provider sector/deal operations
+    ////////////////////////////////////////////////////////////////////////////////
+
+    // Stores deal IDs associated with sectors for a provider.
+    // Deal IDs are added to any already stored for the provider and sector, while the
+    // sector expiration overwrites any expiration stored for the sector.
+    // Returns the root cid of the sector deals map.
+    pub fn put_sector_deal_ids<BS>(
+        &mut self,
+        store: &BS,
+        provider: &Address,
+        sector_deal_ids: &[(SectorNumber, SectorDealIDs)],
+    ) -> Result<(), ActorError>
+    where
+        BS: Blockstore,
+    {
+        let mut provider_sectors = self.load_provider_sectors(store)?;
+        let mut sector_deals = load_provider_sector_deals(store, &provider_sectors, provider)?;
+
+        for (sector_number, deals) in sector_deal_ids {
+            let key = sector_number_key(*sector_number);
+            let mut new_deals = deals.clone();
+            let existing_deal_ids = sector_deals
+                .get(&key)
+                .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to read sector deals")?;
+            if let Some(existing_deal_ids) = existing_deal_ids {
+                new_deals.deals.extend(existing_deal_ids.deals.iter());
+                new_deals.deals.sort();
+            }
+            sector_deals
+                .set(key, new_deals)
+                .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+                    format!("failed to set sector deals for {} {}", provider, sector_number)
+                })?;
+        }
+
+        save_provider_sector_deals(&mut provider_sectors, provider, &mut sector_deals)?;
+        self.save_provider_sectors(&mut provider_sectors)?;
+        Ok(())
+    }
+
+    // Reads and removes the sector deals mapping for an array of sector numbers,
+    pub fn pop_sector_deal_ids<BS>(
+        &mut self,
+        store: &BS,
+        provider: &Address,
+        sector_numbers: impl Iterator<Item = SectorNumber>,
+    ) -> Result<Vec<(SectorNumber, SectorDealIDs)>, ActorError>
+    where
+        BS: Blockstore,
+    {
+        let mut provider_sectors = self.load_provider_sectors(store)?;
+        let mut sector_deals = load_provider_sector_deals(store, &provider_sectors, provider)?;
+
+        let mut popped_sector_deals = Vec::new();
+        for sector_number in sector_numbers {
+            let deals: Option<(_, SectorDealIDs)> = sector_deals
+                .delete(&sector_number_key(sector_number))
+                .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+                    format!("failed to delete sector deals for {}, {}", provider, sector_number)
+                })?;
+            if let Some(deals) = deals {
+                popped_sector_deals.push((sector_number, deals.1.clone()));
+            }
+        }
+
+        // Flush if any of the requested sectors were found.
+        if !popped_sector_deals.is_empty() {
+            if sector_deals.is_empty() {
+                // Remove from top-level map
+                provider_sectors
+                    .delete(&provider.to_bytes())
+                    .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+                        format!("failed to delete sector deals for {}", provider)
+                    })?;
+            } else {
+                save_provider_sector_deals(&mut provider_sectors, provider, &mut sector_deals)?;
+            }
+            self.save_provider_sectors(&mut provider_sectors)?;
+        }
+
+        Ok(popped_sector_deals)
+    }
+
+    // Removes specified deals from the sector deals mapping.
+    // Missing deals are ignored.
+    pub fn remove_sector_deal_ids<BS>(
+        &mut self,
+        store: &BS,
+        provider_sector_deal_ids: &BTreeMap<Address, BTreeMap<SectorNumber, Vec<DealID>>>,
+    ) -> Result<(), ActorError>
+    where
+        BS: Blockstore,
+    {
+        let mut provider_sectors = self.load_provider_sectors(store)?;
+        for (provider, sector_deal_ids) in provider_sector_deal_ids {
+            let mut sector_deals = load_provider_sector_deals(store, &provider_sectors, provider)?;
+            for (sector_number, deals_to_remove) in sector_deal_ids {
+                let key = sector_number_key(*sector_number);
+                let existing_deal_ids = sector_deals
+                    .get(&key)
+                    .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to read sector deals")?;
+                if let Some(existing_deal_ids) = existing_deal_ids {
+                    // The filter below is a linear scan of deals_to_remove.
+                    // This is expected to be a small list, often a singleton, so is usually
+                    // pretty fast.
+                    // Loading into a HashSet could be an improvement for large collections of deals
+                    // in a single sector being removed at one time.
+                    let new_deals = existing_deal_ids
+                        .deals
+                        .iter()
+                        .filter(|deal_id| !deals_to_remove.contains(*deal_id))
+                        .cloned()
+                        .collect();
+
+                    sector_deals
+                        .set(
+                            key,
+                            SectorDealIDs {
+                                sector_expiration: existing_deal_ids.sector_expiration,
+                                deals: new_deals,
+                            },
+                        )
+                        .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+                            format!("failed to set sector deals for {} {}", provider, sector_number)
+                        })?;
+                }
+            }
+            save_provider_sector_deals(&mut provider_sectors, provider, &mut sector_deals)?;
+        }
+        self.save_provider_sectors(&mut provider_sectors)?;
+        Ok(())
+    }
+
+    fn load_provider_sectors<'bs, BS>(
+        &self,
+        store: &'bs BS,
+    ) -> Result<Map<'bs, BS, Cid>, ActorError>
+    where
+        BS: Blockstore,
+    {
+        Map::load_with_bit_width(&self.provider_sectors, store, HAMT_BIT_WIDTH)
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load provider sectors map")
+    }
+
+    fn save_provider_sectors<BS>(
+        &mut self,
+        provider_sectors: &mut Map<BS, Cid>,
+    ) -> Result<(), ActorError>
+    where
+        BS: Blockstore,
+    {
+        self.provider_sectors = provider_sectors
+            .flush()
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush provider sectors map")?;
+        Ok(())
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
     // Deal state operations
     ////////////////////////////////////////////////////////////////////////////////
     pub fn process_deal_update<BS>(
@@ -997,4 +1180,48 @@ fn deal_get_payment_remaining(
     }
 
     Ok(&deal.storage_price_per_epoch * duration_remaining as u64)
+}
+
+fn load_provider_sector_deals<'bs, BS>(
+    store: &'bs BS,
+    provider_sectors: &Map<'bs, BS, Cid>,
+    provider: &Address,
+) -> Result<Map<'bs, BS, SectorDealIDs>, ActorError>
+where
+    BS: Blockstore,
+{
+    let sectors_root: Option<&Cid> = (*provider_sectors)
+        .get(&provider.to_bytes())
+        .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+            format!("failed to get sector deals root for {}", provider)
+        })?;
+
+    let sector_deals: Map<BS, SectorDealIDs> = if let Some(sectors_root) = sectors_root {
+        Map::load_with_bit_width(sectors_root, store, HAMT_BIT_WIDTH)
+            .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+                format!("failed to load sector deals map for {}", provider)
+            })?
+    } else {
+        Map::new_with_bit_width(store, HAMT_BIT_WIDTH)
+    };
+    Ok(sector_deals)
+}
+
+fn save_provider_sector_deals<BS>(
+    provider_sectors: &mut Map<BS, Cid>,
+    provider: &Address,
+    sector_deals: &mut Map<BS, SectorDealIDs>,
+) -> Result<(), ActorError>
+where
+    BS: Blockstore,
+{
+    let sectors_root = sector_deals
+        .flush()
+        .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush sector deals")?;
+    provider_sectors
+        .set(provider.to_bytes().into(), sectors_root)
+        .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+            format!("failed to set sector deals root for {}", provider)
+        })?;
+    Ok(())
 }

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -17,7 +17,7 @@ use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::ActorID;
 
 use crate::Label;
-use fvm_shared::sector::RegisteredSealProof;
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
 
 use super::deal::{ClientDealProposal, DealProposal, DealState};
 
@@ -54,10 +54,10 @@ pub struct GetBalanceReturn {
     pub locked: TokenAmount,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, PartialEq)] // Add Eq when BitField does
 pub struct OnMinerSectorsTerminateParams {
     pub epoch: ChainEpoch,
-    pub deal_ids: Vec<DealID>,
+    pub sectors: BitField,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
@@ -79,6 +79,7 @@ pub struct VerifyDealsForActivationParams {
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
 pub struct SectorDeals {
+    pub sector_number: SectorNumber,
     pub sector_type: RegisteredSealProof,
     pub sector_expiry: ChainEpoch,
     pub deal_ids: Vec<DealID>,

--- a/actors/market/tests/activate_deal_failures.rs
+++ b/actors/market/tests/activate_deal_failures.rs
@@ -33,6 +33,7 @@ fn fail_when_caller_is_not_the_provider_of_the_deal() {
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number: 1,
             sector_expiry,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             deal_ids: vec![deal_id],
@@ -55,6 +56,7 @@ fn fail_when_caller_is_not_a_storage_miner_actor() {
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, PROVIDER_ADDR);
 
     let sector_activation = SectorDeals {
+        sector_number: 1,
         deal_ids: vec![],
         sector_expiry: 0,
         sector_type: RegisteredSealProof::StackedDRG8MiBV1,
@@ -81,6 +83,7 @@ fn fail_when_deal_has_not_been_published_before() {
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number: 1,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             sector_expiry: EPOCHS_IN_DAY,
             deal_ids: vec![DealID::from(42u32)],
@@ -110,12 +113,14 @@ fn fail_when_deal_has_already_been_activated() {
         start_epoch,
         end_epoch,
     );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id]);
+    let sector_number = 7;
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, sector_number, &[deal_id]);
 
     let res = batch_activate_deals_raw(
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number: sector_number + 1,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             sector_expiry,
             deal_ids: vec![deal_id],
@@ -161,11 +166,12 @@ fn fail_when_deal_has_already_been_expired() {
 
     cron_tick(&rt);
 
-    assert_deal_deleted(&rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal, 0);
 
     let mut st: State = rt.get_state::<State>();
     st.next_id = deal_id + 1;
 
-    let res = activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id]);
+    let sector_number = 7;
+    let res = activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, sector_number, &[deal_id]);
     assert_eq!(res.activation_results.codes(), vec![EX_DEAL_EXPIRED])
 }

--- a/actors/market/tests/cron_tick_timedout_deals.rs
+++ b/actors/market/tests/cron_tick_timedout_deals.rs
@@ -56,7 +56,7 @@ fn timed_out_deal_is_slashed_and_deleted() {
     assert_eq!(c_escrow, client_acct.balance);
     assert!(client_acct.locked.is_zero());
     assert_account_zero(&rt, PROVIDER_ADDR);
-    assert_deal_deleted(&rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal, 0);
     check_state(&rt);
 }
 
@@ -128,7 +128,7 @@ fn publishing_timed_out_deal_again_should_work_after_cron_tick_as_it_should_no_l
         ExitCode::OK,
     );
     cron_tick(&rt);
-    assert_deal_deleted(&rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal, 0);
 
     // now publishing should work
     generate_and_publish_deal(&rt, CLIENT_ADDR, &MinerAddresses::default(), START_EPOCH, END_EPOCH);
@@ -194,8 +194,8 @@ fn timed_out_and_verified_deals_are_slashed_deleted() {
     cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     assert_account_zero(&rt, PROVIDER_ADDR);
-    assert_deal_deleted(&rt, deal_ids[0], deal1);
-    assert_deal_deleted(&rt, deal_ids[1], deal2);
-    assert_deal_deleted(&rt, deal_ids[2], deal3);
+    assert_deal_deleted(&rt, deal_ids[0], deal1, 0);
+    assert_deal_deleted(&rt, deal_ids[1], deal2, 0);
+    assert_deal_deleted(&rt, deal_ids[2], deal3, 0);
     check_state(&rt);
 }

--- a/actors/market/tests/deal_api_test.rs
+++ b/actors/market/tests/deal_api_test.rs
@@ -118,7 +118,8 @@ fn activation() {
     // activate the deal
     let activate_epoch = start_epoch - 2;
     rt.set_epoch(activate_epoch);
-    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, activate_epoch, &[id]);
+    let sector_number = 7;
+    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, activate_epoch, sector_number, &[id]);
     let activation: GetDealActivationReturn =
         query_deal(&rt, Method::GetDealActivationExported, id);
     assert_eq!(activate_epoch, activation.activated);
@@ -127,7 +128,7 @@ fn activation() {
     // terminate early
     let terminate_epoch = activate_epoch + 100;
     rt.set_epoch(terminate_epoch);
-    terminate_deals(&rt, PROVIDER_ADDR, &[id]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     let activation: GetDealActivationReturn =
         query_deal(&rt, Method::GetDealActivationExported, id);
     assert_eq!(activate_epoch, activation.activated);

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -1,8 +1,11 @@
 #![allow(dead_code)]
 
 use cid::Cid;
-use fil_actor_market::{BatchActivateDealsParams, BatchActivateDealsResult};
+use fil_actor_market::{
+    sector_number_key, BatchActivateDealsParams, BatchActivateDealsResult, SectorDealIDs,
+};
 use frc46_token::token::types::{TransferFromParams, TransferFromReturn};
+use fvm_ipld_bitfield::BitField;
 use num_traits::{FromPrimitive, Zero};
 use regex::Regex;
 use std::cmp::min;
@@ -29,7 +32,7 @@ use fil_actors_runtime::{
     network::EPOCHS_IN_DAY,
     runtime::{builtins::Type, Policy, Runtime},
     test_utils::*,
-    ActorError, BatchReturn, SetMultimap, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR,
+    ActorError, BatchReturn, Map, SetMultimap, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR,
     DATACAP_TOKEN_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
     STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
@@ -41,7 +44,7 @@ use fvm_shared::crypto::signature::Signature;
 use fvm_shared::deal::DealID;
 use fvm_shared::piece::{PaddedPieceSize, PieceInfo};
 use fvm_shared::reward::ThisEpochRewardReturn;
-use fvm_shared::sector::{RegisteredSealProof, StoragePower};
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
 use fvm_shared::smooth::FilterEstimate;
 use fvm_shared::sys::SendFlags;
 use fvm_shared::{
@@ -317,6 +320,7 @@ pub fn activate_deals(
     sector_expiry: ChainEpoch,
     provider: Address,
     current_epoch: ChainEpoch,
+    sector_number: SectorNumber,
     deal_ids: &[DealID],
 ) -> BatchActivateDealsResult {
     rt.set_epoch(current_epoch);
@@ -325,6 +329,7 @@ pub fn activate_deals(
         rt,
         provider,
         vec![SectorDeals {
+            sector_number,
             deal_ids: deal_ids.into(),
             sector_expiry,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
@@ -351,11 +356,12 @@ pub fn activate_deals(
 pub fn batch_activate_deals(
     rt: &MockRuntime,
     provider: Address,
-    sectors: &[(ChainEpoch, Vec<DealID>)],
+    sectors: &[(SectorNumber, ChainEpoch, Vec<DealID>)],
 ) -> BatchActivateDealsResult {
     let sectors_deals: Vec<SectorDeals> = sectors
         .iter()
-        .map(|(sector_expiry, deal_ids)| SectorDeals {
+        .map(|(sector_number, sector_expiry, deal_ids)| SectorDeals {
+            sector_number: *sector_number,
             deal_ids: deal_ids.clone(),
             sector_expiry: *sector_expiry,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
@@ -412,6 +418,31 @@ pub fn get_deal_state(rt: &MockRuntime, deal_id: DealID) -> DealState {
     let states = DealMetaArray::load(&st.states, &rt.store).unwrap();
     let s = states.get(deal_id).unwrap();
     *s.unwrap()
+}
+
+// Returns the deal IDs associated with a provider address and sector from state
+pub fn get_sector_deal_ids(
+    rt: &MockRuntime,
+    provider: &Address,
+    sector_number: SectorNumber,
+) -> Vec<DealID> {
+    let st: State = rt.get_state();
+    let provider_sectors =
+        Map::load_with_bit_width(&st.provider_sectors, &rt.store, HAMT_BIT_WIDTH).unwrap();
+    let sectors_root: Option<&Cid> = provider_sectors.get(&provider.to_bytes()).unwrap();
+    if let Some(sectors_root) = sectors_root {
+        let sector_deals =
+            Map::load_with_bit_width(sectors_root, &rt.store, HAMT_BIT_WIDTH).unwrap();
+        let deals: Option<&SectorDealIDs> =
+            sector_deals.get(&sector_number_key(sector_number)).unwrap();
+        if let Some(deals) = deals {
+            deals.deals.clone()
+        } else {
+            vec![]
+        }
+    } else {
+        vec![]
+    }
 }
 
 pub fn update_last_updated(rt: &MockRuntime, deal_id: DealID, new_last_updated: ChainEpoch) {
@@ -844,10 +875,14 @@ pub fn assert_deals_not_terminated(rt: &MockRuntime, deal_ids: &[DealID]) {
     }
 }
 
-pub fn assert_deal_deleted(rt: &MockRuntime, deal_id: DealID, p: DealProposal) {
+pub fn assert_deal_deleted(
+    rt: &MockRuntime,
+    deal_id: DealID,
+    p: DealProposal,
+    sector_number: SectorNumber,
+) {
     use cid::multihash::Code;
     use cid::multihash::MultihashDigest;
-    use fil_actors_runtime::Map;
     use fvm_ipld_hamt::BytesKey;
 
     let st: State = rt.get_state();
@@ -872,6 +907,10 @@ pub fn assert_deal_deleted(rt: &MockRuntime, deal_id: DealID, p: DealProposal) {
         >(&st.pending_proposals, &*rt.store, PROPOSALS_AMT_BITWIDTH)
         .unwrap();
     assert!(!pending_deals.contains_key(&BytesKey(p_cid.to_bytes())).unwrap());
+
+    // Check deal is no longer associated with sector
+    let sector_deals = get_sector_deal_ids(rt, &p.provider, sector_number);
+    assert!(!sector_deals.contains(&deal_id));
 }
 
 pub fn assert_deal_failure<F>(add_funds: bool, post_setup: F, exit_code: ExitCode, sig_valid: bool)
@@ -954,6 +993,7 @@ pub fn publish_and_activate_deal(
     rt: &MockRuntime,
     client: Address,
     addrs: &MinerAddresses,
+    sector_number: SectorNumber,
     start_epoch: ChainEpoch,
     end_epoch: ChainEpoch,
     current_epoch: ChainEpoch,
@@ -962,7 +1002,7 @@ pub fn publish_and_activate_deal(
     let deal = generate_deal_and_add_funds(rt, client, addrs, start_epoch, end_epoch);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addrs.worker);
     let deal_ids = publish_deals(rt, addrs, &[deal], TokenAmount::zero(), NO_ALLOCATION_ID); // unverified deal
-    activate_deals(rt, sector_expiry, addrs.provider, current_epoch, &deal_ids);
+    activate_deals(rt, sector_expiry, addrs.provider, current_epoch, sector_number, &deal_ids);
     deal_ids[0]
 }
 
@@ -1117,8 +1157,8 @@ pub fn generate_deal_proposal(
     )
 }
 
-pub fn terminate_deals(rt: &MockRuntime, miner_addr: Address, deal_ids: &[DealID]) {
-    let ret = terminate_deals_raw(rt, miner_addr, deal_ids).unwrap();
+pub fn terminate_deals(rt: &MockRuntime, miner_addr: Address, sectors: &[SectorNumber]) {
+    let ret = terminate_deals_raw(rt, miner_addr, sectors).unwrap();
     assert!(ret.is_none());
     rt.verify();
 }
@@ -1126,13 +1166,13 @@ pub fn terminate_deals(rt: &MockRuntime, miner_addr: Address, deal_ids: &[DealID
 pub fn terminate_deals_raw(
     rt: &MockRuntime,
     miner_addr: Address,
-    deal_ids: &[DealID],
+    sector_numbers: &[SectorNumber],
 ) -> Result<Option<IpldBlock>, ActorError> {
     rt.set_caller(*MINER_ACTOR_CODE_ID, miner_addr);
     rt.expect_validate_caller_type(vec![Type::Miner]);
 
-    let params =
-        OnMinerSectorsTerminateParams { epoch: *rt.epoch.borrow(), deal_ids: deal_ids.to_vec() };
+    let bf = BitField::try_from_bits(sector_numbers.iter().copied()).unwrap();
+    let params = OnMinerSectorsTerminateParams { epoch: *rt.epoch.borrow(), sectors: bf };
 
     rt.call::<MarketActor>(
         Method::OnMinerSectorsTerminate as u64,

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -322,7 +322,7 @@ fn worker_balance_after_withdrawal_must_account_for_slashed_funds() {
     let start_epoch = ChainEpoch::from(10);
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let publish_epoch = ChainEpoch::from(5);
-
+    let sector_number = 7;
     let rt = setup();
 
     // publish deal
@@ -336,13 +336,13 @@ fn worker_balance_after_withdrawal_must_account_for_slashed_funds() {
     );
 
     // activate the deal
-    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, publish_epoch, &[deal_id]);
+    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, publish_epoch, sector_number, &[deal_id]);
     let st = get_deal_state(&rt, deal_id);
     assert_eq!(publish_epoch, st.sector_start_epoch);
 
     // slash the deal
     rt.set_epoch(publish_epoch + 1);
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     let st = get_deal_state(&rt, deal_id);
     assert_eq!(publish_epoch + 1, st.slash_epoch);
 
@@ -698,7 +698,7 @@ fn simple_deal() {
     )[0];
 
     // activate the deal
-    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, publish_epoch, &[deal1_id, deal2_id]);
+    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, publish_epoch, 1, &[deal1_id, deal2_id]);
     let deal1st = get_deal_state(&rt, deal1_id);
     assert_eq!(publish_epoch, deal1st.sector_start_epoch);
     assert_eq!(NO_ALLOCATION_ID, deal1st.verified_claim);
@@ -1057,7 +1057,7 @@ fn publish_a_deal_after_activating_a_previous_deal_which_has_a_start_epoch_far_i
         start_epoch,
         end_epoch,
     );
-    activate_deals(&rt, end_epoch, PROVIDER_ADDR, publish_epoch, &[deal1]);
+    activate_deals(&rt, end_epoch, PROVIDER_ADDR, publish_epoch, 1, &[deal1]);
     let st = get_deal_state(&rt, deal1);
     assert_eq!(publish_epoch, st.sector_start_epoch);
 
@@ -1071,7 +1071,7 @@ fn publish_a_deal_after_activating_a_previous_deal_which_has_a_start_epoch_far_i
         start_epoch + 1,
         end_epoch + 1,
     );
-    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, new_epoch, &[deal2]);
+    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, new_epoch, 2, &[deal2]);
     check_state(&rt);
 }
 
@@ -1315,15 +1315,15 @@ fn active_deals_multiple_times_with_different_providers() {
     let deal5 = generate_and_publish_deal(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch + 1);
 
     // provider1 activates deal1 and deal2 but that does not activate deal3 to deal5
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1, deal2]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, 1, &[deal1, deal2]);
     assert_deals_not_activated(&rt, current_epoch, &[deal3, deal4, deal5]);
 
     // provider2 activates deal5 but that does not activate deal3 or deal4
-    activate_deals(&rt, sector_expiry, provider2_addr, current_epoch, &[deal5]);
+    activate_deals(&rt, sector_expiry, provider2_addr, current_epoch, 1, &[deal5]);
     assert_deals_not_activated(&rt, current_epoch, &[deal3, deal4]);
 
     // provider1 activates deal3
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal3]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, 2, &[deal3]);
     assert_deals_not_activated(&rt, current_epoch, &[deal4]);
     check_state(&rt);
 }
@@ -1334,13 +1334,14 @@ fn fail_when_deal_is_activated_but_proposal_is_not_found() {
     let start_epoch = 50;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
-
+    let sector_number = 7;
     let rt = setup();
 
     let deal_id = publish_and_activate_deal(
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number,
         start_epoch,
         end_epoch,
         0,
@@ -1370,13 +1371,14 @@ fn fail_when_deal_update_epoch_is_in_the_future() {
     let start_epoch = 50;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
-
+    let sector_number = 7;
     let rt = setup();
 
     let deal_id = publish_and_activate_deal(
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number,
         start_epoch,
         end_epoch,
         0,
@@ -1407,6 +1409,7 @@ fn crontick_for_a_deal_at_its_start_epoch_results_in_zero_payment_and_no_slashin
     let start_epoch = ChainEpoch::from(50);
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
+    let sector_number = 7;
 
     // set start epoch to coincide with processing (0 + 0 % 2880 = 0)
     let start_epoch = 0;
@@ -1415,6 +1418,7 @@ fn crontick_for_a_deal_at_its_start_epoch_results_in_zero_payment_and_no_slashin
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number,
         start_epoch,
         end_epoch,
         0,
@@ -1440,13 +1444,14 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
     let start_epoch = ChainEpoch::from(50);
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
-
+    let sector_number = 7;
     let rt = setup();
 
     let deal_id1 = publish_and_activate_deal(
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number,
         start_epoch,
         end_epoch,
         0,
@@ -1458,6 +1463,7 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number + 1,
         start_epoch + 1,
         end_epoch + 1,
         0,
@@ -1467,7 +1473,7 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
     // slash deal1
     let slash_epoch = process_epoch(start_epoch, deal_id2) + ChainEpoch::from(100);
     rt.set_epoch(slash_epoch);
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
 
     // cron tick will slash deal1 and make payment for deal2
     rt.expect_send_simple(
@@ -1480,7 +1486,7 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
     );
     cron_tick(&rt);
 
-    assert_deal_deleted(&rt, deal_id1, d1);
+    assert_deal_deleted(&rt, deal_id1, d1, sector_number);
     let s2 = get_deal_state(&rt, deal_id2);
     assert_eq!(slash_epoch, s2.last_updated_epoch);
     check_state(&rt);
@@ -1490,6 +1496,7 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
 fn cron_reschedules_update_to_new_period() {
     let start_epoch = ChainEpoch::from(1);
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+    let sector_number = 7;
 
     // Publish a deal
     let rt = setup();
@@ -1497,6 +1504,7 @@ fn cron_reschedules_update_to_new_period() {
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number,
         start_epoch,
         end_epoch,
         0,
@@ -1529,6 +1537,7 @@ fn cron_reschedules_update_to_new_period() {
 fn cron_reschedules_update_to_new_period_boundary() {
     let start_epoch = ChainEpoch::from(1);
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+    let sector_number = 7;
 
     // Publish a deal
     let rt = setup();
@@ -1536,6 +1545,7 @@ fn cron_reschedules_update_to_new_period_boundary() {
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number,
         start_epoch,
         end_epoch,
         0,
@@ -1572,6 +1582,7 @@ fn cron_reschedules_many_updates() {
     let start_epoch = ChainEpoch::from(10);
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = start_epoch + 5 * EPOCHS_IN_YEAR;
+    let sector_number = 7;
     // Set a short update interval so we can generate scheduling collisions.
     let update_interval = 100;
 
@@ -1584,6 +1595,7 @@ fn cron_reschedules_many_updates() {
             &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
+            sector_number,
             start_epoch,
             end_epoch + i,
             0,
@@ -1678,6 +1690,7 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
+    let sector_number = 7;
 
     let rt = setup();
     let deal_id = generate_and_publish_deal(
@@ -1693,6 +1706,7 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number,
             sector_expiry,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             deal_ids: vec![deal_id],
@@ -1713,6 +1727,7 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
 fn fail_when_end_epoch_of_deal_greater_than_sector_expiry() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+    let sector_number = 7;
 
     let rt = setup();
     let deal_id = generate_and_publish_deal(
@@ -1727,6 +1742,7 @@ fn fail_when_end_epoch_of_deal_greater_than_sector_expiry() {
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number,
             sector_expiry: end_epoch - 1,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             deal_ids: vec![deal_id],
@@ -1748,6 +1764,7 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
+    let sector_number = 7;
 
     let rt = setup();
     // activate deal1 so it fails later
@@ -1758,7 +1775,7 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
         start_epoch,
         end_epoch,
     );
-    batch_activate_deals(&rt, PROVIDER_ADDR, &[(sector_expiry, vec![deal_id1])]);
+    batch_activate_deals(&rt, PROVIDER_ADDR, &[(sector_number, sector_expiry, vec![deal_id1])]);
 
     let deal_id2 = generate_and_publish_deal(
         &rt,
@@ -1772,6 +1789,7 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number,
             sector_expiry,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             deal_ids: vec![deal_id1, deal_id2],
@@ -1857,8 +1875,10 @@ fn locked_fund_tracking_states() {
 
     // activation doesn't change anything
     let curr = rt.set_epoch(start_epoch - 1);
-    activate_deals(&rt, sector_expiry, p1, curr, &[deal_id1]);
-    activate_deals(&rt, sector_expiry, p2, curr, &[deal_id2]);
+    // Providers happened to use the same sector number.
+    let sector_number = 7;
+    activate_deals(&rt, sector_expiry, p1, curr, sector_number, &[deal_id1]);
+    activate_deals(&rt, sector_expiry, p2, curr, sector_number, &[deal_id2]);
 
     assert_locked_fund_states(&rt, csf.clone(), plc.clone(), clc.clone());
 
@@ -1896,7 +1916,7 @@ fn locked_fund_tracking_states() {
 
     // slash deal1
     rt.set_epoch(curr + 1);
-    terminate_deals(&rt, m1.provider, &[deal_id1]);
+    terminate_deals(&rt, m1.provider, &[sector_number]);
 
     // cron tick to slash deal1 and expire deal2
     rt.set_epoch(end_epoch);

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -53,7 +53,6 @@ fn test_remove_all_error() {
     SetMultimap::new(&rt.store()).remove_all(42).expect("expected no error");
 }
 
-// TODO add array stuff
 #[test]
 fn simple_construction() {
     let rt = MockRuntime {

--- a/actors/market/tests/on_miner_sectors_terminate.rs
+++ b/actors/market/tests/on_miner_sectors_terminate.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fvm_ipld_bitfield::BitField;
 use std::convert::TryInto;
 
 use fil_actor_market::{Actor as MarketActor, Method, OnMinerSectorsTerminateParams};
@@ -17,6 +18,8 @@ use num_traits::Zero;
 mod harness;
 
 use harness::*;
+
+// TODO: test deals in different sector with same provider are not terminated.
 
 #[test]
 fn terminate_multiple_deals_from_multiple_providers() {
@@ -43,37 +46,40 @@ fn terminate_multiple_deals_from_multiple_providers() {
         .collect::<Vec<DealID>>()
         .try_into()
         .unwrap();
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1, deal2, deal3]);
+    let sector_number = 7; // Both providers used the same sector number
+    activate_deals(
+        &rt,
+        sector_expiry,
+        PROVIDER_ADDR,
+        current_epoch,
+        sector_number,
+        &[deal1, deal2, deal3],
+    );
 
     let addrs = MinerAddresses { provider: provider2, ..MinerAddresses::default() };
     let deal4 = generate_and_publish_deal(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch);
     let deal5 = generate_and_publish_deal(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch + 1);
-    activate_deals(&rt, sector_expiry, provider2, current_epoch, &[deal4, deal5]);
+    activate_deals(&rt, sector_expiry, provider2, current_epoch, sector_number, &[deal4, deal5]);
 
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
-    assert_deals_terminated(&rt, current_epoch, &[deal1]);
-    assert_deals_not_terminated(&rt, &[deal2, deal3, deal4, deal5]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
+    assert_deals_terminated(&rt, current_epoch, &[deal1, deal2, deal3]);
+    assert_eq!(Vec::<DealID>::new(), get_sector_deal_ids(&rt, &PROVIDER_ADDR, sector_number));
+    assert_deals_not_terminated(&rt, &[deal4, deal5]);
+    assert_eq!(vec![deal4, deal5], get_sector_deal_ids(&rt, &provider2, sector_number));
 
-    terminate_deals(&rt, provider2, &[deal5]);
-    assert_deals_terminated(&rt, current_epoch, &[deal5]);
-    assert_deals_not_terminated(&rt, &[deal2, deal3, deal4]);
-
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal2, deal3]);
-    assert_deals_terminated(&rt, current_epoch, &[deal2, deal3]);
-    assert_deals_not_terminated(&rt, &[deal4]);
-
-    terminate_deals(&rt, provider2, &[deal4]);
-    assert_deals_terminated(&rt, current_epoch, &[deal4]);
+    terminate_deals(&rt, provider2, &[sector_number]);
+    assert_deals_terminated(&rt, current_epoch, &[deal4, deal5]);
+    assert_eq!(Vec::<DealID>::new(), get_sector_deal_ids(&rt, &provider2, sector_number));
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1312
 #[test]
-fn ignore_deal_proposal_that_does_not_exist() {
+fn ignore_sector_that_does_not_exist() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
     let current_epoch = 5;
+    let sector_number = 7;
 
     let rt = setup();
     rt.set_epoch(current_epoch);
@@ -85,16 +91,15 @@ fn ignore_deal_proposal_that_does_not_exist() {
         start_epoch,
         end_epoch,
     );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
-
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1, 42]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, sector_number, &[deal1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number + 1]);
 
     let s = get_deal_state(&rt, deal1);
-    assert_eq!(s.slash_epoch, current_epoch);
+    assert_eq!(s.slash_epoch, -1);
+    assert_eq!(vec![deal1], get_sector_deal_ids(&rt, &PROVIDER_ADDR, sector_number));
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1326
 #[test]
 fn terminate_valid_deals_along_with_just_expired_deal() {
     let start_epoch = 10;
@@ -126,18 +131,28 @@ fn terminate_valid_deals_along_with_just_expired_deal() {
         start_epoch,
         end_epoch - 1,
     );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1, deal2, deal3]);
+    let sector_number = 7;
+    activate_deals(
+        &rt,
+        sector_expiry,
+        PROVIDER_ADDR,
+        current_epoch,
+        sector_number,
+        &[deal1, deal2, deal3],
+    );
 
     let new_epoch = end_epoch - 1;
     rt.set_epoch(new_epoch);
 
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1, deal2, deal3]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     assert_deals_terminated(&rt, new_epoch, &[deal1, deal2]);
+    // Not cleaned up yet.
     assert_deals_not_terminated(&rt, &[deal3]);
+    // All deals are removed from sector deals mapping at once.
+    assert_eq!(Vec::<DealID>::new(), get_sector_deal_ids(&rt, &PROVIDER_ADDR, sector_number));
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1346
 #[test]
 fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
     let start_epoch = 10;
@@ -171,19 +186,19 @@ fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
         1,
     );
     assert_eq!(2, deal_ids.len());
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &deal_ids);
+    let sector_number = 7;
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, sector_number, &deal_ids);
 
     let new_epoch = end_epoch - 1;
     rt.set_epoch(new_epoch);
     cron_tick(&rt);
 
-    terminate_deals(&rt, PROVIDER_ADDR, &deal_ids);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     assert_deals_terminated(&rt, new_epoch, &deal_ids[0..0]);
-    assert_deal_deleted(&rt, deal_ids[1], deal2);
+    assert_deal_deleted(&rt, deal_ids[1], deal2, sector_number);
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1369
 #[test]
 fn terminating_a_deal_the_second_time_does_not_change_its_slash_epoch() {
     let start_epoch = 10;
@@ -201,20 +216,20 @@ fn terminating_a_deal_the_second_time_does_not_change_its_slash_epoch() {
         start_epoch,
         end_epoch,
     );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
+    let sector_number = 7;
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, sector_number, &[deal1]);
 
     // terminating the deal so slash epoch is the current epoch
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
 
     // set a new epoch and terminate again -> however slash epoch will still be the old epoch.
     rt.set_epoch(current_epoch + 1);
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     let s = get_deal_state(&rt, deal1);
     assert_eq!(s.slash_epoch, current_epoch);
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1387
 #[test]
 fn terminating_new_deals_and_an_already_terminated_deal_only_terminates_the_new_deals() {
     let start_epoch = 10;
@@ -239,15 +254,18 @@ fn terminating_new_deals_and_an_already_terminated_deal_only_terminates_the_new_
         })
         .collect();
     let [deal1, deal2, deal3]: [DealID; 3] = deals.as_slice().try_into().unwrap();
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &deals);
+    // Activate 1 deal
+    let sector_number = 7;
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, sector_number, &deals[0..1]);
+    // Terminate them
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
 
-    // terminating the deal so slash epoch is the current epoch
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
-
-    // set a new epoch and terminate again -> however slash epoch will still be the old epoch.
+    // Activate other deals in the same sector
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, sector_number, &deals[1..3]);
+    // set a new epoch and terminate again
     let new_epoch = current_epoch + 1;
     rt.set_epoch(new_epoch);
-    terminate_deals(&rt, PROVIDER_ADDR, &deals);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
 
     let s1 = get_deal_state(&rt, deal1);
     assert_eq!(s1.slash_epoch, current_epoch);
@@ -261,7 +279,6 @@ fn terminating_new_deals_and_an_already_terminated_deal_only_terminates_the_new_
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1415
 #[test]
 fn do_not_terminate_deal_if_end_epoch_is_equal_to_or_less_than_current_epoch() {
     let start_epoch = 10;
@@ -280,9 +297,10 @@ fn do_not_terminate_deal_if_end_epoch_is_equal_to_or_less_than_current_epoch() {
         start_epoch,
         end_epoch,
     );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
+    let sector_number = 7;
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, sector_number, &[deal1]);
     rt.set_epoch(end_epoch);
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     assert_deals_not_terminated(&rt, &[deal1]);
 
     // deal2 has end epoch less than current epoch when terminate is called
@@ -294,21 +312,22 @@ fn do_not_terminate_deal_if_end_epoch_is_equal_to_or_less_than_current_epoch() {
         start_epoch + 1,
         end_epoch,
     );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal2]);
+    let sector_number = sector_number + 1;
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, sector_number, &[deal2]);
     rt.set_epoch(end_epoch + 1);
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal2]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     assert_deals_not_terminated(&rt, &[deal2]);
 
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/market/market_test.go#L1436
 #[test]
 fn fail_when_caller_is_not_a_storage_miner_actor() {
     let rt = setup();
     rt.expect_validate_caller_type(vec![Type::Miner]);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, PROVIDER_ADDR);
-    let params = OnMinerSectorsTerminateParams { epoch: *rt.epoch.borrow(), deal_ids: vec![] };
+    let params =
+        OnMinerSectorsTerminateParams { epoch: *rt.epoch.borrow(), sectors: BitField::new() };
 
     // XXX: Which exit code is correct: SYS_FORBIDDEN(8) or USR_FORBIDDEN(18)?
     assert_eq!(
@@ -321,99 +340,5 @@ fn fail_when_caller_is_not_a_storage_miner_actor() {
         .exit_code()
     );
 
-    check_state(&rt);
-}
-
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/market/market_test.go#L1448
-#[test]
-fn fail_when_caller_is_not_the_provider_of_the_deal() {
-    let start_epoch = 10;
-    let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
-    let sector_expiry = end_epoch + 100;
-    let current_epoch = 5;
-
-    let provider2 = Address::new_id(501);
-
-    let rt = setup();
-    rt.set_epoch(current_epoch);
-
-    let deal = generate_and_publish_deal(
-        &rt,
-        CLIENT_ADDR,
-        &MinerAddresses::default(),
-        start_epoch,
-        end_epoch,
-    );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal]);
-
-    // XXX: Difference between go messages: 't0501' has turned into 'f0501'.
-    let ret = terminate_deals_raw(&rt, provider2, &[deal]);
-    expect_abort_contains_message(
-        ExitCode::USR_ILLEGAL_STATE,
-        "caller f0501 is not the provider f0102 of deal 0",
-        ret,
-    );
-
-    check_state(&rt);
-}
-
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/market/market_test.go#L1468
-#[test]
-fn fail_when_deal_has_been_published_but_not_activated() {
-    let start_epoch = 10;
-    let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
-    let current_epoch = 5;
-
-    let rt = setup();
-    rt.set_epoch(current_epoch);
-
-    let deal = generate_and_publish_deal(
-        &rt,
-        CLIENT_ADDR,
-        &MinerAddresses::default(),
-        start_epoch,
-        end_epoch,
-    );
-
-    let ret = terminate_deals_raw(&rt, PROVIDER_ADDR, &[deal]);
-    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "no state for deal", ret);
-    rt.verify();
-    check_state(&rt);
-}
-
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/market/market_test.go#L1485
-#[test]
-fn termination_of_all_deals_should_fail_when_one_deal_fails() {
-    let start_epoch = 10;
-    let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
-    let sector_expiry = end_epoch + 100;
-    let current_epoch = 5;
-
-    let rt = setup();
-    rt.set_epoch(current_epoch);
-
-    // deal1 would terminate but deal2 will fail because deal2 has not been activated
-    let deal1 = generate_and_publish_deal(
-        &rt,
-        CLIENT_ADDR,
-        &MinerAddresses::default(),
-        start_epoch,
-        end_epoch,
-    );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
-    let deal2 = generate_and_publish_deal(
-        &rt,
-        CLIENT_ADDR,
-        &MinerAddresses::default(),
-        start_epoch,
-        end_epoch + 1,
-    );
-
-    let ret = terminate_deals_raw(&rt, PROVIDER_ADDR, &[deal1, deal2]);
-    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "no state for deal", ret);
-    rt.verify();
-
-    // verify deal1 has not been terminated
-    assert_deals_not_terminated(&rt, &[deal1]);
     check_state(&rt);
 }

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -17,8 +17,8 @@ pub mod account {
 }
 
 pub mod market {
-
     use super::*;
+    use fvm_ipld_bitfield::BitField;
 
     pub const VERIFY_DEALS_FOR_ACTIVATION_METHOD: u64 = 5;
     pub const BATCH_ACTIVATE_DEALS_METHOD: u64 = 6;
@@ -27,6 +27,7 @@ pub mod market {
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct SectorDeals {
+        pub sector_number: SectorNumber,
         pub sector_type: RegisteredSealProof,
         pub sector_expiry: ChainEpoch,
         pub deal_ids: Vec<DealID>,
@@ -90,13 +91,7 @@ pub mod market {
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct OnMinerSectorsTerminateParams {
         pub epoch: ChainEpoch,
-        pub deal_ids: Vec<DealID>,
-    }
-
-    #[derive(Serialize_tuple)]
-    pub struct OnMinerSectorsTerminateParamsRef<'a> {
-        pub epoch: ChainEpoch,
-        pub deal_ids: &'a [DealID],
+        pub sectors: BitField,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3960,10 +3960,6 @@ fn process_early_terminations(
 
             let mut sectors_terminated: Vec<BitField> = Vec::new();
             let mut total_initial_pledge = TokenAmount::zero();
-            // let mut deals_to_terminate =
-            //     Vec::<ext::market::OnMinerSectorsTerminateParams>::with_capacity(
-            //         result.sectors.len(),
-            //     );
             let mut penalty = TokenAmount::zero();
 
             for (epoch, sector_numbers) in result.iter() {
@@ -3986,9 +3982,6 @@ fn process_early_terminations(
                     deal_ids.extend(sector.deal_ids);
                     total_initial_pledge += sector.initial_pledge;
                 }
-
-                // let params = ext::market::OnMinerSectorsTerminateParams { epoch, deal_ids };
-                // deals_to_terminate.push(params);
             }
 
             // Pay penalty
@@ -4282,9 +4275,9 @@ fn request_terminate_deals(
     sectors: &BitField,
 ) -> Result<(), ActorError> {
     if !sectors.is_empty() {
-        // XXX REVIEW: should we chunk this call?
-        // The sector bitfield representation is now much more efficient.
-        // But possibly still large, or large amount of work in the market.
+        // The sectors bitfield could be large, but will fit into a single parameters block.
+        // The FVM max block size of 1MiB supports 130K 8-byte integers, but the policy parameter
+        // ADDRESSED_SECTORS_MAX (currently 25k) will avoid reaching that.
         let res = extract_send_result(rt.send_simple(
             &STORAGE_MARKET_ACTOR_ADDR,
             ext::market::ON_MINER_SECTORS_TERMINATE_METHOD,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1176,6 +1176,7 @@ impl Actor {
         let sectors_deals: Vec<ext::market::SectorDeals> = validated_updates
             .iter()
             .map(|(usi, _)| ext::market::SectorDeals {
+                sector_number: usi.sector_info.sector_number,
                 deal_ids: usi.update.deals.clone(),
                 sector_expiry: usi.sector_info.expiration,
                 sector_type: usi.sector_info.seal_proof,
@@ -1862,6 +1863,7 @@ impl Actor {
             )?;
 
             sectors_deals.push(ext::market::SectorDeals {
+                sector_number: precommit.sector_number,
                 sector_type: precommit.seal_proof,
                 sector_expiry: precommit.expiration,
                 deal_ids: precommit.deal_ids.clone(),
@@ -3924,7 +3926,7 @@ fn process_early_terminations(
     reward_smoothed: &FilterEstimate,
     quality_adj_power_smoothed: &FilterEstimate,
 ) -> Result</* more */ bool, ActorError> {
-    let (result, more, deals_to_terminate, penalty, pledge_delta) =
+    let (result, more, sectors_terminated, penalty, pledge_delta) =
         rt.transaction(|state: &mut State, rt| {
             let store = rt.store();
             let policy = rt.policy();
@@ -3956,14 +3958,16 @@ fn process_early_terminations(
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load sectors array")
             })?;
 
+            let mut sectors_terminated: Vec<BitField> = Vec::new();
             let mut total_initial_pledge = TokenAmount::zero();
-            let mut deals_to_terminate =
-                Vec::<ext::market::OnMinerSectorsTerminateParams>::with_capacity(
-                    result.sectors.len(),
-                );
+            // let mut deals_to_terminate =
+            //     Vec::<ext::market::OnMinerSectorsTerminateParams>::with_capacity(
+            //         result.sectors.len(),
+            //     );
             let mut penalty = TokenAmount::zero();
 
             for (epoch, sector_numbers) in result.iter() {
+                sectors_terminated.push(sector_numbers.clone());
                 let sectors = sectors
                     .load_sector(sector_numbers)
                     .map_err(|e| e.wrap("failed to load sector infos"))?;
@@ -3983,8 +3987,8 @@ fn process_early_terminations(
                     total_initial_pledge += sector.initial_pledge;
                 }
 
-                let params = ext::market::OnMinerSectorsTerminateParams { epoch, deal_ids };
-                deals_to_terminate.push(params);
+                // let params = ext::market::OnMinerSectorsTerminateParams { epoch, deal_ids };
+                // deals_to_terminate.push(params);
             }
 
             // Pay penalty
@@ -4012,7 +4016,7 @@ fn process_early_terminations(
             penalty = &penalty_from_vesting + penalty_from_balance;
             pledge_delta -= penalty_from_vesting;
 
-            Ok((result, more, deals_to_terminate, penalty, pledge_delta))
+            Ok((result, more, sectors_terminated, penalty, pledge_delta))
         })?;
 
     // We didn't do anything, abort.
@@ -4033,9 +4037,8 @@ fn process_early_terminations(
     notify_pledge_changed(rt, &pledge_delta)?;
 
     // Terminate deals.
-    for params in deals_to_terminate {
-        request_terminate_deals(rt, params.epoch, params.deal_ids)?;
-    }
+    let all_terminated = BitField::union(sectors_terminated.iter());
+    request_terminate_deals(rt, rt.curr_epoch(), &all_terminated)?;
 
     // reschedule cron worker, if necessary.
     Ok(more)
@@ -4276,16 +4279,18 @@ fn request_update_power(rt: &impl Runtime, delta: PowerPair) -> Result<(), Actor
 fn request_terminate_deals(
     rt: &impl Runtime,
     epoch: ChainEpoch,
-    deal_ids: Vec<DealID>,
+    sectors: &BitField,
 ) -> Result<(), ActorError> {
-    const MAX_LENGTH: usize = 8192;
-    for chunk in deal_ids.chunks(MAX_LENGTH) {
+    if !sectors.is_empty() {
+        // XXX REVIEW: should we chunk this call?
+        // The sector bitfield representation is now much more efficient.
+        // But possibly still large, or large amount of work in the market.
         let res = extract_send_result(rt.send_simple(
             &STORAGE_MARKET_ACTOR_ADDR,
             ext::market::ON_MINER_SECTORS_TERMINATE_METHOD,
-            IpldBlock::serialize_cbor(&ext::market::OnMinerSectorsTerminateParamsRef {
+            IpldBlock::serialize_cbor(&ext::market::OnMinerSectorsTerminateParams {
                 epoch,
-                deal_ids: chunk,
+                sectors: sectors.clone(),
             })?,
             TokenAmount::zero(),
         ));
@@ -4299,7 +4304,6 @@ fn request_terminate_deals(
             res?;
         }
     }
-
     Ok(())
 }
 
@@ -4979,6 +4983,7 @@ fn batch_activate_deals_and_claim_allocations(
             let sector_activation_params = activation_infos
                 .iter()
                 .map(|activation_info| ext::market::SectorDeals {
+                    sector_number: activation_info.sector_number,
                     deal_ids: activation_info.deal_ids.clone(),
                     sector_expiry: activation_info.sector_expiry,
                     sector_type: activation_info.sector_type,

--- a/actors/miner/tests/miner_actor_test_precommit_batch.rs
+++ b/actors/miner/tests/miner_actor_test_precommit_batch.rs
@@ -390,6 +390,7 @@ mod miner_actor_precommit_batch {
             let mut sector_deal_data = Vec::new();
             for sector in &sectors {
                 sector_deals.push(SectorDeals {
+                    sector_number: sector.sector_number,
                     sector_type: sector.seal_proof,
                     sector_expiry: sector.expiration,
                     deal_ids: sector.deal_ids.clone(),

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -73,7 +73,10 @@ pub struct Policy {
     /// Maximum number of unique "declarations" in batch operations.
     pub declarations_max: u64,
 
-    /// The maximum number of sector infos that may be required to be loaded in a single invocation.
+    /// The maximum number of sector numbers addressable in a single invocation
+    /// (which implies also the max infos that may be loaded at once).
+    /// One upper bound on this is the max size of a storage block: 1MiB supports 130k at 8 bytes each,
+    /// though bitfields can compress this.
     pub addressed_sectors_max: u64,
 
     pub max_pre_commit_randomness_lookback: ChainEpoch,
@@ -299,7 +302,10 @@ pub mod policy_constants {
     /// Maximum number of unique "declarations" in batch operations.
     pub const DECLARATIONS_MAX: u64 = ADDRESSED_PARTITIONS_MAX;
 
-    /// The maximum number of sector infos that may be required to be loaded in a single invocation.
+    /// The maximum number of sector numbers addressable in a single invocation
+    /// (which implies also the max infos that may be loaded at once).
+    /// One upper bound on this is the max size of a storage block: 1MiB supports 130k at 8 bytes each,
+    /// though bitfields can compress this.
     pub const ADDRESSED_SECTORS_MAX: u64 = 25_000;
 
     pub const MAX_PRE_COMMIT_RANDOMNESS_LOOKBACK: ChainEpoch = EPOCHS_IN_DAY + CHAIN_FINALITY;

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -1143,12 +1143,32 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
 
         let expected_msg = self.expectations.borrow_mut().expect_sends.pop_front().unwrap();
 
-        assert_eq!(expected_msg.to, *to);
-        assert_eq!(expected_msg.method, method);
-        assert_eq!(expected_msg.params, params);
-        assert_eq!(expected_msg.value, value);
-        assert_eq!(expected_msg.gas_limit, gas_limit, "gas limit did not match expectation");
-        assert_eq!(expected_msg.send_flags, send_flags, "send flags did not match expectation");
+        assert_eq!(expected_msg.to, *to, "expected message to {}, was {}", expected_msg.to, to,);
+        assert_eq!(
+            expected_msg.method, method,
+            "expected method {}, was {}",
+            expected_msg.method, method
+        );
+        assert_eq!(
+            expected_msg.params, params,
+            "expected params {:?}, was {:?}",
+            expected_msg.params, params,
+        );
+        assert_eq!(
+            expected_msg.value, value,
+            "expected value {:?}, was {:?}",
+            expected_msg.value, value,
+        );
+        assert_eq!(
+            expected_msg.gas_limit, gas_limit,
+            "expected gas limit {:?}, was {:?}",
+            expected_msg.gas_limit, gas_limit
+        );
+        assert_eq!(
+            expected_msg.send_flags, send_flags,
+            "expected send flags {:?}, was {:?}",
+            expected_msg.send_flags, send_flags
+        );
 
         if let Some(e) = expected_msg.send_error {
             return Err(SendError(e));

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -1143,7 +1143,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
 
         let expected_msg = self.expectations.borrow_mut().expect_sends.pop_front().unwrap();
 
-        assert_eq!(expected_msg.to, *to, "expected message to {}, was {}", expected_msg.to, to,);
+        assert_eq!(expected_msg.to, *to, "expected message to {}, was {}", expected_msg.to, to);
         assert_eq!(
             expected_msg.method, method,
             "expected method {}, was {}",

--- a/test_vm/src/util/workflows.rs
+++ b/test_vm/src/util/workflows.rs
@@ -245,6 +245,7 @@ pub fn precommit_sectors_v2(
                 });
                 if !sector_meta.deals.is_empty() {
                     sectors_with_deals.push(SectorDeals {
+                        sector_number,
                         sector_type: seal_proof,
                         sector_expiry: expiration,
                         deal_ids: sector_meta.deals.clone(),
@@ -308,6 +309,7 @@ pub fn precommit_sectors_v2(
                 });
                 if !sector_meta.deals.is_empty() {
                     sectors_with_deals.push(SectorDeals {
+                        sector_number,
                         sector_type: seal_proof,
                         sector_expiry: expiration,
                         deal_ids: sector_meta.deals.clone(),

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -467,6 +467,7 @@ fn extend_updated_sector_with_claim() {
             Expect::market_activate_deals(
                 miner_id,
                 deal_ids.clone(),
+                initial_sector_info.sector_number,
                 initial_sector_info.expiration,
                 initial_sector_info.seal_proof,
             ),
@@ -479,6 +480,7 @@ fn extend_updated_sector_with_claim() {
             Expect::market_verify_deals(
                 miner_id,
                 vec![SectorDeals {
+                    sector_number: initial_sector_info.sector_number,
                     sector_type: seal_proof,
                     sector_expiry: initial_sector_info.expiration,
                     deal_ids: deal_ids.clone(),

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -1215,6 +1215,7 @@ fn replica_update_verified_deal_test(v: &dyn VM) {
             Expect::market_activate_deals(
                 maddr,
                 deal_ids.clone(),
+                old_sector_info.sector_number,
                 old_sector_info.expiration,
                 old_sector_info.seal_proof,
             ),
@@ -1227,6 +1228,7 @@ fn replica_update_verified_deal_test(v: &dyn VM) {
             Expect::market_verify_deals(
                 maddr,
                 vec![SectorDeals {
+                    sector_number: old_sector_info.sector_number,
                     sector_type: seal_proof,
                     sector_expiry: old_sector_info.expiration,
                     deal_ids: deal_ids.clone(),

--- a/test_vm/tests/terminate_test.rs
+++ b/test_vm/tests/terminate_test.rs
@@ -275,7 +275,7 @@ fn terminate_sectors_test(v: &dyn VM) {
             Expect::power_current_total(miner_id_addr),
             Expect::burn(miner_id_addr, None),
             Expect::power_update_pledge(miner_id_addr, None),
-            Expect::market_sectors_terminate(miner_id_addr, epoch, deal_ids.clone()),
+            Expect::market_sectors_terminate(miner_id_addr, epoch, vec![sector_number]),
             Expect::power_update_claim(miner_id_addr, sector_power.neg()),
         ]),
         ..Default::default()


### PR DESCRIPTION
Adds `provider_sectors` to market state, a `HAMT[Address]HAMT[SectorNumber]SectorDeals`. The value is a sorted vec of deal IDs and the associated sector's expiration epoch. Also adds sector number to deal state, to permit finding and removing that mapping when a deal expires.


Prototype for part of direct data onboarding.