### PR TITLE
Remove uses of Map from most actors

### DIFF
--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -74,7 +74,7 @@ pub struct State {
 }
 
 pub type PendingDealAllocationsMap<BS> = Map2<BS, DealID, AllocationID>;
-pub const PENDING_ALLOCATIONS_CONF: Config =
+pub const PENDING_ALLOCATIONS_CONFIG: Config =
     Config { bit_width: HAMT_BIT_WIDTH, ..DEFAULT_HAMT_CONFIG };
 
 impl State {
@@ -104,7 +104,7 @@ impl State {
 
         let empty_pending_deal_allocation_map = Map2::<&BS, DealID, AllocationID>::empty(
             store,
-            PENDING_ALLOCATIONS_CONF,
+            PENDING_ALLOCATIONS_CONFIG,
             "pending deal allocations",
         )
         .flush()?;
@@ -301,7 +301,7 @@ impl State {
         let mut pending_deal_allocation_ids = PendingDealAllocationsMap::load(
             store,
             &self.pending_deal_allocation_ids,
-            PENDING_ALLOCATIONS_CONF,
+            PENDING_ALLOCATIONS_CONFIG,
             "pending deal allocations",
         )?;
 
@@ -327,7 +327,7 @@ impl State {
         let pending_deal_allocation_ids = PendingDealAllocationsMap::load(
             store,
             &self.pending_deal_allocation_ids,
-            PENDING_ALLOCATIONS_CONF,
+            PENDING_ALLOCATIONS_CONFIG,
             "pending deal allocations",
         )?;
 
@@ -354,7 +354,7 @@ impl State {
         let mut pending_deal_allocation_ids = PendingDealAllocationsMap::load(
             store,
             &self.pending_deal_allocation_ids,
-            PENDING_ALLOCATIONS_CONF,
+            PENDING_ALLOCATIONS_CONFIG,
             "pending deal allocations",
         )?;
 

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -3,7 +3,7 @@
 use cid::Cid;
 use fil_actor_market::{
     BatchActivateDealsParams, BatchActivateDealsResult, PendingDealAllocationsMap,
-    PENDING_ALLOCATIONS_CONF,
+    PENDING_ALLOCATIONS_CONFIG,
 };
 use frc46_token::token::types::{TransferFromParams, TransferFromReturn};
 use num_traits::{FromPrimitive, Zero};
@@ -403,7 +403,7 @@ pub fn get_pending_deal_allocation(rt: &MockRuntime, deal_id: DealID) -> Allocat
     let pending_allocations = PendingDealAllocationsMap::load(
         &rt.store,
         &st.pending_deal_allocation_ids,
-        PENDING_ALLOCATIONS_CONF,
+        PENDING_ALLOCATIONS_CONFIG,
         "pending deal allocations",
     )
     .unwrap();

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -8,7 +8,7 @@ use fil_actor_market::{
     DealArray, DealMetaArray, Label, MarketNotifyDealParams, Method, PendingDealAllocationsMap,
     PublishStorageDealsParams, PublishStorageDealsReturn, SectorDeals, State,
     WithdrawBalanceParams, EX_DEAL_EXPIRED, MARKET_NOTIFY_DEAL_METHOD, NO_ALLOCATION_ID,
-    PENDING_ALLOCATIONS_CONF, PROPOSALS_AMT_BITWIDTH, STATES_AMT_BITWIDTH,
+    PENDING_ALLOCATIONS_CONFIG, PROPOSALS_AMT_BITWIDTH, STATES_AMT_BITWIDTH,
 };
 use fil_actors_runtime::cbor::{deserialize, serialize};
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
@@ -759,7 +759,7 @@ fn deal_expires() {
     let pending_allocs = PendingDealAllocationsMap::load(
         &rt.store,
         &st.pending_deal_allocation_ids,
-        PENDING_ALLOCATIONS_CONF,
+        PENDING_ALLOCATIONS_CONFIG,
         "pending allocations",
     )
     .unwrap();

--- a/actors/multisig/src/types.rs
+++ b/actors/multisig/src/types.rs
@@ -5,15 +5,14 @@ use std::fmt::Display;
 
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{strict_bytes, RawBytes};
-use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
-
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::MethodNum;
-use integer_encoding::VarInt;
 use serde::{Deserialize, Serialize};
+
+use fil_actors_runtime::MapKey;
 
 /// SignersMax is the maximum number of signers allowed in a multisig. If more
 /// are required, please use a combining tree of multisigs.
@@ -24,9 +23,13 @@ pub const SIGNERS_MAX: usize = 256;
 #[serde(transparent)]
 pub struct TxnID(pub i64);
 
-impl TxnID {
-    pub fn key(self) -> BytesKey {
-        self.0.encode_var_vec().into()
+impl MapKey for TxnID {
+    fn from_bytes(b: &[u8]) -> Result<Self, String> {
+        i64::from_bytes(b).map(TxnID)
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, String> {
+        self.0.to_bytes()
     }
 }
 

--- a/actors/power/src/state.rs
+++ b/actors/power/src/state.rs
@@ -5,11 +5,6 @@ use std::ops::Neg;
 
 use anyhow::anyhow;
 use cid::Cid;
-use fil_actors_runtime::runtime::Policy;
-use fil_actors_runtime::{
-    actor_error, make_empty_map, make_map_with_root, make_map_with_root_and_bitwidth,
-    ActorDowncast, ActorError, AsActorError, Map, Multimap,
-};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
@@ -21,12 +16,18 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::{RegisteredPoStProof, StoragePower};
 use fvm_shared::smooth::{AlphaBetaFilter, FilterEstimate, DEFAULT_ALPHA, DEFAULT_BETA};
-use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
+use fvm_shared::ActorID;
 use integer_encoding::VarInt;
 use lazy_static::lazy_static;
 use num_traits::Signed;
 
-use super::{CONSENSUS_MINER_MIN_MINERS, CRON_QUEUE_AMT_BITWIDTH, CRON_QUEUE_HAMT_BITWIDTH};
+use fil_actors_runtime::runtime::Policy;
+use fil_actors_runtime::{
+    actor_error, ActorContext, ActorDowncast, ActorError, AsActorError, Config, Map2, Multimap,
+    DEFAULT_HAMT_CONFIG,
+};
+
+use super::CONSENSUS_MINER_MIN_MINERS;
 
 lazy_static! {
     /// genesis power in bytes = 750,000 GiB
@@ -34,6 +35,13 @@ lazy_static! {
     /// max chain throughput in bytes per epoch = 120 ProveCommits / epoch = 3,840 GiB
     pub static ref INITIAL_QA_POWER_ESTIMATE_VELOCITY: StoragePower = StoragePower::from(3_840) * (1 << 30);
 }
+
+pub const CRON_QUEUE_HAMT_BITWIDTH: u32 = 6;
+pub const CRON_QUEUE_AMT_BITWIDTH: u32 = 6;
+pub const PROOF_VALIDATION_BATCH_AMT_BITWIDTH: u32 = 4;
+
+pub type ClaimsMap<BS> = Map2<BS, Address, Claim>;
+pub const CLAIMS_CONFIG: Config = DEFAULT_HAMT_CONFIG;
 
 /// Storage power actor state
 #[derive(Default, Serialize_tuple, Deserialize_tuple, Clone, Debug)]
@@ -74,18 +82,13 @@ pub struct State {
 
 impl State {
     pub fn new<BS: Blockstore>(store: &BS) -> anyhow::Result<State> {
-        let empty_map = make_empty_map::<_, ()>(store, HAMT_BIT_WIDTH)
-            .flush()
-            .map_err(|e| anyhow!("Failed to create empty map: {}", e))?;
-
+        let empty_claims = ClaimsMap::empty(store, CLAIMS_CONFIG, "empty").flush()?;
         let empty_mmap = Multimap::new(store, CRON_QUEUE_HAMT_BITWIDTH, CRON_QUEUE_AMT_BITWIDTH)
             .root()
-            .map_err(|e| {
-                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "Failed to get empty multimap cid")
-            })?;
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "Failed to get empty multimap cid")?;
         Ok(State {
             cron_event_queue: empty_mmap,
-            claims: empty_map,
+            claims: empty_claims,
             this_epoch_qa_power_smoothed: FilterEstimate::new(
                 INITIAL_QA_POWER_ESTIMATE_POSITION.clone(),
                 INITIAL_QA_POWER_ESTIMATE_VELOCITY.clone(),
@@ -105,18 +108,11 @@ impl State {
         s: &BS,
         miner: ActorID,
     ) -> Result<(StoragePower, bool), ActorError> {
-        let claims = make_map_with_root_and_bitwidth(&self.claims, s, HAMT_BIT_WIDTH)
-            .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
-                format!("failed to load claims for miner: {}", miner)
-            })?;
-
-        let claim = get_claim(&claims, &Address::new_id(miner))
-            .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
-                format!("failed to get claim for miner: {}", miner)
-            })?
-            .with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
-                format!("no claim for actor: {}", miner)
-            })?;
+        let claims = self.load_claims(s)?;
+        let a = &Address::new_id(miner);
+        let claim = claims.get(a)?.with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
+            format!("no claim for actor: {}", miner)
+        })?;
 
         let miner_nominal_power = claim.raw_byte_power.clone();
         let miner_min_power = consensus_miner_min_power(policy, claim.window_post_proof_type)
@@ -141,20 +137,21 @@ impl State {
         &self,
         s: &BS,
         miner: &Address,
-    ) -> anyhow::Result<Option<Claim>> {
-        let claims = make_map_with_root(&self.claims, s)?;
-        get_claim(&claims, miner).map(|s| s.cloned())
+    ) -> Result<Option<Claim>, ActorError> {
+        let claims = self.load_claims(s)?;
+        claims.get(miner).map(|s| s.cloned())
     }
 
     pub(super) fn add_to_claim<BS: Blockstore>(
         &mut self,
         policy: &Policy,
-        claims: &mut Map<BS, Claim>,
+        claims: &mut ClaimsMap<BS>,
         miner: &Address,
         power: &StoragePower,
         qa_power: &StoragePower,
-    ) -> anyhow::Result<()> {
-        let old_claim = get_claim(claims, miner)?
+    ) -> Result<(), ActorError> {
+        let old_claim = claims
+            .get(miner)?
             .ok_or_else(|| actor_error!(not_found, "no claim for actor {}", miner))?;
 
         self.total_qa_bytes_committed += qa_power;
@@ -167,7 +164,8 @@ impl State {
         };
 
         let min_power: StoragePower =
-            consensus_miner_min_power(policy, old_claim.window_post_proof_type)?;
+            consensus_miner_min_power(policy, old_claim.window_post_proof_type)
+                .exit_code(ExitCode::USR_ILLEGAL_STATE)?;
         let prev_below: bool = old_claim.raw_byte_power < min_power;
         let still_below: bool = new_claim.raw_byte_power < min_power;
 
@@ -194,28 +192,40 @@ impl State {
         }
 
         if new_claim.raw_byte_power.is_negative() {
-            return Err(anyhow!(actor_error!(
+            return Err(actor_error!(
                 illegal_state,
                 "negative claimed raw byte power: {}",
                 new_claim.raw_byte_power
-            )));
+            ));
         }
         if new_claim.quality_adj_power.is_negative() {
-            return Err(anyhow!(actor_error!(
+            return Err(actor_error!(
                 illegal_state,
                 "negative claimed quality adjusted power: {}",
                 new_claim.quality_adj_power
-            )));
+            ));
         }
         if self.miner_above_min_power_count < 0 {
-            return Err(anyhow!(actor_error!(
+            return Err(actor_error!(
                 illegal_state,
                 "negative amount of miners lather than min: {}",
                 self.miner_above_min_power_count
-            )));
+            ));
         }
 
         set_claim(claims, miner, new_claim)
+    }
+
+    pub fn load_claims<BS: Blockstore>(&self, s: BS) -> Result<ClaimsMap<BS>, ActorError> {
+        ClaimsMap::load(s, &self.claims, CLAIMS_CONFIG, "claims")
+    }
+
+    pub fn save_claims<BS: Blockstore>(
+        &mut self,
+        claims: &mut ClaimsMap<BS>,
+    ) -> Result<(), ActorError> {
+        self.claims = claims.flush()?;
+        Ok(())
     }
 
     pub(super) fn add_pledge_total(&mut self, amount: TokenAmount) {
@@ -280,13 +290,8 @@ impl State {
     where
         BS: Blockstore,
     {
-        let claims = make_map_with_root::<_, Claim>(&self.claims, store).map_err(|e| {
-            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load claims")
-        })?;
-
-        if !claims.contains_key(&miner_addr.to_bytes()).map_err(|e| {
-            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to look up claim")
-        })? {
+        let claims = self.load_claims(store)?;
+        if !claims.contains_key(miner_addr)? {
             return Err(actor_error!(
                 forbidden,
                 "unknown miner {} forbidden to interact with power actor",
@@ -301,38 +306,30 @@ impl State {
         store: &BS,
         miner: &Address,
     ) -> anyhow::Result<Option<Claim>> {
-        let claims =
-            make_map_with_root_and_bitwidth::<_, Claim>(&self.claims, store, HAMT_BIT_WIDTH)
-                .map_err(|e| {
-                    e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load claims")
-                })?;
-
-        let claim = get_claim(&claims, miner)?;
+        let claims = self.load_claims(store)?;
+        let claim = claims.get(miner)?;
         Ok(claim.cloned())
     }
 
     pub(super) fn delete_claim<BS: Blockstore>(
         &mut self,
         policy: &Policy,
-        claims: &mut Map<BS, Claim>,
+        claims: &mut ClaimsMap<BS>,
         miner: &Address,
     ) -> anyhow::Result<()> {
-        let (rbp, qap) =
-            match get_claim(claims, miner).map_err(|e| e.downcast_wrap("failed to get claim"))? {
-                None => {
-                    return Ok(());
-                }
-                Some(claim) => (claim.raw_byte_power.clone(), claim.quality_adj_power.clone()),
-            };
+        let (rbp, qap) = match claims.get(miner)? {
+            None => {
+                return Ok(());
+            }
+            Some(claim) => (claim.raw_byte_power.clone(), claim.quality_adj_power.clone()),
+        };
 
         // Subtract from stats to remove power
         self.add_to_claim(policy, claims, miner, &rbp.neg(), &qap.neg())
-            .map_err(|e| e.downcast_wrap("failed to subtract miner power before deleting claim"))?;
-
+            .context("subtract miner power before deleting claim")?;
         claims
-            .delete(&miner.to_bytes())
-            .map_err(|e| e.downcast_wrap(format!("failed to delete claim for address {}", miner)))?
-            .ok_or_else(|| anyhow!("failed to delete claim for address: doesn't exist"))?;
+            .delete(miner)?
+            .ok_or_else(|| anyhow!("failed to delete claim for {miner}: doesn't exist"))?;
         Ok(())
     }
 }
@@ -351,39 +348,27 @@ pub(super) fn load_cron_events<BS: Blockstore>(
     Ok(events)
 }
 
-/// Gets claim from claims map by address
-fn get_claim<'m, BS: Blockstore>(
-    claims: &'m Map<BS, Claim>,
-    a: &Address,
-) -> anyhow::Result<Option<&'m Claim>> {
-    claims
-        .get(&a.to_bytes())
-        .map_err(|e| e.downcast_wrap(format!("failed to get claim for address {}", a)))
-}
-
 pub fn set_claim<BS: Blockstore>(
-    claims: &mut Map<BS, Claim>,
+    claims: &mut ClaimsMap<BS>,
     a: &Address,
     claim: Claim,
-) -> anyhow::Result<()> {
+) -> Result<(), ActorError> {
     if claim.raw_byte_power.is_negative() {
-        return Err(anyhow!(actor_error!(
+        return Err(actor_error!(
             illegal_state,
             "negative claim raw power {}",
             claim.raw_byte_power
-        )));
+        ));
     }
     if claim.quality_adj_power.is_negative() {
-        return Err(anyhow!(actor_error!(
+        return Err(actor_error!(
             illegal_state,
             "negative claim quality-adjusted power {}",
             claim.quality_adj_power
-        )));
+        ));
     }
 
-    claims
-        .set(a.to_bytes().into(), claim)
-        .map_err(|e| e.downcast_wrap(format!("failed to set claim for address {}", a)))?;
+    claims.set(a, claim)?;
     Ok(())
 }
 

--- a/actors/power/src/testing.rs
+++ b/actors/power/src/testing.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use fil_actors_runtime::{parse_uint_key, runtime::Policy, Map, MessageAccumulator, Multimap};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{
@@ -11,9 +10,11 @@ use fvm_shared::{
 };
 use num_traits::{Signed, Zero};
 
+use fil_actors_runtime::{parse_uint_key, runtime::Policy, MessageAccumulator, Multimap};
+
 use crate::{
-    consensus_miner_min_power, Claim, CronEvent, State, CRON_QUEUE_AMT_BITWIDTH,
-    CRON_QUEUE_HAMT_BITWIDTH, MAX_MINER_PROVE_COMMITS_PER_EPOCH,
+    consensus_miner_min_power, Claim, ClaimsMap, CronEvent, State, CLAIMS_CONFIG,
+    CRON_QUEUE_AMT_BITWIDTH, CRON_QUEUE_HAMT_BITWIDTH, MAX_MINER_PROVE_COMMITS_PER_EPOCH,
     PROOF_VALIDATION_BATCH_AMT_BITWIDTH,
 };
 
@@ -156,12 +157,10 @@ fn check_claims_invariants<BS: Blockstore>(
     let mut qa_power = StoragePower::zero();
     let mut claims_with_sufficient_power_count = 0;
 
-    match Map::<_, Claim>::load(&state.claims, store) {
+    match ClaimsMap::load(store, &state.claims, CLAIMS_CONFIG, "claims") {
         Ok(claims) => {
-            let ret = claims.for_each(|key, claim| {
-                let address = Address::from_bytes(key)?;
+            let ret = claims.for_each(|address, claim| {
                 claims_by_address.insert(address, claim.clone());
-
                 committed_raw_power += &claim.raw_byte_power;
                 committed_qa_power += &claim.quality_adj_power;
 

--- a/actors/power/src/types.rs
+++ b/actors/power/src/types.rs
@@ -22,10 +22,6 @@ pub const SECTOR_TERMINATION_MANUAL: SectorTermination = 1;
 /// Implicit termination due to unrecovered fault
 pub const SECTOR_TERMINATION_FAULTY: SectorTermination = 3;
 
-pub const CRON_QUEUE_HAMT_BITWIDTH: u32 = 6;
-pub const CRON_QUEUE_AMT_BITWIDTH: u32 = 6;
-pub const PROOF_VALIDATION_BATCH_AMT_BITWIDTH: u32 = 4;
-
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
 pub struct CreateMinerParams {
     pub owner: Address,

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -1,28 +1,10 @@
 use std::cell::RefCell;
 
 use cid::Cid;
-use fil_actor_power::detail::GAS_ON_SUBMIT_VERIFY_SEAL;
-use fil_actor_power::ext::miner::ConfirmSectorProofsParams;
-use fil_actor_power::ext::miner::CONFIRM_SECTOR_PROOFS_VALID_METHOD;
-use fil_actor_power::ext::reward::Method::ThisEpochReward;
-use fil_actor_power::ext::reward::UPDATE_NETWORK_KPI;
-use fil_actor_power::testing::check_state_invariants;
-use fil_actor_power::EnrollCronEventParams;
-use fil_actor_power::CRON_QUEUE_AMT_BITWIDTH;
-use fil_actor_power::CRON_QUEUE_HAMT_BITWIDTH;
-use fil_actor_power::{epoch_key, MinerCountReturn};
-use fil_actor_power::{CronEvent, MinerConsensusCountReturn};
-use fil_actors_runtime::runtime::RuntimePolicy;
-use fil_actors_runtime::test_utils::CRON_ACTOR_CODE_ID;
-use fil_actors_runtime::Multimap;
-use fil_actors_runtime::CRON_ACTOR_ADDR;
-use fil_actors_runtime::REWARD_ACTOR_ADDR;
 use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::{BytesDe, RawBytes};
-use fvm_ipld_hamt::BytesKey;
-use fvm_ipld_hamt::Error;
 use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser::BigIntDe;
 use fvm_shared::bigint::bigint_ser::BigIntSer;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
@@ -39,23 +21,36 @@ use num_traits::Zero;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+use fil_actor_power::detail::GAS_ON_SUBMIT_VERIFY_SEAL;
 use fil_actor_power::ext::init::ExecParams;
+use fil_actor_power::ext::miner::ConfirmSectorProofsParams;
 use fil_actor_power::ext::miner::MinerConstructorParams;
+use fil_actor_power::ext::miner::CONFIRM_SECTOR_PROOFS_VALID_METHOD;
+use fil_actor_power::ext::reward::Method::ThisEpochReward;
+use fil_actor_power::ext::reward::UPDATE_NETWORK_KPI;
+use fil_actor_power::testing::check_state_invariants;
+use fil_actor_power::EnrollCronEventParams;
+use fil_actor_power::CRON_QUEUE_AMT_BITWIDTH;
+use fil_actor_power::CRON_QUEUE_HAMT_BITWIDTH;
+use fil_actor_power::{epoch_key, MinerCountReturn};
 use fil_actor_power::{
     ext, Claim, CreateMinerParams, CreateMinerReturn, CurrentTotalPowerReturn, Method, State,
     UpdateClaimedPowerParams,
 };
-use fil_actors_runtime::builtin::HAMT_BIT_WIDTH;
+use fil_actor_power::{CronEvent, MinerConsensusCountReturn};
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::Runtime;
+use fil_actors_runtime::runtime::RuntimePolicy;
+use fil_actors_runtime::test_utils::CRON_ACTOR_CODE_ID;
 use fil_actors_runtime::test_utils::{
     MockRuntime, ACCOUNT_ACTOR_CODE_ID, MINER_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID,
 };
+use fil_actors_runtime::REWARD_ACTOR_ADDR;
 use fil_actors_runtime::{
-    make_map_with_root_and_bitwidth, ActorError, Map, INIT_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
-    SYSTEM_ACTOR_ADDR,
+    ActorError, INIT_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
-use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fil_actors_runtime::{Map2, MapKey, Multimap};
+use fil_actors_runtime::{CRON_ACTOR_ADDR, DEFAULT_HAMT_CONFIG};
 
 use crate::PowerActor;
 
@@ -207,10 +202,8 @@ impl Harness {
 
     pub fn list_miners(&self, rt: &MockRuntime) -> Vec<Address> {
         let st: State = rt.get_state();
-        let claims: Map<_, Claim> =
-            make_map_with_root_and_bitwidth(&st.claims, rt.store(), HAMT_BIT_WIDTH).unwrap();
-        let keys = collect_keys(claims).unwrap();
-        keys.iter().map(|k| Address::from_bytes(k).unwrap()).collect::<Vec<_>>()
+        let claims = st.load_claims(rt.store()).unwrap();
+        collect_keys(claims).unwrap()
     }
 
     pub fn miner_count(&self, rt: &MockRuntime) -> i64 {
@@ -237,10 +230,8 @@ impl Harness {
     pub fn delete_claim(&mut self, rt: &MockRuntime, miner: &Address) {
         let mut state: State = rt.get_state();
 
-        let mut claims =
-            make_map_with_root_and_bitwidth::<_, Claim>(&state.claims, rt.store(), HAMT_BIT_WIDTH)
-                .unwrap();
-        claims.delete(&miner.to_bytes()).expect("Failed to delete claim");
+        let mut claims = state.load_claims(rt.store()).unwrap();
+        claims.delete(miner).expect("Failed to delete claim");
         state.claims = claims.flush().unwrap();
 
         rt.replace_state(&state);
@@ -489,22 +480,22 @@ pub fn batch_verify_default_output(infos: &[SealVerifyInfo]) -> Vec<bool> {
 }
 
 /// Collects all keys from a map into a vector.
-fn collect_keys<BS, V>(m: Map<BS, V>) -> Result<Vec<BytesKey>, Error>
+fn collect_keys<BS, K, V>(m: Map2<BS, K, V>) -> Result<Vec<K>, ActorError>
 where
     BS: Blockstore,
+    K: MapKey + Clone,
     V: DeserializeOwned + Serialize,
 {
     let mut ret_keys = Vec::new();
     m.for_each(|k, _| {
-        ret_keys.push(k.clone());
+        ret_keys.push(k);
         Ok(())
     })?;
-
     Ok(ret_keys)
 }
 
 pub fn verify_empty_map(rt: &MockRuntime, key: Cid) {
     let map =
-        make_map_with_root_and_bitwidth::<_, BigIntDe>(&key, &rt.store, HAMT_BIT_WIDTH).unwrap();
+        Map2::<_, Vec<u8>, Vec<u8>>::load(&rt.store, &key, DEFAULT_HAMT_CONFIG, "empty?").unwrap();
     map.for_each(|_key, _val| panic!("expected no keys")).unwrap();
 }

--- a/actors/verifreg/src/expiration.rs
+++ b/actors/verifreg/src/expiration.rs
@@ -40,7 +40,7 @@ where
 {
     let mut found_ids = Vec::<u64>::new();
     collection
-        .for_each(owner, |key, record| {
+        .for_each_in(owner, |key, record| {
             if curr_epoch >= record.expiration() {
                 let id = parse_uint_key(key)
                     .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to parse uint key")?;

--- a/actors/verifreg/src/state.rs
+++ b/actors/verifreg/src/state.rs
@@ -5,7 +5,6 @@ use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser::BigIntDe;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PaddedPieceSize;
@@ -13,12 +12,17 @@ use fvm_shared::sector::SectorNumber;
 use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
 
 use fil_actors_runtime::{
-    actor_error, make_empty_map, make_map_with_root_and_bitwidth, ActorError, AsActorError, Map,
-    MapMap,
+    actor_error, ActorError, AsActorError, Config, Map2, MapMap, DEFAULT_HAMT_CONFIG,
 };
 
-use crate::DataCap;
-use crate::{AllocationID, ClaimID};
+use crate::{AddrPairKey, AllocationID, ClaimID};
+use crate::{DataCap, RemoveDataCapProposalID};
+
+pub type DataCapMap<BS> = Map2<BS, Address, DataCap>;
+pub const DATACAP_MAP_CONFIG: Config = DEFAULT_HAMT_CONFIG;
+
+pub type RemoveDataCapProposalMap<BS> = Map2<BS, AddrPairKey, RemoveDataCapProposalID>;
+pub const REMOVE_DATACAP_PROPOSALS_CONFIG: Config = DEFAULT_HAMT_CONFIG;
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone)]
 pub struct State {
@@ -37,11 +41,8 @@ pub struct State {
 
 impl State {
     pub fn new<BS: Blockstore>(store: &BS, root_key: Address) -> Result<State, ActorError> {
-        let empty_map = make_empty_map::<_, ()>(store, HAMT_BIT_WIDTH)
-            .flush()
-            .map_err(|e| actor_error!(illegal_state, "failed to create empty map: {}", e))?;
-
-        let empty_mapmap =
+        let empty_dcap = DataCapMap::empty(store, DATACAP_MAP_CONFIG, "empty").flush()?;
+        let empty_allocs_claims =
             MapMap::<_, (), ActorID, u64>::new(store, HAMT_BIT_WIDTH, HAMT_BIT_WIDTH)
                 .flush()
                 .map_err(|e| {
@@ -50,11 +51,11 @@ impl State {
 
         Ok(State {
             root_key,
-            verifiers: empty_map,
-            remove_data_cap_proposal_ids: empty_map,
-            allocations: empty_mapmap,
+            verifiers: empty_dcap,
+            remove_data_cap_proposal_ids: empty_dcap,
+            allocations: empty_allocs_claims,
             next_allocation_id: 1,
-            claims: empty_mapmap,
+            claims: empty_allocs_claims,
         })
     }
 
@@ -65,15 +66,9 @@ impl State {
         verifier: &Address,
         cap: &DataCap,
     ) -> Result<(), ActorError> {
-        let mut verifiers =
-            make_map_with_root_and_bitwidth::<_, BigIntDe>(&self.verifiers, store, HAMT_BIT_WIDTH)
-                .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load verifiers")?;
-        verifiers
-            .set(verifier.to_bytes().into(), BigIntDe(cap.clone()))
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to set verifier")?;
-        self.verifiers = verifiers
-            .flush()
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush verifiers")?;
+        let mut verifiers = self.load_verifiers(store)?;
+        verifiers.set(verifier, cap.clone())?;
+        self.verifiers = verifiers.flush()?;
         Ok(())
     }
 
@@ -82,18 +77,11 @@ impl State {
         store: &impl Blockstore,
         verifier: &Address,
     ) -> Result<(), ActorError> {
-        let mut verifiers =
-            make_map_with_root_and_bitwidth::<_, BigIntDe>(&self.verifiers, store, HAMT_BIT_WIDTH)
-                .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load verifiers")?;
-
+        let mut verifiers = self.load_verifiers(store)?;
         verifiers
-            .delete(&verifier.to_bytes())
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to remove verifier")?
+            .delete(verifier)?
             .context_code(ExitCode::USR_ILLEGAL_ARGUMENT, "verifier not found")?;
-
-        self.verifiers = verifiers
-            .flush()
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush verifiers")?;
+        self.verifiers = verifiers.flush()?;
         Ok(())
     }
 
@@ -102,21 +90,13 @@ impl State {
         store: &impl Blockstore,
         verifier: &Address,
     ) -> Result<Option<DataCap>, ActorError> {
-        let verifiers =
-            make_map_with_root_and_bitwidth::<_, BigIntDe>(&self.verifiers, store, HAMT_BIT_WIDTH)
-                .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load verifiers")?;
-        let allowance = verifiers
-            .get(&verifier.to_bytes())
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to get verifier")?;
-        Ok(allowance.map(|a| a.0.clone() as DataCap))
+        let verifiers = self.load_verifiers(store)?;
+        let allowance = verifiers.get(verifier)?;
+        Ok(allowance.map(|a| a.clone() as DataCap))
     }
 
-    pub fn load_verifiers<'a, BS: Blockstore>(
-        &self,
-        store: &'a BS,
-    ) -> Result<Map<'a, BS, BigIntDe>, ActorError> {
-        make_map_with_root_and_bitwidth::<_, BigIntDe>(&self.verifiers, store, HAMT_BIT_WIDTH)
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load verifiers")
+    pub fn load_verifiers<BS: Blockstore>(&self, store: BS) -> Result<DataCapMap<BS>, ActorError> {
+        DataCapMap::load(store, &self.verifiers, DATACAP_MAP_CONFIG, "verifiers")
     }
 
     pub fn load_allocs<'a, BS: Blockstore>(

--- a/actors/verifreg/src/state.rs
+++ b/actors/verifreg/src/state.rs
@@ -5,6 +5,7 @@ use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
+use fvm_shared::bigint::bigint_ser::BigIntDe;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PaddedPieceSize;
@@ -18,7 +19,7 @@ use fil_actors_runtime::{
 use crate::{AddrPairKey, AllocationID, ClaimID};
 use crate::{DataCap, RemoveDataCapProposalID};
 
-pub type DataCapMap<BS> = Map2<BS, Address, DataCap>;
+pub type DataCapMap<BS> = Map2<BS, Address, BigIntDe>;
 pub const DATACAP_MAP_CONFIG: Config = DEFAULT_HAMT_CONFIG;
 
 pub type RemoveDataCapProposalMap<BS> = Map2<BS, AddrPairKey, RemoveDataCapProposalID>;
@@ -67,7 +68,7 @@ impl State {
         cap: &DataCap,
     ) -> Result<(), ActorError> {
         let mut verifiers = self.load_verifiers(store)?;
-        verifiers.set(verifier, cap.clone())?;
+        verifiers.set(verifier, BigIntDe(cap.clone()))?;
         self.verifiers = verifiers.flush()?;
         Ok(())
     }
@@ -92,7 +93,7 @@ impl State {
     ) -> Result<Option<DataCap>, ActorError> {
         let verifiers = self.load_verifiers(store)?;
         let allowance = verifiers.get(verifier)?;
-        Ok(allowance.map(|a| a.clone() as DataCap))
+        Ok(allowance.map(|a| a.clone().0))
     }
 
     pub fn load_verifiers<BS: Blockstore>(&self, store: BS) -> Result<DataCapMap<BS>, ActorError> {

--- a/actors/verifreg/src/testing.rs
+++ b/actors/verifreg/src/testing.rs
@@ -39,10 +39,10 @@ pub fn check_state_invariants<BS: Blockstore>(
                     format!("verifier {verifier} should have ID protocol"),
                 );
                 acc.require(
-                    !cap.is_negative(),
-                    format!("verifier {verifier} cap {cap} is negative"),
+                    !cap.0.is_negative(),
+                    format!("verifier {verifier} cap {} is negative", cap.0),
                 );
-                all_verifiers.insert(verifier, cap.clone());
+                all_verifiers.insert(verifier, cap.clone().0);
                 Ok(())
             });
 

--- a/actors/verifreg/src/testing.rs
+++ b/actors/verifreg/src/testing.rs
@@ -1,20 +1,17 @@
-use frc46_token::token::state::decode_actor_id;
 use std::collections::HashMap;
+
+use frc46_token::token::state::decode_actor_id;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_shared::address::{Address, Protocol};
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::ActorID;
+use num_traits::Signed;
 
 use fil_actors_runtime::runtime::policy_constants::{
     MAXIMUM_VERIFIED_ALLOCATION_EXPIRATION, MAXIMUM_VERIFIED_ALLOCATION_TERM,
     MINIMUM_VERIFIED_ALLOCATION_SIZE, MINIMUM_VERIFIED_ALLOCATION_TERM,
 };
-use fil_actors_runtime::shared::HAMT_BIT_WIDTH;
-use fil_actors_runtime::{
-    make_map_with_root_and_bitwidth, parse_uint_key, Map, MessageAccumulator,
-};
-use fvm_ipld_blockstore::Blockstore;
-use fvm_shared::address::{Address, Protocol};
-use fvm_shared::bigint::bigint_ser::BigIntDe;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::ActorID;
-use num_traits::Signed;
+use fil_actors_runtime::{Map2, MessageAccumulator, DEFAULT_HAMT_CONFIG};
 
 use crate::{Allocation, AllocationID, Claim, ClaimID, DataCap, State};
 
@@ -27,19 +24,16 @@ pub struct StateSummary {
 /// Checks internal invariants of verified registry state.
 pub fn check_state_invariants<BS: Blockstore>(
     state: &State,
-    store: &BS,
+    store: BS,
     prior_epoch: ChainEpoch,
 ) -> (StateSummary, MessageAccumulator) {
     let acc = MessageAccumulator::default();
 
     // Load and check verifiers
     let mut all_verifiers = HashMap::new();
-    match Map::<_, BigIntDe>::load(&state.verifiers, store) {
+    match state.load_verifiers(&store) {
         Ok(verifiers) => {
-            let ret = verifiers.for_each(|key, cap| {
-                let verifier = Address::from_bytes(key)?;
-                let cap = &cap.0;
-
+            let ret = verifiers.for_each(|verifier, cap| {
                 acc.require(
                     verifier.protocol() == Protocol::ID,
                     format!("verifier {verifier} should have ID protocol"),
@@ -59,14 +53,19 @@ pub fn check_state_invariants<BS: Blockstore>(
 
     // Load and check allocations
     let mut all_allocations = HashMap::new();
-    match make_map_with_root_and_bitwidth(&state.allocations, store, HAMT_BIT_WIDTH) {
+    match state.load_allocs(&store) {
         Ok(allocations) => {
             let ret = allocations.for_each(|client_key, inner_root| {
                 let client_id = decode_actor_id(client_key).unwrap();
-                match make_map_with_root_and_bitwidth(inner_root, store, HAMT_BIT_WIDTH) {
+                let inner = Map2::<&BS, AllocationID, Allocation>::load(
+                    &store,
+                    inner_root,
+                    DEFAULT_HAMT_CONFIG,
+                    "allocations inner",
+                );
+                match inner {
                     Ok(allocations) => {
-                        let ret = allocations.for_each(|alloc_id_key, allocation: &Allocation| {
-                            let allocation_id = parse_uint_key(alloc_id_key).unwrap();
+                        let ret = allocations.for_each(|allocation_id, allocation: &Allocation| {
                             check_allocation_state(
                                 allocation_id,
                                 allocation,
@@ -95,14 +94,19 @@ pub fn check_state_invariants<BS: Blockstore>(
     }
 
     let mut all_claims = HashMap::new();
-    match make_map_with_root_and_bitwidth(&state.claims, store, HAMT_BIT_WIDTH) {
+    match state.load_claims(&store) {
         Ok(claims) => {
             let ret = claims.for_each(|provider_key, inner_root| {
                 let provider_id = decode_actor_id(provider_key).unwrap();
-                match make_map_with_root_and_bitwidth(inner_root, store, HAMT_BIT_WIDTH) {
+                let inner = Map2::<&BS, ClaimID, Claim>::load(
+                    &store,
+                    inner_root,
+                    DEFAULT_HAMT_CONFIG,
+                    "allocations inner",
+                );
+                match inner {
                     Ok(claims) => {
-                        let ret = claims.for_each(|claim_id_key, claim: &Claim| {
-                            let claim_id = parse_uint_key(claim_id_key).unwrap();
+                        let ret = claims.for_each(|claim_id, claim: &Claim| {
                             check_claim_state(
                                 claim_id,
                                 claim,

--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-use fil_actors_runtime::BatchReturn;
+use fil_actors_runtime::{BatchReturn, MapKey};
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::{bigint_ser, BigInt};
@@ -12,6 +12,7 @@ use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::SectorNumber;
 use fvm_shared::sector::StoragePower;
 use fvm_shared::ActorID;
+use std::fmt::{Debug, Formatter};
 
 use crate::Claim;
 
@@ -91,12 +92,24 @@ impl AddrPairKey {
     pub fn new(first: Address, second: Address) -> Self {
         AddrPairKey { first, second }
     }
+}
 
-    pub fn to_bytes(&self) -> Vec<u8> {
+impl Debug for AddrPairKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        (self.first, self.second).fmt(f)
+    }
+}
+
+impl MapKey for AddrPairKey {
+    fn from_bytes(_b: &[u8]) -> Result<Self, String> {
+        unimplemented!()
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, String> {
         let mut first = self.first.to_bytes();
         let mut second = self.second.to_bytes();
         first.append(&mut second);
-        first
+        Ok(first)
     }
 }
 

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -173,7 +173,7 @@ impl Harness {
 
     pub fn get_verifier_allowance(&self, rt: &MockRuntime, verifier: &Address) -> DataCap {
         let verifiers = rt.get_state::<State>().load_verifiers(&rt.store).unwrap();
-        verifiers.get(verifier).unwrap().unwrap().clone()
+        verifiers.get(verifier).unwrap().unwrap().clone().0
     }
 
     pub fn assert_verifier_removed(&self, rt: &MockRuntime, verifier: &Address) {

--- a/integration_tests/src/tests/verifreg_remove_datacap_test.rs
+++ b/integration_tests/src/tests/verifreg_remove_datacap_test.rs
@@ -1,6 +1,7 @@
 use fil_actor_datacap::{
     DestroyParams, Method as DataCapMethod, MintParams, State as DataCapState,
 };
+use fil_actor_verifreg::state::{RemoveDataCapProposalMap, REMOVE_DATACAP_PROPOSALS_CONFIG};
 use fil_actor_verifreg::{
     AddVerifiedClientParams, DataCap, RemoveDataCapParams, RemoveDataCapRequest,
     RemoveDataCapReturn, SIGNATURE_DOMAIN_SEPARATION_REMOVE_DATA_CAP,
@@ -102,20 +103,21 @@ pub fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
     assert_eq!(balance, TokenAmount::from_whole(verifier_allowance.to_i64().unwrap()));
 
     let store = DynBlockstore::wrap(v.blockstore());
-    let mut proposal_ids = make_map_with_root_and_bitwidth::<_, RemoveDataCapProposalID>(
-        &v_st.remove_data_cap_proposal_ids,
+    let mut proposal_ids = RemoveDataCapProposalMap::load(
         &store,
-        HAMT_BIT_WIDTH,
+        &v_st.remove_data_cap_proposal_ids,
+        REMOVE_DATACAP_PROPOSALS_CONFIG,
+        "remove datacap proposals",
     )
     .unwrap();
 
     assert!(proposal_ids
-        .get(&AddrPairKey::new(verifier1_id_addr, verified_client_id_addr).to_bytes())
+        .get(&AddrPairKey::new(verifier1_id_addr, verified_client_id_addr))
         .unwrap()
         .is_none());
 
     assert!(proposal_ids
-        .get(&AddrPairKey::new(verifier2_id_addr, verified_client_id_addr).to_bytes())
+        .get(&AddrPairKey::new(verifier2_id_addr, verified_client_id_addr))
         .unwrap()
         .is_none());
 
@@ -188,19 +190,23 @@ pub fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
     let v_st: VerifregState = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
     // confirm proposalIds has changed as expected
     let store = DynBlockstore::wrap(v.blockstore());
-    proposal_ids =
-        make_map_with_root_and_bitwidth(&v_st.remove_data_cap_proposal_ids, &store, HAMT_BIT_WIDTH)
-            .unwrap();
+    proposal_ids = RemoveDataCapProposalMap::load(
+        &store,
+        &v_st.remove_data_cap_proposal_ids,
+        REMOVE_DATACAP_PROPOSALS_CONFIG,
+        "remove datacap proposals",
+    )
+    .unwrap();
 
     let verifier1_proposal_id: &RemoveDataCapProposalID = proposal_ids
-        .get(&AddrPairKey::new(verifier1_id_addr, verified_client_id_addr).to_bytes())
+        .get(&AddrPairKey::new(verifier1_id_addr, verified_client_id_addr))
         .unwrap()
         .unwrap();
 
     assert_eq!(1u64, verifier1_proposal_id.id);
 
     let verifier2_proposal_id: &RemoveDataCapProposalID = proposal_ids
-        .get(&AddrPairKey::new(verifier2_id_addr, verified_client_id_addr).to_bytes())
+        .get(&AddrPairKey::new(verifier2_id_addr, verified_client_id_addr))
         .unwrap()
         .unwrap();
 
@@ -273,19 +279,23 @@ pub fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
     // confirm proposalIds has changed as expected
     let v_st: VerifregState = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
     let store = DynBlockstore::wrap(v.blockstore());
-    proposal_ids =
-        make_map_with_root_and_bitwidth(&v_st.remove_data_cap_proposal_ids, &store, HAMT_BIT_WIDTH)
-            .unwrap();
+    proposal_ids = RemoveDataCapProposalMap::load(
+        &store,
+        &v_st.remove_data_cap_proposal_ids,
+        REMOVE_DATACAP_PROPOSALS_CONFIG,
+        "remove datacap proposals",
+    )
+    .unwrap();
 
     let verifier1_proposal_id: &RemoveDataCapProposalID = proposal_ids
-        .get(&AddrPairKey::new(verifier1_id_addr, verified_client_id_addr).to_bytes())
+        .get(&AddrPairKey::new(verifier1_id_addr, verified_client_id_addr))
         .unwrap()
         .unwrap();
 
     assert_eq!(2u64, verifier1_proposal_id.id);
 
     let verifier2_proposal_id: &RemoveDataCapProposalID = proposal_ids
-        .get(&AddrPairKey::new(verifier2_id_addr, verified_client_id_addr).to_bytes())
+        .get(&AddrPairKey::new(verifier2_id_addr, verified_client_id_addr))
         .unwrap()
         .unwrap();
 

--- a/runtime/src/util/mapmap.rs
+++ b/runtime/src/util/mapmap.rs
@@ -102,8 +102,16 @@ where
         in_map.get(&inside_k.key())
     }
 
+    // Iterates over all outer keys.
+    pub fn for_each<F>(&self, f: F) -> Result<(), Error>
+    where
+        F: FnMut(&BytesKey, &Cid) -> anyhow::Result<()>,
+    {
+        self.outer.for_each(f)
+    }
+
     // Runs a function over all values for one outer key.
-    pub fn for_each<F>(&mut self, outside_k: K1, f: F) -> Result<(), Error>
+    pub fn for_each_in<F>(&mut self, outside_k: K1, f: F) -> Result<(), Error>
     where
         F: FnMut(&BytesKey, &V) -> anyhow::Result<()>,
     {

--- a/runtime/tests/mapmap_test.rs
+++ b/runtime/tests/mapmap_test.rs
@@ -32,7 +32,7 @@ fn mapmap_test() {
 
     // for each accounts for all inner keys and values
     let mut count = 0;
-    mm.for_each("tree", |bk, v| -> anyhow::Result<()> {
+    mm.for_each_in("tree", |bk, v| -> anyhow::Result<()> {
         count += 1;
         assert!(
             (bk == &"deciduous".key() && v == &"mango".to_string())
@@ -44,7 +44,7 @@ fn mapmap_test() {
     assert_eq!(2, count);
 
     let mut count = 0;
-    mm.for_each("rock", |bk, v| -> anyhow::Result<()> {
+    mm.for_each_in("rock", |bk, v| -> anyhow::Result<()> {
         count += 1;
         assert_eq!(&"igneous".key(), bk);
         assert_eq!(&"basalt".to_string(), v);
@@ -77,7 +77,7 @@ fn mapmap_test() {
         MapMap::from_root(&store, &root, HAMT_BIT_WIDTH, HAMT_BIT_WIDTH).unwrap();
     let mut count = 0;
     mm_reloaded
-        .for_each("tree", |bk, v| -> anyhow::Result<()> {
+        .for_each_in("tree", |bk, v| -> anyhow::Result<()> {
             count += 1;
             assert!(
                 (bk == &"deciduous".key() && v == &"mango".to_string())


### PR DESCRIPTION
Only the miner actor and some state check utilities remain.

The old Map is also implicitly used in MapMap and Set. I will update those to follow these patterns later too.