### PR TITLE
Adds CommD as option in return value from ActivateDeals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4128,6 +4128,7 @@ dependencies = [
  "fvm_ipld_encoding 0.4.0",
  "fvm_ipld_hamt",
  "fvm_shared",
+ "integer-encoding",
  "multihash 0.18.1",
  "num-traits",
  "serde",

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -86,22 +86,19 @@ pub struct SectorDeals {
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
 pub struct VerifyDealsForActivationReturn {
-    pub sectors: Vec<SectorDealData>,
-}
-
-#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq, Default)]
-pub struct SectorDealData {
-    /// Option::None signifies commitment to empty sector, meaning no deals.
-    pub commd: Option<Cid>,
+    // The unsealed CID computed from the deals specified for each sector.
+    // A None indicates no deals were specified.
+    pub unsealed_cids: Vec<Option<Cid>>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
-#[serde(transparent)]
 pub struct BatchActivateDealsParams {
     /// Deals to activate, grouped by sector.
     /// A failed deal activation will cause other deals in the same sector group to also fail,
     /// but allow other sectors to proceed.
     pub sectors: Vec<SectorDeals>,
+    /// Requests computation of an unsealed CID for each sector from the provided deals.
+    pub compute_cid: bool,
 }
 
 // Information about a verified deal that has been activated.
@@ -121,6 +118,9 @@ pub struct SectorDealActivation {
     pub nonverified_deal_space: BigInt,
     /// Information about each verified deal activated.
     pub verified_infos: Vec<VerifiedDealInfo>,
+    /// Unsealed CID computed from the deals specified for the sector.
+    /// A None indicates no deals were specified, or the computation was not requested.
+    pub unsealed_cid: Option<Cid>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]

--- a/actors/market/tests/activate_deal_failures.rs
+++ b/actors/market/tests/activate_deal_failures.rs
@@ -37,6 +37,7 @@ fn fail_when_caller_is_not_the_provider_of_the_deal() {
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             deal_ids: vec![deal_id],
         }],
+        false,
     )
     .unwrap();
     let res: BatchActivateDealsResult =
@@ -59,7 +60,7 @@ fn fail_when_caller_is_not_a_storage_miner_actor() {
         sector_expiry: 0,
         sector_type: RegisteredSealProof::StackedDRG8MiBV1,
     };
-    let params = BatchActivateDealsParams { sectors: vec![sector_activation] };
+    let params = BatchActivateDealsParams { sectors: vec![sector_activation], compute_cid: false };
 
     expect_abort(
         ExitCode::USR_FORBIDDEN,
@@ -85,6 +86,7 @@ fn fail_when_deal_has_not_been_published_before() {
             sector_expiry: EPOCHS_IN_DAY,
             deal_ids: vec![DealID::from(42u32)],
         }],
+        false,
     )
     .unwrap();
     let res: BatchActivateDealsResult =
@@ -120,6 +122,7 @@ fn fail_when_deal_has_already_been_activated() {
             sector_expiry,
             deal_ids: vec![deal_id],
         }],
+        false,
     )
     .unwrap();
     let res: BatchActivateDealsResult =

--- a/actors/market/tests/batch_activate_deals.rs
+++ b/actors/market/tests/batch_activate_deals.rs
@@ -55,7 +55,7 @@ fn activate_deals_across_multiple_sectors() {
         (END_EPOCH + 2, vec![unverified_deal_2_id]), // contains unverified deal only
     ];
 
-    let res = batch_activate_deals(&rt, PROVIDER_ADDR, &sectors);
+    let res = batch_activate_deals(&rt, PROVIDER_ADDR, &sectors, false);
 
     // three sectors activated successfully
     assert!(res.activation_results.all_ok());
@@ -121,7 +121,7 @@ fn sectors_fail_and_succeed_independently_during_batch_activation() {
         SectorDeals { deal_ids: vec![id_4], sector_type, sector_expiry: END_EPOCH + 2 }, // sector succeeds
     ];
 
-    let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals).unwrap();
+    let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals, false).unwrap();
     let res: BatchActivateDealsResult =
         res.unwrap().deserialize().expect("VerifyDealsForActivation failed!");
 
@@ -172,7 +172,7 @@ fn handles_sectors_empty_of_deals_gracefully() {
         SectorDeals { deal_ids: vec![], sector_type, sector_expiry: END_EPOCH + 2 }, // empty sector
     ];
 
-    let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals).unwrap();
+    let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals, false).unwrap();
     let res: BatchActivateDealsResult =
         res.unwrap().deserialize().expect("VerifyDealsForActivation failed!");
 
@@ -221,7 +221,7 @@ fn fails_to_activate_sectors_containing_duplicate_deals() {
         SectorDeals { deal_ids: vec![id_3], sector_type, sector_expiry: END_EPOCH },
     ];
 
-    let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals).unwrap();
+    let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals, false).unwrap();
     let res: BatchActivateDealsResult =
         res.unwrap().deserialize().expect("VerifyDealsForActivation failed!");
 

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -1699,6 +1699,7 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             deal_ids: vec![deal_id],
         }],
