### PR TITLE
Portable Invocation Traces

### DIFF
--- a/integration_tests/src/expects.rs
+++ b/integration_tests/src/expects.rs
@@ -23,7 +23,7 @@ use fil_actor_power::{UpdateClaimedPowerParams, UpdatePledgeTotalParams};
 use fil_actor_verifreg::GetClaimsParams;
 use fil_actors_runtime::{
     BURNT_FUNDS_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
-    VERIFIED_REGISTRY_ACTOR_ADDR,
+    STORAGE_POWER_ACTOR_ID, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 
 use vm_api::trace::ExpectInvocation;
@@ -32,14 +32,14 @@ use vm_api::trace::ExpectInvocation;
 pub struct Expect {}
 
 impl Expect {
-    pub fn send(from: Address, to: Address, v: Option<TokenAmount>) -> ExpectInvocation {
+    pub fn send(from: ActorID, to: Address, v: Option<TokenAmount>) -> ExpectInvocation {
         ExpectInvocation { from, to, method: METHOD_SEND, value: v, ..Default::default() }
     }
-    pub fn burn(from: Address, v: Option<TokenAmount>) -> ExpectInvocation {
+    pub fn burn(from: ActorID, v: Option<TokenAmount>) -> ExpectInvocation {
         Self::send(from, BURNT_FUNDS_ACTOR_ADDR, v)
     }
     pub fn market_activate_deals(
-        from: Address,
+        from: ActorID,
         deals: Vec<DealID>,
         sector_expiry: ChainEpoch,
         sector_type: RegisteredSealProof,
@@ -61,7 +61,7 @@ impl Expect {
         }
     }
     pub fn market_sectors_terminate(
-        from: Address,
+        from: ActorID,
         epoch: ChainEpoch,
         deal_ids: Vec<DealID>,
     ) -> ExpectInvocation {
@@ -77,7 +77,7 @@ impl Expect {
             ..Default::default()
         }
     }
-    pub fn market_verify_deals(from: Address, sectors: Vec<SectorDeals>) -> ExpectInvocation {
+    pub fn market_verify_deals(from: ActorID, sectors: Vec<SectorDeals>) -> ExpectInvocation {
         let params =
             IpldBlock::serialize_cbor(&VerifyDealsForActivationParams { sectors }).unwrap();
         ExpectInvocation {
@@ -92,7 +92,7 @@ impl Expect {
     }
     pub fn miner_cron(to: Address) -> ExpectInvocation {
         ExpectInvocation {
-            from: STORAGE_POWER_ACTOR_ADDR,
+            from: STORAGE_POWER_ACTOR_ID,
             to,
             method: fil_actor_miner::Method::OnDeferredCronEvent as u64,
             value: Some(TokenAmount::zero()),
@@ -101,7 +101,7 @@ impl Expect {
         }
     }
     pub fn miner_is_controlling_address(
-        from: Address,
+        from: ActorID,
         to: Address,
         address: Address,
     ) -> ExpectInvocation {
@@ -116,7 +116,7 @@ impl Expect {
             ..Default::default()
         }
     }
-    pub fn power_current_total(from: Address) -> ExpectInvocation {
+    pub fn power_current_total(from: ActorID) -> ExpectInvocation {
         ExpectInvocation {
             from,
             to: STORAGE_POWER_ACTOR_ADDR,
@@ -126,7 +126,7 @@ impl Expect {
             ..Default::default()
         }
     }
-    pub fn power_enrol_cron(from: Address) -> ExpectInvocation {
+    pub fn power_enrol_cron(from: ActorID) -> ExpectInvocation {
         // Note: params are unchecked.
         ExpectInvocation {
             from,
@@ -137,7 +137,7 @@ impl Expect {
             ..Default::default()
         }
     }
-    pub fn power_submit_porep(from: Address) -> ExpectInvocation {
+    pub fn power_submit_porep(from: ActorID) -> ExpectInvocation {
         // Note: params are unchecked.
         ExpectInvocation {
             from,
@@ -148,7 +148,7 @@ impl Expect {
             ..Default::default()
         }
     }
-    pub fn power_update_claim(from: Address, delta: PowerPair) -> ExpectInvocation {
+    pub fn power_update_claim(from: ActorID, delta: PowerPair) -> ExpectInvocation {
         let params = IpldBlock::serialize_cbor(&UpdateClaimedPowerParams {
             raw_byte_delta: delta.raw,
             quality_adjusted_delta: delta.qa,
@@ -164,7 +164,7 @@ impl Expect {
             ..Default::default()
         }
     }
-    pub fn power_update_pledge(from: Address, amount: Option<TokenAmount>) -> ExpectInvocation {
+    pub fn power_update_pledge(from: ActorID, amount: Option<TokenAmount>) -> ExpectInvocation {
         let params = amount.map(|a| {
             IpldBlock::serialize_cbor(&UpdatePledgeTotalParams { pledge_delta: a }).unwrap()
         });
@@ -181,7 +181,7 @@ impl Expect {
     pub fn reward_update_kpi() -> ExpectInvocation {
         // Note: params are unchecked
         ExpectInvocation {
-            from: STORAGE_POWER_ACTOR_ADDR,
+            from: STORAGE_POWER_ACTOR_ID,
             to: REWARD_ACTOR_ADDR,
             method: fil_actor_reward::Method::UpdateNetworkKPI as u64,
             value: Some(TokenAmount::zero()),
@@ -189,7 +189,7 @@ impl Expect {
             ..Default::default()
         }
     }
-    pub fn reward_this_epoch(from: Address) -> ExpectInvocation {
+    pub fn reward_this_epoch(from: ActorID) -> ExpectInvocation {
         ExpectInvocation {
             from,
             to: REWARD_ACTOR_ADDR,
@@ -200,7 +200,7 @@ impl Expect {
         }
     }
     pub fn verifreg_get_claims(
-        from: Address,
+        from: ActorID,
         miner: ActorID,
         ids: Vec<ClaimID>,
     ) -> ExpectInvocation {
@@ -217,7 +217,7 @@ impl Expect {
             ..Default::default()
         }
     }
-    pub fn frc42_balance(from: Address, to: Address, address: Address) -> ExpectInvocation {
+    pub fn frc42_balance(from: ActorID, to: Address, address: Address) -> ExpectInvocation {
         let params = Some(IpldBlock::serialize_cbor(&BalanceParams { address }).unwrap());
         ExpectInvocation {
             from,
@@ -230,7 +230,7 @@ impl Expect {
         }
     }
     pub fn frc44_authenticate(
-        from: Address,
+        from: ActorID,
         to: Address,
         message: Vec<u8>,
         signature: Vec<u8>,
@@ -247,7 +247,7 @@ impl Expect {
             ..Default::default()
         }
     }
-    pub fn frc46_burn(from: Address, to: Address, amount: TokenAmount) -> ExpectInvocation {
+    pub fn frc46_burn(from: ActorID, to: Address, amount: TokenAmount) -> ExpectInvocation {
         let params = IpldBlock::serialize_cbor(&BurnParams { amount }).unwrap();
         ExpectInvocation {
             from,
@@ -260,7 +260,7 @@ impl Expect {
         }
     }
     pub fn frc46_receiver(
-        from: Address,
+        from: ActorID,
         to: Address,
         payer: ActorID,
         beneficiary: ActorID,

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -13,8 +13,10 @@ pub mod util;
 
 // accounts for verifreg root signer and msig
 pub const VERIFREG_ROOT_KEY: &[u8] = &[200; fvm_shared::address::BLS_PUB_LEN];
-pub const TEST_VERIFREG_ROOT_SIGNER_ADDR: Address = Address::new_id(FIRST_NON_SINGLETON_ADDR);
-pub const TEST_VERIFREG_ROOT_ADDR: Address = Address::new_id(FIRST_NON_SINGLETON_ADDR + 1);
+pub const TEST_VERIFREG_ROOT_SIGNER_ID: ActorID = FIRST_NON_SINGLETON_ADDR;
+pub const TEST_VERIFREG_ROOT_SIGNER_ADDR: Address = Address::new_id(TEST_VERIFREG_ROOT_SIGNER_ID);
+pub const TEST_VERIFREG_ROOT_ID: ActorID = FIRST_NON_SINGLETON_ADDR + 1;
+pub const TEST_VERIFREG_ROOT_ADDR: Address = Address::new_id(TEST_VERIFREG_ROOT_ID);
 
 // account actor seeding funds created by new_with_singletons
 pub const FAUCET_ROOT_KEY: &[u8] = &[153; fvm_shared::address::BLS_PUB_LEN];

--- a/integration_tests/src/tests/multisig_test.rs
+++ b/integration_tests/src/tests/multisig_test.rs
@@ -28,7 +28,9 @@ pub fn proposal_hash_test(v: &dyn VM) {
     let sys_act_start_bal = v.actor(&SYSTEM_ACTOR_ADDR).unwrap().balance;
     let alice = addrs[0];
     let bob = addrs[1];
+    let bob_id = bob.id().unwrap();
     let msig_addr = create_msig(v, &addrs, 2);
+    let msig_id = msig_addr.id().unwrap();
 
     // fund msig and propose send funds to system actor
     let fil_delta = TokenAmount::from_nano(3);
@@ -89,12 +91,12 @@ pub fn proposal_hash_test(v: &dyn VM) {
         Some(correct_approval_params),
     );
     let expect = ExpectInvocation {
-        from: bob,
+        from: bob_id,
         to: msig_addr,
         method: MsigMethod::Approve as u64,
         subinvocs: Some(vec![
             // Tx goes through to fund the system actor
-            Expect::send(msig_addr, SYSTEM_ACTOR_ADDR, Some(fil_delta.clone())),
+            Expect::send(msig_id, SYSTEM_ACTOR_ADDR, Some(fil_delta.clone())),
         ]),
         ..Default::default()
     };

--- a/integration_tests/src/tests/power_scenario_tests.rs
+++ b/integration_tests/src/tests/power_scenario_tests.rs
@@ -6,7 +6,10 @@ use fil_actor_miner::{
 use fil_actor_power::{CreateMinerParams, Method as PowerMethod};
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::test_utils::make_sealed_cid;
-use fil_actors_runtime::{CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR};
+use fil_actors_runtime::{
+    CRON_ACTOR_ADDR, CRON_ACTOR_ID, INIT_ACTOR_ADDR, INIT_ACTOR_ID, STORAGE_POWER_ACTOR_ADDR,
+    STORAGE_POWER_ACTOR_ID,
+};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::BytesDe;
 use fvm_ipld_encoding::RawBytes;
@@ -15,7 +18,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof};
 use fvm_shared::METHOD_SEND;
 use num_traits::Zero;
-use vm_api::trace::ExpectInvocation;
+use vm_api::trace::{ExpectInvocation, InvocationResult};
 use vm_api::util::{apply_ok, serialize_ok};
 use vm_api::VM;
 
@@ -57,23 +60,23 @@ pub fn power_create_miner_test(v: &dyn VM) {
         )
         .unwrap();
 
-    let owner_id = v.resolve_id_address(&owner).unwrap();
+    let owner_id = v.resolve_id_address(&owner).unwrap().id().unwrap();
     let expect = ExpectInvocation {
         // send to power actor
         from: owner_id,
         to: STORAGE_POWER_ACTOR_ADDR,
         method: PowerMethod::CreateMiner as u64,
         params: Some(IpldBlock::serialize_cbor(&params).unwrap()),
-        ret: Some(res.ret),
+        result: InvocationResult::ok(res.ret),
         subinvocs: Some(vec![
             // request init actor construct miner
             ExpectInvocation {
-                from: STORAGE_POWER_ACTOR_ADDR,
+                from: STORAGE_POWER_ACTOR_ID,
                 to: INIT_ACTOR_ADDR,
                 method: InitMethod::Exec as u64,
                 subinvocs: Some(vec![ExpectInvocation {
                     // init then calls miner constructor
-                    from: INIT_ACTOR_ADDR,
+                    from: INIT_ACTOR_ID,
                     to: Address::new_id(FIRST_TEST_USER_ADDR + 1),
                     method: MinerMethod::Constructor as u64,
                     params: Some(
@@ -157,11 +160,11 @@ pub fn cron_tick_test(v: &dyn VM) {
 
     ExpectInvocation {
         // original send to storage power actor
-        from: CRON_ACTOR_ADDR,
+        from: CRON_ACTOR_ID,
         to: STORAGE_POWER_ACTOR_ADDR,
         method: PowerMethod::OnEpochTickEnd as u64,
         subinvocs: Some(vec![
-            Expect::reward_this_epoch(STORAGE_POWER_ACTOR_ADDR),
+            Expect::reward_this_epoch(STORAGE_POWER_ACTOR_ID),
             // expect miner call to be missing
             Expect::reward_update_kpi(),
         ]),
@@ -185,10 +188,10 @@ pub fn cron_tick_test(v: &dyn VM) {
     );
 
     let sub_invocs = vec![
-        Expect::reward_this_epoch(STORAGE_POWER_ACTOR_ADDR),
+        Expect::reward_this_epoch(STORAGE_POWER_ACTOR_ID),
         // expect call back to miner that was set up in create miner
         ExpectInvocation {
-            from: STORAGE_POWER_ACTOR_ADDR,
+            from: STORAGE_POWER_ACTOR_ID,
             to: id_addr,
             method: MinerMethod::OnDeferredCronEvent as u64,
             value: Some(TokenAmount::zero()),
@@ -201,7 +204,7 @@ pub fn cron_tick_test(v: &dyn VM) {
     // expect call to miner
     ExpectInvocation {
         // original send to storage power actor
-        from: CRON_ACTOR_ADDR,
+        from: CRON_ACTOR_ID,
         to: STORAGE_POWER_ACTOR_ADDR,
         method: PowerMethod::OnEpochTickEnd as u64,
         subinvocs: Some(sub_invocs),

--- a/integration_tests/src/tests/power_scenario_tests.rs
+++ b/integration_tests/src/tests/power_scenario_tests.rs
@@ -18,7 +18,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof};
 use fvm_shared::METHOD_SEND;
 use num_traits::Zero;
-use vm_api::trace::{ExpectInvocation, ExpectResult};
+use vm_api::trace::ExpectInvocation;
 use vm_api::util::{apply_ok, serialize_ok};
 use vm_api::VM;
 
@@ -67,7 +67,7 @@ pub fn power_create_miner_test(v: &dyn VM) {
         to: STORAGE_POWER_ACTOR_ADDR,
         method: PowerMethod::CreateMiner as u64,
         params: Some(IpldBlock::serialize_cbor(&params).unwrap()),
-        result: ExpectResult::ok(Some(res.ret)),
+        return_value: Some(res.ret),
         subinvocs: Some(vec![
             // request init actor construct miner
             ExpectInvocation {

--- a/integration_tests/src/tests/power_scenario_tests.rs
+++ b/integration_tests/src/tests/power_scenario_tests.rs
@@ -18,7 +18,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof};
 use fvm_shared::METHOD_SEND;
 use num_traits::Zero;
-use vm_api::trace::{ExpectInvocation, InvocationResult};
+use vm_api::trace::{ExpectInvocation, ExpectResult};
 use vm_api::util::{apply_ok, serialize_ok};
 use vm_api::VM;
 
@@ -67,7 +67,7 @@ pub fn power_create_miner_test(v: &dyn VM) {
         to: STORAGE_POWER_ACTOR_ADDR,
         method: PowerMethod::CreateMiner as u64,
         params: Some(IpldBlock::serialize_cbor(&params).unwrap()),
-        result: InvocationResult::ok(res.ret),
+        result: ExpectResult::ok(Some(res.ret)),
         subinvocs: Some(vec![
             // request init actor construct miner
             ExpectInvocation {

--- a/integration_tests/src/tests/publish_deals_test.rs
+++ b/integration_tests/src/tests/publish_deals_test.rs
@@ -8,7 +8,9 @@ use fil_actor_verifreg::{AddVerifiedClientParams, Method as VerifregMethod};
 use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::Policy;
-use fil_actors_runtime::{test_utils::*, STORAGE_MARKET_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR};
+use fil_actors_runtime::{
+    test_utils::*, STORAGE_MARKET_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ID, VERIFIED_REGISTRY_ACTOR_ADDR,
+};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
@@ -18,7 +20,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::{RegisteredSealProof, StoragePower};
-use vm_api::trace::ExpectInvocation;
+use vm_api::trace::{ExpectInvocation, InvocationResult};
 use vm_api::util::{apply_ok, serialize_ok};
 use vm_api::VM;
 
@@ -430,6 +432,7 @@ pub fn psd_all_deals_are_bad_test(v: &dyn VM) {
 
 pub fn psd_bad_sig_test(v: &dyn VM) {
     let (a, deal_start) = setup(v);
+    let worker_id = a.worker.id().unwrap();
     let DealOptions { price_per_epoch, provider_collateral, client_collateral, .. } =
         DealOptions::default();
     let deal_label = "deal0".to_string();
@@ -470,15 +473,15 @@ pub fn psd_bad_sig_test(v: &dyn VM) {
     assert_eq!(ExitCode::USR_ILLEGAL_ARGUMENT, ret.code);
 
     ExpectInvocation {
-        from: a.worker,
+        from: worker_id,
         to: STORAGE_MARKET_ACTOR_ADDR,
         method: MarketMethod::PublishStorageDeals as u64,
         subinvocs: Some(vec![
-            Expect::miner_is_controlling_address(STORAGE_MARKET_ACTOR_ADDR, a.maddr, a.worker),
-            Expect::reward_this_epoch(STORAGE_MARKET_ACTOR_ADDR),
-            Expect::power_current_total(STORAGE_MARKET_ACTOR_ADDR),
+            Expect::miner_is_controlling_address(STORAGE_MARKET_ACTOR_ID, a.maddr, a.worker),
+            Expect::reward_this_epoch(STORAGE_MARKET_ACTOR_ID),
+            Expect::power_current_total(STORAGE_MARKET_ACTOR_ID),
             ExpectInvocation {
-                from: STORAGE_MARKET_ACTOR_ADDR,
+                from: STORAGE_MARKET_ACTOR_ID,
                 to: a.client1,
                 method: AccountMethod::AuthenticateMessageExported as u64,
                 params: Some(
@@ -488,11 +491,17 @@ pub fn psd_bad_sig_test(v: &dyn VM) {
                     })
                     .unwrap(),
                 ),
-                code: ExitCode::USR_ILLEGAL_ARGUMENT,
+                result: InvocationResult::CallReturn {
+                    return_value: None,
+                    exit_code: ExitCode::USR_ILLEGAL_ARGUMENT,
+                },
                 ..Default::default()
             },
         ]),
-        code: ExitCode::USR_ILLEGAL_ARGUMENT,
+        result: InvocationResult::CallReturn {
+            return_value: None,
+            exit_code: ExitCode::USR_ILLEGAL_ARGUMENT,
+        },
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());

--- a/integration_tests/src/tests/publish_deals_test.rs
+++ b/integration_tests/src/tests/publish_deals_test.rs
@@ -20,7 +20,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::{RegisteredSealProof, StoragePower};
-use vm_api::trace::{ExpectInvocation, ExpectResult};
+use vm_api::trace::ExpectInvocation;
 use vm_api::util::{apply_ok, serialize_ok};
 use vm_api::VM;
 
@@ -491,17 +491,13 @@ pub fn psd_bad_sig_test(v: &dyn VM) {
                     })
                     .unwrap(),
                 ),
-                result: ExpectResult::ExpectReturn {
-                    return_value: None,
-                    exit_code: ExitCode::USR_ILLEGAL_ARGUMENT,
-                },
+                return_value: None,
+                exit_code: ExitCode::USR_ILLEGAL_ARGUMENT,
                 ..Default::default()
             },
         ]),
-        result: ExpectResult::ExpectReturn {
-            return_value: None,
-            exit_code: ExitCode::USR_ILLEGAL_ARGUMENT,
-        },
+        return_value: None,
+        exit_code: ExitCode::USR_ILLEGAL_ARGUMENT,
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());

--- a/integration_tests/src/tests/publish_deals_test.rs
+++ b/integration_tests/src/tests/publish_deals_test.rs
@@ -20,7 +20,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::{RegisteredSealProof, StoragePower};
-use vm_api::trace::{ExpectInvocation, InvocationResult};
+use vm_api::trace::{ExpectInvocation, ExpectResult};
 use vm_api::util::{apply_ok, serialize_ok};
 use vm_api::VM;
 
@@ -491,14 +491,14 @@ pub fn psd_bad_sig_test(v: &dyn VM) {
                     })
                     .unwrap(),
                 ),
-                result: InvocationResult::CallReturn {
+                result: ExpectResult::ExpectReturn {
                     return_value: None,
                     exit_code: ExitCode::USR_ILLEGAL_ARGUMENT,
                 },
                 ..Default::default()
             },
         ]),
-        result: InvocationResult::CallReturn {
+        result: ExpectResult::ExpectReturn {
             return_value: None,
             exit_code: ExitCode::USR_ILLEGAL_ARGUMENT,
         },

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -12,7 +12,7 @@ use fvm_shared::sector::StoragePower;
 use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
 
 use fil_actor_cron::Method as CronMethod;
-use fil_actor_market::{Method as MarketMethod, SectorDeals};
+use fil_actor_market::Method as MarketMethod;
 use fil_actor_miner::{
     power_for_sector, DisputeWindowedPoStParams, ExpirationExtension, ExtendSectorExpirationParams,
     Method as MinerMethod, PowerPair, ProveCommitSectorParams, ProveReplicaUpdatesParams,
@@ -1029,14 +1029,6 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
                 method: VerifregMethod::ClaimAllocations as u64,
                 ..Default::default()
             },
-            Expect::market_verify_deals(
-                miner_id,
-                vec![SectorDeals {
-                    sector_type: seal_proof,
-                    sector_expiry: old_sector_info.expiration,
-                    deal_ids: deal_ids.clone(),
-                }],
-            ),
             Expect::reward_this_epoch(miner_id),
             Expect::power_current_total(miner_id),
             Expect::power_update_pledge(miner_id, None),

--- a/integration_tests/src/tests/verifreg_remove_datacap_test.rs
+++ b/integration_tests/src/tests/verifreg_remove_datacap_test.rs
@@ -11,18 +11,17 @@ use fil_actor_verifreg::{RemoveDataCapProposal, RemoveDataCapProposalID, State a
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{
     make_map_with_root_and_bitwidth, DATACAP_TOKEN_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
-    VERIFIED_REGISTRY_ACTOR_ADDR,
+    VERIFIED_REGISTRY_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ID,
 };
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::{to_vec, RawBytes};
-use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser::BigIntDe;
 use fvm_shared::bigint::{BigInt, Zero};
 use fvm_shared::crypto::signature::{Signature, SignatureType};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::StoragePower;
-use fvm_shared::HAMT_BIT_WIDTH;
+use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
 use num_traits::ToPrimitive;
 use std::ops::{Div, Sub};
 use vm_api::trace::ExpectInvocation;
@@ -31,11 +30,12 @@ use vm_api::VM;
 
 use crate::expects::Expect;
 use crate::util::{assert_invariants, create_accounts, verifreg_add_verifier};
-use crate::TEST_VERIFREG_ROOT_ADDR;
+use crate::{TEST_VERIFREG_ROOT_ADDR, TEST_VERIFREG_ROOT_ID};
 
 pub fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
     let addrs = create_accounts(v, 4, &TokenAmount::from_whole(10_000));
     let (verifier1, verifier2, verified_client) = (addrs[0], addrs[1], addrs[2]);
+    let verifier1_id = verifier1.id().unwrap();
 
     let verifier1_id_addr = v.resolve_id_address(&verifier1).unwrap();
     let verifier2_id_addr = v.resolve_id_address(&verifier2).unwrap();
@@ -65,12 +65,12 @@ pub fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
     );
 
     ExpectInvocation {
-        from: verifier1,
+        from: verifier1_id,
         to: VERIFIED_REGISTRY_ACTOR_ADDR,
         method: VerifregMethod::AddVerifiedClient as u64,
         params: Some(IpldBlock::serialize_cbor(&add_verified_client_params).unwrap()),
         subinvocs: Some(vec![ExpectInvocation {
-            from: VERIFIED_REGISTRY_ACTOR_ADDR,
+            from: VERIFIED_REGISTRY_ACTOR_ID,
             to: DATACAP_TOKEN_ACTOR_ADDR,
             method: DataCapMethod::MintExported as u64,
             params: Some(IpldBlock::serialize_cbor(&mint_params).unwrap()),
@@ -167,7 +167,7 @@ pub fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
     .unwrap();
 
     expect_remove_datacap(
-        &TEST_VERIFREG_ROOT_ADDR,
+        TEST_VERIFREG_ROOT_ID,
         &remove_datacap_params,
         RemoveDataCapProposalID { id: 0 },
         RemoveDataCapProposalID { id: 0 },
@@ -259,7 +259,7 @@ pub fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
     .unwrap();
 
     expect_remove_datacap(
-        &TEST_VERIFREG_ROOT_ADDR,
+        TEST_VERIFREG_ROOT_ID,
         &remove_datacap_params,
         RemoveDataCapProposalID { id: 1 },
         RemoveDataCapProposalID { id: 1 },
@@ -359,7 +359,7 @@ pub fn remove_datacap_fails_on_verifreg_test(v: &dyn VM) {
 }
 
 fn expect_remove_datacap(
-    sender: &Address,
+    sender: ActorID,
     params: &RemoveDataCapParams,
     proposal_id1: RemoveDataCapProposalID,
     proposal_id2: RemoveDataCapProposalID,
@@ -387,30 +387,30 @@ fn expect_remove_datacap(
     ]
     .concat();
     ExpectInvocation {
-        from: *sender,
+        from: sender,
         to: VERIFIED_REGISTRY_ACTOR_ADDR,
         method: VerifregMethod::RemoveVerifiedClientDataCap as u64,
         params: Some(IpldBlock::serialize_cbor(&params).unwrap()),
         subinvocs: Some(vec![
             Expect::frc44_authenticate(
-                VERIFIED_REGISTRY_ACTOR_ADDR,
+                VERIFIED_REGISTRY_ACTOR_ID,
                 params.verifier_request_1.verifier,
                 payload1.clone(),
                 payload1,
             ),
             Expect::frc44_authenticate(
-                VERIFIED_REGISTRY_ACTOR_ADDR,
+                VERIFIED_REGISTRY_ACTOR_ID,
                 params.verifier_request_2.verifier,
                 payload2.clone(),
                 payload2,
             ),
             Expect::frc42_balance(
-                VERIFIED_REGISTRY_ACTOR_ADDR,
+                VERIFIED_REGISTRY_ACTOR_ID,
                 DATACAP_TOKEN_ACTOR_ADDR,
                 params.verified_client_to_remove,
             ),
             ExpectInvocation {
-                from: VERIFIED_REGISTRY_ACTOR_ADDR,
+                from: VERIFIED_REGISTRY_ACTOR_ID,
                 to: DATACAP_TOKEN_ACTOR_ADDR,
                 method: DataCapMethod::DestroyExported as u64,
                 params: Some(

--- a/integration_tests/src/util/mod.rs
+++ b/integration_tests/src/util/mod.rs
@@ -31,10 +31,12 @@ use crate::{MinerBalances, NetworkStats, TEST_FAUCET_ADDR};
 
 const ACCOUNT_SEED: u64 = 93837778;
 
+/// Returns addresses of created accounts in ID format
 pub fn create_accounts(v: &dyn VM, count: u64, balance: &TokenAmount) -> Vec<Address> {
     create_accounts_seeded(v, count, balance, ACCOUNT_SEED, &TEST_FAUCET_ADDR)
 }
 
+/// Returns addresses of created accounts in ID format
 pub fn create_accounts_seeded(
     v: &dyn VM,
     count: u64,

--- a/integration_tests/src/util/workflows.rs
+++ b/integration_tests/src/util/workflows.rs
@@ -67,6 +67,7 @@ use fil_actors_runtime::test_utils::make_sealed_cid;
 use fil_actors_runtime::CRON_ACTOR_ADDR;
 use fil_actors_runtime::DATACAP_TOKEN_ACTOR_ADDR;
 use fil_actors_runtime::STORAGE_MARKET_ACTOR_ADDR;
+use fil_actors_runtime::STORAGE_MARKET_ACTOR_ID;
 use fil_actors_runtime::STORAGE_POWER_ACTOR_ADDR;
 use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
 use fil_actors_runtime::VERIFIED_REGISTRY_ACTOR_ADDR;
@@ -185,12 +186,14 @@ pub fn miner_prove_sector(
         Some(prove_commit_params),
     );
 
+    let worker_id = v.resolve_id_address(worker).unwrap().id().unwrap();
+
     ExpectInvocation {
-        from: *worker,
+        from: worker_id,
         to: *miner_id,
         method: MinerMethod::ProveCommitSector as u64,
         subinvocs: Some(vec![ExpectInvocation {
-            from: *miner_id,
+            from: miner_id.id().unwrap(),
             to: STORAGE_POWER_ACTOR_ADDR,
             method: PowerMethod::SubmitPoRepForBulkVerify as u64,
             ..Default::default()
@@ -219,7 +222,9 @@ pub fn precommit_sectors_v2(
     exp: Option<ChainEpoch>,
     v2: bool,
 ) -> Vec<SectorPreCommitOnChainInfo> {
-    let mid = v.resolve_id_address(maddr).unwrap();
+    let miner_id_address = v.resolve_id_address(maddr).unwrap();
+    let miner_id = miner_id_address.id().unwrap();
+    let worker_id = v.resolve_id_address(worker).unwrap().id().unwrap();
     let expiration = match exp {
         None => {
             v.epoch()
@@ -234,7 +239,8 @@ pub fn precommit_sectors_v2(
     let mut sectors_with_deals: Vec<SectorDeals> = vec![];
     while sector_idx < count {
         let msg_sector_idx_base = sector_idx;
-        let mut invocs = vec![Expect::reward_this_epoch(mid), Expect::power_current_total(mid)];
+        let mut invocs =
+            vec![Expect::reward_this_epoch(miner_id), Expect::power_current_total(miner_id)];
         if !v2 {
             let mut param_sectors = Vec::<PreCommitSectorParams>::new();
             let mut j = 0;
@@ -261,11 +267,11 @@ pub fn precommit_sectors_v2(
                 j += 1;
             }
             if !sectors_with_deals.is_empty() {
-                invocs.push(Expect::market_verify_deals(mid, sectors_with_deals.clone()));
+                invocs.push(Expect::market_verify_deals(miner_id, sectors_with_deals.clone()));
             }
             if param_sectors.len() > 1 {
                 invocs.push(Expect::burn(
-                    mid,
+                    miner_id,
                     Some(aggregate_pre_commit_network_fee(
                         param_sectors.len() as i64,
                         &TokenAmount::zero(),
@@ -273,7 +279,7 @@ pub fn precommit_sectors_v2(
                 ));
             }
             if expect_cron_enroll && msg_sector_idx_base == 0 {
-                invocs.push(Expect::power_enrol_cron(mid));
+                invocs.push(Expect::power_enrol_cron(miner_id));
             }
 
             apply_ok(
@@ -285,8 +291,8 @@ pub fn precommit_sectors_v2(
                 Some(PreCommitSectorBatchParams { sectors: param_sectors.clone() }),
             );
             let expect = ExpectInvocation {
-                from: *worker,
-                to: mid,
+                from: worker_id,
+                to: miner_id_address,
                 method: MinerMethod::PreCommitSectorBatch as u64,
                 params: Some(
                     IpldBlock::serialize_cbor(&PreCommitSectorBatchParams {
@@ -324,11 +330,11 @@ pub fn precommit_sectors_v2(
                 j += 1;
             }
             if !sectors_with_deals.is_empty() {
-                invocs.push(Expect::market_verify_deals(mid, sectors_with_deals.clone()));
+                invocs.push(Expect::market_verify_deals(miner_id, sectors_with_deals.clone()));
             }
             if param_sectors.len() > 1 {
                 invocs.push(Expect::burn(
-                    mid,
+                    miner_id,
                     Some(aggregate_pre_commit_network_fee(
                         param_sectors.len() as i64,
                         &TokenAmount::zero(),
@@ -336,7 +342,7 @@ pub fn precommit_sectors_v2(
                 ));
             }
             if expect_cron_enroll && msg_sector_idx_base == 0 {
-                invocs.push(Expect::power_enrol_cron(mid));
+                invocs.push(Expect::power_enrol_cron(miner_id));
             }
 
             apply_ok(
@@ -349,8 +355,8 @@ pub fn precommit_sectors_v2(
             );
 
             let expect = ExpectInvocation {
-                from: *worker,
-                to: mid,
+                from: worker_id,
+                to: miner_id_address,
                 method: MinerMethod::PreCommitSectorBatch2 as u64,
                 params: Some(
                     IpldBlock::serialize_cbor(&PreCommitSectorBatchParams2 {
@@ -365,7 +371,7 @@ pub fn precommit_sectors_v2(
         }
     }
     // extract chain state
-    let mstate: MinerState = get_state(v, &mid).unwrap();
+    let mstate: MinerState = get_state(v, &miner_id_address).unwrap();
     (0..count)
         .map(|i| {
             mstate
@@ -413,6 +419,8 @@ pub fn prove_commit_sectors(
     precommits: Vec<SectorPreCommitOnChainInfo>,
     aggregate_size: usize,
 ) {
+    let worker_id = v.resolve_id_address(worker).unwrap().id().unwrap();
+    let miner_id = v.resolve_id_address(maddr).unwrap().id().unwrap();
     let mut precommit_infos = precommits.as_slice();
     while !precommit_infos.is_empty() {
         let batch_size = min(aggregate_size, precommit_infos.len());
@@ -440,15 +448,15 @@ pub fn prove_commit_sectors(
         let expected_fee =
             aggregate_prove_commit_network_fee(to_prove.len() as i64, &TokenAmount::zero());
         ExpectInvocation {
-            from: *worker,
+            from: worker_id,
             to: *maddr,
             method: MinerMethod::ProveCommitAggregate as u64,
             params: Some(prove_commit_aggregate_params_ser),
             subinvocs: Some(vec![
-                Expect::reward_this_epoch(*maddr),
-                Expect::power_current_total(*maddr),
-                Expect::power_update_pledge(*maddr, None),
-                Expect::burn(*maddr, Some(expected_fee)),
+                Expect::reward_this_epoch(miner_id),
+                Expect::power_current_total(miner_id),
+                Expect::power_update_pledge(miner_id, None),
+                Expect::burn(miner_id, Some(expected_fee)),
             ]),
             ..Default::default()
         }
@@ -468,6 +476,8 @@ pub fn miner_extend_sector_expiration2(
     new_expiration: ChainEpoch,
     power_delta: PowerPair,
 ) {
+    let miner_id = miner.id().unwrap();
+    let worker_id = worker.id().unwrap();
     let extension_params = ExtendSectorExpiration2Params {
         extensions: vec![ExpirationExtension2 {
             deadline,
@@ -495,16 +505,16 @@ pub fn miner_extend_sector_expiration2(
 
     let mut subinvocs = vec![];
     if !claim_ids.is_empty() {
-        subinvocs.push(Expect::verifreg_get_claims(*miner, miner.id().unwrap(), claim_ids))
+        subinvocs.push(Expect::verifreg_get_claims(miner_id, miner_id, claim_ids))
     }
-    subinvocs.push(Expect::reward_this_epoch(*miner));
-    subinvocs.push(Expect::power_current_total(*miner));
+    subinvocs.push(Expect::reward_this_epoch(miner_id));
+    subinvocs.push(Expect::power_current_total(miner_id));
     if !power_delta.is_zero() {
-        subinvocs.push(Expect::power_update_claim(*miner, power_delta));
+        subinvocs.push(Expect::power_update_claim(miner_id, power_delta));
     }
 
     ExpectInvocation {
-        from: *worker,
+        from: worker_id,
         to: *miner,
         method: MinerMethod::ExtendSectorExpiration2 as u64,
         subinvocs: Some(subinvocs),
@@ -610,6 +620,8 @@ pub fn submit_windowed_post(
     partition_idx: u64,
     new_power: Option<PowerPair>,
 ) {
+    let miner_id = maddr.id().unwrap();
+    let worker_id = worker.id().unwrap();
     let params = SubmitWindowedPoStParams {
         deadline: dline_info.index,
         partitions: vec![PoStPartition { index: partition_idx, skipped: BitField::new() }],
@@ -633,12 +645,12 @@ pub fn submit_windowed_post(
         if new_pow == PowerPair::zero() {
             subinvocs = Some(vec![])
         } else {
-            subinvocs = Some(vec![Expect::power_update_claim(*maddr, new_pow)])
+            subinvocs = Some(vec![Expect::power_update_claim(miner_id, new_pow)])
         }
     }
 
     ExpectInvocation {
-        from: *worker,
+        from: worker_id,
         to: *maddr,
         method: MinerMethod::SubmitWindowedPoSt as u64,
         subinvocs,
@@ -686,6 +698,8 @@ pub fn withdraw_balance(
     to_withdraw_amount: &TokenAmount,
     expect_withdraw_amount: &TokenAmount,
 ) {
+    let from_id = v.resolve_id_address(from).unwrap().id().unwrap();
+    let miner_id = v.resolve_id_address(m_addr).unwrap().id().unwrap();
     let params = WithdrawBalanceParams { amount_requested: to_withdraw_amount.clone() };
     let withdraw_return: WithdrawBalanceReturn = apply_ok(
         v,
@@ -701,12 +715,12 @@ pub fn withdraw_balance(
     if expect_withdraw_amount.is_positive() {
         let withdraw_balance_params_se = IpldBlock::serialize_cbor(&params).unwrap();
         ExpectInvocation {
-            from: *from,
+            from: from_id,
             to: *m_addr,
             method: MinerMethod::WithdrawBalance as u64,
             params: Some(withdraw_balance_params_se),
             subinvocs: Some(vec![Expect::send(
-                *m_addr,
+                miner_id,
                 *from,
                 Some(expect_withdraw_amount.clone()),
             )]),
@@ -763,16 +777,16 @@ pub fn verifreg_add_verifier(v: &dyn VM, verifier: &Address, data_cap: StoragePo
         Some(proposal),
     );
     ExpectInvocation {
-        from: TEST_VERIFREG_ROOT_SIGNER_ADDR,
+        from: TEST_VERIFREG_ROOT_SIGNER_ID,
         to: TEST_VERIFREG_ROOT_ADDR,
         method: MultisigMethod::Propose as u64,
         subinvocs: Some(vec![ExpectInvocation {
-            from: TEST_VERIFREG_ROOT_ADDR,
+            from: TEST_VERIFREG_ROOT_ID,
             to: VERIFIED_REGISTRY_ACTOR_ADDR,
             method: VerifregMethod::AddVerifier as u64,
             params: Some(IpldBlock::serialize_cbor(&add_verifier_params).unwrap()),
             subinvocs: Some(vec![Expect::frc42_balance(
-                VERIFIED_REGISTRY_ACTOR_ADDR,
+                VERIFIED_REGISTRY_ACTOR_ID,
                 DATACAP_TOKEN_ACTOR_ADDR,
                 *verifier,
             )]),
@@ -789,6 +803,7 @@ pub fn verifreg_add_client(
     client: &Address,
     allowance: StoragePower,
 ) {
+    let verifier_id = v.resolve_id_address(verifier).unwrap().id().unwrap();
     let add_client_params =
         AddVerifiedClientParams { address: *client, allowance: allowance.clone() };
     apply_ok(
@@ -801,11 +816,11 @@ pub fn verifreg_add_client(
     );
     let allowance_tokens = TokenAmount::from_whole(allowance);
     ExpectInvocation {
-        from: *verifier,
+        from: verifier_id,
         to: VERIFIED_REGISTRY_ACTOR_ADDR,
         method: VerifregMethod::AddVerifiedClient as u64,
         subinvocs: Some(vec![ExpectInvocation {
-            from: VERIFIED_REGISTRY_ACTOR_ADDR,
+            from: VERIFIED_REGISTRY_ACTOR_ID,
             to: DATACAP_TOKEN_ACTOR_ADDR,
             method: DataCapMethod::MintExported as u64,
             params: Some(
@@ -817,7 +832,7 @@ pub fn verifreg_add_client(
                 .unwrap(),
             ),
             subinvocs: Some(vec![Expect::frc46_receiver(
-                DATACAP_TOKEN_ACTOR_ADDR,
+                DATACAP_TOKEN_ACTOR_ID,
                 *client,
                 DATACAP_TOKEN_ACTOR_ID,
                 client.id().unwrap(),
@@ -863,6 +878,7 @@ pub fn verifreg_remove_expired_allocations(
     ids: Vec<AllocationID>,
     datacap_refund: u64,
 ) {
+    let caller_id = v.resolve_id_address(caller).unwrap().id().unwrap();
     let params =
         RemoveExpiredAllocationsParams { client: client.id().unwrap(), allocation_ids: ids };
     apply_ok(
@@ -874,11 +890,11 @@ pub fn verifreg_remove_expired_allocations(
         Some(params),
     );
     ExpectInvocation {
-        from: *caller,
+        from: caller_id,
         to: VERIFIED_REGISTRY_ACTOR_ADDR,
         method: VerifregMethod::RemoveExpiredAllocations as u64,
         subinvocs: Some(vec![ExpectInvocation {
-            from: VERIFIED_REGISTRY_ACTOR_ADDR,
+            from: VERIFIED_REGISTRY_ACTOR_ID,
             to: DATACAP_TOKEN_ACTOR_ADDR,
             method: DataCapMethod::TransferExported as u64,
             params: Some(
@@ -890,7 +906,7 @@ pub fn verifreg_remove_expired_allocations(
                 .unwrap(),
             ),
             subinvocs: Some(vec![Expect::frc46_receiver(
-                DATACAP_TOKEN_ACTOR_ADDR,
+                DATACAP_TOKEN_ACTOR_ID,
                 *client,
                 VERIFIED_REGISTRY_ACTOR_ID,
                 client.id().unwrap(),
@@ -941,6 +957,7 @@ pub fn datacap_extend_claim(
         operator_data: operator_data.clone(),
     };
 
+    let client_id = v.resolve_id_address(client).unwrap().id().unwrap();
     apply_ok(
         v,
         client,
@@ -951,11 +968,11 @@ pub fn datacap_extend_claim(
     );
 
     ExpectInvocation {
-        from: *client,
+        from: client_id,
         to: DATACAP_TOKEN_ACTOR_ADDR,
         method: DataCapMethod::TransferExported as u64,
         subinvocs: Some(vec![ExpectInvocation {
-            from: DATACAP_TOKEN_ACTOR_ADDR,
+            from: DATACAP_TOKEN_ACTOR_ID,
             to: VERIFIED_REGISTRY_ACTOR_ADDR,
             method: VerifregMethod::UniversalReceiverHook as u64,
             params: Some(
@@ -977,7 +994,7 @@ pub fn datacap_extend_claim(
                 .unwrap(),
             ),
             subinvocs: Some(vec![Expect::frc46_burn(
-                VERIFIED_REGISTRY_ACTOR_ADDR,
+                VERIFIED_REGISTRY_ACTOR_ID,
                 DATACAP_TOKEN_ACTOR_ADDR,
                 token_amount,
             )]),
@@ -1016,6 +1033,7 @@ pub fn market_publish_deal(
     deal_start: ChainEpoch,
     deal_lifetime: ChainEpoch,
 ) -> PublishStorageDealsReturn {
+    let worker_id = v.resolve_id_address(worker).unwrap().id().unwrap();
     let label = Label::String(deal_label.to_string());
     let proposal = DealProposal {
         piece_cid: make_piece_cid(deal_label.as_bytes()),
@@ -1056,15 +1074,15 @@ pub fn market_publish_deal(
 
     let mut expect_publish_invocs = vec![
         ExpectInvocation {
-            from: STORAGE_MARKET_ACTOR_ADDR,
+            from: STORAGE_MARKET_ACTOR_ID,
             to: *miner_id,
             method: MinerMethod::IsControllingAddressExported as u64,
             ..Default::default()
         },
-        Expect::reward_this_epoch(STORAGE_MARKET_ACTOR_ADDR),
-        Expect::power_current_total(STORAGE_MARKET_ACTOR_ADDR),
+        Expect::reward_this_epoch(STORAGE_MARKET_ACTOR_ID),
+        Expect::power_current_total(STORAGE_MARKET_ACTOR_ID),
         Expect::frc44_authenticate(
-            STORAGE_MARKET_ACTOR_ADDR,
+            STORAGE_MARKET_ACTOR_ID,
             *deal_client,
             proposal_bytes.to_vec(),
             signature.bytes,
@@ -1077,7 +1095,7 @@ pub fn market_publish_deal(
             min(proposal.start_epoch, v.epoch() + MAXIMUM_VERIFIED_ALLOCATION_EXPIRATION);
 
         expect_publish_invocs.push(ExpectInvocation {
-            from: STORAGE_MARKET_ACTOR_ADDR,
+            from: STORAGE_MARKET_ACTOR_ID,
             to: DATACAP_TOKEN_ACTOR_ADDR,
             method: DataCapMethod::BalanceExported as u64,
             params: Some(IpldBlock::serialize_cbor(&deal_client).unwrap()),
@@ -1095,7 +1113,7 @@ pub fn market_publish_deal(
             extensions: vec![],
         };
         expect_publish_invocs.push(ExpectInvocation {
-            from: STORAGE_MARKET_ACTOR_ADDR,
+            from: STORAGE_MARKET_ACTOR_ID,
             to: DATACAP_TOKEN_ACTOR_ADDR,
             method: DataCapMethod::TransferFromExported as u64,
             params: Some(
@@ -1108,7 +1126,7 @@ pub fn market_publish_deal(
                 .unwrap(),
             ),
             subinvocs: Some(vec![ExpectInvocation {
-                from: DATACAP_TOKEN_ACTOR_ADDR,
+                from: DATACAP_TOKEN_ACTOR_ID,
                 to: VERIFIED_REGISTRY_ACTOR_ADDR,
                 method: VerifregMethod::UniversalReceiverHook as u64,
                 params: Some(
@@ -1135,13 +1153,13 @@ pub fn market_publish_deal(
         })
     }
     expect_publish_invocs.push(ExpectInvocation {
-        from: STORAGE_MARKET_ACTOR_ADDR,
+        from: STORAGE_MARKET_ACTOR_ID,
         to: *deal_client,
         method: MARKET_NOTIFY_DEAL_METHOD,
         ..Default::default()
     });
     ExpectInvocation {
-        from: *worker,
+        from: worker_id,
         to: STORAGE_MARKET_ACTOR_ADDR,
         method: MarketMethod::PublishStorageDeals as u64,
         subinvocs: Some(expect_publish_invocs),

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -320,7 +320,13 @@ where
             new_actor_addr_count: RefCell::new(0),
             circ_supply: TokenAmount::from_whole(1_000_000_000),
         };
-        let msg = InternalMessage { from: *from_id, to: *to, value: value.clone(), method, params };
+        let msg = InternalMessage {
+            from: from_id.id().unwrap(),
+            to: *to,
+            value: value.clone(),
+            method,
+            params,
+        };
         let mut new_ctx = InvocationCtx {
             v: self,
             top,

--- a/test_vm/src/messaging.rs
+++ b/test_vm/src/messaging.rs
@@ -22,9 +22,9 @@ use fil_actors_runtime::runtime::{
     ActorCode, DomainSeparationTag, MessageInfo, Policy, Primitives, Runtime, RuntimePolicy,
     Verifier, EMPTY_ARR_CID,
 };
-use fil_actors_runtime::test_utils::*;
 use fil_actors_runtime::{actor_error, SendError};
-use fil_actors_runtime::{ActorError, INIT_ACTOR_ADDR, SYSTEM_ACTOR_ADDR};
+use fil_actors_runtime::{test_utils::*, SYSTEM_ACTOR_ID};
+use fil_actors_runtime::{ActorError, INIT_ACTOR_ADDR};
 
 use fvm_ipld_blockstore::Blockstore;
 
@@ -59,7 +59,7 @@ use fvm_shared::{ActorID, MethodNum, Response, IPLD_RAW, METHOD_CONSTRUCTOR, MET
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::cell::{RefCell, RefMut};
-use vm_api::trace::InvocationTrace;
+use vm_api::trace::{InvocationResult, InvocationTrace};
 use vm_api::util::get_state;
 use vm_api::{new_actor, ActorState, VM};
 
@@ -77,7 +77,7 @@ pub struct TopCtx {
 
 #[derive(Clone, Debug)]
 pub struct InternalMessage {
-    pub from: Address,
+    pub from: ActorID,
     pub to: Address,
     pub value: TokenAmount,
     pub method: MethodNum,
@@ -92,7 +92,7 @@ where
         self.top.originator_call_seq
     }
     fn caller(&self) -> Address {
-        self.msg.from
+        Address::new_id(self.msg.from)
     }
     fn origin(&self) -> Address {
         Address::new_id(self.resolve_address(&self.top.originator_stable_addr).unwrap())
@@ -171,7 +171,7 @@ where
         self.v.set_actor(&INIT_ACTOR_ADDR, init_actor);
 
         let new_actor_msg = InternalMessage {
-            from: SYSTEM_ACTOR_ADDR,
+            from: SYSTEM_ACTOR_ID,
             to: target_id_addr,
             value: TokenAmount::zero(),
             method: METHOD_CONSTRUCTOR,
@@ -223,8 +223,8 @@ where
             value: msg.value,
             method: msg.method,
             params: msg.params,
-            code,
-            ret,
+            // Actors don't return CallErrors
+            result: InvocationResult::CallReturn { return_value: ret, exit_code: code },
             subinvocations: self.subinvocations.take(),
         }
     }
@@ -237,7 +237,7 @@ where
         let prior_root = self.v.checkpoint();
 
         // Transfer funds
-        let mut from_actor = self.v.actor(&self.msg.from).unwrap();
+        let mut from_actor = self.v.actor(&Address::new_id(self.msg.from)).unwrap();
         if !self.msg.value.is_zero() {
             if self.msg.value.is_negative() {
                 return Err(ActorError::unchecked(
@@ -261,7 +261,7 @@ where
 
         // Load, deduct, store from actor before loading to actor to handle self-send case
         from_actor.balance -= &self.msg.value;
-        self.v.set_actor(&self.msg.from, from_actor);
+        self.v.set_actor(&Address::new_id(self.msg.from), from_actor);
 
         let (mut to_actor, ref to_addr) = self.resolve_target(&self.msg.to)?;
         to_actor.balance = to_actor.balance.add(&self.msg.value);
@@ -436,7 +436,7 @@ where
         }
         self.caller_validated.replace(true);
         for addr in addresses {
-            if *addr == self.msg.from {
+            if *addr == Address::new_id(self.msg.from) {
                 return Ok(());
             }
         }
@@ -457,7 +457,8 @@ where
             ));
         }
         self.caller_validated.replace(true);
-        let to_match = ACTOR_TYPES.get(&self.v.actor(&self.msg.from).unwrap().code).unwrap();
+        let to_match =
+            ACTOR_TYPES.get(&self.v.actor(&Address::new_id(self.msg.from)).unwrap().code).unwrap();
         if types.into_iter().any(|t| *t == *to_match) {
             return Ok(());
         }
@@ -510,7 +511,9 @@ where
             return Ok(Response { exit_code: ExitCode::SYS_ASSERTION_FAILED, return_data: None });
         }
 
-        let new_actor_msg = InternalMessage { from: self.to(), to: *to, value, method, params };
+        let from_id = self.resolve_address(&self.to()).unwrap();
+
+        let new_actor_msg = InternalMessage { from: from_id, to: *to, value, method, params };
         let mut new_ctx = InvocationCtx {
             v: self.v,
             top: self.top.clone(),

--- a/test_vm/src/messaging.rs
+++ b/test_vm/src/messaging.rs
@@ -59,7 +59,7 @@ use fvm_shared::{ActorID, MethodNum, Response, IPLD_RAW, METHOD_CONSTRUCTOR, MET
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::cell::{RefCell, RefMut};
-use vm_api::trace::{InvocationResult, InvocationTrace};
+use vm_api::trace::InvocationTrace;
 use vm_api::util::get_state;
 use vm_api::{new_actor, ActorState, VM};
 
@@ -223,8 +223,10 @@ where
             value: msg.value,
             method: msg.method,
             params: msg.params,
-            // Actors don't return CallErrors
-            result: InvocationResult::CallReturn { return_value: ret, exit_code: code },
+            // Actors should wrap syscall errors
+            error_number: None,
+            return_value: ret,
+            exit_code: code,
             subinvocations: self.subinvocations.take(),
         }
     }


### PR DESCRIPTION
A more portable format for invocation traces that are designed to work on real FVMs such as https://github.com/anorth/fvm-workbench/pull/24

Closes https://github.com/filecoin-project/builtin-actors/issues/1365