### PR TITLE
Remove old precommit methods

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -101,7 +101,7 @@ pub enum Method {
     ChangeWorkerAddress = 3,
     ChangePeerID = 4,
     SubmitWindowedPoSt = 5,
-    PreCommitSector = 6,
+    //PreCommitSector = 6, // Deprecated
     ProveCommitSector = 7,
     ExtendSectorExpiration = 8,
     TerminateSectors = 9,
@@ -120,7 +120,7 @@ pub enum Method {
     RepayDebt = 22,
     ChangeOwnerAddress = 23,
     DisputeWindowedPoSt = 24,
-    PreCommitSectorBatch = 25,
+    //PreCommitSectorBatch = 25, // Deprecated
     ProveCommitAggregate = 26,
     ProveReplicaUpdates = 27,
     PreCommitSectorBatch2 = 28,
@@ -1695,54 +1695,6 @@ impl Actor {
         Ok(())
     }
 
-    /// Pledges to seal and commit a single sector.
-    /// See PreCommitSectorBatch for details.
-    fn pre_commit_sector(
-        rt: &impl Runtime,
-        params: PreCommitSectorParams,
-    ) -> Result<(), ActorError> {
-        Self::pre_commit_sector_batch(rt, PreCommitSectorBatchParams { sectors: vec![params] })
-    }
-
-    /// Pledges the miner to seal and commit some new sectors.
-    /// The caller specifies sector numbers, sealed sector data CIDs, seal randomness epoch, expiration, and the IDs
-    /// of any storage deals contained in the sector data. The storage deal proposals must be already submitted
-    /// to the storage market actor.
-    /// A pre-commitment may specify an existing committed-capacity sector that the committed sector will replace
-    /// when proven.
-    /// This method calculates the sector's power, locks a pre-commit deposit for the sector, stores information about the
-    /// sector in state and waits for it to be proven or expire.
-    fn pre_commit_sector_batch(
-        rt: &impl Runtime,
-        params: PreCommitSectorBatchParams,
-    ) -> Result<(), ActorError> {
-        let sectors = params
-            .sectors
-            .into_iter()
-            .map(|spci| {
-                if spci.replace_capacity {
-                    Err(actor_error!(
-                        forbidden,
-                        "cc upgrade through precommit discontinued, use ProveReplicaUpdate"
-                    ))
-                } else {
-                    Ok(SectorPreCommitInfoInner {
-                        seal_proof: spci.seal_proof,
-                        sector_number: spci.sector_number,
-                        sealed_cid: spci.sealed_cid,
-                        seal_rand_epoch: spci.seal_rand_epoch,
-                        deal_ids: spci.deal_ids,
-                        expiration: spci.expiration,
-                        // This entry point computes the unsealed CID from deals via the market.
-                        // A future one will accept it directly as a parameter.
-                        unsealed_cid: None,
-                    })
-                }
-            })
-            .collect::<Result<_, _>>()?;
-        Self::pre_commit_sector_batch_inner(rt, sectors)
-    }
-
     /// Pledges the miner to seal and commit some new sectors.
     /// The caller specifies sector numbers, sealed sector CIDs, unsealed sector CID, seal randomness epoch, expiration, and the IDs
     /// of any storage deals contained in the sector data. The storage deal proposals must be already submitted
@@ -1843,10 +1795,20 @@ impl Actor {
                 ));
             }
 