+        false,
     )
     .unwrap();
 
@@ -1733,6 +1734,7 @@ fn fail_when_end_epoch_of_deal_greater_than_sector_expiry() {
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             deal_ids: vec![deal_id],
         }],
+        false,
     )
     .unwrap();
 
@@ -1760,7 +1762,7 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
         start_epoch,
         end_epoch,
     );
-    batch_activate_deals(&rt, PROVIDER_ADDR, &[(sector_expiry, vec![deal_id1])]);
+    batch_activate_deals(&rt, PROVIDER_ADDR, &[(sector_expiry, vec![deal_id1])], false);
 
     let deal_id2 = generate_and_publish_deal(
         &rt,
@@ -1778,6 +1780,7 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             deal_ids: vec![deal_id1, deal_id2],
         }],
+        false,
     )
     .unwrap();
     let res: BatchActivateDealsResult =

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -51,8 +51,8 @@ fn verify_deal_and_activate_to_get_deal_space_for_unverified_deal_proposal() {
     );
     let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
     let s_response = a_response.activations.get(0).unwrap();
-    assert_eq!(1, v_response.sectors.len());
-    assert_eq!(Some(make_piece_cid("1".as_bytes())), v_response.sectors[0].commd);
+    assert_eq!(1, v_response.unsealed_cids.len());
+    assert_eq!(Some(make_piece_cid("1".as_bytes())), v_response.unsealed_cids[0]);
     assert!(s_response.verified_infos.is_empty());
     assert_eq!(BigInt::from(deal_proposal.piece_size.0), s_response.nonverified_deal_space);
 
@@ -87,8 +87,8 @@ fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
     let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
     let s_response = a_response.activations.get(0).unwrap();
 
-    assert_eq!(1, response.sectors.len());
-    assert_eq!(Some(make_piece_cid("1".as_bytes())), response.sectors[0].commd);
+    assert_eq!(1, response.unsealed_cids.len());
+    assert_eq!(Some(make_piece_cid("1".as_bytes())), response.unsealed_cids[0]);
     assert_eq!(1, s_response.verified_infos.len());
     assert_eq!(deal_proposal.piece_size, s_response.verified_infos[0].size);
     assert_eq!(deal_proposal.client.id().unwrap(), s_response.verified_infos[0].client);
@@ -148,7 +148,7 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
     let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &deal_ids);
     let s_response = a_response.activations.get(0).unwrap();
 
-    assert_eq!(1, response.sectors.len());
+    assert_eq!(1, response.unsealed_cids.len());
     let returned_verified_space: BigInt =
         s_response.verified_infos.iter().map(|info| BigInt::from(info.size.0)).sum();
     assert_eq!(verified_space, returned_verified_space);

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -1,5 +1,4 @@
 use cid::Cid;
-use fil_actors_runtime::BatchReturn;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::bigint::{bigint_ser, BigInt};
@@ -12,12 +11,13 @@ use fvm_shared::sector::{RegisteredSealProof, StoragePower};
 use fvm_shared::smooth::FilterEstimate;
 use fvm_shared::ActorID;
 
