### PR TITLE
ConfirmSectorProofsValid ==> ActivateSectors

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -4955,7 +4955,7 @@ impl From<SectorPreCommitOnChainInfo> for SectorActivation {
     }
 }
 
- /*
+/*
     BuiltinMarket is today's call in CSPV f05 -> f06, return deal weights as today
     BuiltinMarketWithCommD is what PRU should do to avoid double the market calls, return deal weights as today
     SectorContentAdded is the new thing and can include piece manifests, independent calls f05 (or other) and f06, return deal weights per spec
@@ -4963,10 +4963,9 @@ impl From<SectorPreCommitOnChainInfo> for SectorActivation {
 */
 enum DataActivation {
     BuiltinActivation(Vec<DealID>),
-//    BuiltinActivationCheckCommD(Vec<DealID>), // for use in PRU single shot activation and CommD check
-//    SectorContentAdded(), // TODO add in allocids and piece manifest type to handle new activation flow
-//    CC, // we can simplify activate and claim method by moving CC case directly here
-
+    //    BuiltinActivationCheckCommD(Vec<DealID>), // for use in PRU single shot activation and CommD check
+    //    SectorContentAdded(), // TODO add in allocids and piece manifest type to handle new activation flow
+    //    CC, // we can simplify activate and claim method by moving CC case directly here
 }
 
 fn activate_data(


### PR DESCRIPTION
I'm proposing the following refactor to the sector activation flow in ProveCommit(Aggregate) and ProveReplicaUpdate to prepare for the upcoming new activation methods taking in piece manifests.

- Transform sector precommit / replica update data structures into a temporary intermediate `SectorActivation`s
- Call new method `activate_sectors` to do activation
- Specify basic info needed to update sector / miner actor state (sector number, seal proof type, commR etc)
- Per `SectorActivation` specify method of data activation (call old builtin market activate deals, call this alongside CommD check, call SectorContentChanged, no call), in general a call to `activate_sectors` can handle any type of data activation 
  - We may want to restrict heterogeneous data activation methods in a single call in practice but in principle each SectorActivation specifies its data activation scheme
  - It will be simpler to just handle all in a single call
- Per `SectorActivation` specify how to update state, either activate a new sector (Init) or update and existing (Update / Snap) 
  - Same discussion on allowing heterogenous inputs vs restricting at the call site applies

This PR does these changes for ProveCommit and ProveCommitAggregate leaving all but the standard builtin market ActivateDeals data activation unimplemented.  I am also implicitly assuming all activations are new sectors not yet factoring out the pieces to handle PRU in the same code path.