### PR TITLE
fix: explicitly specify HAMT bitwidths everywhere

### DIFF
--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -3,7 +3,7 @@ use crate::{
     SectorOnChainInfo, SectorPreCommitOnChainInfo, Sectors, State,
 };
 use fil_actors_runtime::runtime::Policy;
-use fil_actors_runtime::{parse_uint_key, Map, MessageAccumulator};
+use fil_actors_runtime::{parse_uint_key, Map, MessageAccumulator, DEFAULT_HAMT_CONFIG};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
@@ -343,8 +343,11 @@ fn check_precommits<BS: Blockstore>(
 
     let mut precommit_total = TokenAmount::zero();
 
-    let precommited_sectors =
-        Map::<_, SectorPreCommitOnChainInfo>::load(&state.pre_committed_sectors, store);
+    let precommited_sectors = Map::<_, SectorPreCommitOnChainInfo>::load_with_config(
+        &state.pre_committed_sectors,
+        store,
+        DEFAULT_HAMT_CONFIG,
+    );
 
     match precommited_sectors {
         Ok(precommited_sectors) => {

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -22,6 +22,7 @@ use fil_actor_reward::State as RewardState;
 use fil_actor_verifreg::{DataCap, State as VerifregState};
 
 use fil_actors_runtime::runtime::Policy;
+use fil_actors_runtime::DEFAULT_HAMT_CONFIG;
 use fil_actors_runtime::VERIFIED_REGISTRY_ACTOR_ADDR;
 
 use fil_actors_runtime::Map;
@@ -82,7 +83,7 @@ where
 impl<'a, BS: Blockstore> Tree<'a, BS> {
     /// Loads a tree from a root CID and store
     pub fn load(store: &'a BS, root: &Cid) -> anyhow::Result<Self> {
-        let map = Map::load(root, store)?;
+        let map = Map::load_with_config(root, store, DEFAULT_HAMT_CONFIG)?;
 
         Ok(Tree { map, store })
     }


### PR DESCRIPTION
This _doesn't_ migrate to the new `Map2` interface everywhere, it just avoids the use of `Hamt::load` and `Hamt::new`, which will be deprecated in the next release of `fvm_ipld_hamt`.

part of #1346