+use fil_actors_runtime::BatchReturn;
+
 pub mod account {
     pub const PUBKEY_ADDRESS_METHOD: u64 = 2;
 }
 
 pub mod market {
-
     use super::*;
 
     pub const VERIFY_DEALS_FOR_ACTIVATION_METHOD: u64 = 5;
@@ -32,9 +32,9 @@ pub mod market {
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
-    #[serde(transparent)]
     pub struct BatchActivateDealsParams {
         pub sectors: Vec<SectorDeals>,
+        pub compute_cid: bool,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
@@ -57,24 +57,17 @@ pub mod market {
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
-    pub struct DealActivation {
+    pub struct SectorDealActivation {
         #[serde(with = "bigint_ser")]
         pub nonverified_deal_space: BigInt,
         pub verified_infos: Vec<VerifiedDealInfo>,
+        pub unsealed_cid: Option<Cid>,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
     pub struct BatchActivateDealsResult {
         pub activation_results: BatchReturn,
-        pub activations: Vec<DealActivation>,
-    }
-
-    #[derive(Serialize_tuple, Deserialize_tuple, Clone, Default)]
-    pub struct DealSpaces {
-        #[serde(with = "bigint_ser")]
-        pub deal_space: BigInt,
-        #[serde(with = "bigint_ser")]
-        pub verified_deal_space: BigInt,
+        pub activations: Vec<SectorDealActivation>,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
@@ -101,14 +94,8 @@ pub mod market {
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple, Default, Clone)]
-    pub struct SectorDealData {
-        /// Option::None signifies commitment to empty sector, meaning no deals.
-        pub commd: Option<Cid>,
-    }
-
-    #[derive(Serialize_tuple, Deserialize_tuple, Default, Clone)]
     pub struct VerifyDealsForActivationReturn {
-        pub sectors: Vec<SectorDealData>,
+        pub unsealed_cids: Vec<Option<Cid>>,
     }
 }
 

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1162,52 +1162,33 @@ impl Actor {
                 sector_type: usi.sector_info.seal_proof,
             })
             .collect();
+        // Request CommD computation while activating deals.
         let (batch_return, deals_spaces) =
-            batch_activate_deals_and_claim_allocations(rt, &activation_infos)?;
+            batch_activate_deals_and_claim_allocations(rt, &activation_infos, true)?;
 
         // associate the successfully activated sectors with the ReplicaUpdateInner and SectorOnChainInfo
-        let validated_updates: Vec<(&UpdateAndSectorInfo, ext::market::DealSpaces)> =
+        let validated_updates: Vec<(&UpdateAndSectorInfo, DealActivationInfo)> =
             batch_return.successes(&update_sector_infos).into_iter().zip(deals_spaces).collect();
 
         if validated_updates.is_empty() {
             return Err(actor_error!(illegal_argument, "no valid updates"));
         }
 
-        let sectors_deals: Vec<ext::market::SectorDeals> = validated_updates
-            .iter()
-            .map(|(usi, _)| ext::market::SectorDeals {
-                deal_ids: usi.update.deals.clone(),
-                sector_expiry: usi.sector_info.expiration,
-                sector_type: usi.sector_info.seal_proof,
-            })
-            .collect();
-
         // Errors past this point cause the prove_replica_updates call to fail (no more skipping sectors)
-        let deal_data = request_deal_data(rt, &sectors_deals)?;
-        if deal_data.sectors.len() != validated_updates.len() {
-            return Err(actor_error!(
-                illegal_state,
-                "deal weight request returned {} records, expected {}",
-                deal_data.sectors.len(),
-                validated_updates.len()
-            ));
-        }
-
         struct UpdateWithDetails<'a> {
             update: &'a ReplicaUpdateInner,
             sector_info: &'a SectorOnChainInfo,
-            deal_spaces: &'a ext::market::DealSpaces,
+            deal_info: &'a DealActivationInfo,
             full_unsealed_cid: Cid,
         }
 
         // Group declarations by deadline
         let mut decls_by_deadline = BTreeMap::<u64, Vec<UpdateWithDetails>>::new();
         let mut deadlines_to_load = Vec::<u64>::new();
-        for ((usi, deal_spaces), deal_data) in
-            validated_updates.iter().zip(deal_data.sectors.iter())
-        {
-            let computed_commd =
-                CompactCommD::new(deal_data.commd).get_cid(usi.sector_info.seal_proof)?;
+        for (usi, deal_activation) in &validated_updates {
+            // Computation of CommD was requested, so None can be interpreted as zero data.
+            let computed_commd = CompactCommD::new(deal_activation.unsealed_cid)
+                .get_cid(usi.sector_info.seal_proof)?;
             if let Some(ref declared_commd) = usi.update.new_unsealed_cid {
                 if !declared_commd.eq(&computed_commd) {
                     info!(
@@ -1224,7 +1205,7 @@ impl Actor {
             decls_by_deadline.entry(dl).or_default().push(UpdateWithDetails {
                 update: usi.update,
                 sector_info: &usi.sector_info,
-                deal_spaces,
+                deal_info: deal_activation,
                 full_unsealed_cid: computed_commd,
             });
         }
@@ -1304,9 +1285,9 @@ impl Actor {
                     let duration = new_sector_info.expiration - new_sector_info.power_base_epoch;
 
                     new_sector_info.deal_weight =
-                        with_details.deal_spaces.deal_space.clone() * duration;
+                        with_details.deal_info.unverified_space.clone() * duration;
                     new_sector_info.verified_deal_weight =
-                        with_details.deal_spaces.verified_deal_space.clone() * duration;
+                        with_details.deal_info.verified_space.clone() * duration;
 
                     // compute initial pledge
                     let qa_pow = qa_power_for_weight(
@@ -1870,12 +1851,12 @@ impl Actor {
         // gather information from other actors
         let reward_stats = request_current_epoch_block_reward(rt)?;
         let power_total = request_current_total_power(rt)?;
-        let deal_data_vec = request_deal_data(rt, &sectors_deals)?;
-        if deal_data_vec.sectors.len() != sectors.len() {
+        let verify_return = verify_deals(rt, &sectors_deals)?;
+        if verify_return.unsealed_cids.len() != sectors.len() {
             return Err(actor_error!(
                 illegal_state,
                 "deal weight request returned {} records, expected {}",
-                deal_data_vec.sectors.len(),
+                verify_return.unsealed_cids.len(),
                 sectors.len()
             ));
         }
@@ -1946,19 +1927,19 @@ impl Actor {
                     return Err(actor_error!(illegal_argument, "too many deals for sector {} > {}", precommit.deal_ids.len(), deal_count_max));
                 }
 
-                let deal_data = &deal_data_vec.sectors[i];
+                let computed_cid = &verify_return.unsealed_cids[i];
 
                 // 1. verify that precommit.unsealed_cid is correct
                 // 2. create a new on_chain_precommit
 
                 let commd = match precommit.unsealed_cid {
                     // if the CommD is unknown, use CommD computed by the market
-                    None => CompactCommD::new(deal_data.commd),
+                    None => CompactCommD::new(*computed_cid),
                     Some(x) => x,
                 };
-                if commd.0 != deal_data.commd {
+                if commd.0 != *computed_cid {
                     return Err(actor_error!(illegal_argument, "computed {:?} and passed {:?} CommDs not equal",
-                            deal_data.commd, commd));
+                            computed_cid, commd));
                 }
 
 
@@ -4408,7 +4389,7 @@ fn get_verify_info(
     })
 }
 
-fn request_deal_data(
+fn verify_deals(
     rt: &impl Runtime,
     sectors: &[ext::market::SectorDeals],
 ) -> Result<ext::market::VerifyDealsForActivationReturn, ActorError> {
@@ -4419,7 +4400,7 @@ fn request_deal_data(
     }
     if deal_count == 0 {
         return Ok(ext::market::VerifyDealsForActivationReturn {
-            sectors: vec![Default::default(); sectors.len()],
+            unsealed_cids: vec![None; sectors.len()],
         });
     }
 
@@ -4812,7 +4793,7 @@ fn confirm_sector_proofs_valid_internal(
         .collect();
 
     let (batch_return, activated_sectors) =
-        batch_activate_deals_and_claim_allocations(rt, &deals_activation_infos)?;
+        batch_activate_deals_and_claim_allocations(rt, &deals_activation_infos, false)?;
 
     let (total_pledge, newly_vested) = rt.transaction(|state: &mut State, rt| {
         let policy = rt.policy();
@@ -4838,8 +4819,8 @@ fn confirm_sector_proofs_valid_internal(
                 continue;
             }
 
-            let deal_weight = deal_spaces.deal_space * duration;
-            let verified_deal_weight = deal_spaces.verified_deal_space * duration;
+            let deal_weight = deal_spaces.unverified_space * duration;
+            let verified_deal_weight = deal_spaces.verified_space * duration;
 
             let power = qa_power_for_weight(
                 info.sector_size,
@@ -4956,20 +4937,29 @@ fn confirm_sector_proofs_valid_internal(
     Ok(())
 }
 
+struct DealActivationInfo {
+    pub unverified_space: BigInt,
+    pub verified_space: BigInt,
+    // None indicates either no deals or computation was not requested.
+    pub unsealed_cid: Option<Cid>,
+}
+
 /// Activates the deals then claims allocations for any verified deals
 /// Successfully activated sectors have their DealSpaces returned
 /// Failure to claim datacap for any verified deal results in the whole batch failing
 fn batch_activate_deals_and_claim_allocations(
     rt: &impl Runtime,
     activation_infos: &[DealsActivationInfo],
-) -> Result<(BatchReturn, Vec<ext::market::DealSpaces>), ActorError> {
+    compute_unsealed_cid: bool,
+) -> Result<(BatchReturn, Vec<DealActivationInfo>), ActorError> {
     let batch_activation_res = match activation_infos.iter().all(|p| p.deal_ids.is_empty()) {
         true => ext::market::BatchActivateDealsResult {
             // if all sectors are empty of deals, skip calling the market actor
             activations: vec![
-                ext::market::DealActivation {
+                ext::market::SectorDealActivation {
                     nonverified_deal_space: BigInt::default(),
                     verified_infos: Vec::default(),
+                    unsealed_cid: None,
                 };
                 activation_infos.len()
             ],
@@ -4989,6 +4979,7 @@ fn batch_activate_deals_and_claim_allocations(
                 ext::market::BATCH_ACTIVATE_DEALS_METHOD,
                 IpldBlock::serialize_cbor(&ext::market::BatchActivateDealsParams {
                     sectors: sector_activation_params,
+                    compute_cid: compute_unsealed_cid,
                 })?,
                 TokenAmount::zero(),
             ))?;
@@ -5065,9 +5056,10 @@ fn batch_activate_deals_and_claim_allocations(
         .activations
         .iter()
         .zip(claim_res.sector_claims)
-        .map(|(sector_deals, sector_claim)| ext::market::DealSpaces {
-            verified_deal_space: sector_claim.claimed_space,
-            deal_space: sector_deals.nonverified_deal_space.clone(),
+        .map(|(sector_deals, sector_claim)| DealActivationInfo {
+            unverified_space: sector_deals.nonverified_deal_space.clone(),
+            verified_space: sector_claim.claimed_space,
+            unsealed_cid: sector_deals.unsealed_cid,
         })
         .collect();
 

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1191,10 +1191,13 @@ impl Actor {
                 .get_cid(usi.sector_info.seal_proof)?;
             if let Some(ref declared_commd) = usi.update.new_unsealed_cid {
                 if !declared_commd.eq(&computed_commd) {
-                    info!(
-                        "unsealed CID does not match with deals: expected {}, got {}, sector: {}",
-                        computed_commd, declared_commd, usi.update.sector_number
-                    );
+                    return Err(actor_error!(
+                        illegal_argument,
+                        "unsealed CID does not match deals for sector {}, expected {} was {}",
+                        usi.update.sector_number,
+                        computed_commd,
+                        declared_commd
+                    ));
                 }
             }
             let dl = usi.update.deadline;

--- a/actors/miner/tests/aggregate_prove_commit.rs
+++ b/actors/miner/tests/aggregate_prove_commit.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use fil_actor_market::DealSpaces;
 use fil_actor_miner::{
     initial_pledge_for_power, qa_power_for_weight, PowerPair, QUALITY_BASE_MULTIPLIER,
     VERIFIED_DEAL_WEIGHT_MULTIPLIER,
@@ -34,15 +33,12 @@ fn valid_precommits_then_aggregate_provecommit() {
 
     let prove_commit_epoch = precommit_epoch + rt.policy.pre_commit_challenge_delay + 1;
     // something on deadline boundary but > 180 days
+    let deal_space = 0;
     let verified_deal_space = actor.sector_size as u64;
     let expiration =
         dl_info.period_end() + rt.policy.wpost_proving_period * DEFAULT_SECTOR_EXPIRATION;
     // fill the sector with verified seals
     let duration = expiration - prove_commit_epoch;
-    let deal_spaces = DealSpaces {
-        deal_space: BigInt::zero(),
-        verified_deal_space: BigInt::from(verified_deal_space),
-    };
 
     let mut precommits = vec![];
     let mut sector_nos_bf = BitField::new();
@@ -90,8 +86,8 @@ fn valid_precommits_then_aggregate_provecommit() {
     // The sector is exactly full with verified deals, so expect fully verified power.
     let expected_power = BigInt::from(actor.sector_size as i64)
         * (VERIFIED_DEAL_WEIGHT_MULTIPLIER.clone() / QUALITY_BASE_MULTIPLIER.clone());
-    let deal_weight = deal_spaces.deal_space * duration;
-    let verified_deal_weight = deal_spaces.verified_deal_space * duration;
+    let deal_weight = BigInt::from(deal_space) * duration;
+    let verified_deal_weight = BigInt::from(verified_deal_space) * duration;
     let qa_power = qa_power_for_weight(
         actor.sector_size,
         expiration - *rt.epoch.borrow(),

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -1,10 +1,5 @@
-use fil_actor_market::{DealSpaces, SectorDealData};
-use fil_actor_miner::{
-    initial_pledge_for_power, max_prove_commit_duration, pre_commit_deposit_for_power,
-    qa_power_for_weight, qa_power_max, PowerPair, PreCommitSectorBatchParams, VestSpec,
-};
-use fil_actors_runtime::test_utils::make_piece_cid;
-use fil_actors_runtime::{runtime::Runtime, test_utils::expect_abort, DealWeight};
+use std::collections::HashMap;
+
 use fvm_shared::{
     bigint::{BigInt, Zero},
     clock::ChainEpoch,
@@ -13,11 +8,16 @@ use fvm_shared::{
     sector::{StoragePower, MAX_SECTOR_NUMBER},
     smooth::FilterEstimate,
 };
-use std::collections::HashMap;
+
+use fil_actor_miner::{
+    initial_pledge_for_power, max_prove_commit_duration, pre_commit_deposit_for_power,
+    qa_power_for_weight, qa_power_max, PowerPair, PreCommitSectorBatchParams, VestSpec,
+};
+use fil_actors_runtime::test_utils::make_piece_cid;
+use fil_actors_runtime::{runtime::Runtime, test_utils::expect_abort, DealWeight};
+use util::*;
 
 mod util;
-
-use util::*;
 
 // an expiration ~10 days greater than effective min expiration taking into account 30 days max
 // between pre and prove commit
@@ -46,11 +46,9 @@ fn prove_single_sector() {
     let expiration =
         dl_info.period_end() + DEFAULT_SECTOR_EXPIRATION * rt.policy.wpost_proving_period; // something on deadline boundary but > 180 days
                                                                                            // Fill the sector with verified deals
+    let deal_space = BigInt::zero();
     let verified_deal = test_verified_deal(h.sector_size as u64);
-    let deal_spaces = DealSpaces {
-        deal_space: BigInt::zero(),
-        verified_deal_space: BigInt::from(verified_deal.size.0),
-    };
+    let verified_deal_space = BigInt::from(verified_deal.size.0);
 
     // Pre-commit with a deal in order to exercise non-zero deal weights.
     let precommit_params =
@@ -101,8 +99,8 @@ fn prove_single_sector() {
 
     // The sector is exactly full with verified deals, so expect fully verified power.
     let duration = precommit.info.expiration - prove_commit_epoch;
-    let deal_weight = deal_spaces.deal_space * duration;
-    let verified_deal_weight = deal_spaces.verified_deal_space * duration;
+    let deal_weight = deal_space * duration;
+    let verified_deal_weight = verified_deal_space * duration;
     let expected_power = StoragePower::from(h.sector_size as u64)
         * (VERIFIED_DEAL_WEIGHT_MULTIPLIER / QUALITY_BASE_MULTIPLIER);
     let qa_power =
@@ -187,11 +185,7 @@ fn prove_sectors_from_batch_pre_commit() {
     let verified_deal_weight = deal_space * DealWeight::from(deal_lifespan);
 
     let conf = PreCommitBatchConfig {
-        sector_deal_data: vec![
-            SectorDealData { commd: None },
-            SectorDealData { commd: Some(make_piece_cid(b"1")) },
-            SectorDealData { commd: Some(make_piece_cid(b"2|3")) },
-        ],
+        sector_unsealed_cid: vec![None, Some(make_piece_cid(b"1")), Some(make_piece_cid(b"2|3"))],
         first_for_miner: true,
     };
 

--- a/integration_tests/src/expects.rs
+++ b/integration_tests/src/expects.rs
@@ -43,9 +43,11 @@ impl Expect {
         deals: Vec<DealID>,
         sector_expiry: ChainEpoch,
         sector_type: RegisteredSealProof,
+        compute_cid: bool,
     ) -> ExpectInvocation {
         let params = IpldBlock::serialize_cbor(&BatchActivateDealsParams {
             sectors: vec![SectorDeals { deal_ids: deals, sector_expiry, sector_type }],
+            compute_cid,
         })
         .unwrap();
         ExpectInvocation {

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -628,6 +628,7 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
                 deal_ids.clone(),
                 initial_sector_info.expiration,
                 initial_sector_info.seal_proof,
+                true,
             ),
             ExpectInvocation {
                 from: miner_id,

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -1,4 +1,12 @@
-use fil_actor_market::{DealMetaArray, SectorDeals, State as MarketState};
+use fvm_ipld_bitfield::BitField;
+use fvm_shared::address::Address;
+use fvm_shared::bigint::Zero;
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::piece::{PaddedPieceSize, PieceInfo};
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
+
+use fil_actor_market::{DealMetaArray, State as MarketState};
 use fil_actor_miner::{
     max_prove_commit_duration, power_for_sector, ExpirationExtension, ExpirationExtension2,
     ExtendSectorExpiration2Params, ExtendSectorExpirationParams, Method as MinerMethod, PowerPair,
@@ -6,17 +14,10 @@ use fil_actor_miner::{
 };
 use fil_actor_verifreg::Method as VerifregMethod;
 use fil_actors_runtime::runtime::Policy;
-use fil_actors_runtime::test_utils::{make_piece_cid, make_sealed_cid};
+use fil_actors_runtime::test_utils::make_sealed_cid;
 use fil_actors_runtime::{
     DealWeight, EPOCHS_IN_DAY, STORAGE_MARKET_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
-use fvm_ipld_bitfield::BitField;
-use fvm_shared::address::Address;
-use fvm_shared::bigint::Zero;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::piece::PaddedPieceSize;
-use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
 use vm_api::trace::ExpectInvocation;
 use vm_api::util::{apply_ok, get_state, mutate_state, DynBlockstore};
 use vm_api::VM;
@@ -25,9 +26,9 @@ use crate::expects::Expect;
 use crate::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
     advance_by_deadline_to_index, advance_to_proving_deadline, bf_all, create_accounts,
-    create_miner, cron_tick, expect_invariants, invariant_failure_patterns, market_add_balance,
-    market_publish_deal, miner_precommit_sector, miner_prove_sector, sector_deadline,
-    submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
+    create_miner, cron_tick, expect_invariants, get_deal, invariant_failure_patterns,
+    market_add_balance, market_publish_deal, miner_precommit_sector, miner_prove_sector,
+    sector_deadline, submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -592,17 +593,26 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
     .ids;
 
     // replica update
-    let new_cid = make_sealed_cid(b"replica1");
+    let new_sealed_cid = make_sealed_cid(b"replica1");
+    let deal = get_deal(v, deal_ids[0]);
+    let new_unsealed_cid = v
+        .primitives()
+        .compute_unsealed_sector_cid(
+            seal_proof,
+            &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
+        )
+        .unwrap();
+
     let (d_idx, p_idx) = sector_deadline(v, &miner_id, sector_number);
     let replica_update = ReplicaUpdate2 {
         sector_number,
         deadline: d_idx,
         partition: p_idx,
-        new_sealed_cid: new_cid,
+        new_sealed_cid,
         deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
         replica_proof: vec![],
-        new_unsealed_cid: make_piece_cid(b"unsealed from itest vm"),
+        new_unsealed_cid,
     };
     let updated_sectors: BitField = apply_ok(
         v,
@@ -636,14 +646,6 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
                 method: VerifregMethod::ClaimAllocations as u64,
                 ..Default::default()
             },
-            Expect::market_verify_deals(
-                miner_id,
-                vec![SectorDeals {
-                    sector_type: seal_proof,
-                    sector_expiry: initial_sector_info.expiration,
-                    deal_ids: deal_ids.clone(),
-                }],
-            ),
             Expect::reward_this_epoch(miner_id),
             Expect::power_current_total(miner_id),
             Expect::power_update_pledge(miner_id, None),

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -1010,6 +1010,7 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
                 deal_ids.clone(),
                 old_sector_info.expiration,
                 old_sector_info.seal_proof,
+                true,
             ),
             ExpectInvocation {
                 from: maddr,

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -1,18 +1,3 @@
-use fil_actor_cron::Method as CronMethod;
-use fil_actor_market::{Method as MarketMethod, SectorDeals};
-use fil_actor_miner::{
-    power_for_sector, DisputeWindowedPoStParams, ExpirationExtension, ExtendSectorExpirationParams,
-    Method as MinerMethod, PowerPair, ProveCommitSectorParams, ProveReplicaUpdatesParams,
-    ProveReplicaUpdatesParams2, ReplicaUpdate, ReplicaUpdate2, SectorOnChainInfo, Sectors,
-    State as MinerState, TerminateSectorsParams, TerminationDeclaration, SECTORS_AMT_BITWIDTH,
-};
-use fil_actor_verifreg::Method as VerifregMethod;
-use fil_actors_runtime::runtime::Policy;
-use fil_actors_runtime::test_utils::{make_piece_cid, make_sealed_cid};
-use fil_actors_runtime::VERIFIED_REGISTRY_ACTOR_ADDR;
-use fil_actors_runtime::{
-    Array, CRON_ACTOR_ADDR, EPOCHS_IN_DAY, STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
-};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
@@ -21,10 +6,26 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::piece::PaddedPieceSize;
+use fvm_shared::piece::{PaddedPieceSize, PieceInfo};
 use fvm_shared::sector::SectorSize;
 use fvm_shared::sector::StoragePower;
 use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
+
+use fil_actor_cron::Method as CronMethod;
+use fil_actor_market::Method as MarketMethod;
+use fil_actor_miner::{
+    power_for_sector, DisputeWindowedPoStParams, ExpirationExtension, ExtendSectorExpirationParams,
+    Method as MinerMethod, PowerPair, ProveCommitSectorParams, ProveReplicaUpdatesParams,
+    ProveReplicaUpdatesParams2, ReplicaUpdate, ReplicaUpdate2, SectorOnChainInfo, Sectors,
+    State as MinerState, TerminateSectorsParams, TerminationDeclaration, SECTORS_AMT_BITWIDTH,
+};
+use fil_actor_verifreg::Method as VerifregMethod;
+use fil_actors_runtime::runtime::Policy;
+use fil_actors_runtime::test_utils::make_sealed_cid;
+use fil_actors_runtime::VERIFIED_REGISTRY_ACTOR_ADDR;
+use fil_actors_runtime::{
+    Array, CRON_ACTOR_ADDR, EPOCHS_IN_DAY, STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+};
 use vm_api::trace::ExpectInvocation;
 use vm_api::util::{apply_code, apply_ok, get_state, mutate_state, DynBlockstore};
 use vm_api::VM;
@@ -33,7 +34,7 @@ use crate::expects::Expect;
 use crate::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_index, advance_to_proving_deadline,
     assert_invariants, bf_all, check_sector_active, check_sector_faulty, create_accounts,
-    create_miner, deadline_state, declare_recovery, expect_invariants, get_network_stats,
+    create_miner, deadline_state, declare_recovery, expect_invariants, get_deal, get_network_stats,
     invariant_failure_patterns, make_bitfield, market_publish_deal, miner_balance, miner_power,
     precommit_sectors, prove_commit_sectors, sector_info, submit_invalid_post,
     submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
@@ -975,16 +976,24 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
     );
 
     // replica update
-    let new_cid = make_sealed_cid(b"replica1");
+    let new_sealed_cid = make_sealed_cid(b"replica1");
+    let deal = get_deal(v, deal_ids[0]);
+    let new_unsealed_cid = v
+        .primitives()
+        .compute_unsealed_sector_cid(
+            seal_proof,
+            &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
+        )
+        .unwrap();
     let replica_update = ReplicaUpdate2 {
         sector_number,
         deadline: d_idx,
         partition: p_idx,
-        new_sealed_cid: new_cid,
+        new_sealed_cid,
         deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
         replica_proof: vec![],
-        new_unsealed_cid: make_piece_cid(b"unsealed from itest vm"),
+        new_unsealed_cid,
     };
     let updated_sectors: BitField = apply_ok(
         v,
@@ -1018,14 +1027,6 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
                 method: VerifregMethod::ClaimAllocations as u64,
                 ..Default::default()
             },
-            Expect::market_verify_deals(
-                maddr,
-                vec![SectorDeals {
-                    sector_type: seal_proof,
-                    sector_expiry: old_sector_info.expiration,
-                    deal_ids: deal_ids.clone(),
-                }],
-            ),
             Expect::reward_this_epoch(maddr),
             Expect::power_current_total(maddr),
             Expect::power_update_pledge(maddr, None),
@@ -1044,7 +1045,7 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
     assert_eq!(1, new_sector_info.deal_ids.len());
     assert_eq!(deal_ids[0], new_sector_info.deal_ids[0]);
     assert_eq!(old_sector_info.sealed_cid, new_sector_info.sector_key_cid.unwrap());
-    assert_eq!(new_cid, new_sector_info.sealed_cid);
+    assert_eq!(new_sealed_cid, new_sector_info.sealed_cid);
 }
 
 pub fn replica_update_verified_deal_max_term_violated_test(v: &dyn VM) {
@@ -1084,16 +1085,24 @@ pub fn replica_update_verified_deal_max_term_violated_test(v: &dyn VM) {
     );
 
     // replica update
-    let new_cid = make_sealed_cid(b"replica1");
+    let new_sealed_cid = make_sealed_cid(b"replica1");
+    let deal = get_deal(v, deal_ids[0]);
+    let new_unsealed_cid = v
+        .primitives()
+        .compute_unsealed_sector_cid(
+            seal_proof,
+            &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
+        )
+        .unwrap();
     let replica_update = ReplicaUpdate2 {
         sector_number,
         deadline: d_idx,
         partition: p_idx,
-        new_sealed_cid: new_cid,
+        new_sealed_cid,
         deals: deal_ids,
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
         replica_proof: vec![],
-        new_unsealed_cid: make_piece_cid(b"unsealed from itest vm"),
+        new_unsealed_cid,
     };
     apply_code(
         v,
@@ -1273,13 +1282,13 @@ pub fn create_miner_and_upgrade_sector(
     let deal_ids = create_deals(1, v, worker, worker, maddr);
 
     // replica update
-    let new_cid = make_sealed_cid(b"replica1");
+    let new_sealed_cid = make_sealed_cid(b"replica1");
     let updated_sectors: BitField = if !v2 {
         let replica_update = ReplicaUpdate {
             sector_number,
             deadline: d_idx,
             partition: p_idx,
-            new_sealed_cid: new_cid,
+            new_sealed_cid,
             deals: deal_ids.clone(),
             update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
             replica_proof: vec![],
@@ -1293,15 +1302,23 @@ pub fn create_miner_and_upgrade_sector(
             Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         )
     } else {
+        let deal = get_deal(v, deal_ids[0]);
+        let new_unsealed_cid = v
+            .primitives()
+            .compute_unsealed_sector_cid(
+                seal_proof,
+                &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
+            )
+            .unwrap();
         let replica_update = ReplicaUpdate2 {
             sector_number,
             deadline: d_idx,
             partition: p_idx,
-            new_sealed_cid: new_cid,
+            new_sealed_cid,
             deals: deal_ids.clone(),
             update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
             replica_proof: vec![],
-            new_unsealed_cid: make_piece_cid(b"unsealed from itest vm"),
+            new_unsealed_cid,
         };
         apply_ok(
             v,
@@ -1321,6 +1338,6 @@ pub fn create_miner_and_upgrade_sector(
     assert_eq!(1, new_sector_info.deal_ids.len());
     assert_eq!(deal_ids[0], new_sector_info.deal_ids[0]);
     assert_eq!(old_sector_info.sealed_cid, new_sector_info.sector_key_cid.unwrap());
-    assert_eq!(new_cid, new_sector_info.sealed_cid);
+    assert_eq!(new_sealed_cid, new_sector_info.sealed_cid);
     (new_sector_info, worker, maddr, d_idx, p_idx, seal_proof.sector_size().unwrap())
 }

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -37,6 +37,7 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_hamt = { workspace = true }
 fvm_shared = { workspace = true }
+integer-encoding = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
 vm_api = { workspace = true }

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -20,7 +20,7 @@ fn extend2_legacy_sector_with_deals() {
 }
 
 #[test]
-fn extend_updated_sector_with_claim() { // FIXME fail here
+fn extend_updated_sector_with_claim() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     extend_updated_sector_with_claims_test(&v);

--- a/test_vm/tests/extend_sectors_test.rs
+++ b/test_vm/tests/extend_sectors_test.rs
@@ -20,7 +20,7 @@ fn extend2_legacy_sector_with_deals() {
 }
 
 #[test]
-fn extend_updated_sector_with_claim() {
+fn extend_updated_sector_with_claim() { // FIXME fail here
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     extend_updated_sector_with_claims_test(&v);

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -140,7 +140,7 @@ fn deal_included_in_multiple_sectors_failure() {
 }
 
 #[test]
-fn replica_update_verified_deal() { // FIXME fail here
+fn replica_update_verified_deal() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
 

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -140,7 +140,7 @@ fn deal_included_in_multiple_sectors_failure() {
 }
 
 #[test]
-fn replica_update_verified_deal() {
+fn replica_update_verified_deal() { // FIXME fail here
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
 


### PR DESCRIPTION
This avoids ProveReplicaUpdates calling the market twice consecutively.

Note this is based on `master`, it's not only part of direct data onboarding.

Closes #1308 