### PR TITLE
Speed up very slow market test

### DIFF
--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -821,14 +821,17 @@ pub fn expect_query_network_info(rt: &MockRuntime) {
     );
 }
 
-pub fn assert_n_good_deals<BS>(dobe: &SetMultimap<BS>, epoch: ChainEpoch, n: isize)
-where
+pub fn assert_n_good_deals<BS>(
+    dobe: &SetMultimap<BS>,
+    updates_interval: ChainEpoch,
+    epoch: ChainEpoch,
+    n: isize,
+) where
     BS: fvm_ipld_blockstore::Blockstore,
 {
-    let deal_updates_interval = Policy::default().deal_updates_interval;
     let mut count = 0;
     dobe.for_each(epoch, |id| {
-        assert_eq!(epoch % deal_updates_interval, (id as i64) % deal_updates_interval);
+        assert_eq!(epoch % updates_interval, (id as i64) % updates_interval);
         count += 1;
         Ok(())
     })

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -485,6 +485,10 @@ pub fn expect_abort<T: fmt::Debug>(exit_code: ExitCode, res: Result<T, ActorErro
 impl<BS: Blockstore> MockRuntime<BS> {
     ///// Runtime access for tests /////
 
+    pub fn set_policy(&mut self, policy: Policy) {
+        self.policy = policy;
+    }
+
     pub fn get_state<T: DeserializeOwned>(&self) -> T {
         self.store_get(self.state.borrow().as_ref().unwrap())
     }


### PR DESCRIPTION
Some market tests iterated a number of times proportional to the deal updates interval, which was recently multiplied by 30. This change sets the policy update interval for those tests explicitly. We can probably gain quite a bit by setting explicit policy through many tests.