-            if let Some(ref commd) = precommit.unsealed_cid.as_ref().and_then(|c| c.0) {
-                if !is_unsealed_sector(commd) {
-                    return Err(actor_error!(illegal_argument, "unsealed CID had wrong prefix"));
+            if let Some(compact_commd) = &precommit.unsealed_cid {
+                if let Some(commd) = compact_commd.0 {
+                    if !is_unsealed_sector(&commd) {
+                        return Err(actor_error!(
+                            illegal_argument,
+                            "unsealed CID had wrong prefix"
+                        ));
+                    }
                 }
+            } else {
+                return Err(actor_error!(
+                    illegal_argument,
+                    "unspecified CompactCommD not allowed past nv21, need explicit None value for CC or CommD"
+                ));
             }
 
             // Require sector lifetime meets minimum by assuming activation happens at last epoch permitted for seal proof.
@@ -1951,11 +1913,7 @@ impl Actor {
                 // 1. verify that precommit.unsealed_cid is correct
                 // 2. create a new on_chain_precommit
 
-                let commd = match precommit.unsealed_cid {
-                    // if the CommD is unknown, use CommD computed by the market
-                    None => CompactCommD::new(deal_data.commd),
-                    Some(x) => x,
-                };
+                let commd = precommit.unsealed_cid.unwrap();
                 if commd.0 != deal_data.commd {
                     return Err(actor_error!(illegal_argument, "computed {:?} and passed {:?} CommDs not equal",
                             deal_data.commd, commd));
@@ -5096,7 +5054,6 @@ impl ActorCode for Actor {
         ChangeWorkerAddress|ChangeWorkerAddressExported => change_worker_address,
         ChangePeerID|ChangePeerIDExported => change_peer_id,
         SubmitWindowedPoSt => submit_windowed_post,
-        PreCommitSector => pre_commit_sector,
         ProveCommitSector => prove_commit_sector,
         ExtendSectorExpiration => extend_sector_expiration,
         TerminateSectors => terminate_sectors,
@@ -5115,7 +5072,6 @@ impl ActorCode for Actor {
         RepayDebt|RepayDebtExported => repay_debt,
         ChangeOwnerAddress|ChangeOwnerAddressExported => change_owner_address,
         DisputeWindowedPoSt => dispute_windowed_post,
-        PreCommitSectorBatch => pre_commit_sector_batch,
         ProveCommitAggregate => prove_commit_aggregate,
         ProveReplicaUpdates => prove_replica_updates,
         PreCommitSectorBatch2 => pre_commit_sector_batch2,

--- a/actors/miner/tests/miner_actor_test_precommit_batch.rs
+++ b/actors/miner/tests/miner_actor_test_precommit_batch.rs
@@ -34,7 +34,6 @@ struct DealSpec {
 }
 
 fn assert_simple_batch(
-    v2: bool,
     batch_size: usize,
     balance_surplus: TokenAmount,
     base_fee: TokenAmount,
@@ -44,10 +43,7 @@ fn assert_simple_batch(
 ) {
     let period_offset = ChainEpoch::from(100);
 
-    let h = ActorHarness::new_with_options(HarnessOptions {
-        use_v2_pre_commit_and_replica_update: v2,
-        proving_period_offset: period_offset,
-    });
+    let h = ActorHarness::new_with_options(HarnessOptions { proving_period_offset: period_offset });
     let rt = h.new_runtime();
 
     let precommit_epoch = period_offset + 1;
@@ -158,47 +154,25 @@ mod miner_actor_precommit_batch {
     };
     use fil_actors_runtime::{STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR};
     use fvm_ipld_encoding::ipld_block::IpldBlock;
-    use test_case::test_case;
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn one_sector(v2: bool) {
-        assert_simple_batch(v2, 1, TokenAmount::zero(), TokenAmount::zero(), &[], ExitCode::OK, "");
+    #[test]
+    fn one_sector() {
+        assert_simple_batch(1, TokenAmount::zero(), TokenAmount::zero(), &[], ExitCode::OK, "");
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn thirty_two_sectors(v2: bool) {
-        assert_simple_batch(
-            v2,
-            32,
-            TokenAmount::zero(),
-            TokenAmount::zero(),
-            &[],
-            ExitCode::OK,
-            "",
-        );
+    #[test]
+    fn thirty_two_sectors() {
+        assert_simple_batch(32, TokenAmount::zero(), TokenAmount::zero(), &[], ExitCode::OK, "");
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn max_sectors(v2: bool) {
-        assert_simple_batch(
-            v2,
-            256,
-            TokenAmount::zero(),
-            TokenAmount::zero(),
-            &[],
-            ExitCode::OK,
-            "",
-        );
+    #[test]
+    fn max_sectors() {
+        assert_simple_batch(256, TokenAmount::zero(), TokenAmount::zero(), &[], ExitCode::OK, "");
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn one_deal(v2: bool) {
+    #[test]
+    fn one_deal() {
         assert_simple_batch(
-            v2,
             3,
             TokenAmount::zero(),
             TokenAmount::zero(),
@@ -207,12 +181,9 @@ mod miner_actor_precommit_batch {
             "",
         );
     }
-
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn many_deals(v2: bool) {
+    #[test]
+    fn many_deals() {
         assert_simple_batch(
-            v2,
             3,
             TokenAmount::zero(),
             TokenAmount::zero(),
@@ -226,11 +197,9 @@ mod miner_actor_precommit_batch {
         );
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn empty_batch(v2: bool) {
+    #[test]
+    fn empty_batch() {
         assert_simple_batch(
-            v2,
             0,
             TokenAmount::zero(),
             TokenAmount::zero(),
@@ -240,11 +209,9 @@ mod miner_actor_precommit_batch {
         );
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn too_many_sectors(v2: bool) {
+    #[test]
+    fn too_many_sectors() {
         assert_simple_batch(
-            v2,
             Policy::default().pre_commit_sector_batch_max_size + 1,
             TokenAmount::zero(),
             TokenAmount::zero(),
@@ -253,12 +220,9 @@ mod miner_actor_precommit_batch {
             "batch of 257 too large",
         );
     }
-
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn insufficient_balance(v2: bool) {
+    #[test]
+    fn insufficient_balance() {
         assert_simple_batch(
-            v2,
             10,
             TokenAmount::from_atto(-1),
             TokenAmount::zero(),
@@ -268,19 +232,16 @@ mod miner_actor_precommit_batch {
         );
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn one_bad_apple_ruins_batch(v2: bool) {
+    #[test]
+    fn one_bad_apple_ruins_batch() {
         // This test does not enumerate all the individual conditions that could cause a single precommit
         // to be rejected. Those are covered in the PreCommitSector tests, and we know that that
         // method is implemented in terms of a batch of one.
 
         let period_offset = ChainEpoch::from(100);
 
-        let h = ActorHarness::new_with_options(HarnessOptions {
-            use_v2_pre_commit_and_replica_update: v2,
-            proving_period_offset: period_offset,
-        });
+        let h =
+            ActorHarness::new_with_options(HarnessOptions { proving_period_offset: period_offset });
 
         let rt = h.new_runtime();
 
@@ -313,15 +274,12 @@ mod miner_actor_precommit_batch {
         rt.reset();
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn duplicate_sector_rejects_batch(v2: bool) {
+    #[test]
+    fn duplicate_sector_rejects_batch() {
         let period_offset = ChainEpoch::from(100);
 
-        let h = ActorHarness::new_with_options(HarnessOptions {
-            use_v2_pre_commit_and_replica_update: v2,
-            proving_period_offset: period_offset,
-        });
+        let h =
+            ActorHarness::new_with_options(HarnessOptions { proving_period_offset: period_offset });
         let rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
@@ -357,10 +315,8 @@ mod miner_actor_precommit_batch {
     fn mismatch_of_commd() {
         let period_offset = ChainEpoch::from(100);
 
-        let h = ActorHarness::new_with_options(HarnessOptions {
-            use_v2_pre_commit_and_replica_update: true,
-            proving_period_offset: period_offset,
-        });
+        let h =
+            ActorHarness::new_with_options(HarnessOptions { proving_period_offset: period_offset });
         let rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -149,18 +149,19 @@ pub struct ActorHarness {
     pub epoch_reward_smooth: FilterEstimate,
     pub epoch_qa_power_smooth: FilterEstimate,
 
+    pub base_fee: TokenAmount,
+
     pub options: HarnessOptions,
 }
 
 pub struct HarnessOptions {
     pub proving_period_offset: ChainEpoch,
-    pub use_v2_pre_commit_and_replica_update: bool,
 }
 
 impl Default for HarnessOptions {
     // could be a derive(Default) but I expect options in future that won't be such
     fn default() -> Self {
-        HarnessOptions { proving_period_offset: 0, use_v2_pre_commit_and_replica_update: false }
+        HarnessOptions { proving_period_offset: 0 }
     }
 }
 
@@ -198,6 +199,8 @@ impl ActorHarness {
 
             epoch_reward_smooth: FilterEstimate::new(rwd.atto().clone(), BigInt::from(0)),
             epoch_qa_power_smooth: FilterEstimate::new(pwr, BigInt::from(0)),
+
+            base_fee: TokenAmount::zero(),
 
             options,
         }
@@ -551,55 +554,6 @@ impl ActorHarness {
         ProveCommitSectorParams { sector_number: sector_no, proof: vec![0u8; 192] }
     }
 
-    pub fn pre_commit_sector_batch_v2(
-        &self,
-        rt: &MockRuntime,
-        params: PreCommitSectorBatchParams2,
-        first_for_miner: bool,
-        base_fee: &TokenAmount,
-    ) -> Result<Option<IpldBlock>, ActorError> {
-        if self.options.use_v2_pre_commit_and_replica_update {
-            self.pre_commit_sector_batch_inner(
-                rt,
-                &params.sectors,
-                Method::PreCommitSectorBatch2 as u64,
-                params.clone(),
-                first_for_miner,
-                base_fee,
-            )
-        } else {
-            let mut deal_data = Vec::new();
-            let v1 = params
-                .sectors
-                .iter()
-                .map(|s| {
-                    deal_data.push(SectorDealData { commd: s.unsealed_cid.0 });
-                    PreCommitSectorParams {
-                        seal_proof: s.seal_proof,
-                        sector_number: s.sector_number,
-                        sealed_cid: s.sealed_cid,
-                        seal_rand_epoch: s.seal_rand_epoch,
-                        deal_ids: s.deal_ids.clone(),
-                        expiration: s.expiration,
-                        // unused
-                        replace_capacity: false,
-                        replace_sector_deadline: 0,
-                        replace_sector_partition: 0,
-                        replace_sector_number: 0,
-                    }
-                })
-                .collect();
-
-            self.pre_commit_sector_batch_inner(
-                rt,
-                &params.sectors,
-                Method::PreCommitSectorBatch as u64,
-                PreCommitSectorBatchParams { sectors: v1 },
-                first_for_miner,
-                base_fee,
-            )
-        }
-    }
     pub fn pre_commit_sector_batch(
         &self,
         rt: &MockRuntime,
@@ -622,28 +576,17 @@ impl ActorHarness {
             })
             .collect();
 
-        if self.options.use_v2_pre_commit_and_replica_update {
-            return self.pre_commit_sector_batch_inner(
-                rt,
-                &v2,
-                Method::PreCommitSectorBatch2 as u64,
-                PreCommitSectorBatchParams2 { sectors: v2.clone() },
-                conf.first_for_miner,
-                base_fee,
-            );
-        } else {
-            self.pre_commit_sector_batch_inner(
-                rt,
-                &v2,
-                Method::PreCommitSectorBatch as u64,
-                params,
-                conf.first_for_miner,
-                base_fee,
-            )
-        }
+        return self.pre_commit_sector_batch_v2(
+            rt,
+            &v2,
+            Method::PreCommitSectorBatch2 as u64,
+            PreCommitSectorBatchParams2 { sectors: v2.clone() },
+            conf.first_for_miner,
+            base_fee,
+        );
     }
 
-    fn pre_commit_sector_batch_inner(
+    fn pre_commit_sector_batch_v2(
         &self,
         rt: &MockRuntime,
         sectors: &[SectorPreCommitInfo],
@@ -685,10 +628,13 @@ impl ActorHarness {
         }
 
         let state = self.get_state(rt);
+
+        let mut expected_network_fee = TokenAmount::zero();
+        if sectors.len() > 1 {
+            expected_network_fee = aggregate_pre_commit_network_fee(sectors.len() as i64, base_fee);
+        }
         // burn networkFee
-        if state.fee_debt.is_positive() || sectors.len() > 1 {
-            let expected_network_fee =
-                aggregate_pre_commit_network_fee(sectors.len() as i64, base_fee);
+        if state.fee_debt.is_positive() || expected_network_fee.is_positive() {
             let expected_burn = expected_network_fee + state.fee_debt;
             rt.expect_send_simple(
                 BURNT_FUNDS_ACTOR_ADDR,
@@ -743,63 +689,11 @@ impl ActorHarness {
         conf: PreCommitConfig,
         first: bool,
     ) -> Result<Option<IpldBlock>, ActorError> {
-        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
-        rt.expect_validate_caller_addr(self.caller_addrs());
-        self.expect_query_network_info(rt);
-
-        if !params.deal_ids.is_empty() {
-            let vdparams = VerifyDealsForActivationParams {
-                sectors: vec![SectorDeals {
-                    sector_type: params.seal_proof,
-                    sector_expiry: params.expiration,
-                    deal_ids: params.deal_ids.clone(),
-                }],
-            };
-            let vdreturn = VerifyDealsForActivationReturn { sectors: vec![conf.0] };
-
-            rt.expect_send_simple(
-                STORAGE_MARKET_ACTOR_ADDR,
-                MarketMethod::VerifyDealsForActivation as u64,
-                IpldBlock::serialize_cbor(&vdparams).unwrap(),
-                TokenAmount::zero(),
-                IpldBlock::serialize_cbor(&vdreturn).unwrap(),
-                ExitCode::OK,
-            );
-        }
-        // in the original test the else branch does some redundant checks which we can omit.
-
-        let state = self.get_state(rt);
-        if state.fee_debt.is_positive() {
-            rt.expect_send_simple(
-                BURNT_FUNDS_ACTOR_ADDR,
-                METHOD_SEND,
-                None,
-                state.fee_debt.clone(),
-                None,
-                ExitCode::OK,
-            );
-        }
-
-        if first {
-            let dlinfo = new_deadline_info_from_offset_and_epoch(
-                &rt.policy,
-                state.proving_period_start,
-                *rt.epoch.borrow(),
-            );
-            let cron_params = make_deadline_cron_event_params(dlinfo.last());
-            rt.expect_send_simple(
-                STORAGE_POWER_ACTOR_ADDR,
-                PowerMethod::EnrollCronEvent as u64,
-                IpldBlock::serialize_cbor(&cron_params).unwrap(),
-                TokenAmount::zero(),
-                None,
-                ExitCode::OK,
-            );
-        }
-
-        let result = rt.call::<Actor>(
-            Method::PreCommitSector as u64,
-            IpldBlock::serialize_cbor(&params.clone()).unwrap(),
+        let result = self.pre_commit_sector_batch(
+            rt,
+            PreCommitSectorBatchParams { sectors: vec![params] },
+            &PreCommitBatchConfig { sector_deal_data: vec![conf.0], first_for_miner: first },
+            &self.base_fee,
         );
         result
     }
@@ -811,12 +705,14 @@ impl ActorHarness {
         conf: PreCommitConfig,
         first: bool,
     ) -> SectorPreCommitOnChainInfo {
-        let result = self.pre_commit_sector(rt, params.clone(), conf, first);
-
-        expect_empty(result.unwrap());
+        let result = self.pre_commit_sector_batch_and_get(
+            rt,
+            PreCommitSectorBatchParams { sectors: vec![params] },
+            &PreCommitBatchConfig { sector_deal_data: vec![conf.0], first_for_miner: first },
+            &self.base_fee,
+        );
         rt.verify();
-
-        self.get_precommit(rt, params.sector_number)
+        result[0].clone()
     }
 
     pub fn has_precommit(&self, rt: &MockRuntime, sector_number: SectorNumber) -> bool {

--- a/integration_tests/src/tests/batch_onboarding.rs
+++ b/integration_tests/src/tests/batch_onboarding.rs
@@ -47,7 +47,7 @@ impl Onboarding {
     }
 }
 
-pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
+pub fn batch_onboarding_test(v: &dyn VM) {
     let seal_proof = &RegisteredSealProof::StackedDRG32GiBV1P1;
 
     let mut proven_count = 0;
@@ -104,7 +104,6 @@ pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
                 next_sector_no,
                 next_sector_no == 0,
                 None,
-                v2,
             );
             precommmits.append(&mut new_precommits);
             next_sector_no += item.pre_commit_sector_count as u64;

--- a/integration_tests/src/tests/batch_onboarding_deals_test.rs
+++ b/integration_tests/src/tests/batch_onboarding_deals_test.rs
@@ -6,6 +6,7 @@ use fil_actor_miner::{
 use fil_actor_miner::{Method as MinerMethod, ProveCommitAggregateParams};
 use fil_actors_runtime::runtime::policy::policy_constants::PRE_COMMIT_CHALLENGE_DELAY;
 use fil_actors_runtime::runtime::Policy;
+use fil_actors_runtime::test_utils::make_piece_cid;
 use fil_actors_runtime::STORAGE_MARKET_ACTOR_ADDR;
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
@@ -13,7 +14,8 @@ use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::piece::{PaddedPieceSize, PieceInfo};
+use fvm_shared::error::ExitCode;
+use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::{RegisteredSealProof, StoragePower};
 use num_traits::Zero;
 
@@ -23,13 +25,84 @@ use vm_api::VM;
 use crate::deals::{DealBatcher, DealOptions};
 use crate::util::{
     advance_to_proving_deadline, bf_all, create_accounts, create_miner, get_network_stats,
-    make_bitfield, market_add_balance, miner_balance, precommit_sectors_v2, submit_windowed_post,
+    make_bitfield, market_add_balance, miner_balance, precommit_meta_data_from_deals,
+    precommit_sectors_v2, precommit_sectors_v2_expect_code, submit_windowed_post,
     verifreg_add_client, verifreg_add_verifier, PrecommitMetadata,
 };
 
 const BATCH_SIZE: usize = 8;
-const PRECOMMIT_V2: bool = true;
 const SEAL_PROOF: RegisteredSealProof = RegisteredSealProof::StackedDRG32GiBV1P1;
+
+pub fn pre_commit_requires_commd_test(v: &dyn VM) {
+    let deal_duration: ChainEpoch = Policy::default().min_sector_expiration;
+    let sector_duration: ChainEpoch =
+        deal_duration + Policy::default().market_default_allocation_term_buffer;
+
+    let addrs = create_accounts(v, 2, &TokenAmount::from_whole(10_000));
+    let (owner, client) = (addrs[0], addrs[1]);
+    let worker = owner;
+
+    // Create miner
+    let (miner, _) = create_miner(
+        v,
+        &owner,
+        &worker,
+        SEAL_PROOF.registered_window_post_proof().unwrap(),
+        &TokenAmount::from_whole(1000),
+    );
+
+    // Fund storage market accounts.
+    market_add_balance(v, &owner, &miner, &TokenAmount::from_whole(1000));
+    market_add_balance(v, &client, &client, &TokenAmount::from_whole(1000));
+
+    // Publish a deal for the sector.
+    let deal_opts = DealOptions {
+        piece_size: PaddedPieceSize(32 * (1 << 30)),
+        verified: false,
+        deal_start: v.epoch() + max_prove_commit_duration(&Policy::default(), SEAL_PROOF).unwrap(),
+        deal_lifetime: deal_duration,
+        ..DealOptions::default()
+    };
+    let mut batcher = DealBatcher::new(v, deal_opts);
+    batcher.stage(client, miner);
+    let ret = batcher.publish_ok(worker);
+    let good_inputs = bf_all(ret.valid_deals);
+    assert_eq!(vec![0], good_inputs);
+
+    // precommit without specifying commD fails
+    let sector_number = 100;
+    precommit_sectors_v2_expect_code(
+        v,
+        1,
+        1,
+        vec![PrecommitMetadata { deals: vec![0], commd: CompactCommD(None) }],
+        &worker,
+        &miner,
+        SEAL_PROOF,
+        sector_number,
+        true,
+        Some(sector_duration),
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+    );
+
+    // precommit specifying the wrong commD fails
+    precommit_sectors_v2_expect_code(
+        v,
+        1,
+        1,
+        vec![PrecommitMetadata {
+            deals: vec![0],
+            commd: CompactCommD(Some(make_piece_cid("This is not commP".as_bytes()))),
+        }],
+        &worker,
+        &miner,
+        SEAL_PROOF,
+        sector_number,
+        true,
+        Some(sector_duration),
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+    );
+}
 
 // Tests batch onboarding of sectors with verified deals.
 pub fn batch_onboarding_deals_test(v: &dyn VM) {
@@ -74,17 +147,7 @@ pub fn batch_onboarding_deals_test(v: &dyn VM) {
     // Associate deals with sectors.
     let sector_precommit_data = deals
         .into_iter()
-        .map(|(id, deal)| PrecommitMetadata {
-            deals: vec![id],
-            commd: CompactCommD::of(
-                v.primitives()
-                    .compute_unsealed_sector_cid(
-                        SEAL_PROOF,
-                        &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
-                    )
-                    .unwrap(),
-            ),
-        })
+        .map(|(id, _)| precommit_meta_data_from_deals(v, vec![id], SEAL_PROOF))
         .collect();
 
     // Pre-commit as single batch.
@@ -99,7 +162,6 @@ pub fn batch_onboarding_deals_test(v: &dyn VM) {
         0,
         true,
         Some(sector_duration),
-        PRECOMMIT_V2,
     );
     let first_sector_no = precommits[0].info.sector_number;
 

--- a/integration_tests/src/tests/commit_post_test.rs
+++ b/integration_tests/src/tests/commit_post_test.rs
@@ -12,7 +12,7 @@ use crate::expects::Expect;
 use crate::util::{
     advance_by_deadline_to_epoch, advance_to_proving_deadline, assert_invariants, create_accounts,
     create_miner, expect_invariants, get_network_stats, invariant_failure_patterns, miner_balance,
-    precommit_sectors, submit_windowed_post,
+    precommit_sectors_v2, submit_windowed_post,
 };
 use crate::TEST_VM_RAND_ARRAY;
 use fil_actor_cron::Method as CronMethod;
@@ -60,7 +60,7 @@ fn setup(v: &dyn VM) -> (MinerInfo, SectorInfo) {
 
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
-    precommit_sectors(v, 1, 1, &worker, &id_addr, seal_proof, sector_number, true, None);
+    precommit_sectors_v2(v, 1, 1, vec![], &worker, &id_addr, seal_proof, sector_number, true, None);
 
     let balances = miner_balance(v, &id_addr);
     assert!(balances.pre_commit_deposit.is_positive());
@@ -292,11 +292,21 @@ pub fn overdue_precommit_test(v: &dyn VM) {
 
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
-    let precommit =
-        precommit_sectors(v, 1, 1, &worker, &id_addr, seal_proof, sector_number, true, None)
-            .get(0)
-            .unwrap()
-            .clone();
+    let precommit = precommit_sectors_v2(
+        v,
+        1,
+        1,
+        vec![],
+        &worker,
+        &id_addr,
+        seal_proof,
+        sector_number,
+        true,
+        None,
+    )
+    .get(0)
+    .unwrap()
+    .clone();
 
     let balances = miner_balance(v, &id_addr);
     assert!(balances.pre_commit_deposit.is_positive());
@@ -400,10 +410,11 @@ pub fn aggregate_bad_sector_number_test(v: &dyn VM) {
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
     let mut precommited_sector_nos = BitField::try_from_bits(
-        precommit_sectors(
+        precommit_sectors_v2(
             v,
             4,
             policy.pre_commit_sector_batch_max_size,
+            vec![],
             &worker,
             &id_addr,
             seal_proof,
@@ -471,10 +482,11 @@ pub fn aggregate_size_limits_test(v: &dyn VM) {
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
     let precommited_sector_nos = BitField::try_from_bits(
-        precommit_sectors(
+        precommit_sectors_v2(
             v,
             oversized_batch,
             policy.pre_commit_sector_batch_max_size,
+            vec![],
             &worker,
             &id_addr,
             seal_proof,
@@ -572,10 +584,11 @@ pub fn aggregate_bad_sender_test(v: &dyn VM) {
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
     let precommited_sector_nos = BitField::try_from_bits(
-        precommit_sectors(
+        precommit_sectors_v2(
             v,
             4,
             policy.pre_commit_sector_batch_max_size,
+            vec![],
             &worker,
             &id_addr,
             seal_proof,
@@ -639,10 +652,11 @@ pub fn aggregate_one_precommit_expires_test(v: &dyn VM) {
 
     // early precommit
     let early_precommit_time = v.epoch();
-    let early_precommits = precommit_sectors(
+    let early_precommits = precommit_sectors_v2(
         v,
         1,
         policy.pre_commit_sector_batch_max_size,
+        vec![],
         &worker,
         &id_addr,
         seal_proof,
@@ -658,10 +672,11 @@ pub fn aggregate_one_precommit_expires_test(v: &dyn VM) {
 
     // later precommits
 
-    let later_precommits = precommit_sectors(
+    let later_precommits = precommit_sectors_v2(
         v,
         3,
         policy.pre_commit_sector_batch_max_size,
+        vec![],
         &worker,
         &id_addr,
         seal_proof,

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -25,8 +25,9 @@ use crate::expects::Expect;
 use crate::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_index, advance_to_proving_deadline,
     bf_all, create_accounts, create_miner, cron_tick, market_add_balance, market_publish_deal,
-    miner_precommit_sector, miner_prove_sector, sector_deadline, submit_windowed_post,
-    verifreg_add_client, verifreg_add_verifier,
+    miner_precommit_one_sector_v2, miner_prove_sector, precommit_meta_data_from_deals,
+    sector_deadline, submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
+    PrecommitMetadata,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -154,13 +155,14 @@ pub fn commit_sector_with_max_duration_deal_test(v: &dyn VM) {
     //
     // Precommit, prove and PoSt empty sector (more fully tested in TestCommitPoStFlow)
     //
-    miner_precommit_sector(
+    miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number,
-        deals,
+        precommit_meta_data_from_deals(v, deals, seal_proof),
+        true,
         deal_start + deal_lifetime,
     );
 
@@ -217,13 +219,14 @@ pub fn extend_sector_up_to_max_relative_extension_test(v: &dyn VM) {
     let sector_start =
         v.epoch() + max_prove_commit_duration(&Policy::default(), seal_proof).unwrap();
 
-    miner_precommit_sector(
+    miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number,
-        vec![],
+        PrecommitMetadata::default(),
+        true,
         sector_start + 180 * EPOCHS_IN_DAY,
     );
 
@@ -308,7 +311,16 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
 
     let expiration = v.epoch() + 360 * EPOCHS_IN_DAY;
 
-    miner_precommit_sector(v, &worker, &miner_id, seal_proof, sector_number, vec![], expiration);
+    miner_precommit_one_sector_v2(
+        v,
+        &worker,
+        &miner_id,
+        seal_proof,
+        sector_number,
+        PrecommitMetadata::default(),
+        true,
+        expiration,
+    );
 
     // advance time by a day and prove the sector
     let prove_epoch = v.epoch() + EPOCHS_IN_DAY;

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -35,7 +35,7 @@ use crate::util::{
     assert_invariants, bf_all, check_sector_active, check_sector_faulty, create_accounts,
     create_miner, deadline_state, declare_recovery, expect_invariants, get_network_stats,
     invariant_failure_patterns, make_bitfield, market_publish_deal, miner_balance, miner_power,
-    precommit_sectors, prove_commit_sectors, sector_info, submit_invalid_post,
+    precommit_sectors_v2, prove_commit_sectors, sector_info, submit_invalid_post,
     submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
 };
 
@@ -166,10 +166,11 @@ pub fn prove_replica_update_multi_dline_test(v: &dyn VM) {
     let first_sector_number_p2 = seal_proof.window_post_partitions_sector().unwrap();
     let expiration = v.epoch() + policy.max_sector_expiration_extension;
 
-    let new_precommits = precommit_sectors(
+    let new_precommits = precommit_sectors_v2(
         v,
         more_than_one_partition,
         batch_size,
+        vec![],
         &worker,
         &maddr,
         seal_proof,
@@ -826,10 +827,11 @@ pub fn deal_included_in_multiple_sectors_failure_test(v: &dyn VM) {
     //
     //
     let first_sector_number = 100;
-    let precommits = precommit_sectors(
+    let precommits = precommit_sectors_v2(
         v,
         policy.min_aggregated_sectors as usize,
         policy.pre_commit_sector_batch_max_size,
+        vec![],
         &worker,
         &maddr,
         seal_proof,
@@ -1113,8 +1115,18 @@ pub fn create_sector(
 ) -> (u64, u64) {
     // precommit
     let exp = v.epoch() + Policy::default().max_sector_expiration_extension;
-    let precommits =
-        precommit_sectors(v, 1, 1, &worker, &maddr, seal_proof, sector_number, true, Some(exp));
+    let precommits = precommit_sectors_v2(
+        v,
+        1,
+        1,
+        vec![],
+        &worker,
+        &maddr,
+        seal_proof,
+        sector_number,
+        true,
+        Some(exp),
+    );
     assert_eq!(1, precommits.len());
     assert_eq!(sector_number, precommits[0].info.sector_number);
     let balances = miner_balance(v, &maddr);

--- a/integration_tests/src/tests/terminate_test.rs
+++ b/integration_tests/src/tests/terminate_test.rs
@@ -3,16 +3,16 @@ use fil_actor_market::{
     DealMetaArray, Method as MarketMethod, State as MarketState, WithdrawBalanceParams,
 };
 use fil_actor_miner::{
-    power_for_sector, Method as MinerMethod, PreCommitSectorParams, ProveCommitSectorParams,
-    State as MinerState, TerminateSectorsParams, TerminationDeclaration,
+    power_for_sector, Method as MinerMethod, ProveCommitSectorParams, State as MinerState,
+    TerminateSectorsParams, TerminationDeclaration,
 };
 use fil_actor_power::State as PowerState;
 use fil_actor_verifreg::{Method as VerifregMethod, VerifierParams};
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{
-    test_utils::*, CRON_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
-    SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+    CRON_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
@@ -30,7 +30,8 @@ use crate::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
     advance_to_proving_deadline, create_accounts, create_miner, expect_invariants,
     invariant_failure_patterns, make_bitfield, market_publish_deal, miner_balance,
-    submit_windowed_post, verifreg_add_verifier,
+    miner_precommit_one_sector_v2, precommit_meta_data_from_deals, submit_windowed_post,
+    verifreg_add_verifier,
 };
 
 pub fn terminate_sectors_test(v: &dyn VM) {
@@ -41,7 +42,6 @@ pub fn terminate_sectors_test(v: &dyn VM) {
 
     let m_balance = TokenAmount::from_whole(1_000);
     let sector_number = 100;
-    let sealed_cid = make_sealed_cid(b"s100");
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
 
     let (miner_id_addr, miner_robust_addr) = create_miner(
@@ -162,21 +162,16 @@ pub fn terminate_sectors_test(v: &dyn VM) {
         assert_eq!(None, state);
     }
     //    precommit_sectors(&v, 1, 1, worker, robust_addr, seal_proof, sector_number, true, None);
-    apply_ok(
+
+    miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_robust_addr,
-        &TokenAmount::zero(),
-        MinerMethod::PreCommitSector as u64,
-        Some(PreCommitSectorParams {
-            seal_proof,
-            sector_number,
-            sealed_cid,
-            seal_rand_epoch: v.epoch() - 1,
-            deal_ids: deal_ids.clone(),
-            expiration: v.epoch() + 220 * EPOCHS_IN_DAY,
-            ..Default::default()
-        }),
+        seal_proof,
+        sector_number,
+        precommit_meta_data_from_deals(v, deal_ids.clone(), seal_proof),
+        true,
+        v.epoch() + 220 * EPOCHS_IN_DAY,
     );
     let prove_time = v.epoch() + Policy::default().pre_commit_challenge_delay + 1;
     advance_by_deadline_to_epoch(v, &miner_id_addr, prove_time);

--- a/integration_tests/src/tests/verified_claim_test.rs
+++ b/integration_tests/src/tests/verified_claim_test.rs
@@ -31,9 +31,9 @@ use crate::util::{
     advance_by_deadline_to_index, advance_to_proving_deadline, assert_invariants, create_accounts,
     create_miner, cron_tick, datacap_extend_claim, datacap_get_balance, expect_invariants,
     invariant_failure_patterns, market_add_balance, market_publish_deal,
-    miner_extend_sector_expiration2, miner_precommit_sector, miner_prove_sector, sector_deadline,
-    submit_windowed_post, verifreg_add_client, verifreg_add_verifier, verifreg_extend_claim_terms,
-    verifreg_remove_expired_allocations,
+    miner_extend_sector_expiration2, miner_precommit_one_sector_v2, miner_prove_sector,
+    precommit_meta_data_from_deals, sector_deadline, submit_windowed_post, verifreg_add_client,
+    verifreg_add_verifier, verifreg_extend_claim_terms, verifreg_remove_expired_allocations,
 };
 
 /// Tests a scenario involving a verified deal from the built-in market, with associated
@@ -88,13 +88,14 @@ pub fn verified_claim_scenario_test(v: &dyn VM) {
 
     // Precommit and prove the sector for the max term allowed by the deal.
     let sector_term = deal_term_min + MARKET_DEFAULT_ALLOCATION_TERM_BUFFER;
-    let _precommit = miner_precommit_sector(
+    let _precommit = miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number,
-        deals.clone(),
+        precommit_meta_data_from_deals(v, deals.clone(), seal_proof),
+        true,
         deal_start + sector_term,
     );
 
@@ -524,23 +525,25 @@ pub fn deal_passes_claim_fails_test(v: &dyn VM) {
         sector_start - max_prove_commit_duration(&Policy::default(), seal_proof).unwrap(),
     );
     let sector_number_a = 0;
-    let _precommit = miner_precommit_sector(
+    let _precommit = miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number_a,
-        vec![deal],
+        precommit_meta_data_from_deals(v, vec![deal], seal_proof),
+        true,
         sector_start + sector_term,
     );
     let sector_number_b = 1;
-    let _precommit = miner_precommit_sector(
+    let _precommit = miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number_b,
-        vec![bad_deal],
+        precommit_meta_data_from_deals(v, vec![bad_deal], seal_proof),
+        false,
         sector_start + sector_term,
     );
 

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -1,14 +1,12 @@
 use fil_actors_integration_tests::tests::batch_onboarding_test;
 use fvm_ipld_blockstore::MemoryBlockstore;
-use test_case::test_case;
 use test_vm::TestVM;
 
 // Test for batch pre-commit and aggregate prove-commit onboarding sectors (no deals).
-#[test_case(false; "v1")]
-#[test_case(true; "v2")]
-fn batch_onboarding(v2: bool) {
+#[test]
+fn batch_onboarding() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
-    batch_onboarding_test(&v, v2);
+    batch_onboarding_test(&v);
 }

--- a/test_vm/tests/batch_onboarding_deals_test.rs
+++ b/test_vm/tests/batch_onboarding_deals_test.rs
@@ -1,4 +1,6 @@
-use fil_actors_integration_tests::tests::batch_onboarding_deals_test;
+use fil_actors_integration_tests::tests::{
+    batch_onboarding_deals_test, pre_commit_requires_commd_test,
+};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use test_vm::TestVM;
 
@@ -7,4 +9,11 @@ fn batch_onboarding_deals() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     batch_onboarding_deals_test(&v);
+}
+
+#[test]
+fn pre_commit_requires_commd() {
+    let store = MemoryBlockstore::new();
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    pre_commit_requires_commd_test(&v);
 }

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -7,8 +7,9 @@ use fil_actors_integration_tests::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
     advance_by_deadline_to_index, advance_to_proving_deadline, create_accounts, create_miner,
     cron_tick, expect_invariants, invariant_failure_patterns, market_add_balance,
-    market_publish_deal, miner_precommit_sector, miner_prove_sector, submit_windowed_post,
-    verifreg_add_client, verifreg_add_verifier,
+    market_publish_deal, miner_precommit_one_sector_v2, miner_prove_sector,
+    precommit_meta_data_from_deals, submit_windowed_post, verifreg_add_client,
+    verifreg_add_verifier,
 };
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{DealWeight, EPOCHS_IN_DAY};
@@ -91,13 +92,14 @@ fn extend_legacy_sector_with_deals_inner<BS: Blockstore>(
     // Precommit, prove and PoSt empty sector (more fully tested in TestCommitPoStFlow)
     //
 
-    miner_precommit_sector(
+    miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number,
-        deals,
+        precommit_meta_data_from_deals(v, deals, seal_proof),
+        true,
         deal_start + 180 * EPOCHS_IN_DAY,
     );
 


### PR DESCRIPTION
Deprecate old precommit methods and enforce including CommD

Miner actor now enforces CompactCommD, meaning it is valid to provide `Some(CompactCommD(None))` in the precommit unsealed field to compactly specify a CC sector but not valid to specify `None` directly in this field.