### PR TITLE
Remove deprecated precommit methods

### DIFF
--- a/actors/miner/tests/miner_actor_test_precommit_batch.rs
+++ b/actors/miner/tests/miner_actor_test_precommit_batch.rs
@@ -34,7 +34,6 @@ struct DealSpec {
 }
 
 fn assert_simple_batch(
-    v2: bool,
     batch_size: usize,
     balance_surplus: TokenAmount,
     base_fee: TokenAmount,
@@ -44,10 +43,7 @@ fn assert_simple_batch(
 ) {
     let period_offset = ChainEpoch::from(100);
 
-    let h = ActorHarness::new_with_options(HarnessOptions {
-        use_v2_pre_commit_and_replica_update: v2,
-        proving_period_offset: period_offset,
-    });
+    let h = ActorHarness::new_with_options(HarnessOptions { proving_period_offset: period_offset });
     let rt = h.new_runtime();
 
     let precommit_epoch = period_offset + 1;
@@ -158,47 +154,25 @@ mod miner_actor_precommit_batch {
     };
     use fil_actors_runtime::{STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR};
     use fvm_ipld_encoding::ipld_block::IpldBlock;
-    use test_case::test_case;
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn one_sector(v2: bool) {
-        assert_simple_batch(v2, 1, TokenAmount::zero(), TokenAmount::zero(), &[], ExitCode::OK, "");
+    #[test]
+    fn one_sector() {
+        assert_simple_batch(1, TokenAmount::zero(), TokenAmount::zero(), &[], ExitCode::OK, "");
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn thirty_two_sectors(v2: bool) {
-        assert_simple_batch(
-            v2,
-            32,
-            TokenAmount::zero(),
-            TokenAmount::zero(),
-            &[],
-            ExitCode::OK,
-            "",
-        );
+    #[test]
+    fn thirty_two_sectors() {
+        assert_simple_batch(32, TokenAmount::zero(), TokenAmount::zero(), &[], ExitCode::OK, "");
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn max_sectors(v2: bool) {
-        assert_simple_batch(
-            v2,
-            256,
-            TokenAmount::zero(),
-            TokenAmount::zero(),
-            &[],
-            ExitCode::OK,
-            "",
-        );
+    #[test]
+    fn max_sectors() {
+        assert_simple_batch(256, TokenAmount::zero(), TokenAmount::zero(), &[], ExitCode::OK, "");
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn one_deal(v2: bool) {
+    #[test]
+    fn one_deal() {
         assert_simple_batch(
-            v2,
             3,
             TokenAmount::zero(),
             TokenAmount::zero(),
@@ -207,12 +181,9 @@ mod miner_actor_precommit_batch {
             "",
         );
     }
-
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn many_deals(v2: bool) {
+    #[test]
+    fn many_deals() {
         assert_simple_batch(
-            v2,
             3,
             TokenAmount::zero(),
             TokenAmount::zero(),
@@ -226,11 +197,9 @@ mod miner_actor_precommit_batch {
         );
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn empty_batch(v2: bool) {
+    #[test]
+    fn empty_batch() {
         assert_simple_batch(
-            v2,
             0,
             TokenAmount::zero(),
             TokenAmount::zero(),
@@ -240,11 +209,9 @@ mod miner_actor_precommit_batch {
         );
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn too_many_sectors(v2: bool) {
+    #[test]
+    fn too_many_sectors() {
         assert_simple_batch(
-            v2,
             Policy::default().pre_commit_sector_batch_max_size + 1,
             TokenAmount::zero(),
             TokenAmount::zero(),
@@ -253,12 +220,9 @@ mod miner_actor_precommit_batch {
             "batch of 257 too large",
         );
     }
-
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn insufficient_balance(v2: bool) {
+    #[test]
+    fn insufficient_balance() {
         assert_simple_batch(
-            v2,
             10,
             TokenAmount::from_atto(-1),
             TokenAmount::zero(),
@@ -268,19 +232,16 @@ mod miner_actor_precommit_batch {
         );
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn one_bad_apple_ruins_batch(v2: bool) {
+    #[test]
+    fn one_bad_apple_ruins_batch() {
         // This test does not enumerate all the individual conditions that could cause a single precommit
         // to be rejected. Those are covered in the PreCommitSector tests, and we know that that
         // method is implemented in terms of a batch of one.
 
         let period_offset = ChainEpoch::from(100);
 
-        let h = ActorHarness::new_with_options(HarnessOptions {
-            use_v2_pre_commit_and_replica_update: v2,
-            proving_period_offset: period_offset,
-        });
+        let h =
+            ActorHarness::new_with_options(HarnessOptions { proving_period_offset: period_offset });
 
         let rt = h.new_runtime();
 
@@ -313,15 +274,12 @@ mod miner_actor_precommit_batch {
         rt.reset();
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn duplicate_sector_rejects_batch(v2: bool) {
+    #[test]
+    fn duplicate_sector_rejects_batch() {
         let period_offset = ChainEpoch::from(100);
 
-        let h = ActorHarness::new_with_options(HarnessOptions {
-            use_v2_pre_commit_and_replica_update: v2,
-            proving_period_offset: period_offset,
-        });
+        let h =
+            ActorHarness::new_with_options(HarnessOptions { proving_period_offset: period_offset });
         let rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
@@ -357,10 +315,8 @@ mod miner_actor_precommit_batch {
     fn mismatch_of_commd() {
         let period_offset = ChainEpoch::from(100);
 
-        let h = ActorHarness::new_with_options(HarnessOptions {
-            use_v2_pre_commit_and_replica_update: true,
-            proving_period_offset: period_offset,
-        });
+        let h =
+            ActorHarness::new_with_options(HarnessOptions { proving_period_offset: period_offset });
         let rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -149,18 +149,19 @@ pub struct ActorHarness {
     pub epoch_reward_smooth: FilterEstimate,
     pub epoch_qa_power_smooth: FilterEstimate,
 
+    pub base_fee: TokenAmount,
+
     pub options: HarnessOptions,
 }
 
 pub struct HarnessOptions {
     pub proving_period_offset: ChainEpoch,
-    pub use_v2_pre_commit_and_replica_update: bool,
 }
 
 impl Default for HarnessOptions {
     // could be a derive(Default) but I expect options in future that won't be such
     fn default() -> Self {
-        HarnessOptions { proving_period_offset: 0, use_v2_pre_commit_and_replica_update: false }
+        HarnessOptions { proving_period_offset: 0 }
     }
 }
 
@@ -198,6 +199,8 @@ impl ActorHarness {
 
             epoch_reward_smooth: FilterEstimate::new(rwd.atto().clone(), BigInt::from(0)),
             epoch_qa_power_smooth: FilterEstimate::new(pwr, BigInt::from(0)),
+
+            base_fee: TokenAmount::zero(),
 
             options,
         }
@@ -551,55 +554,6 @@ impl ActorHarness {
         ProveCommitSectorParams { sector_number: sector_no, proof: vec![0u8; 192] }
     }
 
-    pub fn pre_commit_sector_batch_v2(
-        &self,
-        rt: &MockRuntime,
-        params: PreCommitSectorBatchParams2,
-        first_for_miner: bool,
-        base_fee: &TokenAmount,
-    ) -> Result<Option<IpldBlock>, ActorError> {
-        if self.options.use_v2_pre_commit_and_replica_update {
-            self.pre_commit_sector_batch_inner(
-                rt,
-                &params.sectors,
-                Method::PreCommitSectorBatch2 as u64,
-                params.clone(),
-                first_for_miner,
-                base_fee,
-            )
-        } else {
-            let mut deal_data = Vec::new();
-            let v1 = params
-                .sectors
-                .iter()
-                .map(|s| {
-                    deal_data.push(SectorDealData { commd: s.unsealed_cid.0 });
-                    PreCommitSectorParams {
-                        seal_proof: s.seal_proof,
-                        sector_number: s.sector_number,
-                        sealed_cid: s.sealed_cid,
-                        seal_rand_epoch: s.seal_rand_epoch,
-                        deal_ids: s.deal_ids.clone(),
-                        expiration: s.expiration,
-                        // unused
-                        replace_capacity: false,
-                        replace_sector_deadline: 0,
-                        replace_sector_partition: 0,
-                        replace_sector_number: 0,
-                    }
-                })
-                .collect();
-
-            self.pre_commit_sector_batch_inner(
-                rt,
-                &params.sectors,
-                Method::PreCommitSectorBatch as u64,
-                PreCommitSectorBatchParams { sectors: v1 },
-                first_for_miner,
-                base_fee,
-            )
-        }
-    }
     pub fn pre_commit_sector_batch(
         &self,
         rt: &MockRuntime,
@@ -622,28 +576,17 @@ impl ActorHarness {
             })
             .collect();
 
-        if self.options.use_v2_pre_commit_and_replica_update {
-            return self.pre_commit_sector_batch_inner(
-                rt,
-                &v2,
-                Method::PreCommitSectorBatch2 as u64,
-                PreCommitSectorBatchParams2 { sectors: v2.clone() },
-                conf.first_for_miner,
-                base_fee,
-            );
-        } else {
-            self.pre_commit_sector_batch_inner(
-                rt,
-                &v2,
-                Method::PreCommitSectorBatch as u64,
-                params,
-                conf.first_for_miner,
-                base_fee,
-            )
-        }
+        return self.pre_commit_sector_batch_v2(
+            rt,
+            &v2,
+            Method::PreCommitSectorBatch2 as u64,
+            PreCommitSectorBatchParams2 { sectors: v2.clone() },
+            conf.first_for_miner,
+            base_fee,
+        );
     }
 
-    fn pre_commit_sector_batch_inner(
+    fn pre_commit_sector_batch_v2(
         &self,
         rt: &MockRuntime,
         sectors: &[SectorPreCommitInfo],
@@ -686,10 +629,13 @@ impl ActorHarness {
         }
 
         let state = self.get_state(rt);
+
+        let mut expected_network_fee = TokenAmount::zero();
+        if sectors.len() > 1 {
+            expected_network_fee = aggregate_pre_commit_network_fee(sectors.len() as i64, base_fee);
+        }
         // burn networkFee
-        if state.fee_debt.is_positive() || sectors.len() > 1 {
-            let expected_network_fee =
-                aggregate_pre_commit_network_fee(sectors.len() as i64, base_fee);
+        if state.fee_debt.is_positive() || expected_network_fee.is_positive() {
             let expected_burn = expected_network_fee + state.fee_debt;
             rt.expect_send_simple(
                 BURNT_FUNDS_ACTOR_ADDR,
@@ -744,64 +690,11 @@ impl ActorHarness {
         conf: PreCommitConfig,
         first: bool,
     ) -> Result<Option<IpldBlock>, ActorError> {
-        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
-        rt.expect_validate_caller_addr(self.caller_addrs());
-        self.expect_query_network_info(rt);
-
-        if !params.deal_ids.is_empty() {
-            let vdparams = VerifyDealsForActivationParams {
-                sectors: vec![SectorDeals {
-                    sector_number: params.sector_number,
-                    sector_type: params.seal_proof,
-                    sector_expiry: params.expiration,
-                    deal_ids: params.deal_ids.clone(),
-                }],
-            };
-            let vdreturn = VerifyDealsForActivationReturn { sectors: vec![conf.0] };
-
-            rt.expect_send_simple(
-                STORAGE_MARKET_ACTOR_ADDR,
-                MarketMethod::VerifyDealsForActivation as u64,
-                IpldBlock::serialize_cbor(&vdparams).unwrap(),
-                TokenAmount::zero(),
-                IpldBlock::serialize_cbor(&vdreturn).unwrap(),
-                ExitCode::OK,
-            );
-        }
-        // in the original test the else branch does some redundant checks which we can omit.
-
-        let state = self.get_state(rt);
-        if state.fee_debt.is_positive() {
-            rt.expect_send_simple(
-                BURNT_FUNDS_ACTOR_ADDR,
-                METHOD_SEND,
-                None,
-                state.fee_debt.clone(),
-                None,
-                ExitCode::OK,
-            );
-        }
-
-        if first {
-            let dlinfo = new_deadline_info_from_offset_and_epoch(
-                &rt.policy,
-                state.proving_period_start,
-                *rt.epoch.borrow(),
-            );
-            let cron_params = make_deadline_cron_event_params(dlinfo.last());
-            rt.expect_send_simple(
-                STORAGE_POWER_ACTOR_ADDR,
-                PowerMethod::EnrollCronEvent as u64,
-                IpldBlock::serialize_cbor(&cron_params).unwrap(),
-                TokenAmount::zero(),
-                None,
-                ExitCode::OK,
-            );
-        }
-
-        let result = rt.call::<Actor>(
-            Method::PreCommitSector as u64,
-            IpldBlock::serialize_cbor(&params.clone()).unwrap(),
+        let result = self.pre_commit_sector_batch(
+            rt,
+            PreCommitSectorBatchParams { sectors: vec![params] },
+            &PreCommitBatchConfig { sector_deal_data: vec![conf.0], first_for_miner: first },
+            &self.base_fee,
         );
         result
     }
@@ -813,12 +706,14 @@ impl ActorHarness {
         conf: PreCommitConfig,
         first: bool,
     ) -> SectorPreCommitOnChainInfo {
-        let result = self.pre_commit_sector(rt, params.clone(), conf, first);
-
-        expect_empty(result.unwrap());
+        let result = self.pre_commit_sector_batch_and_get(
+            rt,
+            PreCommitSectorBatchParams { sectors: vec![params] },
+            &PreCommitBatchConfig { sector_deal_data: vec![conf.0], first_for_miner: first },
+            &self.base_fee,
+        );
         rt.verify();
-
-        self.get_precommit(rt, params.sector_number)
+        result[0].clone()
     }
 
     pub fn has_precommit(&self, rt: &MockRuntime, sector_number: SectorNumber) -> bool {

--- a/integration_tests/src/tests/batch_onboarding.rs
+++ b/integration_tests/src/tests/batch_onboarding.rs
@@ -47,7 +47,7 @@ impl Onboarding {
     }
 }
 
-pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
+pub fn batch_onboarding_test(v: &dyn VM) {
     let seal_proof = &RegisteredSealProof::StackedDRG32GiBV1P1;
 
     let mut proven_count = 0;
@@ -104,7 +104,6 @@ pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
                 next_sector_no,
                 next_sector_no == 0,
                 None,
-                v2,
             );
             precommmits.append(&mut new_precommits);
             next_sector_no += item.pre_commit_sector_count as u64;

--- a/integration_tests/src/tests/batch_onboarding_deals_test.rs
+++ b/integration_tests/src/tests/batch_onboarding_deals_test.rs
@@ -6,6 +6,7 @@ use fil_actor_miner::{
 use fil_actor_miner::{Method as MinerMethod, ProveCommitAggregateParams};
 use fil_actors_runtime::runtime::policy::policy_constants::PRE_COMMIT_CHALLENGE_DELAY;
 use fil_actors_runtime::runtime::Policy;
+use fil_actors_runtime::test_utils::make_piece_cid;
 use fil_actors_runtime::STORAGE_MARKET_ACTOR_ADDR;
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
@@ -13,7 +14,8 @@ use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::piece::{PaddedPieceSize, PieceInfo};
+use fvm_shared::error::ExitCode;
+use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::{RegisteredSealProof, StoragePower};
 use num_traits::Zero;
 
@@ -23,13 +25,84 @@ use vm_api::VM;
 use crate::deals::{DealBatcher, DealOptions};
 use crate::util::{
     advance_to_proving_deadline, bf_all, create_accounts, create_miner, get_network_stats,
-    make_bitfield, market_add_balance, miner_balance, precommit_sectors_v2, submit_windowed_post,
+    make_bitfield, market_add_balance, miner_balance, precommit_meta_data_from_deals,
+    precommit_sectors_v2, precommit_sectors_v2_expect_code, submit_windowed_post,
     verifreg_add_client, verifreg_add_verifier, PrecommitMetadata,
 };
 
 const BATCH_SIZE: usize = 8;
-const PRECOMMIT_V2: bool = true;
 const SEAL_PROOF: RegisteredSealProof = RegisteredSealProof::StackedDRG32GiBV1P1;
+
+pub fn pre_commit_requires_commd_test(v: &dyn VM) {
+    let deal_duration: ChainEpoch = Policy::default().min_sector_expiration;
+    let sector_duration: ChainEpoch =
+        deal_duration + Policy::default().market_default_allocation_term_buffer;
+
+    let addrs = create_accounts(v, 2, &TokenAmount::from_whole(10_000));
+    let (owner, client) = (addrs[0], addrs[1]);
+    let worker = owner;
+
+    // Create miner
+    let (miner, _) = create_miner(
+        v,
+        &owner,
+        &worker,
+        SEAL_PROOF.registered_window_post_proof().unwrap(),
+        &TokenAmount::from_whole(1000),
+    );
+
+    // Fund storage market accounts.
+    market_add_balance(v, &owner, &miner, &TokenAmount::from_whole(1000));
+    market_add_balance(v, &client, &client, &TokenAmount::from_whole(1000));
+
+    // Publish a deal for the sector.
+    let deal_opts = DealOptions {
+        piece_size: PaddedPieceSize(32 * (1 << 30)),
+        verified: false,
+        deal_start: v.epoch() + max_prove_commit_duration(&Policy::default(), SEAL_PROOF).unwrap(),
+        deal_lifetime: deal_duration,
+        ..DealOptions::default()
+    };
+    let mut batcher = DealBatcher::new(v, deal_opts);
+    batcher.stage(client, miner);
+    let ret = batcher.publish_ok(worker);
+    let good_inputs = bf_all(ret.valid_deals);
+    assert_eq!(vec![0], good_inputs);
+
+    // precommit without specifying commD fails
+    let sector_number = 100;
+    precommit_sectors_v2_expect_code(
+        v,
+        1,
+        1,
+        vec![PrecommitMetadata { deals: vec![0], commd: CompactCommD(None) }],
+        &worker,
+        &miner,
+        SEAL_PROOF,
+        sector_number,
+        true,
+        Some(sector_duration),
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+    );
+
+    // precommit specifying the wrong commD fails
+    precommit_sectors_v2_expect_code(
+        v,
+        1,
+        1,
+        vec![PrecommitMetadata {
+            deals: vec![0],
+            commd: CompactCommD(Some(make_piece_cid("This is not commP".as_bytes()))),
+        }],
+        &worker,
+        &miner,
+        SEAL_PROOF,
+        sector_number,
+        true,
+        Some(sector_duration),
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+    );
+}
 
 // Tests batch onboarding of sectors with verified deals.
 pub fn batch_onboarding_deals_test(v: &dyn VM) {
@@ -74,17 +147,7 @@ pub fn batch_onboarding_deals_test(v: &dyn VM) {
     // Associate deals with sectors.
     let sector_precommit_data = deals
         .into_iter()
-        .map(|(id, deal)| PrecommitMetadata {
-            deals: vec![id],
-            commd: CompactCommD::of(
-                v.primitives()
-                    .compute_unsealed_sector_cid(
-                        SEAL_PROOF,
-                        &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
-                    )
-                    .unwrap(),
-            ),
-        })
+        .map(|(id, _)| precommit_meta_data_from_deals(v, vec![id], SEAL_PROOF))
         .collect();
 
     // Pre-commit as single batch.
@@ -99,7 +162,6 @@ pub fn batch_onboarding_deals_test(v: &dyn VM) {
         0,
         true,
         Some(sector_duration),
-        PRECOMMIT_V2,
     );
     let first_sector_no = precommits[0].info.sector_number;
 

--- a/integration_tests/src/tests/commit_post_test.rs
+++ b/integration_tests/src/tests/commit_post_test.rs
@@ -12,7 +12,7 @@ use crate::expects::Expect;
 use crate::util::{
     advance_by_deadline_to_epoch, advance_to_proving_deadline, assert_invariants, create_accounts,
     create_miner, expect_invariants, get_network_stats, invariant_failure_patterns, miner_balance,
-    precommit_sectors, submit_windowed_post,
+    precommit_sectors_v2, submit_windowed_post,
 };
 use crate::TEST_VM_RAND_ARRAY;
 use fil_actor_cron::Method as CronMethod;
@@ -60,7 +60,7 @@ fn setup(v: &dyn VM) -> (MinerInfo, SectorInfo) {
 
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
-    precommit_sectors(v, 1, 1, &worker, &id_addr, seal_proof, sector_number, true, None);
+    precommit_sectors_v2(v, 1, 1, vec![], &worker, &id_addr, seal_proof, sector_number, true, None);
 
     let balances = miner_balance(v, &id_addr);
     assert!(balances.pre_commit_deposit.is_positive());
@@ -292,11 +292,21 @@ pub fn overdue_precommit_test(v: &dyn VM) {
 
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
-    let precommit =
-        precommit_sectors(v, 1, 1, &worker, &id_addr, seal_proof, sector_number, true, None)
-            .get(0)
-            .unwrap()
-            .clone();
+    let precommit = precommit_sectors_v2(
+        v,
+        1,
+        1,
+        vec![],
+        &worker,
+        &id_addr,
+        seal_proof,
+        sector_number,
+        true,
+        None,
+    )
+    .get(0)
+    .unwrap()
+    .clone();
 
     let balances = miner_balance(v, &id_addr);
     assert!(balances.pre_commit_deposit.is_positive());
@@ -400,10 +410,11 @@ pub fn aggregate_bad_sector_number_test(v: &dyn VM) {
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
     let mut precommited_sector_nos = BitField::try_from_bits(
-        precommit_sectors(
+        precommit_sectors_v2(
             v,
             4,
             policy.pre_commit_sector_batch_max_size,
+            vec![],
             &worker,
             &id_addr,
             seal_proof,
@@ -471,10 +482,11 @@ pub fn aggregate_size_limits_test(v: &dyn VM) {
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
     let precommited_sector_nos = BitField::try_from_bits(
-        precommit_sectors(
+        precommit_sectors_v2(
             v,
             oversized_batch,
             policy.pre_commit_sector_batch_max_size,
+            vec![],
             &worker,
             &id_addr,
             seal_proof,
@@ -572,10 +584,11 @@ pub fn aggregate_bad_sender_test(v: &dyn VM) {
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
     let precommited_sector_nos = BitField::try_from_bits(
-        precommit_sectors(
+        precommit_sectors_v2(
             v,
             4,
             policy.pre_commit_sector_batch_max_size,
+            vec![],
             &worker,
             &id_addr,
             seal_proof,
@@ -639,10 +652,11 @@ pub fn aggregate_one_precommit_expires_test(v: &dyn VM) {
 
     // early precommit
     let early_precommit_time = v.epoch();
-    let early_precommits = precommit_sectors(
+    let early_precommits = precommit_sectors_v2(
         v,
         1,
         policy.pre_commit_sector_batch_max_size,
+        vec![],
         &worker,
         &id_addr,
         seal_proof,
@@ -658,10 +672,11 @@ pub fn aggregate_one_precommit_expires_test(v: &dyn VM) {
 
     // later precommits
 
-    let later_precommits = precommit_sectors(
+    let later_precommits = precommit_sectors_v2(
         v,
         3,
         policy.pre_commit_sector_batch_max_size,
+        vec![],
         &worker,
         &id_addr,
         seal_proof,

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -25,8 +25,9 @@ use crate::expects::Expect;
 use crate::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_index, advance_to_proving_deadline,
     bf_all, create_accounts, create_miner, cron_tick, market_add_balance, market_publish_deal,
-    miner_precommit_sector, miner_prove_sector, sector_deadline, submit_windowed_post,
-    verifreg_add_client, verifreg_add_verifier,
+    miner_precommit_one_sector_v2, miner_prove_sector, precommit_meta_data_from_deals,
+    sector_deadline, submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
+    PrecommitMetadata,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -154,13 +155,14 @@ pub fn commit_sector_with_max_duration_deal_test(v: &dyn VM) {
     //
     // Precommit, prove and PoSt empty sector (more fully tested in TestCommitPoStFlow)
     //
-    miner_precommit_sector(
+    miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number,
-        deals,
+        precommit_meta_data_from_deals(v, deals, seal_proof),
+        true,
         deal_start + deal_lifetime,
     );
 
@@ -217,13 +219,14 @@ pub fn extend_sector_up_to_max_relative_extension_test(v: &dyn VM) {
     let sector_start =
         v.epoch() + max_prove_commit_duration(&Policy::default(), seal_proof).unwrap();
 
-    miner_precommit_sector(
+    miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number,
-        vec![],
+        PrecommitMetadata::default(),
+        true,
         sector_start + 180 * EPOCHS_IN_DAY,
     );
 
@@ -308,7 +311,16 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
 
     let expiration = v.epoch() + 360 * EPOCHS_IN_DAY;
 
-    miner_precommit_sector(v, &worker, &miner_id, seal_proof, sector_number, vec![], expiration);
+    miner_precommit_one_sector_v2(
+        v,
+        &worker,
+        &miner_id,
+        seal_proof,
+        sector_number,
+        PrecommitMetadata::default(),
+        true,
+        expiration,
+    );
 
     // advance time by a day and prove the sector
     let prove_epoch = v.epoch() + EPOCHS_IN_DAY;

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -35,7 +35,7 @@ use crate::util::{
     assert_invariants, bf_all, check_sector_active, check_sector_faulty, create_accounts,
     create_miner, deadline_state, declare_recovery, expect_invariants, get_network_stats,
     invariant_failure_patterns, make_bitfield, market_publish_deal, miner_balance, miner_power,
-    precommit_sectors, prove_commit_sectors, sector_info, submit_invalid_post,
+    precommit_sectors_v2, prove_commit_sectors, sector_info, submit_invalid_post,
     submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
 };
 
@@ -166,10 +166,11 @@ pub fn prove_replica_update_multi_dline_test(v: &dyn VM) {
     let first_sector_number_p2 = seal_proof.window_post_partitions_sector().unwrap();
     let expiration = v.epoch() + policy.max_sector_expiration_extension;
 
-    let new_precommits = precommit_sectors(
+    let new_precommits = precommit_sectors_v2(
         v,
         more_than_one_partition,
         batch_size,
+        vec![],
         &worker,
         &maddr,
         seal_proof,
@@ -826,10 +827,11 @@ pub fn deal_included_in_multiple_sectors_failure_test(v: &dyn VM) {
     //
     //
     let first_sector_number = 100;
-    let precommits = precommit_sectors(
+    let precommits = precommit_sectors_v2(
         v,
         policy.min_aggregated_sectors as usize,
         policy.pre_commit_sector_batch_max_size,
+        vec![],
         &worker,
         &maddr,
         seal_proof,
@@ -1115,8 +1117,18 @@ pub fn create_sector(
 ) -> (u64, u64) {
     // precommit
     let exp = v.epoch() + Policy::default().max_sector_expiration_extension;
-    let precommits =
-        precommit_sectors(v, 1, 1, &worker, &maddr, seal_proof, sector_number, true, Some(exp));
+    let precommits = precommit_sectors_v2(
+        v,
+        1,
+        1,
+        vec![],
+        &worker,
+        &maddr,
+        seal_proof,
+        sector_number,
+        true,
+        Some(exp),
+    );
     assert_eq!(1, precommits.len());
     assert_eq!(sector_number, precommits[0].info.sector_number);
     let balances = miner_balance(v, &maddr);

--- a/integration_tests/src/tests/terminate_test.rs
+++ b/integration_tests/src/tests/terminate_test.rs
@@ -3,16 +3,16 @@ use fil_actor_market::{
     DealMetaArray, Method as MarketMethod, State as MarketState, WithdrawBalanceParams,
 };
 use fil_actor_miner::{
-    power_for_sector, Method as MinerMethod, PreCommitSectorParams, ProveCommitSectorParams,
-    State as MinerState, TerminateSectorsParams, TerminationDeclaration,
+    power_for_sector, Method as MinerMethod, ProveCommitSectorParams, State as MinerState,
+    TerminateSectorsParams, TerminationDeclaration,
 };
 use fil_actor_power::State as PowerState;
 use fil_actor_verifreg::{Method as VerifregMethod, VerifierParams};
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{
-    test_utils::*, CRON_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
-    SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+    CRON_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
@@ -30,7 +30,8 @@ use crate::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
     advance_to_proving_deadline, create_accounts, create_miner, expect_invariants,
     invariant_failure_patterns, make_bitfield, market_publish_deal, miner_balance,
-    submit_windowed_post, verifreg_add_verifier,
+    miner_precommit_one_sector_v2, precommit_meta_data_from_deals, submit_windowed_post,
+    verifreg_add_verifier,
 };
 
 pub fn terminate_sectors_test(v: &dyn VM) {
@@ -41,7 +42,6 @@ pub fn terminate_sectors_test(v: &dyn VM) {
 
     let m_balance = TokenAmount::from_whole(1_000);
     let sector_number = 100;
-    let sealed_cid = make_sealed_cid(b"s100");
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
 
     let (miner_id_addr, miner_robust_addr) = create_miner(
@@ -162,21 +162,16 @@ pub fn terminate_sectors_test(v: &dyn VM) {
         assert_eq!(None, state);
     }
     //    precommit_sectors(&v, 1, 1, worker, robust_addr, seal_proof, sector_number, true, None);
-    apply_ok(
+
+    miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_robust_addr,
-        &TokenAmount::zero(),
-        MinerMethod::PreCommitSector as u64,
-        Some(PreCommitSectorParams {
-            seal_proof,
-            sector_number,
-            sealed_cid,
-            seal_rand_epoch: v.epoch() - 1,
-            deal_ids: deal_ids.clone(),
-            expiration: v.epoch() + 220 * EPOCHS_IN_DAY,
-            ..Default::default()
-        }),
+        seal_proof,
+        sector_number,
+        precommit_meta_data_from_deals(v, deal_ids.clone(), seal_proof),
+        true,
+        v.epoch() + 220 * EPOCHS_IN_DAY,
     );
     let prove_time = v.epoch() + Policy::default().pre_commit_challenge_delay + 1;
     advance_by_deadline_to_epoch(v, &miner_id_addr, prove_time);

--- a/integration_tests/src/tests/verified_claim_test.rs
+++ b/integration_tests/src/tests/verified_claim_test.rs
@@ -31,9 +31,9 @@ use crate::util::{
     advance_by_deadline_to_index, advance_to_proving_deadline, assert_invariants, create_accounts,
     create_miner, cron_tick, datacap_extend_claim, datacap_get_balance, expect_invariants,
     invariant_failure_patterns, market_add_balance, market_publish_deal,
-    miner_extend_sector_expiration2, miner_precommit_sector, miner_prove_sector, sector_deadline,
-    submit_windowed_post, verifreg_add_client, verifreg_add_verifier, verifreg_extend_claim_terms,
-    verifreg_remove_expired_allocations,
+    miner_extend_sector_expiration2, miner_precommit_one_sector_v2, miner_prove_sector,
+    precommit_meta_data_from_deals, sector_deadline, submit_windowed_post, verifreg_add_client,
+    verifreg_add_verifier, verifreg_extend_claim_terms, verifreg_remove_expired_allocations,
 };
 
 /// Tests a scenario involving a verified deal from the built-in market, with associated
@@ -88,13 +88,14 @@ pub fn verified_claim_scenario_test(v: &dyn VM) {
 
     // Precommit and prove the sector for the max term allowed by the deal.
     let sector_term = deal_term_min + MARKET_DEFAULT_ALLOCATION_TERM_BUFFER;
-    let _precommit = miner_precommit_sector(
+    let _precommit = miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number,
-        deals.clone(),
+        precommit_meta_data_from_deals(v, deals.clone(), seal_proof),
+        true,
         deal_start + sector_term,
     );
 
@@ -524,23 +525,25 @@ pub fn deal_passes_claim_fails_test(v: &dyn VM) {
         sector_start - max_prove_commit_duration(&Policy::default(), seal_proof).unwrap(),
     );
     let sector_number_a = 0;
-    let _precommit = miner_precommit_sector(
+    let _precommit = miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number_a,
-        vec![deal],
+        precommit_meta_data_from_deals(v, vec![deal], seal_proof),
+        true,
         sector_start + sector_term,
     );
     let sector_number_b = 1;
-    let _precommit = miner_precommit_sector(
+    let _precommit = miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number_b,
-        vec![bad_deal],
+        precommit_meta_data_from_deals(v, vec![bad_deal], seal_proof),
+        false,
         sector_start + sector_term,
     );
 

--- a/integration_tests/src/util/workflows.rs
+++ b/integration_tests/src/util/workflows.rs
@@ -2,22 +2,17 @@ use std::cmp::min;
 
 use fil_actor_cron::Method as CronMethod;
 use fil_actor_datacap::Method as DataCapMethod;
-use fil_actor_market::ClientDealProposal;
-use fil_actor_market::DealProposal;
-use fil_actor_market::Label;
-use fil_actor_market::Method as MarketMethod;
-use fil_actor_market::PublishStorageDealsParams;
-use fil_actor_market::PublishStorageDealsReturn;
-use fil_actor_market::SectorDeals;
-use fil_actor_market::MARKET_NOTIFY_DEAL_METHOD;
+use fil_actor_market::{
+    ClientDealProposal, DealProposal, Label, Method as MarketMethod, PublishStorageDealsParams,
+    PublishStorageDealsReturn, SectorDeals, State as MarketState, MARKET_NOTIFY_DEAL_METHOD,
+};
 use fil_actor_miner::{
     aggregate_pre_commit_network_fee, aggregate_prove_commit_network_fee,
     max_prove_commit_duration, ChangeBeneficiaryParams, CompactCommD, DeadlineInfo,
     DeclareFaultsRecoveredParams, ExpirationExtension2, ExtendSectorExpiration2Params,
-    Method as MinerMethod, PoStPartition, PowerPair, PreCommitSectorBatchParams,
-    PreCommitSectorBatchParams2, PreCommitSectorParams, ProveCommitAggregateParams,
-    ProveCommitSectorParams, RecoveryDeclaration, SectorClaim, SectorPreCommitInfo,
-    SectorPreCommitOnChainInfo, State as MinerState, SubmitWindowedPoStParams,
+    Method as MinerMethod, PoStPartition, PowerPair, PreCommitSectorBatchParams2,
+    ProveCommitAggregateParams, ProveCommitSectorParams, RecoveryDeclaration, SectorClaim,
+    SectorPreCommitInfo, SectorPreCommitOnChainInfo, State as MinerState, SubmitWindowedPoStParams,
     WithdrawBalanceParams, WithdrawBalanceReturn,
 };
 use fil_actor_multisig::Method as MultisigMethod;
@@ -61,7 +56,8 @@ use fvm_shared::crypto::signature::Signature;
 use fvm_shared::crypto::signature::SignatureType;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::piece::PaddedPieceSize;
+use fvm_shared::error::ExitCode;
+use fvm_shared::piece::{PaddedPieceSize, PieceInfo};
 use fvm_shared::randomness::Randomness;
 use fvm_shared::sector::PoStProof;
 use fvm_shared::sector::RegisteredPoStProof;
@@ -70,9 +66,9 @@ use fvm_shared::sector::SectorNumber;
 use fvm_shared::sector::StoragePower;
 use num_traits::Zero;
 use vm_api::trace::ExpectInvocation;
-use vm_api::util::apply_ok;
 use vm_api::util::get_state;
 use vm_api::util::DynBlockstore;
+use vm_api::util::{apply_code, apply_ok};
 use vm_api::VM;
 
 use crate::*;
@@ -127,44 +123,30 @@ pub fn create_miner(
     (res.id_address, res.robust_address)
 }
 
-pub fn miner_precommit_sector(
+#[allow(clippy::too_many_arguments)]
+pub fn miner_precommit_one_sector_v2(
     v: &dyn VM,
     worker: &Address,
-    miner_id: &Address,
+    maddr: &Address,
     seal_proof: RegisteredSealProof,
     sector_number: SectorNumber,
-    deal_ids: Vec<DealID>,
+    meta_data: PrecommitMetadata,
+    expect_cron_enroll: bool,
     expiration: ChainEpoch,
 ) -> SectorPreCommitOnChainInfo {
-    let sealed_cid = make_sealed_cid(b"s100");
-
-    let params = PreCommitSectorParams {
+    precommit_sectors_v2(
+        v,
+        1,
+        1,
+        vec![meta_data],
+        worker,
+        maddr,
         seal_proof,
         sector_number,
-        sealed_cid,
-        seal_rand_epoch: v.epoch() - 1,
-        deal_ids,
-        expiration,
-        replace_capacity: false,
-        replace_sector_deadline: 0,
-        replace_sector_partition: 0,
-        replace_sector_number: 0,
-    };
-
-    apply_ok(
-        v,
-        worker,
-        miner_id,
-        &TokenAmount::zero(),
-        MinerMethod::PreCommitSector as u64,
-        Some(params),
-    );
-
-    let state: MinerState = get_state(v, miner_id).unwrap();
-    state
-        .get_precommitted_sector(&DynBlockstore::wrap(v.blockstore()), sector_number)
-        .unwrap()
-        .unwrap()
+        expect_cron_enroll,
+        Some(expiration),
+    )[0]
+    .clone()
 }
 
 pub fn miner_prove_sector(
@@ -198,9 +180,109 @@ pub fn miner_prove_sector(
     .matches(v.take_invocations().last().unwrap());
 }
 
+#[derive(Default)]
 pub struct PrecommitMetadata {
     pub deals: Vec<DealID>,
     pub commd: CompactCommD,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn precommit_sectors_v2_expect_code(
+    v: &dyn VM,
+    count: usize,
+    batch_size: usize,
+    metadata: Vec<PrecommitMetadata>, // Per-sector deal metadata, or empty vector for no deals.
+    worker: &Address,
+    maddr: &Address,
+    seal_proof: RegisteredSealProof,
+    sector_number_base: SectorNumber,
+    expect_cron_enroll: bool,
+    exp: Option<ChainEpoch>,
+    code: ExitCode,
+) {
+    let mid = v.resolve_id_address(maddr).unwrap();
+    let expiration = match exp {
+        None => {
+            v.epoch()
+                + Policy::default().min_sector_expiration
+                + max_prove_commit_duration(&Policy::default(), seal_proof).unwrap()
+        }
+        Some(e) => e,
+    };
+
+    let mut sector_idx: usize = 0;
+    let no_deals = PrecommitMetadata::default();
+    let mut sectors_with_deals: Vec<SectorDeals> = vec![];
+    while sector_idx < count {
+        let msg_sector_idx_base = sector_idx;
+        let mut invocs = vec![Expect::reward_this_epoch(mid), Expect::power_current_total(mid)];
+        let mut param_sectors = Vec::<SectorPreCommitInfo>::new();
+        let mut j = 0;
+        while j < batch_size && sector_idx < count {
+            let sector_number = sector_number_base + sector_idx as u64;
+            let sector_meta = metadata.get(sector_idx).unwrap_or(&no_deals);
+            param_sectors.push(SectorPreCommitInfo {
+                seal_proof,
+                sector_number,
+                sealed_cid: make_sealed_cid(format!("sn: {}", sector_number).as_bytes()),
+                seal_rand_epoch: v.epoch() - 1,
+                deal_ids: sector_meta.deals.clone(),
+                expiration,
+                unsealed_cid: sector_meta.commd.clone(),
+            });
+            if !sector_meta.deals.is_empty() {
+                sectors_with_deals.push(SectorDeals {
+                    sector_number,
+                    sector_type: seal_proof,
+                    sector_expiry: expiration,
+                    deal_ids: sector_meta.deals.clone(),
+                });
+            }
+            sector_idx += 1;
+            j += 1;
+        }
+        if !sectors_with_deals.is_empty() {
+            invocs.push(Expect::market_verify_deals(mid, sectors_with_deals.clone()));
+        }
+        if param_sectors.len() > 1 {
+            invocs.push(Expect::burn(
+                mid,
+                Some(aggregate_pre_commit_network_fee(
+                    param_sectors.len() as i64,
+                    &TokenAmount::zero(),
+                )),
+            ));
+        }
+        if expect_cron_enroll && msg_sector_idx_base == 0 {
+            invocs.push(Expect::power_enrol_cron(mid));
+        }
+
+        apply_code(
+            v,
+            worker,
+            maddr,
+            &TokenAmount::zero(),
+            MinerMethod::PreCommitSectorBatch2 as u64,
+            Some(PreCommitSectorBatchParams2 { sectors: param_sectors.clone() }),
+            code,
+        );
+        if code == ExitCode::OK {
+            let expect = ExpectInvocation {
+                from: *worker,
+                to: mid,
+                method: MinerMethod::PreCommitSectorBatch2 as u64,
+                params: Some(
+                    IpldBlock::serialize_cbor(&PreCommitSectorBatchParams2 {
+                        sectors: param_sectors,
+                    })
+                    .unwrap(),
+                ),
+                subinvocs: Some(invocs),
+                ..Default::default()
+            };
+            expect.matches(v.take_invocations().last().unwrap());
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -215,155 +297,22 @@ pub fn precommit_sectors_v2(
     sector_number_base: SectorNumber,
     expect_cron_enroll: bool,
     exp: Option<ChainEpoch>,
-    v2: bool,
 ) -> Vec<SectorPreCommitOnChainInfo> {
     let mid = v.resolve_id_address(maddr).unwrap();
-    let expiration = match exp {
-        None => {
-            v.epoch()
-                + Policy::default().min_sector_expiration
-                + max_prove_commit_duration(&Policy::default(), seal_proof).unwrap()
-        }
-        Some(e) => e,
-    };
+    precommit_sectors_v2_expect_code(
+        v,
+        count,
+        batch_size,
+        metadata,
+        worker,
+        maddr,
+        seal_proof,
+        sector_number_base,
+        expect_cron_enroll,
+        exp,
+        ExitCode::OK,
+    );
 
-    let mut sector_idx: usize = 0;
-    let no_deals = PrecommitMetadata { deals: vec![], commd: CompactCommD::default() };
-    let mut sectors_with_deals: Vec<SectorDeals> = vec![];
-    while sector_idx < count {
-        let msg_sector_idx_base = sector_idx;
-        let mut invocs = vec![Expect::reward_this_epoch(mid), Expect::power_current_total(mid)];
-        if !v2 {
-            let mut param_sectors = Vec::<PreCommitSectorParams>::new();
-            let mut j = 0;
-            while j < batch_size && sector_idx < count {
-                let sector_number = sector_number_base + sector_idx as u64;
-                let sector_meta = metadata.get(sector_idx).unwrap_or(&no_deals);
-                param_sectors.push(PreCommitSectorParams {
-                    seal_proof,
-                    sector_number,
-                    sealed_cid: make_sealed_cid(format!("sn: {}", sector_number).as_bytes()),
-                    seal_rand_epoch: v.epoch() - 1,
-                    deal_ids: sector_meta.deals.clone().clone(),
-                    expiration,
-                    ..Default::default()
-                });
-                if !sector_meta.deals.is_empty() {
-                    sectors_with_deals.push(SectorDeals {
-                        sector_number,
-                        sector_type: seal_proof,
-                        sector_expiry: expiration,
-                        deal_ids: sector_meta.deals.clone(),
-                    });
-                }
-                sector_idx += 1;
-                j += 1;
-            }
-            if !sectors_with_deals.is_empty() {
-                invocs.push(Expect::market_verify_deals(mid, sectors_with_deals.clone()));
-            }
-            if param_sectors.len() > 1 {
-                invocs.push(Expect::burn(
-                    mid,
-                    Some(aggregate_pre_commit_network_fee(
-                        param_sectors.len() as i64,
-                        &TokenAmount::zero(),
-                    )),
-                ));
-            }
-            if expect_cron_enroll && msg_sector_idx_base == 0 {
-                invocs.push(Expect::power_enrol_cron(mid));
-            }
-
-            apply_ok(
-                v,
-                worker,
-                maddr,
-                &TokenAmount::zero(),
-                MinerMethod::PreCommitSectorBatch as u64,
-                Some(PreCommitSectorBatchParams { sectors: param_sectors.clone() }),
-            );
-            let expect = ExpectInvocation {
-                from: *worker,
-                to: mid,
-                method: MinerMethod::PreCommitSectorBatch as u64,
-                params: Some(
-                    IpldBlock::serialize_cbor(&PreCommitSectorBatchParams {
-                        sectors: param_sectors,
-                    })
-                    .unwrap(),
-                ),
-                subinvocs: Some(invocs),
-                ..Default::default()
-            };
-            expect.matches(v.take_invocations().last().unwrap())
-        } else {
-            let mut param_sectors = Vec::<SectorPreCommitInfo>::new();
-            let mut j = 0;
-            while j < batch_size && sector_idx < count {
-                let sector_number = sector_number_base + sector_idx as u64;
-                let sector_meta = metadata.get(sector_idx).unwrap_or(&no_deals);
-                param_sectors.push(SectorPreCommitInfo {
-                    seal_proof,
-                    sector_number,
-                    sealed_cid: make_sealed_cid(format!("sn: {}", sector_number).as_bytes()),
-                    seal_rand_epoch: v.epoch() - 1,
-                    deal_ids: sector_meta.deals.clone(),
-                    expiration,
-                    unsealed_cid: sector_meta.commd.clone(),
-                });
-                if !sector_meta.deals.is_empty() {
-                    sectors_with_deals.push(SectorDeals {
-                        sector_number,
-                        sector_type: seal_proof,
-                        sector_expiry: expiration,
-                        deal_ids: sector_meta.deals.clone(),
-                    });
-                }
-                sector_idx += 1;
-                j += 1;
-            }
-            if !sectors_with_deals.is_empty() {
-                invocs.push(Expect::market_verify_deals(mid, sectors_with_deals.clone()));
-            }
-            if param_sectors.len() > 1 {
-                invocs.push(Expect::burn(
-                    mid,
-                    Some(aggregate_pre_commit_network_fee(
-                        param_sectors.len() as i64,
-                        &TokenAmount::zero(),
-                    )),
-                ));
-            }
-            if expect_cron_enroll && msg_sector_idx_base == 0 {
-                invocs.push(Expect::power_enrol_cron(mid));
-            }
-
-            apply_ok(
-                v,
-                worker,
-                maddr,
-                &TokenAmount::zero(),
-                MinerMethod::PreCommitSectorBatch2 as u64,
-                Some(PreCommitSectorBatchParams2 { sectors: param_sectors.clone() }),
-            );
-
-            let expect = ExpectInvocation {
-                from: *worker,
-                to: mid,
-                method: MinerMethod::PreCommitSectorBatch2 as u64,
-                params: Some(
-                    IpldBlock::serialize_cbor(&PreCommitSectorBatchParams2 {
-                        sectors: param_sectors,
-                    })
-                    .unwrap(),
-                ),
-                subinvocs: Some(invocs),
-                ..Default::default()
-            };
-            expect.matches(v.take_invocations().last().unwrap())
-        }
-    }
     // extract chain state
     let mstate: MinerState = get_state(v, &mid).unwrap();
     (0..count)
@@ -379,31 +328,27 @@ pub fn precommit_sectors_v2(
         .collect()
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn precommit_sectors(
+pub fn precommit_meta_data_from_deals(
     v: &dyn VM,
-    count: usize,
-    batch_size: usize,
-    worker: &Address,
-    maddr: &Address,
+    deal_ids: Vec<u64>,
     seal_proof: RegisteredSealProof,
-    sector_number_base: SectorNumber,
-    expect_cron_enroll: bool,
-    exp: Option<ChainEpoch>,
-) -> Vec<SectorPreCommitOnChainInfo> {
-    precommit_sectors_v2(
-        v,
-        count,
-        batch_size,
-        vec![], // no deals
-        worker,
-        maddr,
-        seal_proof,
-        sector_number_base,
-        expect_cron_enroll,
-        exp,
-        false,
-    )
+) -> PrecommitMetadata {
+    let state: MarketState = get_state(v, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
+    let pieces: Vec<PieceInfo> = deal_ids
+        .clone()
+        .into_iter()
+        .map(|id: u64| {
+            let deal = state.get_proposal(&DynBlockstore::wrap(v.blockstore()), id).unwrap();
+            PieceInfo { size: deal.piece_size, cid: deal.piece_cid }
+        })
+        .collect();
+
+    PrecommitMetadata {
+        deals: deal_ids,
+        commd: CompactCommD::of(
+            v.primitives().compute_unsealed_sector_cid(seal_proof, &pieces).unwrap(),
+        ),
+    }
 }
 
 pub fn prove_commit_sectors(

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -1,14 +1,12 @@
 use fil_actors_integration_tests::tests::batch_onboarding_test;
 use fvm_ipld_blockstore::MemoryBlockstore;
-use test_case::test_case;
 use test_vm::TestVM;
 
 // Test for batch pre-commit and aggregate prove-commit onboarding sectors (no deals).
-#[test_case(false; "v1")]
-#[test_case(true; "v2")]
-fn batch_onboarding(v2: bool) {
+#[test]
+fn batch_onboarding() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
-    batch_onboarding_test(&v, v2);
+    batch_onboarding_test(&v);
 }

--- a/test_vm/tests/batch_onboarding_deals_test.rs
+++ b/test_vm/tests/batch_onboarding_deals_test.rs
@@ -1,4 +1,6 @@
-use fil_actors_integration_tests::tests::batch_onboarding_deals_test;
+use fil_actors_integration_tests::tests::{
+    batch_onboarding_deals_test, pre_commit_requires_commd_test,
+};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use test_vm::TestVM;
 
@@ -7,4 +9,11 @@ fn batch_onboarding_deals() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     batch_onboarding_deals_test(&v);
+}
+
+#[test]
+fn pre_commit_requires_commd() {
+    let store = MemoryBlockstore::new();
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    pre_commit_requires_commd_test(&v);
 }

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -7,8 +7,9 @@ use fil_actors_integration_tests::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
     advance_by_deadline_to_index, advance_to_proving_deadline, create_accounts, create_miner,
     cron_tick, expect_invariants, invariant_failure_patterns, market_add_balance,
-    market_publish_deal, miner_precommit_sector, miner_prove_sector, submit_windowed_post,
-    verifreg_add_client, verifreg_add_verifier,
+    market_publish_deal, miner_precommit_one_sector_v2, miner_prove_sector,
+    precommit_meta_data_from_deals, submit_windowed_post, verifreg_add_client,
+    verifreg_add_verifier,
 };
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{DealWeight, EPOCHS_IN_DAY};
@@ -91,13 +92,14 @@ fn extend_legacy_sector_with_deals_inner<BS: Blockstore>(
     // Precommit, prove and PoSt empty sector (more fully tested in TestCommitPoStFlow)
     //
 
-    miner_precommit_sector(
+    miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number,
-        deals,
+        precommit_meta_data_from_deals(v, deals, seal_proof),
+        true,
         deal_start + 180 * EPOCHS_IN_DAY,
     );
 


### PR DESCRIPTION
This is #1352 applied to the integration branch `integration/direct-onboarding`.

- PreCommitSector and PreCommitBatch deprecated
- PreCommitBatchV2 now requires specifying (compact) CommD
- Move all testing to use PreCommitBatchV2