### PR TITLE
Refactor: extract precommit validation and svi conversion to shared method

### DIFF
--- a/actors/market/src/deal.rs
+++ b/actors/market/src/deal.rs
@@ -11,6 +11,7 @@ use fvm_shared::commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED};
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PaddedPieceSize;
+use fvm_shared::sector::SectorNumber;
 use libipld_core::ipld::Ipld;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::{TryFrom, TryInto};
@@ -136,6 +137,8 @@ pub struct ClientDealProposal {
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy, Serialize_tuple, Deserialize_tuple)]
 pub struct DealState {
+    // 0 if not yet included in proven sector (0 is also a valid sector number)
+    pub sector_number: SectorNumber,
     // -1 if not yet included in proven sector
     pub sector_start_epoch: ChainEpoch,
     // -1 if deal state never updated

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -6,10 +6,11 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use cid::multihash::{Code, MultihashDigest, MultihashGeneric};
 use cid::Cid;
-use fil_actors_runtime::{extract_send_result, BatchReturnGen, FIRST_ACTOR_SPECIFIC_EXIT_CODE};
 use frc46_token::token::types::{BalanceReturn, TransferFromParams, TransferFromReturn};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
@@ -19,14 +20,14 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::reward::ThisEpochRewardReturn;
-use fvm_shared::sector::{RegisteredSealProof, SectorSize, StoragePower};
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber, SectorSize, StoragePower};
+use fvm_shared::sys::SendFlags;
 use fvm_shared::{ActorID, METHOD_CONSTRUCTOR, METHOD_SEND};
 use integer_encoding::VarInt;
 use log::info;
 use num_derive::FromPrimitive;
 use num_traits::Zero;
 
-use crate::balance_table::BalanceTable;
 use fil_actors_runtime::cbor::{deserialize, serialize};
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Policy, Runtime};
@@ -35,10 +36,9 @@ use fil_actors_runtime::{
     AsActorError, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR, DATACAP_TOKEN_ACTOR_ADDR,
     REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
-use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
-use fvm_shared::sys::SendFlags;
+use fil_actors_runtime::{extract_send_result, BatchReturnGen, FIRST_ACTOR_SPECIFIC_EXIT_CODE};
 
+use crate::balance_table::BalanceTable;
 use crate::ext::verifreg::{AllocationID, AllocationRequest};
 
 pub use self::deal::*;
@@ -541,6 +541,7 @@ impl Actor {
             let mut batch_gen = BatchReturnGen::new(params.sectors.len());
             let mut activations: Vec<SectorDealActivation> = vec![];
             let mut activated_deals: HashSet<DealID> = HashSet::new();
+            let mut sector_deals: Vec<(SectorNumber, SectorDealIDs)> = vec![];
 
             for p in params.sectors {
                 let proposal_array = st.get_proposal_array(rt.store())?;
@@ -577,6 +578,8 @@ impl Actor {
                         continue;
                     }
                 };
+
+                sector_deals.push((p.sector_number, SectorDealIDs { deals: p.deal_ids.clone() }));
 
                 // Update deal states
                 let mut verified_infos = Vec::new();
@@ -632,6 +635,7 @@ impl Actor {
                         deal_states.push((
                             *deal_id,
                             DealState {
+                                sector_number: p.sector_number,
                                 sector_start_epoch: curr_epoch,
                                 last_updated_epoch: EPOCH_UNDEFINED,
                                 slash_epoch: EPOCH_UNDEFINED,
@@ -664,8 +668,8 @@ impl Actor {
                 }
             }
 
+            st.put_sector_deal_ids(rt.store(), &miner_addr, &sector_deals)?;
             st.put_deal_states(rt.store(), &deal_states)?;
-
             Ok((activations, batch_gen.gen()))
         })?;
 
@@ -683,10 +687,18 @@ impl Actor {
         let miner_addr = rt.message().caller();
 
         rt.transaction(|st: &mut State, rt| {
-            let mut deal_states: Vec<(DealID, DealState)> = vec![];
+            // The sector deals mapping is removed all at once.
+            // Other deal clean-up is deferred to cron.
+            let sector_deals =
+                st.pop_sector_deal_ids(rt.store(), &miner_addr, params.sectors.iter())?;
+            let all_deal_ids = sector_deals
+                .iter()
+                .flat_map(|(_, deal_ids)| deal_ids.deals.iter())
+                .collect::<Vec<_>>();
 
-            for id in params.deal_ids {
-                let deal = st.find_proposal(rt.store(), id)?;
+            let mut deal_states: Vec<(DealID, DealState)> = vec![];
+            for id in all_deal_ids {
+                let deal = st.find_proposal(rt.store(), *id)?;
                 // The deal may have expired and been deleted before the sector is terminated.
                 // Nothing to do, but continue execution for the other deals.
                 if deal.is_none() {
@@ -712,7 +724,7 @@ impl Actor {
                 }
 
                 let mut state: DealState = st
-                    .find_deal_state(rt.store(), id)?
+                    .find_deal_state(rt.store(), *id)?
                     // A deal with a proposal but no state is not activated, but then it should not be
                     // part of a sector that is terminating.
                     .ok_or_else(|| actor_error!(illegal_argument, "no state for deal {}", id))?;
@@ -727,7 +739,7 @@ impl Actor {
                 // and slashing of provider collateral happens in cron_tick.
                 state.slash_epoch = params.epoch;
 
-                deal_states.push((id, state));
+                deal_states.push((*id, state));
             }
 
             st.put_deal_states(rt.store(), &deal_states)?;
@@ -744,6 +756,10 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             let last_cron = st.last_cron;
+            let mut provider_deals_to_remove: BTreeMap<
+                Address,
+                BTreeMap<SectorNumber, Vec<DealID>>,
+            > = BTreeMap::new();
             let mut new_updates_scheduled: BTreeMap<ChainEpoch, Vec<DealID>> = BTreeMap::new();
             let mut epochs_completed: Vec<ChainEpoch> = vec![];
 
@@ -828,7 +844,14 @@ impl Actor {
 
                         // Delete proposal and state simultaneously.
                         let deleted = st.remove_deal_state(rt.store(), deal_id)?;
-                        if deleted.is_none() {
+                        if let Some(deleted) = deleted {
+                            provider_deals_to_remove
+                                .entry(deal.provider)
+                                .or_default()
+                                .entry(deleted.sector_number)
+                                .or_default()
+                                .push(deal_id);
+                        } else {
                             return Err(actor_error!(
                                 illegal_state,
                                 "failed to delete deal state: does not exist"
@@ -868,7 +891,9 @@ impl Actor {
                 }
                 epochs_completed.push(i);
             }
-
+            // Remove the provider->sector->deal mappings.
+            // The sectors may still have other deals, so we can't remove the sector altogether.
+            st.remove_sector_deal_ids(rt.store(), &provider_deals_to_remove)?;
             st.remove_deals_by_epoch(rt.store(), &epochs_completed)?;
             st.put_batch_deals_by_epoch(rt.store(), &new_updates_scheduled)?;
             st.last_cron = rt.curr_epoch();
@@ -1420,6 +1445,11 @@ fn request_current_network_power(
 }
 
 pub fn deal_id_key(k: DealID) -> BytesKey {
+    let bz = k.encode_var_vec();
+    bz.into()
+}
+
+pub fn sector_number_key(k: SectorNumber) -> BytesKey {
     let bz = k.encode_var_vec();
     bz.into()
 }

--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -159,6 +159,27 @@ impl State {
             + &self.total_client_storage_fee
     }
 
+    pub fn load_deal_states<'bs, BS>(
+        &self,
+        store: &'bs BS,
+    ) -> Result<DealMetaArray<'bs, BS>, ActorError>
+    where
+        BS: Blockstore,
+    {
+        DealMetaArray::load(&self.states, store)
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load deal state array")
+    }
+
+    fn save_deal_states<BS>(&mut self, states: &mut DealMetaArray<BS>) -> Result<(), ActorError>
+    where
+        BS: Blockstore,
+    {
+        self.states = states
+            .flush()
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush deal states")?;
+        Ok(())
+    }
+
     pub fn find_deal_state<BS>(
         &self,
         store: &BS,
@@ -167,14 +188,8 @@ impl State {
     where
         BS: Blockstore,
     {
-        let states = DealMetaArray::load(&self.states, store)
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load deal state array")?;
-
-        let found = states.get(deal_id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
-            format!("no such deal state for {}", deal_id)
-        })?;
-
-        Ok(found.cloned())
+        let states = self.load_deal_states(store)?;
+        find_deal_state(&states, deal_id)
     }
 
     pub fn put_deal_states<BS>(
@@ -185,21 +200,14 @@ impl State {
     where
         BS: Blockstore,
     {
-        let mut states = DealMetaArray::load(&self.states, store)
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load deal proposal array")?;
-
+        let mut states = self.load_deal_states(store)?;
         new_deal_states.iter().try_for_each(|(id, deal_state)| -> Result<(), ActorError> {
             states
                 .set(*id, *deal_state)
                 .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to set deal state")?;
             Ok(())
         })?;
-
-        self.states = states
-            .flush()
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush deal states")?;
-
-        Ok(())
+        self.save_deal_states(&mut states)
     }
 
     pub fn remove_deal_state<BS>(
@@ -210,28 +218,20 @@ impl State {
     where
         BS: Blockstore,
     {
-        let mut states = DealMetaArray::load(&self.states, store)
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load deal proposal array")?;
-
-        let rval_deal_state = states
+        let mut states = self.load_deal_states(store)?;
+        let removed = states
             .delete(deal_id)
             .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to delete deal state")?;
-
-        self.states = states
-            .flush()
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush deal states")?;
-
-        Ok(rval_deal_state)
+        self.save_deal_states(&mut states)?;
+        Ok(removed)
     }
 
-    pub fn get_proposal_array<'a, BS>(&'a self, store: &'a BS) -> Result<DealArray<BS>, ActorError>
+    pub fn load_proposals<'bs, BS>(&self, store: &'bs BS) -> Result<DealArray<'bs, BS>, ActorError>
     where
         BS: Blockstore,
     {
-        let deal_proposals = DealArray::load(&self.proposals, store)
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load deal proposal array")?;
-
-        Ok(deal_proposals)
+        DealArray::load(&self.proposals, store)
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load deal proposal array")
     }
 
     pub fn get_proposal<BS: Blockstore>(
@@ -239,15 +239,7 @@ impl State {
         store: &BS,
         id: DealID,
     ) -> Result<DealProposal, ActorError> {
-        let found = self.find_proposal(store, id)?.ok_or_else(|| {
-            if id < self.next_id {
-                // If the deal ID has been used, it must have been cleaned up.
-                ActorError::unchecked(EX_DEAL_EXPIRED, format!("deal {} expired", id))
-            } else {
-                ActorError::not_found(format!("no such deal {}", id))
-            }
-        })?;
-        Ok(found)
+        get_proposal(&self.load_proposals(store)?, id, self.next_id)
     }
 
     pub fn find_proposal<BS>(
@@ -258,14 +250,7 @@ impl State {
     where
         BS: Blockstore,
     {
-        let deal_proposals = self.get_proposal_array(store)?;
-
-        let proposal =
-            deal_proposals.get(deal_id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
-                format!("failed to load deal proposal {}", deal_id)
-            })?;
-
-        Ok(proposal.cloned())
+        find_proposal(&self.load_proposals(store)?, deal_id)
     }
 
     pub fn remove_proposal<BS>(
@@ -317,6 +302,32 @@ impl State {
         Ok(())
     }
 
+    pub fn load_pending_deal_allocation_ids<BS>(
+        &mut self,
+        store: BS,
+    ) -> Result<PendingDealAllocationsMap<BS>, ActorError>
+    where
+        BS: Blockstore,
+    {
+        PendingDealAllocationsMap::load(
+            store,
+            &self.pending_deal_allocation_ids,
+            PENDING_ALLOCATIONS_CONFIG,
+            "pending deal allocations",
+        )
+    }
+
+    pub fn save_pending_deal_allocation_ids<BS>(
+        &mut self,
+        pending_deal_allocation_ids: &mut PendingDealAllocationsMap<BS>,
+    ) -> Result<(), ActorError>
+    where
+        BS: Blockstore,
+    {
+        self.pending_deal_allocation_ids = pending_deal_allocation_ids.flush()?;
+        Ok(())
+    }
+
     pub fn put_pending_deal_allocation_ids<BS>(
         &mut self,
         store: &BS,
@@ -325,21 +336,14 @@ impl State {
     where
         BS: Blockstore,
     {
-        let mut pending_deal_allocation_ids = PendingDealAllocationsMap::load(
-            store,
-            &self.pending_deal_allocation_ids,
-            PENDING_ALLOCATIONS_CONFIG,
-            "pending deal allocations",
-        )?;
-
+        let mut pending_deal_allocation_ids = self.load_pending_deal_allocation_ids(store)?;
         new_pending_deal_allocation_ids.iter().try_for_each(
             |(deal_id, allocation_id)| -> Result<(), ActorError> {
                 pending_deal_allocation_ids.set(deal_id, *allocation_id)?;
                 Ok(())
             },
         )?;
-
-        self.pending_deal_allocation_ids = pending_deal_allocation_ids.flush()?;
+        self.save_pending_deal_allocation_ids(&mut pending_deal_allocation_ids)?;
         Ok(())
     }
 
@@ -351,12 +355,7 @@ impl State {
     where
         BS: Blockstore,
     {
-        let pending_deal_allocation_ids = PendingDealAllocationsMap::load(
-            store,
-            &self.pending_deal_allocation_ids,
-            PENDING_ALLOCATIONS_CONFIG,
-            "pending deal allocations",
-        )?;
+        let pending_deal_allocation_ids = self.load_pending_deal_allocation_ids(store)?;
 
         let mut allocation_ids: Vec<AllocationID> = vec![];
         deal_id_keys.iter().try_for_each(|deal_id| -> Result<(), ActorError> {
@@ -373,26 +372,15 @@ impl State {
     pub fn remove_pending_deal_allocation_id<BS>(
         &mut self,
         store: &BS,
-        deal_id_key: DealID,
+        deal_id: DealID,
     ) -> Result<Option<AllocationID>, ActorError>
     where
         BS: Blockstore,
     {
-        let mut pending_deal_allocation_ids = PendingDealAllocationsMap::load(
-            store,
-            &self.pending_deal_allocation_ids,
-            PENDING_ALLOCATIONS_CONFIG,
-            "pending deal allocations",
-        )?;
-
-        let rval_allocation_id = pending_deal_allocation_ids
-            .delete(&deal_id_key)
-            .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
-                format!("no such deal proposal {:#?}", deal_id_key)
-            })?;
-
-        self.pending_deal_allocation_ids = pending_deal_allocation_ids.flush()?;
-        Ok(rval_allocation_id)
+        let mut pending_deal_allocation_ids = self.load_pending_deal_allocation_ids(store)?;
+        let maybe_alloc_id = pending_deal_allocation_ids.delete(&deal_id)?;
+        self.save_pending_deal_allocation_ids(&mut pending_deal_allocation_ids)?;
+        Ok(maybe_alloc_id)
     }
 
     pub fn put_deals_by_epoch<BS>(
@@ -531,18 +519,30 @@ impl State {
         Ok(ex)
     }
 
-    pub fn has_pending_deal<BS>(&self, store: &BS, key: Cid) -> Result<bool, ActorError>
+    pub fn load_pending_deals<'bs, BS>(&self, store: &'bs BS) -> Result<Set<'bs, BS>, ActorError>
     where
         BS: Blockstore,
     {
-        let pending_deals = Set::from_root(store, &self.pending_proposals)
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to get pending deals")?;
+        Set::from_root(store, &self.pending_proposals)
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to get pending deals")
+    }
 
-        let rval = pending_deals
-            .has(&key.to_bytes())
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to get pending deals")?;
+    fn save_pending_deals<BS>(&mut self, pending_deals: &mut Set<BS>) -> Result<(), ActorError>
+    where
+        BS: Blockstore,
+    {
+        self.pending_proposals = pending_deals
+            .root()
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush pending deals")?;
+        Ok(())
+    }
 
-        Ok(rval)
+    pub fn has_pending_deal<BS>(&self, store: &BS, key: &Cid) -> Result<bool, ActorError>
+    where
+        BS: Blockstore,
+    {
+        let pending_deals = self.load_pending_deals(store)?;
+        has_pending_deal(&pending_deals, key)
     }
 
     pub fn put_pending_deals<BS>(
@@ -553,9 +553,7 @@ impl State {
     where
         BS: Blockstore,
     {
-        let mut pending_deals = Set::from_root(store, &self.pending_proposals)
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load pending deals")?;
-
+        let mut pending_deals = self.load_pending_deals(store)?;
         new_pending_deals.iter().try_for_each(|key: &Cid| -> Result<(), ActorError> {
             pending_deals
                 .put(key.to_bytes().into())
@@ -563,11 +561,7 @@ impl State {
             Ok(())
         })?;
 
-        self.pending_proposals = pending_deals
-            .root()
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush pending deals")?;
-
-        Ok(())
+        self.save_pending_deals(&mut pending_deals)
     }
 
     pub fn remove_pending_deal<BS>(
@@ -578,20 +572,15 @@ impl State {
     where
         BS: Blockstore,
     {
-        let mut pending_deals = Set::from_root(store, &self.pending_proposals)
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load pending deals")?;
-
-        let rval_pending_deal = pending_deals
+        let mut pending_deals = self.load_pending_deals(store)?;
+        let removed = pending_deals
             .delete(&pending_deal_key.to_bytes())
             .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
                 format!("failed to delete pending proposal {}", pending_deal_key)
             })?;
 
-        self.pending_proposals = pending_deals
-            .root()
-            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to flush pending deals")?;
-
-        Ok(rval_pending_deal)
+        self.save_pending_deals(&mut pending_deals)?;
+        Ok(removed)
     }
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -1085,6 +1074,57 @@ fn deal_get_payment_remaining(
     }
 
     Ok(&deal.storage_price_per_epoch * duration_remaining as u64)
+}
+
+pub fn get_proposal<BS: Blockstore>(
+    proposals: &DealArray<BS>,
+    id: DealID,
+    next_id: DealID,
+) -> Result<DealProposal, ActorError> {
+    let found = find_proposal(proposals, id)?.ok_or_else(|| {
+        if id < next_id {
+            // If the deal ID has been used, it must have been cleaned up.
+            ActorError::unchecked(EX_DEAL_EXPIRED, format!("deal {} expired", id))
+        } else {
+            ActorError::not_found(format!("no such deal {}", id))
+        }
+    })?;
+    Ok(found)
+}
+
+pub fn find_proposal<BS>(
+    proposals: &DealArray<BS>,
+    deal_id: DealID,
+) -> Result<Option<DealProposal>, ActorError>
+where
+    BS: Blockstore,
+{
+    let proposal = proposals.get(deal_id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+        format!("failed to load deal proposal {}", deal_id)
+    })?;
+    Ok(proposal.cloned())
+}
+
+pub fn find_deal_state<BS>(
+    states: &DealMetaArray<BS>,
+    deal_id: DealID,
+) -> Result<Option<DealState>, ActorError>
+where
+    BS: Blockstore,
+{
+    let state = states.get(deal_id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+        format!("failed to load deal state {}", deal_id)
+    })?;
+    Ok(state.cloned())
+}
+
+pub fn has_pending_deal<BS>(pending: &Set<BS>, key: &Cid) -> Result<bool, ActorError>
+where
+    BS: Blockstore,
+{
+    pending
+        .has(&key.to_bytes())
+        .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to lookup pending deal")
 }
 
 fn load_provider_sector_deals<BS>(

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -17,7 +17,7 @@ use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::ActorID;
 
 use crate::Label;
-use fvm_shared::sector::RegisteredSealProof;
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
 
 use super::deal::{ClientDealProposal, DealProposal, DealState};
 
@@ -54,10 +54,10 @@ pub struct GetBalanceReturn {
     pub locked: TokenAmount,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, PartialEq)] // Add Eq when BitField does
 pub struct OnMinerSectorsTerminateParams {
     pub epoch: ChainEpoch,
-    pub deal_ids: Vec<DealID>,
+    pub sectors: BitField,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
@@ -79,6 +79,7 @@ pub struct VerifyDealsForActivationParams {
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
 pub struct SectorDeals {
+    pub sector_number: SectorNumber,
     pub sector_type: RegisteredSealProof,
     pub sector_expiry: ChainEpoch,
     pub deal_ids: Vec<DealID>,

--- a/actors/market/tests/activate_deal_failures.rs
+++ b/actors/market/tests/activate_deal_failures.rs
@@ -1,25 +1,27 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fil_actor_market::{Actor as MarketActor, Method, SectorDeals, State, EX_DEAL_EXPIRED};
-use fil_actor_market::{BatchActivateDealsParams, BatchActivateDealsResult};
+use fvm_shared::address::Address;
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::deal::DealID;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
+use fvm_shared::METHOD_SEND;
+use num_traits::Zero;
+
+use fil_actor_market::ext::miner::{PieceReturn, SectorChanges};
+use fil_actor_market::BatchActivateDealsResult;
+use fil_actor_market::{DealProposal, SectorDeals, EX_DEAL_EXPIRED, NO_ALLOCATION_ID};
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
-use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::test_utils::*;
 use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
-use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_shared::address::Address;
-use fvm_shared::deal::DealID;
-use fvm_shared::error::ExitCode;
-use fvm_shared::sector::RegisteredSealProof;
-use fvm_shared::METHOD_SEND;
+use harness::*;
 
 mod harness;
 
-use harness::*;
-
 #[test]
-fn fail_when_caller_is_not_the_provider_of_the_deal() {
+fn reject_caller_not_provider() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
@@ -27,154 +29,120 @@ fn fail_when_caller_is_not_the_provider_of_the_deal() {
     let rt = setup();
     let provider2_addr = Address::new_id(201);
     let addrs = MinerAddresses { provider: provider2_addr, ..MinerAddresses::default() };
-    let deal_id = generate_and_publish_deal(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch);
+    let deal = generate_deal_and_add_funds(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch);
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addrs.worker);
+    let deal_id =
+        publish_deals(&rt, &addrs, &[deal.clone()], TokenAmount::zero(), NO_ALLOCATION_ID)[0];
 
-    let res = batch_activate_deals_raw(
-        &rt,
-        PROVIDER_ADDR,
-        vec![SectorDeals {
-            sector_number: 1,
-            sector_expiry,
-            sector_type: RegisteredSealProof::StackedDRG8MiBV1,
-            deal_ids: vec![deal_id],
-        }],
-        false,
-    )
-    .unwrap();
-    let res: BatchActivateDealsResult =
-        res.unwrap().deserialize().expect("BatchActivateDealsResult failed to deserialize");
-
-    assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_FORBIDDEN]);
-
+    assert_activation_failure(&rt, deal_id, &deal, 1, sector_expiry, ExitCode::USR_FORBIDDEN);
     rt.verify();
     check_state(&rt);
 }
 
 #[test]
-fn fail_when_caller_is_not_a_storage_miner_actor() {
-    let rt = setup();
-    rt.expect_validate_caller_type(vec![Type::Miner]);
-    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, PROVIDER_ADDR);
-
-    let sector_activation = SectorDeals {
-        sector_number: 1,
-        deal_ids: vec![],
-        sector_expiry: 0,
-        sector_type: RegisteredSealProof::StackedDRG8MiBV1,
-    };
-    let params = BatchActivateDealsParams { sectors: vec![sector_activation], compute_cid: false };
-
-    expect_abort(
-        ExitCode::USR_FORBIDDEN,
-        rt.call::<MarketActor>(
-            Method::BatchActivateDeals as u64,
-            IpldBlock::serialize_cbor(&params).unwrap(),
-        ),
-    );
-
-    rt.verify();
-    check_state(&rt);
-}
-
-#[test]
-fn fail_when_deal_has_not_been_published_before() {
-    let rt = setup();
-
-    let res = batch_activate_deals_raw(
-        &rt,
-        PROVIDER_ADDR,
-        vec![SectorDeals {
-            sector_number: 1,
-            sector_type: RegisteredSealProof::StackedDRG8MiBV1,
-            sector_expiry: EPOCHS_IN_DAY,
-            deal_ids: vec![DealID::from(42u32)],
-        }],
-        false,
-    )
-    .unwrap();
-    let res: BatchActivateDealsResult =
-        res.unwrap().deserialize().expect("BatchActivateDealsResult failed to deserialize");
-
-    assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_NOT_FOUND]);
-
-    rt.verify();
-    check_state(&rt);
-}
-
-#[test]
-fn fail_when_deal_has_already_been_activated() {
+fn reject_unknown_deal() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
 
     let rt = setup();
-    let deal_id = generate_and_publish_deal(
+    let deal = generate_deal_proposal(CLIENT_ADDR, PROVIDER_ADDR, start_epoch, end_epoch);
+    assert_activation_failure(&rt, 1234, &deal, 1, sector_expiry, ExitCode::USR_NOT_FOUND);
+    rt.verify();
+    check_state(&rt);
+}
+
+#[test]
+fn reject_deal_already_active() {
+    let start_epoch = 10;
+    let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+    let sector_expiry = end_epoch + 100;
+
+    let rt = setup();
+    let addrs = MinerAddresses::default();
+    let deal = generate_deal_and_add_funds(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch);
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addrs.worker);
+    let deal_id =
+        publish_deals(&rt, &addrs, &[deal.clone()], TokenAmount::zero(), NO_ALLOCATION_ID)[0];
+    let sno = 7;
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, sno, &[deal_id]);
+
+    assert_activation_failure(
         &rt,
-        CLIENT_ADDR,
-        &MinerAddresses::default(),
-        start_epoch,
-        end_epoch,
+        deal_id,
+        &deal,
+        sno,
+        sector_expiry,
+        ExitCode::USR_ILLEGAL_ARGUMENT,
     );
-    let sector_number = 7;
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, sector_number, &[deal_id]);
-
-    let res = batch_activate_deals_raw(
-        &rt,
-        PROVIDER_ADDR,
-        vec![SectorDeals {
-            sector_number: sector_number + 1,
-            sector_type: RegisteredSealProof::StackedDRG8MiBV1,
-            sector_expiry,
-            deal_ids: vec![deal_id],
-        }],
-        false,
-    )
-    .unwrap();
-    let res: BatchActivateDealsResult =
-        res.unwrap().deserialize().expect("BatchActivateDealsResult failed to deserialize");
-
-    assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_ILLEGAL_ARGUMENT]);
 
     rt.verify();
     check_state(&rt);
 }
 
 #[test]
-fn fail_when_deal_has_already_been_expired() {
+fn reject_proposal_expired() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
 
     let rt = setup();
-    let deal_id = generate_and_publish_deal(
-        &rt,
-        CLIENT_ADDR,
-        &MinerAddresses::default(),
-        start_epoch,
-        end_epoch,
-    );
-
-    let deal_proposal = get_deal_proposal(&rt, deal_id);
+    let addrs = MinerAddresses::default();
+    let deal = generate_deal_and_add_funds(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch);
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, addrs.worker);
+    let deal_id =
+        publish_deals(&rt, &addrs, &[deal.clone()], TokenAmount::zero(), NO_ALLOCATION_ID)[0];
 
     let current = end_epoch + 25;
     rt.set_epoch(current);
+    assert_activation_failure(&rt, deal_id, &deal, 1, sector_expiry, EX_DEAL_EXPIRED);
+
+    // Show the same behaviour after the deal is cleaned up from state.
     rt.expect_send_simple(
         BURNT_FUNDS_ACTOR_ADDR,
         METHOD_SEND,
         None,
-        deal_proposal.provider_collateral.clone(),
+        deal.provider_collateral.clone(),
         None,
         ExitCode::OK,
     );
-
     cron_tick(&rt);
+    assert_deal_deleted(&rt, deal_id, &deal, 0);
 
-    assert_deal_deleted(&rt, deal_id, deal_proposal, 0);
+    assert_activation_failure(&rt, deal_id, &deal, 1, sector_expiry, EX_DEAL_EXPIRED);
+}
 
-    let mut st: State = rt.get_state::<State>();
-    st.next_id = deal_id + 1;
+// Verifies that a deal cannot be activated via either BatchActivateDeals or SectorContentChanged.
+fn assert_activation_failure(
+    rt: &MockRuntime,
+    deal_id: DealID,
+    deal: &DealProposal,
+    sector_number: SectorNumber,
+    sector_expiry: ChainEpoch,
+    exit: ExitCode,
+) {
+    let res = batch_activate_deals_raw(
+        rt,
+        PROVIDER_ADDR,
+        vec![SectorDeals {
+            sector_number,
+            sector_expiry,
+            sector_type: RegisteredSealProof::StackedDRG8MiBV1,
+            deal_ids: vec![deal_id],
+        }],
+        false,
+    )
+    .unwrap();
+    let res: BatchActivateDealsResult =
+        res.unwrap().deserialize().expect("BatchActivateDealsResult failed to deserialize");
+    assert_eq!(res.activation_results.codes(), vec![exit]);
 
-    let sector_number = 7;
-    let res = activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, sector_number, &[deal_id]);
-    assert_eq!(res.activation_results.codes(), vec![EX_DEAL_EXPIRED])
+    let piece = piece_info_from_deal(deal_id, deal);
+    let changes = vec![SectorChanges {
+        sector: 1,
+        minimum_commitment_epoch: sector_expiry,
+        added: vec![piece],
+    }];
+    let ret = sector_content_changed(rt, PROVIDER_ADDR, changes).unwrap();
+    assert_eq!(vec![PieceReturn { code: exit, data: vec![] }], ret.sectors[0].added);
 }

--- a/actors/market/tests/activate_deal_failures.rs
+++ b/actors/market/tests/activate_deal_failures.rs
@@ -33,6 +33,7 @@ fn fail_when_caller_is_not_the_provider_of_the_deal() {
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number: 1,
             sector_expiry,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             deal_ids: vec![deal_id],
@@ -56,6 +57,7 @@ fn fail_when_caller_is_not_a_storage_miner_actor() {
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, PROVIDER_ADDR);
 
     let sector_activation = SectorDeals {
+        sector_number: 1,
         deal_ids: vec![],
         sector_expiry: 0,
         sector_type: RegisteredSealProof::StackedDRG8MiBV1,
@@ -82,6 +84,7 @@ fn fail_when_deal_has_not_been_published_before() {
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number: 1,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             sector_expiry: EPOCHS_IN_DAY,
             deal_ids: vec![DealID::from(42u32)],
@@ -112,12 +115,14 @@ fn fail_when_deal_has_already_been_activated() {
         start_epoch,
         end_epoch,
     );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id]);
+    let sector_number = 7;
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, sector_number, &[deal_id]);
 
     let res = batch_activate_deals_raw(
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number: sector_number + 1,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             sector_expiry,
             deal_ids: vec![deal_id],
@@ -164,11 +169,12 @@ fn fail_when_deal_has_already_been_expired() {
 
     cron_tick(&rt);
 
-    assert_deal_deleted(&rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal, 0);
 
     let mut st: State = rt.get_state::<State>();
     st.next_id = deal_id + 1;
 
-    let res = activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id]);
+    let sector_number = 7;
+    let res = activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, sector_number, &[deal_id]);
     assert_eq!(res.activation_results.codes(), vec![EX_DEAL_EXPIRED])
 }

--- a/actors/market/tests/batch_activate_deals.rs
+++ b/actors/market/tests/batch_activate_deals.rs
@@ -22,6 +22,44 @@ const MINER_ADDRESSES: MinerAddresses = MinerAddresses {
 };
 
 #[test]
+fn activate_deals_one_sector() {
+    let rt = setup();
+    let epoch = rt.set_epoch(START_EPOCH);
+    let deals = [
+        create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH, false),
+        create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH + 1, false),
+        create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH + 2, true),
+    ];
+    let next_allocation_id = 1;
+    let datacap_required = TokenAmount::from_whole(deals[2].piece_size.0);
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids =
+        publish_deals(&rt, &MINER_ADDRESSES, &deals, datacap_required, next_allocation_id);
+
+    // Reverse deal IDs to check they are stored sorted in state.
+    let mut deal_ids_reversed = deal_ids.clone();
+    deal_ids_reversed.reverse();
+    let sectors = [(1, END_EPOCH + 10, deal_ids_reversed)];
+    let res = batch_activate_deals(&rt, PROVIDER_ADDR, &sectors, false);
+    assert!(res.activation_results.all_ok());
+
+    // Deal IDs are stored under the sector, in correct order.
+    assert_eq!(deal_ids, get_sector_deal_ids(&rt, &PROVIDER_ADDR, 1));
+
+    for id in deal_ids.iter() {
+        let state = get_deal_state(&rt, *id);
+        assert_eq!(1, state.sector_number);
+        assert_eq!(epoch, state.sector_start_epoch);
+        if *id == deal_ids[2] {
+            assert_eq!(state.verified_claim, next_allocation_id);
+        } else {
+            assert_eq!(state.verified_claim, NO_ALLOCATION_ID);
+        }
+    }
+    check_state(&rt);
+}
+
+#[test]
 fn activate_deals_across_multiple_sectors() {
     let rt = setup();
     let create_deal = |end_epoch, verified| {
@@ -50,9 +88,9 @@ fn activate_deals_across_multiple_sectors() {
 
     // group into sectors
     let sectors = [
-        (END_EPOCH, vec![verified_deal_1_id, unverified_deal_1_id]), // contains both verified and unverified deals
-        (END_EPOCH + 1, vec![verified_deal_2_id]),                   // contains verified deal only
-        (END_EPOCH + 2, vec![unverified_deal_2_id]), // contains unverified deal only
+        (1, END_EPOCH, vec![verified_deal_1_id, unverified_deal_1_id]), // contains both verified and unverified deals
+        (2, END_EPOCH + 1, vec![verified_deal_2_id]), // contains verified deal only
+        (3, END_EPOCH + 2, vec![unverified_deal_2_id]), // contains unverified deal only
     ];
 
     let res = batch_activate_deals(&rt, PROVIDER_ADDR, &sectors, false);
@@ -109,16 +147,34 @@ fn sectors_fail_and_succeed_independently_during_batch_activation() {
     let id_4 = deal_ids[3];
 
     // activate the first deal so it will fail later
-    activate_deals(&rt, END_EPOCH, PROVIDER_ADDR, 0, &[id_1]);
+    activate_deals(&rt, END_EPOCH, PROVIDER_ADDR, 0, 1, &[id_1]);
     // activate the third deal so it will fail later
-    activate_deals(&rt, END_EPOCH + 1, PROVIDER_ADDR, 0, &[id_3]);
+    activate_deals(&rt, END_EPOCH + 1, PROVIDER_ADDR, 0, 3, &[id_3]);
 
     let sector_type = RegisteredSealProof::StackedDRG8MiBV1;
     // group into sectors
     let sectors_deals = vec![
-        SectorDeals { deal_ids: vec![id_1, id_2], sector_type, sector_expiry: END_EPOCH }, // 1 bad deal causes whole sector to fail
-        SectorDeals { deal_ids: vec![id_3], sector_type, sector_expiry: END_EPOCH + 1 }, // bad deal causes whole sector to fail
-        SectorDeals { deal_ids: vec![id_4], sector_type, sector_expiry: END_EPOCH + 2 }, // sector succeeds
+        // 1 bad deal causes whole sector to fail
+        SectorDeals {
+            sector_number: 1,
+            deal_ids: vec![id_1, id_2],
+            sector_type,
+            sector_expiry: END_EPOCH,
+        },
+        // bad deal causes whole sector to fail
+        SectorDeals {
+            sector_number: 3,
+            deal_ids: vec![id_3],
+            sector_type,
+            sector_expiry: END_EPOCH + 1,
+        },
+        // sector succeeds
+        SectorDeals {
+            sector_number: 4,
+            deal_ids: vec![id_4],
+            sector_type,
+            sector_expiry: END_EPOCH + 2,
+        },
     ];
 
     let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals, false).unwrap();
@@ -167,9 +223,17 @@ fn handles_sectors_empty_of_deals_gracefully() {
     let sector_type = RegisteredSealProof::StackedDRG8MiBV1;
     // group into sectors
     let sectors_deals = vec![
-        SectorDeals { deal_ids: vec![], sector_type, sector_expiry: END_EPOCH }, // empty sector
-        SectorDeals { deal_ids: vec![id_1], sector_type, sector_expiry: END_EPOCH + 1 }, // sector with one valid deal
-        SectorDeals { deal_ids: vec![], sector_type, sector_expiry: END_EPOCH + 2 }, // empty sector
+        // empty sector
+        SectorDeals { sector_number: 1, deal_ids: vec![], sector_type, sector_expiry: END_EPOCH },
+        // sector with one valid deal
+        SectorDeals {
+            sector_number: 2,
+            deal_ids: vec![id_1],
+            sector_type,
+            sector_expiry: END_EPOCH,
+        },
+        // empty sector
+        SectorDeals { sector_number: 3, deal_ids: vec![], sector_type, sector_expiry: END_EPOCH },
     ];
 
     let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals, false).unwrap();
@@ -214,11 +278,26 @@ fn fails_to_activate_sectors_containing_duplicate_deals() {
     // group into sectors
     let sectors_deals = vec![
         // activate deal 1
-        SectorDeals { deal_ids: vec![id_1], sector_type, sector_expiry: END_EPOCH },
+        SectorDeals {
+            sector_number: 1,
+            deal_ids: vec![id_1],
+            sector_type,
+            sector_expiry: END_EPOCH,
+        },
         // duplicate id_1 so no deals activated here
-        SectorDeals { deal_ids: vec![id_3, id_1, id_2], sector_type, sector_expiry: END_EPOCH }, // duplicate with sector 1 so all fail
+        SectorDeals {
+            sector_number: 2,
+            deal_ids: vec![id_3, id_1, id_2],
+            sector_type,
+            sector_expiry: END_EPOCH,
+        }, // duplicate with sector 1 so all fail
         // since id_3 wasn't activated earlier this is a valid request
-        SectorDeals { deal_ids: vec![id_3], sector_type, sector_expiry: END_EPOCH },
+        SectorDeals {
+            sector_number: 3,
+            deal_ids: vec![id_3],
+            sector_type,
+            sector_expiry: END_EPOCH,
+        },
     ];
 
     let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals, false).unwrap();
@@ -246,5 +325,45 @@ fn fails_to_activate_sectors_containing_duplicate_deals() {
     let s = states.get(id_2).unwrap();
     assert!(s.is_none());
 
+    check_state(&rt);
+}
+
+#[test]
+fn activate_new_deals_in_existing_sector() {
+    // At time of writing, the miner actor won't do this.
+    // But future re-snap could allow it.
+    let rt = setup();
+    let deals = vec![
+        create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH, false),
+        create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH + 1, false),
+        create_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH + 2, false),
+    ];
+
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids = publish_deals(&rt, &MINER_ADDRESSES, &deals, TokenAmount::zero(), 0);
+    assert_eq!(3, deal_ids.len());
+
+    // Activate deals separately, and out of order.
+    let sector_number = 1;
+    batch_activate_deals(
+        &rt,
+        PROVIDER_ADDR,
+        &[(sector_number, END_EPOCH + 10, vec![deal_ids[0], deal_ids[2]])],
+        false,
+    );
+    batch_activate_deals(
+        &rt,
+        PROVIDER_ADDR,
+        &[(sector_number, END_EPOCH + 10, vec![deal_ids[1]])],
+        false,
+    );
+
+    // all deals are activated
+    assert_eq!(0, get_deal_state(&rt, deal_ids[0]).sector_start_epoch);
+    assert_eq!(0, get_deal_state(&rt, deal_ids[1]).sector_start_epoch);
+    assert_eq!(0, get_deal_state(&rt, deal_ids[2]).sector_start_epoch);
+
+    // All deals stored under the sector, in order.
+    assert_eq!(deal_ids, get_sector_deal_ids(&rt, &PROVIDER_ADDR, sector_number));
     check_state(&rt);
 }

--- a/actors/market/tests/cron_tick_deal_expiry.rs
+++ b/actors/market/tests/cron_tick_deal_expiry.rs
@@ -49,7 +49,7 @@ fn deal_is_correctly_processed_if_first_cron_after_expiry() {
     assert!(slashed.is_zero());
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&rt, deal_id, deal_proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
     check_state(&rt);
 }
 
@@ -124,7 +124,7 @@ fn regular_payments_till_deal_expires_and_then_locked_funds_are_unlocked() {
     assert!(slashed.is_zero());
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&rt, deal_id, deal_proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
     check_state(&rt);
 }
 
@@ -155,7 +155,7 @@ fn payment_for_a_deal_if_deal_is_already_expired_before_a_cron_tick() {
     assert_eq!((end - start) * &deal_proposal.storage_price_per_epoch, pay);
     assert!(slashed.is_zero());
 
-    assert_deal_deleted(&rt, deal_id, deal_proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
 
     // running cron tick again doesn't do anything
     cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
@@ -198,7 +198,7 @@ fn expired_deal_should_unlock_the_remaining_client_and_provider_locked_balance_a
     assert!(provider_acct.locked.is_zero());
 
     // deal should be deleted
-    assert_deal_deleted(&rt, deal_id, deal_proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
     check_state(&rt);
 }
 

--- a/actors/market/tests/cron_tick_deal_slashing.rs
+++ b/actors/market/tests/cron_tick_deal_slashing.rs
@@ -105,7 +105,7 @@ fn deal_is_slashed() {
         );
         assert_eq!(tc.payment, pay);
         assert_eq!(deal_proposal.provider_collateral, slashed);
-        assert_deal_deleted(&rt, deal_id, deal_proposal, sector_number);
+        assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
 
         check_state(&rt);
     }
@@ -148,7 +148,7 @@ fn deal_is_slashed_at_the_end_epoch_should_not_be_slashed_and_should_be_consider
     assert!(slashed.is_zero());
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&rt, deal_id, deal_proposal, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER);
 
     check_state(&rt);
 }
@@ -194,7 +194,7 @@ fn deal_payment_and_slashing_correctly_processed_in_same_crontick() {
     assert_eq!(deal_proposal.provider_collateral, slashed);
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&rt, deal_id, deal_proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
     check_state(&rt);
 }
 
@@ -258,9 +258,9 @@ fn slash_multiple_deals_in_the_same_epoch() {
     );
     cron_tick(&rt);
 
-    assert_deal_deleted(&rt, deal_id1, deal_proposal1, SECTOR_NUMBER);
-    assert_deal_deleted(&rt, deal_id2, deal_proposal2, SECTOR_NUMBER);
-    assert_deal_deleted(&rt, deal_id3, deal_proposal3, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id1, &deal_proposal1, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id2, &deal_proposal2, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id3, &deal_proposal3, SECTOR_NUMBER);
     check_state(&rt);
 }
 
@@ -324,7 +324,7 @@ fn regular_payments_till_deal_is_slashed_and_then_slashing_is_processed() {
     assert_eq!(slashed, deal_proposal.provider_collateral);
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&rt, deal_id, deal_proposal, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER);
     check_state(&rt);
 }
 
@@ -378,6 +378,6 @@ fn regular_payments_till_deal_expires_and_then_we_attempt_to_slash_it_but_it_wil
     assert!(slashed.is_zero());
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&rt, deal_id, deal_proposal, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER);
     check_state(&rt);
 }

--- a/actors/market/tests/cron_tick_timedout_deals.rs
+++ b/actors/market/tests/cron_tick_timedout_deals.rs
@@ -56,7 +56,7 @@ fn timed_out_deal_is_slashed_and_deleted() {
     assert_eq!(c_escrow, client_acct.balance);
     assert!(client_acct.locked.is_zero());
     assert_account_zero(&rt, PROVIDER_ADDR);
-    assert_deal_deleted(&rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal, 0);
     check_state(&rt);
 }
 
@@ -128,7 +128,7 @@ fn publishing_timed_out_deal_again_should_work_after_cron_tick_as_it_should_no_l
         ExitCode::OK,
     );
     cron_tick(&rt);
-    assert_deal_deleted(&rt, deal_id, deal_proposal);
+    assert_deal_deleted(&rt, deal_id, deal_proposal, 0);
 
     // now publishing should work
     generate_and_publish_deal(&rt, CLIENT_ADDR, &MinerAddresses::default(), START_EPOCH, END_EPOCH);
@@ -194,8 +194,8 @@ fn timed_out_and_verified_deals_are_slashed_deleted() {
     cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     assert_account_zero(&rt, PROVIDER_ADDR);
-    assert_deal_deleted(&rt, deal_ids[0], deal1);
-    assert_deal_deleted(&rt, deal_ids[1], deal2);
-    assert_deal_deleted(&rt, deal_ids[2], deal3);
+    assert_deal_deleted(&rt, deal_ids[0], deal1, 0);
+    assert_deal_deleted(&rt, deal_ids[1], deal2, 0);
+    assert_deal_deleted(&rt, deal_ids[2], deal3, 0);
     check_state(&rt);
 }

--- a/actors/market/tests/cron_tick_timedout_deals.rs
+++ b/actors/market/tests/cron_tick_timedout_deals.rs
@@ -56,7 +56,7 @@ fn timed_out_deal_is_slashed_and_deleted() {
     assert_eq!(c_escrow, client_acct.balance);
     assert!(client_acct.locked.is_zero());
     assert_account_zero(&rt, PROVIDER_ADDR);
-    assert_deal_deleted(&rt, deal_id, deal_proposal, 0);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, 0);
     check_state(&rt);
 }
 
@@ -128,7 +128,7 @@ fn publishing_timed_out_deal_again_should_work_after_cron_tick_as_it_should_no_l
         ExitCode::OK,
     );
     cron_tick(&rt);
-    assert_deal_deleted(&rt, deal_id, deal_proposal, 0);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, 0);
 
     // now publishing should work
     generate_and_publish_deal(&rt, CLIENT_ADDR, &MinerAddresses::default(), START_EPOCH, END_EPOCH);
@@ -194,8 +194,8 @@ fn timed_out_and_verified_deals_are_slashed_deleted() {
     cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     assert_account_zero(&rt, PROVIDER_ADDR);
-    assert_deal_deleted(&rt, deal_ids[0], deal1, 0);
-    assert_deal_deleted(&rt, deal_ids[1], deal2, 0);
-    assert_deal_deleted(&rt, deal_ids[2], deal3, 0);
+    assert_deal_deleted(&rt, deal_ids[0], &deal1, 0);
+    assert_deal_deleted(&rt, deal_ids[1], &deal2, 0);
+    assert_deal_deleted(&rt, deal_ids[2], &deal3, 0);
     check_state(&rt);
 }

--- a/actors/market/tests/deal_api_test.rs
+++ b/actors/market/tests/deal_api_test.rs
@@ -118,7 +118,8 @@ fn activation() {
     // activate the deal
     let activate_epoch = start_epoch - 2;
     rt.set_epoch(activate_epoch);
-    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, activate_epoch, &[id]);
+    let sector_number = 7;
+    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, activate_epoch, sector_number, &[id]);
     let activation: GetDealActivationReturn =
         query_deal(&rt, Method::GetDealActivationExported, id);
     assert_eq!(activate_epoch, activation.activated);
@@ -127,7 +128,7 @@ fn activation() {
     // terminate early
     let terminate_epoch = activate_epoch + 100;
     rt.set_epoch(terminate_epoch);
-    terminate_deals(&rt, PROVIDER_ADDR, &[id]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     let activation: GetDealActivationReturn =
         query_deal(&rt, Method::GetDealActivationExported, id);
     assert_eq!(activate_epoch, activation.activated);

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -15,6 +15,9 @@ use std::collections::BTreeMap;
 use std::{cell::RefCell, collections::HashMap};
 
 use fil_actor_market::ext::account::{AuthenticateMessageParams, AUTHENTICATE_MESSAGE_METHOD};
+use fil_actor_market::ext::miner::{
+    PieceInfo, SectorChanges, SectorContentChangedParams, SectorContentChangedReturn,
+};
 use fil_actor_market::ext::verifreg::{AllocationID, AllocationRequest, AllocationsResponse};
 use fil_actor_market::{
     ext, ext::miner::GetControlAddressesReturnParams, next_update_epoch,
@@ -41,7 +44,7 @@ use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::{ChainEpoch, EPOCH_UNDEFINED};
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::deal::DealID;
-use fvm_shared::piece::{PaddedPieceSize, PieceInfo};
+use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::reward::ThisEpochRewardReturn;
 use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
 use fvm_shared::smooth::FilterEstimate;
@@ -397,6 +400,23 @@ pub fn batch_activate_deals_raw(
     rt.verify();
 
     Ok(ret)
+}
+
+pub fn sector_content_changed(
+    rt: &MockRuntime,
+    provider: Address,
+    sectors: Vec<SectorChanges>,
+) -> Result<SectorContentChangedReturn, ActorError> {
+    rt.set_caller(*MINER_ACTOR_CODE_ID, provider);
+    rt.expect_validate_caller_type(vec![Type::Miner]);
+    let params = SectorContentChangedParams { sectors };
+
+    let ret = rt.call::<MarketActor>(
+        Method::SectorContentChangedExported as u64,
+        IpldBlock::serialize_cbor(&params).unwrap(),
+    )?;
+    rt.verify();
+    Ok(ret.unwrap().deserialize().expect("SectorContentChanged failed"))
 }
 
 pub fn get_deal_proposal(rt: &MockRuntime, deal_id: DealID) -> DealProposal {
@@ -888,7 +908,7 @@ pub fn assert_deals_not_terminated(rt: &MockRuntime, deal_ids: &[DealID]) {
 pub fn assert_deal_deleted(
     rt: &MockRuntime,
     deal_id: DealID,
-    p: DealProposal,
+    p: &DealProposal,
     sector_number: SectorNumber,
 ) {
     use cid::multihash::Code;
@@ -908,7 +928,7 @@ pub fn assert_deal_deleted(
     assert!(s.is_none());
 
     let mh_code = Code::Blake2b256;
-    let p_cid = Cid::new_v1(fvm_ipld_encoding::DAG_CBOR, mh_code.digest(&to_vec(&p).unwrap()));
+    let p_cid = Cid::new_v1(fvm_ipld_encoding::DAG_CBOR, mh_code.digest(&to_vec(p).unwrap()));
     // Check that the deal_id is not in st.pending_proposals.
     let pending_deals = Set::from_root(rt.store(), &st.pending_proposals).unwrap();
     assert!(!pending_deals.has(&BytesKey(p_cid.to_bytes())).unwrap());
@@ -1198,14 +1218,17 @@ pub fn verify_deals_for_activation<F>(
     piece_info_override: F,
 ) -> VerifyDealsForActivationReturn
 where
-    F: Fn(usize) -> Option<Vec<PieceInfo>>,
+    F: Fn(usize) -> Option<Vec<fvm_shared::piece::PieceInfo>>,
 {
     rt.expect_validate_caller_type(vec![Type::Miner]);
     rt.set_caller(*MINER_ACTOR_CODE_ID, provider);
 
     for (i, sd) in sector_deals.iter().enumerate() {
         let pi = piece_info_override(i).unwrap_or_else(|| {
-            vec![PieceInfo { cid: make_piece_cid("1".as_bytes()), size: PaddedPieceSize(2048) }]
+            vec![fvm_shared::piece::PieceInfo {
+                cid: make_piece_cid("1".as_bytes()),
+                size: PaddedPieceSize(2048),
+            }]
         });
         rt.expect_compute_unsealed_sector_cid(
             sd.sector_type,
@@ -1227,4 +1250,12 @@ where
         .expect("VerifyDealsForActivation failed!");
     rt.verify();
     ret
+}
+
+pub fn piece_info_from_deal(id: DealID, deal: &DealProposal) -> PieceInfo {
+    PieceInfo {
+        data: deal.piece_cid,
+        size: deal.piece_size,
+        payload: serialize(&id, "deal id").unwrap(),
+    }
 }

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -52,7 +52,6 @@ fn test_remove_all_error() {
     SetMultimap::new(&rt.store()).remove_all(42).expect("expected no error");
 }
 
-// TODO add array stuff
 #[test]
 fn simple_construction() {
     let rt = MockRuntime {
@@ -320,7 +319,7 @@ fn worker_balance_after_withdrawal_must_account_for_slashed_funds() {
     let start_epoch = ChainEpoch::from(10);
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let publish_epoch = ChainEpoch::from(5);
-
+    let sector_number = 7;
     let rt = setup();
 
     // publish deal
@@ -334,13 +333,13 @@ fn worker_balance_after_withdrawal_must_account_for_slashed_funds() {
     );
 
     // activate the deal
-    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, publish_epoch, &[deal_id]);
+    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, publish_epoch, sector_number, &[deal_id]);
     let st = get_deal_state(&rt, deal_id);
     assert_eq!(publish_epoch, st.sector_start_epoch);
 
     // slash the deal
     rt.set_epoch(publish_epoch + 1);
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     let st = get_deal_state(&rt, deal_id);
     assert_eq!(publish_epoch + 1, st.slash_epoch);
 
@@ -696,7 +695,7 @@ fn simple_deal() {
     )[0];
 
     // activate the deal
-    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, publish_epoch, &[deal1_id, deal2_id]);
+    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, publish_epoch, 1, &[deal1_id, deal2_id]);
     let deal1st = get_deal_state(&rt, deal1_id);
     assert_eq!(publish_epoch, deal1st.sector_start_epoch);
     assert_eq!(NO_ALLOCATION_ID, deal1st.verified_claim);
@@ -1059,7 +1058,7 @@ fn publish_a_deal_after_activating_a_previous_deal_which_has_a_start_epoch_far_i
         start_epoch,
         end_epoch,
     );
-    activate_deals(&rt, end_epoch, PROVIDER_ADDR, publish_epoch, &[deal1]);
+    activate_deals(&rt, end_epoch, PROVIDER_ADDR, publish_epoch, 1, &[deal1]);
     let st = get_deal_state(&rt, deal1);
     assert_eq!(publish_epoch, st.sector_start_epoch);
 
@@ -1073,7 +1072,7 @@ fn publish_a_deal_after_activating_a_previous_deal_which_has_a_start_epoch_far_i
         start_epoch + 1,
         end_epoch + 1,
     );
-    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, new_epoch, &[deal2]);
+    activate_deals(&rt, end_epoch + 1, PROVIDER_ADDR, new_epoch, 2, &[deal2]);
     check_state(&rt);
 }
 
@@ -1317,15 +1316,15 @@ fn active_deals_multiple_times_with_different_providers() {
     let deal5 = generate_and_publish_deal(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch + 1);
 
     // provider1 activates deal1 and deal2 but that does not activate deal3 to deal5
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1, deal2]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, 1, &[deal1, deal2]);
     assert_deals_not_activated(&rt, current_epoch, &[deal3, deal4, deal5]);
 
     // provider2 activates deal5 but that does not activate deal3 or deal4
-    activate_deals(&rt, sector_expiry, provider2_addr, current_epoch, &[deal5]);
+    activate_deals(&rt, sector_expiry, provider2_addr, current_epoch, 1, &[deal5]);
     assert_deals_not_activated(&rt, current_epoch, &[deal3, deal4]);
 
     // provider1 activates deal3
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal3]);
+    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, 2, &[deal3]);
     assert_deals_not_activated(&rt, current_epoch, &[deal4]);
     check_state(&rt);
 }
@@ -1336,13 +1335,14 @@ fn fail_when_deal_is_activated_but_proposal_is_not_found() {
     let start_epoch = 50;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
-
+    let sector_number = 7;
     let rt = setup();
 
     let deal_id = publish_and_activate_deal(
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number,
         start_epoch,
         end_epoch,
         0,
@@ -1372,13 +1372,14 @@ fn fail_when_deal_update_epoch_is_in_the_future() {
     let start_epoch = 50;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
-
+    let sector_number = 7;
     let rt = setup();
 
     let deal_id = publish_and_activate_deal(
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number,
         start_epoch,
         end_epoch,
         0,
@@ -1409,6 +1410,7 @@ fn crontick_for_a_deal_at_its_start_epoch_results_in_zero_payment_and_no_slashin
     let start_epoch = ChainEpoch::from(50);
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
+    let sector_number = 7;
 
     // set start epoch to coincide with processing (0 + 0 % 2880 = 0)
     let start_epoch = 0;
@@ -1417,6 +1419,7 @@ fn crontick_for_a_deal_at_its_start_epoch_results_in_zero_payment_and_no_slashin
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number,
         start_epoch,
         end_epoch,
         0,
@@ -1442,13 +1445,14 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
     let start_epoch = ChainEpoch::from(50);
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
-
+    let sector_number = 7;
     let rt = setup();
 
     let deal_id1 = publish_and_activate_deal(
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number,
         start_epoch,
         end_epoch,
         0,
@@ -1460,6 +1464,7 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number + 1,
         start_epoch + 1,
         end_epoch + 1,
         0,
@@ -1469,7 +1474,7 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
     // slash deal1
     let slash_epoch = process_epoch(start_epoch, deal_id2) + ChainEpoch::from(100);
     rt.set_epoch(slash_epoch);
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
 
     // cron tick will slash deal1 and make payment for deal2
     rt.expect_send_simple(
@@ -1482,7 +1487,7 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
     );
     cron_tick(&rt);
 
-    assert_deal_deleted(&rt, deal_id1, d1);
+    assert_deal_deleted(&rt, deal_id1, d1, sector_number);
     let s2 = get_deal_state(&rt, deal_id2);
     assert_eq!(slash_epoch, s2.last_updated_epoch);
     check_state(&rt);
@@ -1492,6 +1497,7 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
 fn cron_reschedules_update_to_new_period() {
     let start_epoch = ChainEpoch::from(1);
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+    let sector_number = 7;
 
     // Publish a deal
     let rt = setup();
@@ -1499,6 +1505,7 @@ fn cron_reschedules_update_to_new_period() {
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number,
         start_epoch,
         end_epoch,
         0,
@@ -1531,6 +1538,7 @@ fn cron_reschedules_update_to_new_period() {
 fn cron_reschedules_update_to_new_period_boundary() {
     let start_epoch = ChainEpoch::from(1);
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+    let sector_number = 7;
 
     // Publish a deal
     let rt = setup();
@@ -1538,6 +1546,7 @@ fn cron_reschedules_update_to_new_period_boundary() {
         &rt,
         CLIENT_ADDR,
         &MinerAddresses::default(),
+        sector_number,
         start_epoch,
         end_epoch,
         0,
@@ -1574,6 +1583,7 @@ fn cron_reschedules_many_updates() {
     let start_epoch = ChainEpoch::from(10);
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = start_epoch + 5 * EPOCHS_IN_YEAR;
+    let sector_number = 7;
     // Set a short update interval so we can generate scheduling collisions.
     let update_interval = 100;
 
@@ -1586,6 +1596,7 @@ fn cron_reschedules_many_updates() {
             &rt,
             CLIENT_ADDR,
             &MinerAddresses::default(),
+            sector_number,
             start_epoch,
             end_epoch + i,
             0,
@@ -1680,6 +1691,7 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
+    let sector_number = 7;
 
     let rt = setup();
     let deal_id = generate_and_publish_deal(
@@ -1695,6 +1707,7 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number,
             sector_expiry,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             deal_ids: vec![deal_id],
@@ -1716,6 +1729,7 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
 fn fail_when_end_epoch_of_deal_greater_than_sector_expiry() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+    let sector_number = 7;
 
     let rt = setup();
     let deal_id = generate_and_publish_deal(
@@ -1730,6 +1744,7 @@ fn fail_when_end_epoch_of_deal_greater_than_sector_expiry() {
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number,
             sector_expiry: end_epoch - 1,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             deal_ids: vec![deal_id],
@@ -1752,6 +1767,7 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
+    let sector_number = 7;
 
     let rt = setup();
     // activate deal1 so it fails later
@@ -1762,7 +1778,12 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
         start_epoch,
         end_epoch,
     );
-    batch_activate_deals(&rt, PROVIDER_ADDR, &[(sector_expiry, vec![deal_id1])], false);
+    batch_activate_deals(
+        &rt,
+        PROVIDER_ADDR,
+        &[(sector_number, sector_expiry, vec![deal_id1])],
+        false,
+    );
 
     let deal_id2 = generate_and_publish_deal(
         &rt,
@@ -1776,6 +1797,7 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number,
             sector_expiry,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             deal_ids: vec![deal_id1, deal_id2],
@@ -1862,8 +1884,10 @@ fn locked_fund_tracking_states() {
 
     // activation doesn't change anything
     let curr = rt.set_epoch(start_epoch - 1);
-    activate_deals(&rt, sector_expiry, p1, curr, &[deal_id1]);
-    activate_deals(&rt, sector_expiry, p2, curr, &[deal_id2]);
+    // Providers happened to use the same sector number.
+    let sector_number = 7;
+    activate_deals(&rt, sector_expiry, p1, curr, sector_number, &[deal_id1]);
+    activate_deals(&rt, sector_expiry, p2, curr, sector_number, &[deal_id2]);
 
     assert_locked_fund_states(&rt, csf.clone(), plc.clone(), clc.clone());
 
@@ -1901,7 +1925,7 @@ fn locked_fund_tracking_states() {
 
     // slash deal1
     rt.set_epoch(curr + 1);
-    terminate_deals(&rt, m1.provider, &[deal_id1]);
+    terminate_deals(&rt, m1.provider, &[sector_number]);
 
     // cron tick to slash deal1 and expire deal2
     rt.set_epoch(end_epoch);

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -1487,7 +1487,7 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
     );
     cron_tick(&rt);
 
-    assert_deal_deleted(&rt, deal_id1, d1, sector_number);
+    assert_deal_deleted(&rt, deal_id1, &d1, sector_number);
     let s2 = get_deal_state(&rt, deal_id2);
     assert_eq!(slash_epoch, s2.last_updated_epoch);
     check_state(&rt);
@@ -1719,7 +1719,7 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
     let res: BatchActivateDealsResult =
         res.unwrap().deserialize().expect("VerifyDealsForActivation failed!");
 
-    assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_ILLEGAL_ARGUMENT]);
+    assert_eq!(res.activation_results.codes(), vec![EX_DEAL_EXPIRED]);
 
     rt.verify();
     check_state(&rt);

--- a/actors/market/tests/on_miner_sectors_terminate.rs
+++ b/actors/market/tests/on_miner_sectors_terminate.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fvm_ipld_bitfield::BitField;
 use std::convert::TryInto;
 
 use fil_actor_market::{Actor as MarketActor, Method, OnMinerSectorsTerminateParams};
@@ -17,6 +18,49 @@ use num_traits::Zero;
 mod harness;
 
 use harness::*;
+
+#[test]
+fn terminate_multiple_deals_from_single_provider() {
+    let start_epoch = 10;
+    let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
+    let sector_expiry = end_epoch + 100;
+    let current_epoch = 5;
+
+    let rt = setup();
+    rt.set_epoch(current_epoch);
+
+    // IDs are both deal and sector IDs.
+    let [id1, id2, id3]: [DealID; 3] = (end_epoch..end_epoch + 3)
+        .map(|epoch| {
+            let id = generate_and_publish_deal(
+                &rt,
+                CLIENT_ADDR,
+                &MinerAddresses::default(),
+                start_epoch,
+                epoch,
+            );
+            let ret = activate_deals(
+                &rt,
+                sector_expiry,
+                PROVIDER_ADDR,
+                current_epoch,
+                id, // use deal ID as unique sector number
+                &[id],
+            );
+            assert!(ret.activation_results.all_ok());
+            id
+        })
+        .collect::<Vec<DealID>>()
+        .try_into()
+        .unwrap();
+
+    terminate_deals(&rt, PROVIDER_ADDR, &[id1]);
+    assert_deals_terminated(&rt, current_epoch, &[id1]);
+    assert_deals_not_terminated(&rt, &[id2, id3]);
+
+    terminate_deals(&rt, PROVIDER_ADDR, &[id2, id3]);
+    assert_deals_terminated(&rt, current_epoch, &[id1, id2, id3]);
+}
 
 #[test]
 fn terminate_multiple_deals_from_multiple_providers() {
@@ -43,37 +87,49 @@ fn terminate_multiple_deals_from_multiple_providers() {
         .collect::<Vec<DealID>>()
         .try_into()
         .unwrap();
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1, deal2, deal3]);
+    let sector_number = 7; // Both providers used the same sector number
+    let ret = activate_deals(
+        &rt,
+        sector_expiry,
+        PROVIDER_ADDR,
+        current_epoch,
+        sector_number,
+        &[deal1, deal2, deal3],
+    );
+    assert!(ret.activation_results.all_ok());
 
     let addrs = MinerAddresses { provider: provider2, ..MinerAddresses::default() };
     let deal4 = generate_and_publish_deal(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch);
     let deal5 = generate_and_publish_deal(&rt, CLIENT_ADDR, &addrs, start_epoch, end_epoch + 1);
-    activate_deals(&rt, sector_expiry, provider2, current_epoch, &[deal4, deal5]);
+    let ret = activate_deals(
+        &rt,
+        sector_expiry,
+        provider2,
+        current_epoch,
+        sector_number,
+        &[deal4, deal5],
+    );
+    assert!(ret.activation_results.all_ok());
 
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
-    assert_deals_terminated(&rt, current_epoch, &[deal1]);
-    assert_deals_not_terminated(&rt, &[deal2, deal3, deal4, deal5]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
+    assert_deals_terminated(&rt, current_epoch, &[deal1, deal2, deal3]);
+    assert_eq!(Vec::<DealID>::new(), get_sector_deal_ids(&rt, &PROVIDER_ADDR, sector_number));
+    assert_deals_not_terminated(&rt, &[deal4, deal5]);
+    assert_eq!(vec![deal4, deal5], get_sector_deal_ids(&rt, &provider2, sector_number));
 
-    terminate_deals(&rt, provider2, &[deal5]);
-    assert_deals_terminated(&rt, current_epoch, &[deal5]);
-    assert_deals_not_terminated(&rt, &[deal2, deal3, deal4]);
-
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal2, deal3]);
-    assert_deals_terminated(&rt, current_epoch, &[deal2, deal3]);
-    assert_deals_not_terminated(&rt, &[deal4]);
-
-    terminate_deals(&rt, provider2, &[deal4]);
-    assert_deals_terminated(&rt, current_epoch, &[deal4]);
+    terminate_deals(&rt, provider2, &[sector_number]);
+    assert_deals_terminated(&rt, current_epoch, &[deal4, deal5]);
+    assert_eq!(Vec::<DealID>::new(), get_sector_deal_ids(&rt, &provider2, sector_number));
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1312
 #[test]
-fn ignore_deal_proposal_that_does_not_exist() {
+fn ignore_sector_that_does_not_exist() {
     let start_epoch = 10;
     let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
     let sector_expiry = end_epoch + 100;
     let current_epoch = 5;
+    let sector_number = 7;
 
     let rt = setup();
     rt.set_epoch(current_epoch);
@@ -85,16 +141,17 @@ fn ignore_deal_proposal_that_does_not_exist() {
         start_epoch,
         end_epoch,
     );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
-
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1, 42]);
+    let ret =
+        activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, sector_number, &[deal1]);
+    assert!(ret.activation_results.all_ok());
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number + 1]);
 
     let s = get_deal_state(&rt, deal1);
-    assert_eq!(s.slash_epoch, current_epoch);
+    assert_eq!(s.slash_epoch, -1);
+    assert_eq!(vec![deal1], get_sector_deal_ids(&rt, &PROVIDER_ADDR, sector_number));
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1326
 #[test]
 fn terminate_valid_deals_along_with_just_expired_deal() {
     let start_epoch = 10;
@@ -126,18 +183,29 @@ fn terminate_valid_deals_along_with_just_expired_deal() {
         start_epoch,
         end_epoch - 1,
     );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1, deal2, deal3]);
+    let sector_number = 7;
+    let ret = activate_deals(
+        &rt,
+        sector_expiry,
+        PROVIDER_ADDR,
+        current_epoch,
+        sector_number,
+        &[deal1, deal2, deal3],
+    );
+    assert!(ret.activation_results.all_ok());
 
     let new_epoch = end_epoch - 1;
     rt.set_epoch(new_epoch);
 
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1, deal2, deal3]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     assert_deals_terminated(&rt, new_epoch, &[deal1, deal2]);
+    // Not cleaned up yet.
     assert_deals_not_terminated(&rt, &[deal3]);
+    // All deals are removed from sector deals mapping at once.
+    assert_eq!(Vec::<DealID>::new(), get_sector_deal_ids(&rt, &PROVIDER_ADDR, sector_number));
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1346
 #[test]
 fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
     let start_epoch = 10;
@@ -171,19 +239,21 @@ fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
         1,
     );
     assert_eq!(2, deal_ids.len());
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &deal_ids);
+    let sector_number = 7;
+    let ret =
+        activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, sector_number, &deal_ids);
+    assert!(ret.activation_results.all_ok());
 
     let new_epoch = end_epoch - 1;
     rt.set_epoch(new_epoch);
     cron_tick(&rt);
 
-    terminate_deals(&rt, PROVIDER_ADDR, &deal_ids);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     assert_deals_terminated(&rt, new_epoch, &deal_ids[0..0]);
-    assert_deal_deleted(&rt, deal_ids[1], deal2);
+    assert_deal_deleted(&rt, deal_ids[1], deal2, sector_number);
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1369
 #[test]
 fn terminating_a_deal_the_second_time_does_not_change_its_slash_epoch() {
     let start_epoch = 10;
@@ -201,20 +271,22 @@ fn terminating_a_deal_the_second_time_does_not_change_its_slash_epoch() {
         start_epoch,
         end_epoch,
     );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
+    let sector_number = 7;
+    let ret =
+        activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, sector_number, &[deal1]);
+    assert!(ret.activation_results.all_ok());
 
     // terminating the deal so slash epoch is the current epoch
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
 
     // set a new epoch and terminate again -> however slash epoch will still be the old epoch.
     rt.set_epoch(current_epoch + 1);
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     let s = get_deal_state(&rt, deal1);
     assert_eq!(s.slash_epoch, current_epoch);
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1387
 #[test]
 fn terminating_new_deals_and_an_already_terminated_deal_only_terminates_the_new_deals() {
     let start_epoch = 10;
@@ -239,15 +311,34 @@ fn terminating_new_deals_and_an_already_terminated_deal_only_terminates_the_new_
         })
         .collect();
     let [deal1, deal2, deal3]: [DealID; 3] = deals.as_slice().try_into().unwrap();
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &deals);
+    // Activate 1 deal
+    let sector_number = 7;
+    let ret = activate_deals(
+        &rt,
+        sector_expiry,
+        PROVIDER_ADDR,
+        current_epoch,
+        sector_number,
+        &deals[0..1],
+    );
+    assert!(ret.activation_results.all_ok());
+    // Terminate them
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
 
-    // terminating the deal so slash epoch is the current epoch
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
-
-    // set a new epoch and terminate again -> however slash epoch will still be the old epoch.
+    // Activate other deals in the same sector
+    let ret = activate_deals(
+        &rt,
+        sector_expiry,
+        PROVIDER_ADDR,
+        current_epoch,
+        sector_number,
+        &deals[1..3],
+    );
+    assert!(ret.activation_results.all_ok());
+    // set a new epoch and terminate again
     let new_epoch = current_epoch + 1;
     rt.set_epoch(new_epoch);
-    terminate_deals(&rt, PROVIDER_ADDR, &deals);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
 
     let s1 = get_deal_state(&rt, deal1);
     assert_eq!(s1.slash_epoch, current_epoch);
@@ -261,7 +352,6 @@ fn terminating_new_deals_and_an_already_terminated_deal_only_terminates_the_new_
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/d56b240af24517443ce1f8abfbdab7cb22d331f1/actors/builtin/market/market_test.go#L1415
 #[test]
 fn do_not_terminate_deal_if_end_epoch_is_equal_to_or_less_than_current_epoch() {
     let start_epoch = 10;
@@ -280,9 +370,12 @@ fn do_not_terminate_deal_if_end_epoch_is_equal_to_or_less_than_current_epoch() {
         start_epoch,
         end_epoch,
     );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
+    let sector_number = 7;
+    let ret =
+        activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, sector_number, &[deal1]);
+    assert!(ret.activation_results.all_ok());
     rt.set_epoch(end_epoch);
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal1]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     assert_deals_not_terminated(&rt, &[deal1]);
 
     // deal2 has end epoch less than current epoch when terminate is called
@@ -294,23 +387,25 @@ fn do_not_terminate_deal_if_end_epoch_is_equal_to_or_less_than_current_epoch() {
         start_epoch + 1,
         end_epoch,
     );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal2]);
+    let sector_number = sector_number + 1;
+    let ret =
+        activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, sector_number, &[deal2]);
+    assert!(ret.activation_results.all_ok());
     rt.set_epoch(end_epoch + 1);
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal2]);
+    terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     assert_deals_not_terminated(&rt, &[deal2]);
 
     check_state(&rt);
 }
 
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/market/market_test.go#L1436
 #[test]
 fn fail_when_caller_is_not_a_storage_miner_actor() {
     let rt = setup();
     rt.expect_validate_caller_type(vec![Type::Miner]);
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, PROVIDER_ADDR);
-    let params = OnMinerSectorsTerminateParams { epoch: *rt.epoch.borrow(), deal_ids: vec![] };
+    let params =
+        OnMinerSectorsTerminateParams { epoch: *rt.epoch.borrow(), sectors: BitField::new() };
 
-    // XXX: Which exit code is correct: SYS_FORBIDDEN(8) or USR_FORBIDDEN(18)?
     assert_eq!(
         ExitCode::USR_FORBIDDEN,
         rt.call::<MarketActor>(
@@ -321,99 +416,5 @@ fn fail_when_caller_is_not_a_storage_miner_actor() {
         .exit_code()
     );
 
-    check_state(&rt);
-}
-
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/market/market_test.go#L1448
-#[test]
-fn fail_when_caller_is_not_the_provider_of_the_deal() {
-    let start_epoch = 10;
-    let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
-    let sector_expiry = end_epoch + 100;
-    let current_epoch = 5;
-
-    let provider2 = Address::new_id(501);
-
-    let rt = setup();
-    rt.set_epoch(current_epoch);
-
-    let deal = generate_and_publish_deal(
-        &rt,
-        CLIENT_ADDR,
-        &MinerAddresses::default(),
-        start_epoch,
-        end_epoch,
-    );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal]);
-
-    // XXX: Difference between go messages: 't0501' has turned into 'f0501'.
-    let ret = terminate_deals_raw(&rt, provider2, &[deal]);
-    expect_abort_contains_message(
-        ExitCode::USR_ILLEGAL_STATE,
-        "caller f0501 is not the provider f0102 of deal 0",
-        ret,
-    );
-
-    check_state(&rt);
-}
-
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/market/market_test.go#L1468
-#[test]
-fn fail_when_deal_has_been_published_but_not_activated() {
-    let start_epoch = 10;
-    let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
-    let current_epoch = 5;
-
-    let rt = setup();
-    rt.set_epoch(current_epoch);
-
-    let deal = generate_and_publish_deal(
-        &rt,
-        CLIENT_ADDR,
-        &MinerAddresses::default(),
-        start_epoch,
-        end_epoch,
-    );
-
-    let ret = terminate_deals_raw(&rt, PROVIDER_ADDR, &[deal]);
-    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "no state for deal", ret);
-    rt.verify();
-    check_state(&rt);
-}
-
-// Converted from: https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/market/market_test.go#L1485
-#[test]
-fn termination_of_all_deals_should_fail_when_one_deal_fails() {
-    let start_epoch = 10;
-    let end_epoch = start_epoch + 200 * EPOCHS_IN_DAY;
-    let sector_expiry = end_epoch + 100;
-    let current_epoch = 5;
-
-    let rt = setup();
-    rt.set_epoch(current_epoch);
-
-    // deal1 would terminate but deal2 will fail because deal2 has not been activated
-    let deal1 = generate_and_publish_deal(
-        &rt,
-        CLIENT_ADDR,
-        &MinerAddresses::default(),
-        start_epoch,
-        end_epoch,
-    );
-    activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &[deal1]);
-    let deal2 = generate_and_publish_deal(
-        &rt,
-        CLIENT_ADDR,
-        &MinerAddresses::default(),
-        start_epoch,
-        end_epoch + 1,
-    );
-
-    let ret = terminate_deals_raw(&rt, PROVIDER_ADDR, &[deal1, deal2]);
-    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "no state for deal", ret);
-    rt.verify();
-
-    // verify deal1 has not been terminated
-    assert_deals_not_terminated(&rt, &[deal1]);
     check_state(&rt);
 }

--- a/actors/market/tests/on_miner_sectors_terminate.rs
+++ b/actors/market/tests/on_miner_sectors_terminate.rs
@@ -250,7 +250,7 @@ fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
 
     terminate_deals(&rt, PROVIDER_ADDR, &[sector_number]);
     assert_deals_terminated(&rt, new_epoch, &deal_ids[0..0]);
-    assert_deal_deleted(&rt, deal_ids[1], deal2, sector_number);
+    assert_deal_deleted(&rt, deal_ids[1], &deal2, sector_number);
     check_state(&rt);
 }
 

--- a/actors/market/tests/random_cron_epoch_during_publish.rs
+++ b/actors/market/tests/random_cron_epoch_during_publish.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fil_actor_market::EX_DEAL_EXPIRED;
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
@@ -104,7 +105,7 @@ fn deals_are_scheduled_for_expiry_later_than_the_end_epoch() {
     rt.set_epoch(curr);
     let (pay, _) = cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, curr, deal_id);
     assert_eq!(&deal_proposal.storage_price_per_epoch, &pay);
-    assert_deal_deleted(&rt, deal_id, deal_proposal, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER);
     check_state(&rt);
 }
 
@@ -132,7 +133,7 @@ fn deal_is_processed_after_its_end_epoch_should_expire_correctly() {
     assert!(slashed.is_zero());
     let duration = END_EPOCH - START_EPOCH;
     assert_eq!(duration * &deal_proposal.storage_price_per_epoch, pay);
-    assert_deal_deleted(&rt, deal_id, deal_proposal, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER);
     check_state(&rt);
 }
 
@@ -153,7 +154,7 @@ fn activation_after_deal_start_epoch_but_before_it_is_processed_fails() {
 
     let res =
         activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, curr_epoch, SECTOR_NUMBER, &[deal_id]);
-    assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_ILLEGAL_ARGUMENT]);
+    assert_eq!(res.activation_results.codes(), vec![EX_DEAL_EXPIRED]);
     check_state(&rt);
 }
 
@@ -181,6 +182,6 @@ fn cron_processing_of_deal_after_missed_activation_should_fail_and_slash() {
     );
     cron_tick(&rt);
 
-    assert_deal_deleted(&rt, deal_id, deal_proposal, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER);
     check_state(&rt);
 }

--- a/actors/market/tests/sector_content_changed.rs
+++ b/actors/market/tests/sector_content_changed.rs
@@ -1,0 +1,397 @@
+use cid::Cid;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::deal::DealID;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
+use fvm_shared::piece::PaddedPieceSize;
+use multihash::Code::Sha2_256;
+use multihash::MultihashDigest;
+use num_traits::Zero;
+
+use fil_actor_market::ext::miner::{
+    PieceInfo, PieceReturn, SectorChanges, SectorContentChangedParams,
+};
+use fil_actor_market::{DealProposal, Method, NO_ALLOCATION_ID};
+use fil_actors_runtime::cbor::serialize;
+use fil_actors_runtime::runtime::builtins::Type;
+use fil_actors_runtime::test_utils::{expect_abort, MockRuntime, ACCOUNT_ACTOR_CODE_ID};
+use fil_actors_runtime::EPOCHS_IN_DAY;
+use harness::*;
+
+mod harness;
+
+const START_EPOCH: ChainEpoch = 10;
+const END_EPOCH: ChainEpoch = 200 * EPOCHS_IN_DAY;
+const MINER_ADDRESSES: MinerAddresses = MinerAddresses {
+    owner: OWNER_ADDR,
+    worker: WORKER_ADDR,
+    provider: PROVIDER_ADDR,
+    control: vec![],
+};
+
+// These tests share a lot in common with those for BatchActivateDeals,
+// as they perform similar functions.
+
+#[test]
+fn empty_params() {
+    let rt = setup();
+
+    // Empty params
+    let changes = vec![];
+    let ret = sector_content_changed(&rt, PROVIDER_ADDR, changes).unwrap();
+    assert_eq!(0, ret.sectors.len());
+
+    // Sector with no pieces
+    let changes =
+        vec![SectorChanges { sector: 1, minimum_commitment_epoch: END_EPOCH, added: vec![] }];
+    let ret = sector_content_changed(&rt, PROVIDER_ADDR, changes).unwrap();
+    assert_eq!(1, ret.sectors.len());
+    assert_eq!(0, ret.sectors[0].added.len());
+    check_state(&rt);
+}
+
+#[test]
+fn simple_one_sector() {
+    let rt = setup();
+    let epoch = rt.set_epoch(START_EPOCH);
+    let mut deals = create_deals(&rt, 3);
+    deals[2].verified_deal = true;
+
+    let next_allocation_id = 1;
+    let datacap_required = TokenAmount::from_whole(deals[2].piece_size.0);
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids =
+        publish_deals(&rt, &MINER_ADDRESSES, &deals, datacap_required, next_allocation_id);
+
+    let mut pieces = pieces_from_deals(&deal_ids, &deals);
+    pieces.reverse();
+
+    let sno = 7;
+    let changes = vec![SectorChanges {
+        sector: sno,
+        minimum_commitment_epoch: END_EPOCH + 10,
+        added: pieces,
+    }];
+    let ret = sector_content_changed(&rt, PROVIDER_ADDR, changes).unwrap();
+    assert_eq!(1, ret.sectors.len());
+    assert_eq!(3, ret.sectors[0].added.len());
+    assert!(ret.sectors[0].added.iter().all(|r| r.code == ExitCode::OK));
+
+    // Deal IDs are stored under the sector, in correct order.
+    assert_eq!(deal_ids, get_sector_deal_ids(&rt, &PROVIDER_ADDR, sno));
+
+    // Deal states include allocation IDs from when they were published.
+    for id in deal_ids.iter() {
+        let state = get_deal_state(&rt, *id);
+        assert_eq!(sno, state.sector_number);
+        assert_eq!(epoch, state.sector_start_epoch);
+        if *id == deal_ids[2] {
+            assert_eq!(state.verified_claim, next_allocation_id);
+        } else {
+            assert_eq!(state.verified_claim, NO_ALLOCATION_ID);
+        }
+    }
+    check_state(&rt);
+}
+
+#[test]
+fn simple_multiple_sectors() {
+    let rt = setup();
+    let deals = create_deals(&rt, 3);
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids =
+        publish_deals(&rt, &MINER_ADDRESSES, &deals, TokenAmount::zero(), NO_ALLOCATION_ID);
+    let pieces = pieces_from_deals(&deal_ids, &deals);
+
+    let changes = vec![
+        SectorChanges {
+            sector: 1,
+            minimum_commitment_epoch: END_EPOCH + 10,
+            added: pieces[0..1].to_vec(),
+        },
+        // Same sector referenced twice, it's ok.
+        SectorChanges {
+            sector: 1,
+            minimum_commitment_epoch: END_EPOCH + 10,
+            added: pieces[1..2].to_vec(),
+        },
+        SectorChanges {
+            sector: 2,
+            minimum_commitment_epoch: END_EPOCH + 10,
+            added: pieces[2..3].to_vec(),
+        },
+    ];
+    let ret = sector_content_changed(&rt, PROVIDER_ADDR, changes).unwrap();
+    assert_eq!(3, ret.sectors.len());
+    assert_eq!(vec![PieceReturn { code: ExitCode::OK, data: vec![] }], ret.sectors[0].added);
+    assert_eq!(vec![PieceReturn { code: ExitCode::OK, data: vec![] }], ret.sectors[1].added);
+    assert_eq!(vec![PieceReturn { code: ExitCode::OK, data: vec![] }], ret.sectors[2].added);
+
+    // Deal IDs are stored under the right sector, in correct order.
+    assert_eq!(deal_ids[0..2], get_sector_deal_ids(&rt, &PROVIDER_ADDR, 1));
+    assert_eq!(deal_ids[2..3], get_sector_deal_ids(&rt, &PROVIDER_ADDR, 2));
+}
+
+#[test]
+fn new_deal_existing_sector() {
+    let rt = setup();
+    let deals = create_deals(&rt, 3);
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids =
+        publish_deals(&rt, &MINER_ADDRESSES, &deals, TokenAmount::zero(), NO_ALLOCATION_ID);
+    let pieces = pieces_from_deals(&deal_ids, &deals);
+
+    let changes = vec![SectorChanges {
+        sector: 1,
+        minimum_commitment_epoch: END_EPOCH + 10,
+        added: pieces[1..3].to_vec(),
+    }];
+    sector_content_changed(&rt, PROVIDER_ADDR, changes).unwrap();
+
+    let changes = vec![SectorChanges {
+        sector: 1,
+        minimum_commitment_epoch: END_EPOCH + 10,
+        added: pieces[0..1].to_vec(),
+    }];
+    sector_content_changed(&rt, PROVIDER_ADDR, changes).unwrap();
+
+    // All deal IDs are stored under the right sector, in correct order.
+    assert_eq!(deal_ids[0..3], get_sector_deal_ids(&rt, &PROVIDER_ADDR, 1));
+}
+
+#[test]
+fn piece_must_match_deal() {
+    let rt = setup();
+    let deals = create_deals(&rt, 2);
+
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids =
+        publish_deals(&rt, &MINER_ADDRESSES, &deals, TokenAmount::zero(), NO_ALLOCATION_ID);
+    let mut pieces = pieces_from_deals(&deal_ids, &deals);
+    // Wrong CID
+    pieces[0].data = Cid::new_v1(0, Sha2_256.digest(&[1, 2, 3, 4]));
+    // Wrong size
+    pieces[1].size = PaddedPieceSize(1234);
+    // Deal doesn't exist
+    pieces.push(PieceInfo {
+        data: Cid::new_v1(0, Sha2_256.digest(&[1, 2, 3, 4])),
+        size: PaddedPieceSize(1234),
+        payload: serialize(&1234, "deal id").unwrap(),
+    });
+
+    let changes =
+        vec![SectorChanges { sector: 1, minimum_commitment_epoch: END_EPOCH + 10, added: pieces }];
+    let ret = sector_content_changed(&rt, PROVIDER_ADDR, changes).unwrap();
+    assert_eq!(1, ret.sectors.len());
+    assert_eq!(
+        vec![
+            PieceReturn { code: ExitCode::USR_ILLEGAL_ARGUMENT, data: vec![] },
+            PieceReturn { code: ExitCode::USR_ILLEGAL_ARGUMENT, data: vec![] },
+            PieceReturn { code: ExitCode::USR_NOT_FOUND, data: vec![] },
+        ],
+        ret.sectors[0].added
+    );
+
+    check_state(&rt);
+}
+
+#[test]
+fn invalid_deal_id_rejected() {
+    let rt = setup();
+    let deals = create_deals(&rt, 1);
+
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids =
+        publish_deals(&rt, &MINER_ADDRESSES, &deals, TokenAmount::zero(), NO_ALLOCATION_ID);
+    let mut pieces = pieces_from_deals(&deal_ids, &deals);
+    // Append a byte to the deal ID.
+    let mut buf = pieces[0].payload.to_vec();
+    buf.push(123);
+    pieces[0].payload = buf.into();
+
+    let changes =
+        vec![SectorChanges { sector: 1, minimum_commitment_epoch: END_EPOCH + 10, added: pieces }];
+    let ret = sector_content_changed(&rt, PROVIDER_ADDR, changes).unwrap();
+    assert_eq!(1, ret.sectors.len());
+    assert_eq!(
+        vec![PieceReturn { code: ExitCode::USR_SERIALIZATION, data: vec![] },],
+        ret.sectors[0].added
+    );
+
+    check_state(&rt);
+}
+
+#[test]
+fn failures_isolated() {
+    let rt = setup();
+    let deals = create_deals(&rt, 4);
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids =
+        publish_deals(&rt, &MINER_ADDRESSES, &deals, TokenAmount::zero(), NO_ALLOCATION_ID);
+    let mut pieces = pieces_from_deals(&deal_ids, &deals);
+
+    // Break second and third pieces.
+    pieces[1].size = PaddedPieceSize(1234);
+    pieces[2].size = PaddedPieceSize(1234);
+    let changes = vec![
+        SectorChanges {
+            sector: 1,
+            minimum_commitment_epoch: END_EPOCH + 10,
+            added: pieces[0..2].to_vec(),
+        },
+        SectorChanges {
+            sector: 2,
+            minimum_commitment_epoch: END_EPOCH + 10,
+            added: pieces[2..3].to_vec(),
+        },
+        SectorChanges {
+            sector: 3,
+            minimum_commitment_epoch: END_EPOCH + 10,
+            added: pieces[3..4].to_vec(),
+        },
+    ];
+
+    let ret = sector_content_changed(&rt, PROVIDER_ADDR, changes).unwrap();
+    assert_eq!(3, ret.sectors.len());
+    // Broken second piece still allows first piece in same sector to activate.
+    assert_eq!(
+        vec![
+            PieceReturn { code: ExitCode::OK, data: vec![] },
+            PieceReturn { code: ExitCode::USR_ILLEGAL_ARGUMENT, data: vec![] }
+        ],
+        ret.sectors[0].added
+    );
+    // Broken third piece
+    assert_eq!(
+        vec![PieceReturn { code: ExitCode::USR_ILLEGAL_ARGUMENT, data: vec![] }],
+        ret.sectors[1].added
+    );
+    // Ok fourth piece.
+    assert_eq!(vec![PieceReturn { code: ExitCode::OK, data: vec![] }], ret.sectors[2].added);
+
+    // Successful deal IDs are stored under the right sector, in correct order.
+    assert_eq!(deal_ids[0..1], get_sector_deal_ids(&rt, &PROVIDER_ADDR, 1));
+    assert_eq!(deal_ids[3..4], get_sector_deal_ids(&rt, &PROVIDER_ADDR, 3));
+}
+
+#[test]
+fn rejects_duplicates_in_same_sector() {
+    let rt = setup();
+    let deals = create_deals(&rt, 2);
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids =
+        publish_deals(&rt, &MINER_ADDRESSES, &deals, TokenAmount::zero(), NO_ALLOCATION_ID);
+    let pieces = pieces_from_deals(&deal_ids, &deals);
+
+    let changes = vec![
+        // Same deal twice in one sector change.
+        SectorChanges {
+            sector: 1,
+            minimum_commitment_epoch: END_EPOCH + 10,
+            added: vec![pieces[0].clone(), pieces[0].clone(), pieces[1].clone()],
+        },
+    ];
+    let ret = sector_content_changed(&rt, PROVIDER_ADDR, changes).unwrap();
+    assert_eq!(1, ret.sectors.len());
+    // The first piece succeeds just once, the second piece succeeds too.
+    assert_eq!(
+        vec![
+            PieceReturn { code: ExitCode::OK, data: vec![] },
+            PieceReturn { code: ExitCode::USR_ILLEGAL_ARGUMENT, data: vec![] },
+            PieceReturn { code: ExitCode::OK, data: vec![] },
+        ],
+        ret.sectors[0].added
+    );
+
+    // Deal IDs are stored under the right sector, in correct order.
+    assert_eq!(deal_ids[0..2], get_sector_deal_ids(&rt, &PROVIDER_ADDR, 1));
+    assert_eq!(Vec::<DealID>::new(), get_sector_deal_ids(&rt, &PROVIDER_ADDR, 2));
+}
+
+#[test]
+fn rejects_duplicates_across_sectors() {
+    let rt = setup();
+    let deals = create_deals(&rt, 3);
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
+    let deal_ids =
+        publish_deals(&rt, &MINER_ADDRESSES, &deals, TokenAmount::zero(), NO_ALLOCATION_ID);
+    let pieces = pieces_from_deals(&deal_ids, &deals);
+
+    let changes = vec![
+        SectorChanges {
+            sector: 1,
+            minimum_commitment_epoch: END_EPOCH + 10,
+            added: vec![pieces[0].clone()],
+        },
+        // Same piece again, referencing same sector, plus a new piece.
+        SectorChanges {
+            sector: 1,
+            minimum_commitment_epoch: END_EPOCH + 10,
+            added: vec![pieces[0].clone(), pieces[1].clone()],
+        },
+        // Same deal piece in a different sector, plus second piece agoin, plus a new piece.
+        SectorChanges {
+            sector: 2,
+            minimum_commitment_epoch: END_EPOCH + 10,
+            added: vec![pieces[0].clone(), pieces[1].clone(), pieces[2].clone()],
+        },
+    ];
+    let ret = sector_content_changed(&rt, PROVIDER_ADDR, changes).unwrap();
+    assert_eq!(3, ret.sectors.len());
+    // Succeeds in the first time.
+    assert_eq!(vec![PieceReturn { code: ExitCode::OK, data: vec![] },], ret.sectors[0].added);
+    // Fails second time, but other piece succeeds.
+    assert_eq!(
+        vec![
+            PieceReturn { code: ExitCode::USR_ILLEGAL_ARGUMENT, data: vec![] },
+            PieceReturn { code: ExitCode::OK, data: vec![] },
+        ],
+        ret.sectors[1].added
+    );
+    // Both duplicates fail, but third piece succeeds.
+    assert_eq!(
+        vec![
+            PieceReturn { code: ExitCode::USR_ILLEGAL_ARGUMENT, data: vec![] },
+            PieceReturn { code: ExitCode::USR_ILLEGAL_ARGUMENT, data: vec![] },
+            PieceReturn { code: ExitCode::OK, data: vec![] },
+        ],
+        ret.sectors[2].added
+    );
+
+    // Deal IDs are stored under the right sector, in correct order.
+    assert_eq!(deal_ids[0..2], get_sector_deal_ids(&rt, &PROVIDER_ADDR, 1));
+    assert_eq!(deal_ids[2..3], get_sector_deal_ids(&rt, &PROVIDER_ADDR, 2));
+}
+
+#[test]
+fn require_miner_caller() {
+    let rt = setup();
+    let changes = vec![];
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, PROVIDER_ADDR); // Not a miner
+    rt.expect_validate_caller_type(vec![Type::Miner]);
+    let params = SectorContentChangedParams { sectors: changes };
+
+    expect_abort(
+        ExitCode::USR_FORBIDDEN,
+        rt.call::<fil_actor_market::Actor>(
+            Method::SectorContentChangedExported as u64,
+            IpldBlock::serialize_cbor(&params).unwrap(),
+        ),
+    );
+}
+
+fn create_deals(rt: &MockRuntime, count: i64) -> Vec<DealProposal> {
+    (0..count)
+        .map(|i| create_deal(rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH + i, false))
+        .collect()
+}
+
+fn pieces_from_deals(deal_ids: &[DealID], deals: &[DealProposal]) -> Vec<PieceInfo> {
+    deal_ids.iter().zip(deals).map(|(id, deal)| piece_info_from_deal(*id, deal)).collect()
+}
+
+// TODO
+
+// - See activate_deals_failures
+// - test bad deal ID, serialise

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -1,15 +1,6 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-mod harness;
-
-use fil_actor_market::{Actor as MarketActor, Method, SectorDeals, VerifyDealsForActivationParams};
-use fil_actors_runtime::runtime::builtins::Type;
-use fil_actors_runtime::test_utils::{
-    expect_abort, expect_abort_contains_message, make_piece_cid, ACCOUNT_ACTOR_CODE_ID,
-    MINER_ACTOR_CODE_ID,
-};
-use fil_actors_runtime::EPOCHS_IN_DAY;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
@@ -18,8 +9,18 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::sector::RegisteredSealProof;
-use harness::*;
 use num_traits::Zero;
+
+use fil_actor_market::{Actor as MarketActor, Method, SectorDeals, VerifyDealsForActivationParams};
+use fil_actors_runtime::runtime::builtins::Type;
+use fil_actors_runtime::test_utils::{
+    expect_abort, expect_abort_contains_message, make_piece_cid, ACCOUNT_ACTOR_CODE_ID,
+    MINER_ACTOR_CODE_ID,
+};
+use fil_actors_runtime::EPOCHS_IN_DAY;
+use harness::*;
+
+mod harness;
 
 const START_EPOCH: ChainEpoch = 10;
 const CURR_EPOCH: ChainEpoch = START_EPOCH;
@@ -267,7 +268,7 @@ fn fail_when_current_epoch_is_greater_than_proposal_start_epoch() {
         }],
     };
     expect_abort(
-        ExitCode::USR_ILLEGAL_ARGUMENT,
+        fil_actor_market::EX_DEAL_EXPIRED,
         rt.call::<MarketActor>(
             Method::VerifyDealsForActivation as u64,
             IpldBlock::serialize_cbor(&params).unwrap(),

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -38,18 +38,20 @@ fn verify_deal_and_activate_to_get_deal_space_for_unverified_deal_proposal() {
     let deal_id =
         generate_and_publish_deal(&rt, CLIENT_ADDR, &MINER_ADDRESSES, START_EPOCH, END_EPOCH);
     let deal_proposal = get_deal_proposal(&rt, deal_id);
-
+    let sector_number = 7;
     let v_response = verify_deals_for_activation(
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number,
             sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
             sector_expiry: SECTOR_EXPIRY,
             deal_ids: vec![deal_id],
         }],
         |_| None,
     );
-    let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
+    let a_response =
+        activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, sector_number, &[deal_id]);
     let s_response = a_response.activations.get(0).unwrap();
     assert_eq!(1, v_response.unsealed_cids.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), v_response.unsealed_cids[0]);
@@ -72,11 +74,12 @@ fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
         next_allocation_id,
     );
     let deal_proposal = get_deal_proposal(&rt, deal_id);
-
+    let sector_number = 7;
     let response = verify_deals_for_activation(
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number,
             sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
             sector_expiry: SECTOR_EXPIRY,
             deal_ids: vec![deal_id],
@@ -84,7 +87,8 @@ fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
         |_| None,
     );
 
-    let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &[deal_id]);
+    let a_response =
+        activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, sector_number, &[deal_id]);
     let s_response = a_response.activations.get(0).unwrap();
 
     assert_eq!(1, response.unsealed_cids.len());
@@ -123,10 +127,12 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
     let deal_ids = publish_deals(&rt, &MINER_ADDRESSES, &deals, datacap_required, 1);
     assert_eq!(4, deal_ids.len());
 
+    let sector_number = 7;
     let response = verify_deals_for_activation(
         &rt,
         PROVIDER_ADDR,
         vec![SectorDeals {
+            sector_number,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             sector_expiry: SECTOR_EXPIRY,
             deal_ids: deal_ids.clone(),
@@ -145,7 +151,8 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
     let unverified_space =
         BigInt::from(unverified_deal_1.piece_size.0 + unverified_deal_2.piece_size.0);
 
-    let a_response = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, &deal_ids);
+    let a_response =
+        activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, sector_number, &deal_ids);
     let s_response = a_response.activations.get(0).unwrap();
 
     assert_eq!(1, response.unsealed_cids.len());
@@ -165,9 +172,10 @@ fn fail_when_caller_is_not_a_storage_miner_actor() {
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
     rt.expect_validate_caller_type(vec![Type::Miner]);
-
+    let sector_number = 7;
     let params = VerifyDealsForActivationParams {
         sectors: vec![SectorDeals {
+            sector_number,
             sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
             sector_expiry: SECTOR_EXPIRY,
             deal_ids: vec![deal_id],
@@ -188,9 +196,10 @@ fn fail_when_caller_is_not_a_storage_miner_actor() {
 #[test]
 fn fail_when_deal_proposal_is_not_found() {
     let rt = setup();
-
+    let sector_number = 7;
     let params = VerifyDealsForActivationParams {
         sectors: vec![SectorDeals {
+            sector_number,
             sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
             sector_expiry: SECTOR_EXPIRY,
             deal_ids: vec![1],
@@ -218,9 +227,10 @@ fn fail_when_caller_is_not_the_provider() {
 
     rt.set_caller(*MINER_ACTOR_CODE_ID, Address::new_id(205));
     rt.expect_validate_caller_type(vec![Type::Miner]);
-
+    let sector_number = 7;
     let params = VerifyDealsForActivationParams {
         sectors: vec![SectorDeals {
+            sector_number,
             sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
             sector_expiry: SECTOR_EXPIRY,
             deal_ids: vec![deal_id],
@@ -247,9 +257,10 @@ fn fail_when_current_epoch_is_greater_than_proposal_start_epoch() {
 
     rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
     rt.expect_validate_caller_type(vec![Type::Miner]);
-
+    let sector_number = 7;
     let params = VerifyDealsForActivationParams {
         sectors: vec![SectorDeals {
+            sector_number,
             sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
             sector_expiry: SECTOR_EXPIRY,
             deal_ids: vec![deal_id],
@@ -275,9 +286,10 @@ fn fail_when_deal_end_epoch_is_greater_than_sector_expiration() {
 
     rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
     rt.expect_validate_caller_type(vec![Type::Miner]);
-
+    let sector_number = 7;
     let params = VerifyDealsForActivationParams {
         sectors: vec![SectorDeals {
+            sector_number,
             sector_type: RegisteredSealProof::StackedDRG2KiBV1P1,
             sector_expiry: END_EPOCH - 1,
             deal_ids: vec![deal_id],
@@ -303,9 +315,10 @@ fn fail_when_the_same_deal_id_is_passed_multiple_times() {
 
     rt.set_caller(*MINER_ACTOR_CODE_ID, PROVIDER_ADDR);
     rt.expect_validate_caller_type(vec![Type::Miner]);
-
+    let sector_number = 7;
     let params = VerifyDealsForActivationParams {
         sectors: vec![SectorDeals {
+            sector_number,
             sector_type: RegisteredSealProof::StackedDRG8MiBV1,
             sector_expiry: SECTOR_EXPIRY,
             deal_ids: vec![deal_id, deal_id],

--- a/actors/miner/src/ext.rs
+++ b/actors/miner/src/ext.rs
@@ -19,6 +19,7 @@ pub mod account {
 
 pub mod market {
     use super::*;
+    use fvm_ipld_bitfield::BitField;
 
     pub const VERIFY_DEALS_FOR_ACTIVATION_METHOD: u64 = 5;
     pub const BATCH_ACTIVATE_DEALS_METHOD: u64 = 6;
@@ -26,6 +27,7 @@ pub mod market {
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct SectorDeals {
+        pub sector_number: SectorNumber,
         pub sector_type: RegisteredSealProof,
         pub sector_expiry: ChainEpoch,
         pub deal_ids: Vec<DealID>,
@@ -73,13 +75,7 @@ pub mod market {
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct OnMinerSectorsTerminateParams {
         pub epoch: ChainEpoch,
-        pub deal_ids: Vec<DealID>,
-    }
-
-    #[derive(Serialize_tuple)]
-    pub struct OnMinerSectorsTerminateParamsRef<'a> {
-        pub epoch: ChainEpoch,
-        pub deal_ids: &'a [DealID],
+        pub sectors: BitField,
     }
 
     #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -101,7 +101,7 @@ pub enum Method {
     ChangeWorkerAddress = 3,
     ChangePeerID = 4,
     SubmitWindowedPoSt = 5,
-    PreCommitSector = 6,
+    //PreCommitSector = 6, // Deprecated
     ProveCommitSector = 7,
     ExtendSectorExpiration = 8,
     TerminateSectors = 9,
@@ -120,7 +120,7 @@ pub enum Method {
     RepayDebt = 22,
     ChangeOwnerAddress = 23,
     DisputeWindowedPoSt = 24,
-    PreCommitSectorBatch = 25,
+    //PreCommitSectorBatch = 25, // Deprecated
     ProveCommitAggregate = 26,
     ProveReplicaUpdates = 27,
     PreCommitSectorBatch2 = 28,
@@ -1679,54 +1679,6 @@ impl Actor {
         Ok(())
     }
 
-    /// Pledges to seal and commit a single sector.
-    /// See PreCommitSectorBatch for details.
-    fn pre_commit_sector(
-        rt: &impl Runtime,
-        params: PreCommitSectorParams,
-    ) -> Result<(), ActorError> {
-        Self::pre_commit_sector_batch(rt, PreCommitSectorBatchParams { sectors: vec![params] })
-    }
-
-    /// Pledges the miner to seal and commit some new sectors.
-    /// The caller specifies sector numbers, sealed sector data CIDs, seal randomness epoch, expiration, and the IDs
-    /// of any storage deals contained in the sector data. The storage deal proposals must be already submitted
-    /// to the storage market actor.
-    /// A pre-commitment may specify an existing committed-capacity sector that the committed sector will replace
-    /// when proven.
-    /// This method calculates the sector's power, locks a pre-commit deposit for the sector, stores information about the
-    /// sector in state and waits for it to be proven or expire.
-    fn pre_commit_sector_batch(
-        rt: &impl Runtime,
-        params: PreCommitSectorBatchParams,
-    ) -> Result<(), ActorError> {
-        let sectors = params
-            .sectors
-            .into_iter()
-            .map(|spci| {
-                if spci.replace_capacity {
-                    Err(actor_error!(
-                        forbidden,
-                        "cc upgrade through precommit discontinued, use ProveReplicaUpdate"
-                    ))
-                } else {
-                    Ok(SectorPreCommitInfoInner {
-                        seal_proof: spci.seal_proof,
-                        sector_number: spci.sector_number,
-                        sealed_cid: spci.sealed_cid,
-                        seal_rand_epoch: spci.seal_rand_epoch,
-                        deal_ids: spci.deal_ids,
-                        expiration: spci.expiration,
-                        // This entry point computes the unsealed CID from deals via the market.
-                        // A future one will accept it directly as a parameter.
-                        unsealed_cid: None,
-                    })
-                }
-            })
-            .collect::<Result<_, _>>()?;
-        Self::pre_commit_sector_batch_inner(rt, sectors)
-    }
-
     /// Pledges the miner to seal and commit some new sectors.
     /// The caller specifies sector numbers, sealed sector CIDs, unsealed sector CID, seal randomness epoch, expiration, and the IDs
     /// of any storage deals contained in the sector data. The storage deal proposals must be already submitted
@@ -1827,10 +1779,20 @@ impl Actor {
                 ));
             }
 
-            if let Some(ref commd) = precommit.unsealed_cid.as_ref().and_then(|c| c.0) {
-                if !is_unsealed_sector(commd) {
-                    return Err(actor_error!(illegal_argument, "unsealed CID had wrong prefix"));
+            if let Some(compact_commd) = &precommit.unsealed_cid {
+                if let Some(commd) = compact_commd.0 {
+                    if !is_unsealed_sector(&commd) {
+                        return Err(actor_error!(
+                            illegal_argument,
+                            "unsealed CID had wrong prefix"
+                        ));
+                    }
                 }
+            } else {
+                return Err(actor_error!(
+                    illegal_argument,
+                    "unspecified CompactCommD not allowed past nv21, need explicit None value for CC or CommD"
+                ));
             }
 
             // Require sector lifetime meets minimum by assuming activation happens at last epoch permitted for seal proof.
@@ -1936,11 +1898,7 @@ impl Actor {
                 // 1. verify that precommit.unsealed_cid is correct
                 // 2. create a new on_chain_precommit
 
-                let commd = match precommit.unsealed_cid {
-                    // if the CommD is unknown, use CommD computed by the market
-                    None => CompactCommD::new(*computed_cid),
-                    Some(x) => x,
-                };
+                let commd = precommit.unsealed_cid.unwrap();
                 if commd.0 != *computed_cid {
                     return Err(actor_error!(illegal_argument, "computed {:?} and passed {:?} CommDs not equal",
                             computed_cid, commd));
@@ -5088,7 +5046,6 @@ impl ActorCode for Actor {
         ChangeWorkerAddress|ChangeWorkerAddressExported => change_worker_address,
         ChangePeerID|ChangePeerIDExported => change_peer_id,
         SubmitWindowedPoSt => submit_windowed_post,
-        PreCommitSector => pre_commit_sector,
         ProveCommitSector => prove_commit_sector,
         ExtendSectorExpiration => extend_sector_expiration,
         TerminateSectors => terminate_sectors,
@@ -5107,7 +5064,6 @@ impl ActorCode for Actor {
         RepayDebt|RepayDebtExported => repay_debt,
         ChangeOwnerAddress|ChangeOwnerAddressExported => change_owner_address,
         DisputeWindowedPoSt => dispute_windowed_post,
-        PreCommitSectorBatch => pre_commit_sector_batch,
         ProveCommitAggregate => prove_commit_aggregate,
         ProveReplicaUpdates => prove_replica_updates,
         PreCommitSectorBatch2 => pre_commit_sector_batch2,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1846,6 +1846,7 @@ impl Actor {
             )?;
 
             sectors_deals.push(ext::market::SectorDeals {
+                sector_number: precommit.sector_number,
                 sector_type: precommit.seal_proof,
                 sector_expiry: precommit.expiration,
                 deal_ids: precommit.deal_ids.clone(),
@@ -3908,7 +3909,7 @@ fn process_early_terminations(
     reward_smoothed: &FilterEstimate,
     quality_adj_power_smoothed: &FilterEstimate,
 ) -> Result</* more */ bool, ActorError> {
-    let (result, more, deals_to_terminate, penalty, pledge_delta) =
+    let (result, more, sectors_terminated, penalty, pledge_delta) =
         rt.transaction(|state: &mut State, rt| {
             let store = rt.store();
             let policy = rt.policy();
@@ -3940,14 +3941,12 @@ fn process_early_terminations(
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load sectors array")
             })?;
 
+            let mut sectors_terminated: Vec<BitField> = Vec::new();
             let mut total_initial_pledge = TokenAmount::zero();
-            let mut deals_to_terminate =
-                Vec::<ext::market::OnMinerSectorsTerminateParams>::with_capacity(
-                    result.sectors.len(),
-                );
             let mut penalty = TokenAmount::zero();
 
             for (epoch, sector_numbers) in result.iter() {
+                sectors_terminated.push(sector_numbers.clone());
                 let sectors = sectors
                     .load_sector(sector_numbers)
                     .map_err(|e| e.wrap("failed to load sector infos"))?;
@@ -3966,9 +3965,6 @@ fn process_early_terminations(
                     deal_ids.extend(sector.deal_ids);
                     total_initial_pledge += sector.initial_pledge;
                 }
-
-                let params = ext::market::OnMinerSectorsTerminateParams { epoch, deal_ids };
-                deals_to_terminate.push(params);
             }
 
             // Pay penalty
@@ -3996,7 +3992,7 @@ fn process_early_terminations(
             penalty = &penalty_from_vesting + penalty_from_balance;
             pledge_delta -= penalty_from_vesting;
 
-            Ok((result, more, deals_to_terminate, penalty, pledge_delta))
+            Ok((result, more, sectors_terminated, penalty, pledge_delta))
         })?;
 
     // We didn't do anything, abort.
@@ -4017,9 +4013,8 @@ fn process_early_terminations(
     notify_pledge_changed(rt, &pledge_delta)?;
 
     // Terminate deals.
-    for params in deals_to_terminate {
-        request_terminate_deals(rt, params.epoch, params.deal_ids)?;
-    }
+    let all_terminated = BitField::union(sectors_terminated.iter());
+    request_terminate_deals(rt, rt.curr_epoch(), &all_terminated)?;
 
     // reschedule cron worker, if necessary.
     Ok(more)
@@ -4260,16 +4255,18 @@ fn request_update_power(rt: &impl Runtime, delta: PowerPair) -> Result<(), Actor
 fn request_terminate_deals(
     rt: &impl Runtime,
     epoch: ChainEpoch,
-    deal_ids: Vec<DealID>,
+    sectors: &BitField,
 ) -> Result<(), ActorError> {
-    const MAX_LENGTH: usize = 8192;
-    for chunk in deal_ids.chunks(MAX_LENGTH) {
+    if !sectors.is_empty() {
+        // The sectors bitfield could be large, but will fit into a single parameters block.
+        // The FVM max block size of 1MiB supports 130K 8-byte integers, but the policy parameter
+        // ADDRESSED_SECTORS_MAX (currently 25k) will avoid reaching that.
         let res = extract_send_result(rt.send_simple(
             &STORAGE_MARKET_ACTOR_ADDR,
             ext::market::ON_MINER_SECTORS_TERMINATE_METHOD,
-            IpldBlock::serialize_cbor(&ext::market::OnMinerSectorsTerminateParamsRef {
+            IpldBlock::serialize_cbor(&ext::market::OnMinerSectorsTerminateParams {
                 epoch,
-                deal_ids: chunk,
+                sectors: sectors.clone(),
             })?,
             TokenAmount::zero(),
         ));
@@ -4283,7 +4280,6 @@ fn request_terminate_deals(
             res?;
         }
     }
-
     Ok(())
 }
 
@@ -4972,6 +4968,7 @@ fn batch_activate_deals_and_claim_allocations(
             let sector_activation_params = activation_infos
                 .iter()
                 .map(|activation_info| ext::market::SectorDeals {
+                    sector_number: activation_info.sector_number,
                     deal_ids: activation_info.deal_ids.clone(),
                     sector_expiry: activation_info.sector_expiry,
                     sector_type: activation_info.sector_type,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -4969,6 +4969,7 @@ fn batch_activate_deals_and_claim_allocations(
                 size: info.size,
             })
             .collect();
+
         verified_claims.push(ext::verifreg::SectorAllocationClaims {
             sector: activation_info.sector_number,
             expiry: activation_info.sector_expiry,

--- a/actors/miner/tests/miner_actor_test_precommit_batch.rs
+++ b/actors/miner/tests/miner_actor_test_precommit_batch.rs
@@ -34,7 +34,6 @@ struct DealSpec {
 }
 
 fn assert_simple_batch(
-    v2: bool,
     batch_size: usize,
     balance_surplus: TokenAmount,
     base_fee: TokenAmount,
@@ -44,10 +43,7 @@ fn assert_simple_batch(
 ) {
     let period_offset = ChainEpoch::from(100);
 
-    let h = ActorHarness::new_with_options(HarnessOptions {
-        use_v2_pre_commit_and_replica_update: v2,
-        proving_period_offset: period_offset,
-    });
+    let h = ActorHarness::new_with_options(HarnessOptions { proving_period_offset: period_offset });
     let rt = h.new_runtime();
 
     let precommit_epoch = period_offset + 1;
@@ -156,47 +152,25 @@ mod miner_actor_precommit_batch {
     };
     use fil_actors_runtime::{STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR};
     use fvm_ipld_encoding::ipld_block::IpldBlock;
-    use test_case::test_case;
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn one_sector(v2: bool) {
-        assert_simple_batch(v2, 1, TokenAmount::zero(), TokenAmount::zero(), &[], ExitCode::OK, "");
+    #[test]
+    fn one_sector() {
+        assert_simple_batch(1, TokenAmount::zero(), TokenAmount::zero(), &[], ExitCode::OK, "");
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn thirty_two_sectors(v2: bool) {
-        assert_simple_batch(
-            v2,
-            32,
-            TokenAmount::zero(),
-            TokenAmount::zero(),
-            &[],
-            ExitCode::OK,
-            "",
-        );
+    #[test]
+    fn thirty_two_sectors() {
+        assert_simple_batch(32, TokenAmount::zero(), TokenAmount::zero(), &[], ExitCode::OK, "");
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn max_sectors(v2: bool) {
-        assert_simple_batch(
-            v2,
-            256,
-            TokenAmount::zero(),
-            TokenAmount::zero(),
-            &[],
-            ExitCode::OK,
-            "",
-        );
+    #[test]
+    fn max_sectors() {
+        assert_simple_batch(256, TokenAmount::zero(), TokenAmount::zero(), &[], ExitCode::OK, "");
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn one_deal(v2: bool) {
+    #[test]
+    fn one_deal() {
         assert_simple_batch(
-            v2,
             3,
             TokenAmount::zero(),
             TokenAmount::zero(),
@@ -205,12 +179,9 @@ mod miner_actor_precommit_batch {
             "",
         );
     }
-
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn many_deals(v2: bool) {
+    #[test]
+    fn many_deals() {
         assert_simple_batch(
-            v2,
             3,
             TokenAmount::zero(),
             TokenAmount::zero(),
@@ -224,11 +195,9 @@ mod miner_actor_precommit_batch {
         );
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn empty_batch(v2: bool) {
+    #[test]
+    fn empty_batch() {
         assert_simple_batch(
-            v2,
             0,
             TokenAmount::zero(),
             TokenAmount::zero(),
@@ -238,11 +207,9 @@ mod miner_actor_precommit_batch {
         );
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn too_many_sectors(v2: bool) {
+    #[test]
+    fn too_many_sectors() {
         assert_simple_batch(
-            v2,
             Policy::default().pre_commit_sector_batch_max_size + 1,
             TokenAmount::zero(),
             TokenAmount::zero(),
@@ -251,12 +218,9 @@ mod miner_actor_precommit_batch {
             "batch of 257 too large",
         );
     }
-
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn insufficient_balance(v2: bool) {
+    #[test]
+    fn insufficient_balance() {
         assert_simple_batch(
-            v2,
             10,
             TokenAmount::from_atto(-1),
             TokenAmount::zero(),
@@ -266,19 +230,16 @@ mod miner_actor_precommit_batch {
         );
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn one_bad_apple_ruins_batch(v2: bool) {
+    #[test]
+    fn one_bad_apple_ruins_batch() {
         // This test does not enumerate all the individual conditions that could cause a single precommit
         // to be rejected. Those are covered in the PreCommitSector tests, and we know that that
         // method is implemented in terms of a batch of one.
 
         let period_offset = ChainEpoch::from(100);
 
-        let h = ActorHarness::new_with_options(HarnessOptions {
-            use_v2_pre_commit_and_replica_update: v2,
-            proving_period_offset: period_offset,
-        });
+        let h =
+            ActorHarness::new_with_options(HarnessOptions { proving_period_offset: period_offset });
 
         let rt = h.new_runtime();
 
@@ -311,15 +272,12 @@ mod miner_actor_precommit_batch {
         rt.reset();
     }
 
-    #[test_case(false; "v1")]
-    #[test_case(true; "v2")]
-    fn duplicate_sector_rejects_batch(v2: bool) {
+    #[test]
+    fn duplicate_sector_rejects_batch() {
         let period_offset = ChainEpoch::from(100);
 
-        let h = ActorHarness::new_with_options(HarnessOptions {
-            use_v2_pre_commit_and_replica_update: v2,
-            proving_period_offset: period_offset,
-        });
+        let h =
+            ActorHarness::new_with_options(HarnessOptions { proving_period_offset: period_offset });
         let rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());
@@ -355,10 +313,8 @@ mod miner_actor_precommit_batch {
     fn mismatch_of_commd() {
         let period_offset = ChainEpoch::from(100);
 
-        let h = ActorHarness::new_with_options(HarnessOptions {
-            use_v2_pre_commit_and_replica_update: true,
-            proving_period_offset: period_offset,
-        });
+        let h =
+            ActorHarness::new_with_options(HarnessOptions { proving_period_offset: period_offset });
         let rt = h.new_runtime();
 
         rt.set_balance(BIG_BALANCE.clone());

--- a/actors/miner/tests/miner_actor_test_precommit_batch.rs
+++ b/actors/miner/tests/miner_actor_test_precommit_batch.rs
@@ -388,6 +388,7 @@ mod miner_actor_precommit_batch {
             let mut sector_deal_data = Vec::new();
             for sector in &sectors {
                 sector_deals.push(SectorDeals {
+                    sector_number: sector.sector_number,
                     sector_type: sector.seal_proof,
                     sector_expiry: sector.expiration,
                     deal_ids: sector.deal_ids.clone(),

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -658,6 +658,7 @@ impl ActorHarness {
         let mut any_deals = false;
         for sector in sectors.iter() {
             sector_deals.push(SectorDeals {
+                sector_number: sector.sector_number,
                 sector_type: sector.seal_proof,
                 sector_expiry: sector.expiration,
                 deal_ids: sector.deal_ids.clone(),
@@ -747,6 +748,7 @@ impl ActorHarness {
         if !params.deal_ids.is_empty() {
             let vdparams = VerifyDealsForActivationParams {
                 sectors: vec![SectorDeals {
+                    sector_number: params.sector_number,
                     sector_type: params.seal_proof,
                     sector_expiry: params.expiration,
                     deal_ids: params.deal_ids.clone(),
@@ -1061,6 +1063,7 @@ impl ActorHarness {
             if !pc.info.deal_ids.is_empty() {
                 let deal_space = cfg.deal_space(pc.info.sector_number);
                 let activate_params = SectorDeals {
+                    sector_number: pc.info.sector_number,
                     deal_ids: pc.info.deal_ids.clone(),
                     sector_expiry: pc.info.expiration,
                     sector_type: pc.info.seal_proof,
@@ -1110,6 +1113,7 @@ impl ActorHarness {
             } else {
                 // empty deal ids
                 sector_activation_params.push(SectorDeals {
+                    sector_number: pc.info.sector_number,
                     deal_ids: vec![],
                     sector_expiry: pc.info.expiration,
                     sector_type: RegisteredSealProof::StackedDRG8MiBV1,
@@ -2050,15 +2054,8 @@ impl ActorHarness {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
         rt.expect_validate_caller_addr(self.caller_addrs());
 
-        let mut deal_ids: Vec<DealID> = Vec::new();
-        let mut sector_infos: Vec<SectorOnChainInfo> = Vec::new();
-
-        for sector in sectors.iter() {
-            let sector = self.get_sector(rt, sector);
-            deal_ids.extend(sector.deal_ids.iter());
-            sector_infos.push(sector);
-        }
-
+        let sector_infos: Vec<SectorOnChainInfo> =
+            sectors.iter().map(|sno| self.get_sector(rt, sno)).collect();
         self.expect_query_network_info(rt);
 
         let mut pledge_delta = TokenAmount::zero();
@@ -2090,22 +2087,16 @@ impl ActorHarness {
             );
         }
 
-        if !deal_ids.is_empty() {
-            let max_length = 8192;
-            let size = deal_ids.len().min(max_length);
-            let params = OnMinerSectorsTerminateParams {
-                epoch: *rt.epoch.borrow(),
-                deal_ids: deal_ids[0..size].to_owned(),
-            };
-            rt.expect_send_simple(
-                STORAGE_MARKET_ACTOR_ADDR,
-                ON_MINER_SECTORS_TERMINATE_METHOD,
-                IpldBlock::serialize_cbor(&params).unwrap(),
-                TokenAmount::zero(),
-                None,
-                ExitCode::OK,
-            );
-        }
+        let params =
+            OnMinerSectorsTerminateParams { epoch: *rt.epoch.borrow(), sectors: sectors.clone() };
+        rt.expect_send_simple(
+            STORAGE_MARKET_ACTOR_ADDR,
+            ON_MINER_SECTORS_TERMINATE_METHOD,
+            IpldBlock::serialize_cbor(&params).unwrap(),
+            TokenAmount::zero(),
+            None,
+            ExitCode::OK,
+        );
 
         let sector_power = power_for_sectors(self.sector_size, &sector_infos);
         let params = UpdateClaimedPowerParams {

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -146,18 +146,19 @@ pub struct ActorHarness {
     pub epoch_reward_smooth: FilterEstimate,
     pub epoch_qa_power_smooth: FilterEstimate,
 
+    pub base_fee: TokenAmount,
+
     pub options: HarnessOptions,
 }
 
 pub struct HarnessOptions {
     pub proving_period_offset: ChainEpoch,
-    pub use_v2_pre_commit_and_replica_update: bool,
 }
 
 impl Default for HarnessOptions {
     // could be a derive(Default) but I expect options in future that won't be such
     fn default() -> Self {
-        HarnessOptions { proving_period_offset: 0, use_v2_pre_commit_and_replica_update: false }
+        HarnessOptions { proving_period_offset: 0 }
     }
 }
 
@@ -195,6 +196,8 @@ impl ActorHarness {
 
             epoch_reward_smooth: FilterEstimate::new(rwd.atto().clone(), BigInt::from(0)),
             epoch_qa_power_smooth: FilterEstimate::new(pwr, BigInt::from(0)),
+
+            base_fee: TokenAmount::zero(),
 
             options,
         }
@@ -548,55 +551,6 @@ impl ActorHarness {
         ProveCommitSectorParams { sector_number: sector_no, proof: vec![0u8; 192] }
     }
 
-    pub fn pre_commit_sector_batch_v2(
-        &self,
-        rt: &MockRuntime,
-        params: PreCommitSectorBatchParams2,
-        first_for_miner: bool,
-        base_fee: &TokenAmount,
-    ) -> Result<Option<IpldBlock>, ActorError> {
-        if self.options.use_v2_pre_commit_and_replica_update {
-            self.pre_commit_sector_batch_inner(
-                rt,
-                &params.sectors,
-                Method::PreCommitSectorBatch2 as u64,
-                params.clone(),
-                first_for_miner,
-                base_fee,
-            )
-        } else {
-            let mut commds = Vec::new();
-            let v1 = params
-                .sectors
-                .iter()
-                .map(|s| {
-                    commds.push(s.unsealed_cid.0);
-                    PreCommitSectorParams {
-                        seal_proof: s.seal_proof,
-                        sector_number: s.sector_number,
-                        sealed_cid: s.sealed_cid,
-                        seal_rand_epoch: s.seal_rand_epoch,
-                        deal_ids: s.deal_ids.clone(),
-                        expiration: s.expiration,
-                        // unused
-                        replace_capacity: false,
-                        replace_sector_deadline: 0,
-                        replace_sector_partition: 0,
-                        replace_sector_number: 0,
-                    }
-                })
-                .collect();
-
-            self.pre_commit_sector_batch_inner(
-                rt,
-                &params.sectors,
-                Method::PreCommitSectorBatch as u64,
-                PreCommitSectorBatchParams { sectors: v1 },
-                first_for_miner,
-                base_fee,
-            )
-        }
-    }
     pub fn pre_commit_sector_batch(
         &self,
         rt: &MockRuntime,
@@ -619,28 +573,17 @@ impl ActorHarness {
             })
             .collect();
 
-        if self.options.use_v2_pre_commit_and_replica_update {
-            return self.pre_commit_sector_batch_inner(
-                rt,
-                &v2,
-                Method::PreCommitSectorBatch2 as u64,
-                PreCommitSectorBatchParams2 { sectors: v2.clone() },
-                conf.first_for_miner,
-                base_fee,
-            );
-        } else {
-            self.pre_commit_sector_batch_inner(
-                rt,
-                &v2,
-                Method::PreCommitSectorBatch as u64,
-                params,
-                conf.first_for_miner,
-                base_fee,
-            )
-        }
+        return self.pre_commit_sector_batch_v2(
+            rt,
+            &v2,
+            Method::PreCommitSectorBatch2 as u64,
+            PreCommitSectorBatchParams2 { sectors: v2.clone() },
+            conf.first_for_miner,
+            base_fee,
+        );
     }
 
-    fn pre_commit_sector_batch_inner(
+    fn pre_commit_sector_batch_v2(
         &self,
         rt: &MockRuntime,
         sectors: &[SectorPreCommitInfo],
@@ -683,10 +626,13 @@ impl ActorHarness {
         }
 
         let state = self.get_state(rt);
+
+        let mut expected_network_fee = TokenAmount::zero();
+        if sectors.len() > 1 {
+            expected_network_fee = aggregate_pre_commit_network_fee(sectors.len() as i64, base_fee);
+        }
         // burn networkFee
-        if state.fee_debt.is_positive() || sectors.len() > 1 {
-            let expected_network_fee =
-                aggregate_pre_commit_network_fee(sectors.len() as i64, base_fee);
+        if state.fee_debt.is_positive() || expected_network_fee.is_positive() {
             let expected_burn = expected_network_fee + state.fee_debt;
             rt.expect_send_simple(
                 BURNT_FUNDS_ACTOR_ADDR,
@@ -741,64 +687,11 @@ impl ActorHarness {
         conf: PreCommitConfig,
         first: bool,
     ) -> Result<Option<IpldBlock>, ActorError> {
-        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
-        rt.expect_validate_caller_addr(self.caller_addrs());
-        self.expect_query_network_info(rt);
-
-        if !params.deal_ids.is_empty() {
-            let vdparams = VerifyDealsForActivationParams {
-                sectors: vec![SectorDeals {
-                    sector_number: params.sector_number,
-                    sector_type: params.seal_proof,
-                    sector_expiry: params.expiration,
-                    deal_ids: params.deal_ids.clone(),
-                }],
-            };
-            let vdreturn = VerifyDealsForActivationReturn { unsealed_cids: vec![conf.0] };
-
-            rt.expect_send_simple(
-                STORAGE_MARKET_ACTOR_ADDR,
-                MarketMethod::VerifyDealsForActivation as u64,
-                IpldBlock::serialize_cbor(&vdparams).unwrap(),
-                TokenAmount::zero(),
-                IpldBlock::serialize_cbor(&vdreturn).unwrap(),
-                ExitCode::OK,
-            );
-        }
-        // in the original test the else branch does some redundant checks which we can omit.
-
-        let state = self.get_state(rt);
-        if state.fee_debt.is_positive() {
-            rt.expect_send_simple(
-                BURNT_FUNDS_ACTOR_ADDR,
-                METHOD_SEND,
-                None,
-                state.fee_debt.clone(),
-                None,
-                ExitCode::OK,
-            );
-        }
-
-        if first {
-            let dlinfo = new_deadline_info_from_offset_and_epoch(
-                &rt.policy,
-                state.proving_period_start,
-                *rt.epoch.borrow(),
-            );
-            let cron_params = make_deadline_cron_event_params(dlinfo.last());
-            rt.expect_send_simple(
-                STORAGE_POWER_ACTOR_ADDR,
-                PowerMethod::EnrollCronEvent as u64,
-                IpldBlock::serialize_cbor(&cron_params).unwrap(),
-                TokenAmount::zero(),
-                None,
-                ExitCode::OK,
-            );
-        }
-
-        let result = rt.call::<Actor>(
-            Method::PreCommitSector as u64,
-            IpldBlock::serialize_cbor(&params.clone()).unwrap(),
+        let result = self.pre_commit_sector_batch(
+            rt,
+            PreCommitSectorBatchParams { sectors: vec![params] },
+            &PreCommitBatchConfig { sector_unsealed_cid: vec![conf.0], first_for_miner: first },
+            &self.base_fee,
         );
         result
     }
@@ -810,12 +703,14 @@ impl ActorHarness {
         conf: PreCommitConfig,
         first: bool,
     ) -> SectorPreCommitOnChainInfo {
-        let result = self.pre_commit_sector(rt, params.clone(), conf, first);
-
-        expect_empty(result.unwrap());
+        let result = self.pre_commit_sector_batch_and_get(
+            rt,
+            PreCommitSectorBatchParams { sectors: vec![params] },
+            &PreCommitBatchConfig { sector_unsealed_cid: vec![conf.0], first_for_miner: first },
+            &self.base_fee,
+        );
         rt.verify();
-
-        self.get_precommit(rt, params.sector_number)
+        result[0].clone()
     }
 
     pub fn has_precommit(&self, rt: &MockRuntime, sector_number: SectorNumber) -> bool {

--- a/integration_tests/src/expects.rs
+++ b/integration_tests/src/expects.rs
@@ -1,13 +1,14 @@
 use frc46_token::receiver::{FRC46TokenReceived, FRC46_TOKEN_TYPE};
 use frc46_token::token::types::BurnParams;
 use fvm_actor_utils::receiver::UniversalReceiverParams;
+use fvm_ipld_bitfield::BitField;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::sector::RegisteredSealProof;
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
 use fvm_shared::{ActorID, METHOD_SEND};
 use num_traits::Zero;
 
@@ -41,12 +42,18 @@ impl Expect {
     pub fn market_activate_deals(
         from: ActorID,
         deals: Vec<DealID>,
+        sector_number: SectorNumber,
         sector_expiry: ChainEpoch,
         sector_type: RegisteredSealProof,
         compute_cid: bool,
     ) -> ExpectInvocation {
         let params = IpldBlock::serialize_cbor(&BatchActivateDealsParams {
-            sectors: vec![SectorDeals { deal_ids: deals, sector_expiry, sector_type }],
+            sectors: vec![SectorDeals {
+                sector_number,
+                deal_ids: deals,
+                sector_expiry,
+                sector_type,
+            }],
             compute_cid,
         })
         .unwrap();
@@ -63,10 +70,12 @@ impl Expect {
     pub fn market_sectors_terminate(
         from: ActorID,
         epoch: ChainEpoch,
-        deal_ids: Vec<DealID>,
+        sectors: Vec<SectorNumber>,
     ) -> ExpectInvocation {
+        let bf = BitField::try_from_bits(sectors).unwrap();
         let params =
-            IpldBlock::serialize_cbor(&OnMinerSectorsTerminateParams { epoch, deal_ids }).unwrap();
+            IpldBlock::serialize_cbor(&OnMinerSectorsTerminateParams { epoch, sectors: bf })
+                .unwrap();
         ExpectInvocation {
             from,
             to: STORAGE_MARKET_ACTOR_ADDR,

--- a/integration_tests/src/tests/batch_onboarding.rs
+++ b/integration_tests/src/tests/batch_onboarding.rs
@@ -47,7 +47,7 @@ impl Onboarding {
     }
 }
 
-pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
+pub fn batch_onboarding_test(v: &dyn VM) {
     let seal_proof = &RegisteredSealProof::StackedDRG32GiBV1P1;
 
     let mut proven_count = 0;
@@ -104,7 +104,6 @@ pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
                 next_sector_no,
                 next_sector_no == 0,
                 None,
-                v2,
             );
             precommmits.append(&mut new_precommits);
             next_sector_no += item.pre_commit_sector_count as u64;

--- a/integration_tests/src/tests/batch_onboarding_deals_test.rs
+++ b/integration_tests/src/tests/batch_onboarding_deals_test.rs
@@ -6,13 +6,15 @@ use fil_actor_miner::{
 use fil_actor_miner::{Method as MinerMethod, ProveCommitAggregateParams};
 use fil_actors_runtime::runtime::policy::policy_constants::PRE_COMMIT_CHALLENGE_DELAY;
 use fil_actors_runtime::runtime::Policy;
+use fil_actors_runtime::test_utils::make_piece_cid;
 use fil_actors_runtime::STORAGE_MARKET_ACTOR_ADDR;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::piece::{PaddedPieceSize, PieceInfo};
+use fvm_shared::error::ExitCode;
+use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::{RegisteredSealProof, StoragePower};
 use num_traits::Zero;
 
@@ -22,13 +24,84 @@ use vm_api::VM;
 use crate::deals::{DealBatcher, DealOptions};
 use crate::util::{
     advance_to_proving_deadline, bf_all, create_accounts, create_miner, get_network_stats,
-    make_bitfield, market_add_balance, miner_balance, precommit_sectors_v2, submit_windowed_post,
+    make_bitfield, market_add_balance, miner_balance, precommit_meta_data_from_deals,
+    precommit_sectors_v2, precommit_sectors_v2_expect_code, submit_windowed_post,
     verifreg_add_client, verifreg_add_verifier, PrecommitMetadata,
 };
 
 const BATCH_SIZE: usize = 8;
-const PRECOMMIT_V2: bool = true;
 const SEAL_PROOF: RegisteredSealProof = RegisteredSealProof::StackedDRG32GiBV1P1;
+
+pub fn pre_commit_requires_commd_test(v: &dyn VM) {
+    let deal_duration: ChainEpoch = Policy::default().min_sector_expiration;
+    let sector_duration: ChainEpoch =
+        deal_duration + Policy::default().market_default_allocation_term_buffer;
+
+    let addrs = create_accounts(v, 2, &TokenAmount::from_whole(10_000));
+    let (owner, client) = (addrs[0], addrs[1]);
+    let worker = owner;
+
+    // Create miner
+    let (miner, _) = create_miner(
+        v,
+        &owner,
+        &worker,
+        SEAL_PROOF.registered_window_post_proof().unwrap(),
+        &TokenAmount::from_whole(1000),
+    );
+
+    // Fund storage market accounts.
+    market_add_balance(v, &owner, &miner, &TokenAmount::from_whole(1000));
+    market_add_balance(v, &client, &client, &TokenAmount::from_whole(1000));
+
+    // Publish a deal for the sector.
+    let deal_opts = DealOptions {
+        piece_size: PaddedPieceSize(32 * (1 << 30)),
+        verified: false,
+        deal_start: v.epoch() + max_prove_commit_duration(&Policy::default(), SEAL_PROOF).unwrap(),
+        deal_lifetime: deal_duration,
+        ..DealOptions::default()
+    };
+    let mut batcher = DealBatcher::new(v, deal_opts);
+    batcher.stage(client, miner);
+    let ret = batcher.publish_ok(worker);
+    let good_inputs = bf_all(ret.valid_deals);
+    assert_eq!(vec![0], good_inputs);
+
+    // precommit without specifying commD fails
+    let sector_number = 100;
+    precommit_sectors_v2_expect_code(
+        v,
+        1,
+        1,
+        vec![PrecommitMetadata { deals: vec![0], commd: CompactCommD(None) }],
+        &worker,
+        &miner,
+        SEAL_PROOF,
+        sector_number,
+        true,
+        Some(sector_duration),
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+    );
+
+    // precommit specifying the wrong commD fails
+    precommit_sectors_v2_expect_code(
+        v,
+        1,
+        1,
+        vec![PrecommitMetadata {
+            deals: vec![0],
+            commd: CompactCommD(Some(make_piece_cid("This is not commP".as_bytes()))),
+        }],
+        &worker,
+        &miner,
+        SEAL_PROOF,
+        sector_number,
+        true,
+        Some(sector_duration),
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+    );
+}
 
 // Tests batch onboarding of sectors with verified deals.
 pub fn batch_onboarding_deals_test(v: &dyn VM) {
@@ -73,17 +146,7 @@ pub fn batch_onboarding_deals_test(v: &dyn VM) {
     // Associate deals with sectors.
     let sector_precommit_data = deals
         .into_iter()
-        .map(|(id, deal)| PrecommitMetadata {
-            deals: vec![id],
-            commd: CompactCommD::of(
-                v.primitives()
-                    .compute_unsealed_sector_cid(
-                        SEAL_PROOF,
-                        &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
-                    )
-                    .unwrap(),
-            ),
-        })
+        .map(|(id, _)| precommit_meta_data_from_deals(v, vec![id], SEAL_PROOF))
         .collect();
 
     // Pre-commit as single batch.
@@ -98,7 +161,6 @@ pub fn batch_onboarding_deals_test(v: &dyn VM) {
         0,
         true,
         Some(sector_duration),
-        PRECOMMIT_V2,
     );
     let first_sector_no = precommits[0].info.sector_number;
 

--- a/integration_tests/src/tests/commit_post_test.rs
+++ b/integration_tests/src/tests/commit_post_test.rs
@@ -12,7 +12,7 @@ use crate::expects::Expect;
 use crate::util::{
     advance_by_deadline_to_epoch, advance_to_proving_deadline, assert_invariants, create_accounts,
     create_miner, expect_invariants, get_network_stats, invariant_failure_patterns, miner_balance,
-    precommit_sectors, submit_windowed_post,
+    precommit_sectors_v2, submit_windowed_post,
 };
 use crate::TEST_VM_RAND_ARRAY;
 use fil_actor_cron::Method as CronMethod;
@@ -62,7 +62,7 @@ fn setup(v: &dyn VM) -> (MinerInfo, SectorInfo) {
 
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
-    precommit_sectors(v, 1, 1, &worker, &id_addr, seal_proof, sector_number, true, None);
+    precommit_sectors_v2(v, 1, 1, vec![], &worker, &id_addr, seal_proof, sector_number, true, None);
 
     let balances = miner_balance(v, &id_addr);
     assert!(balances.pre_commit_deposit.is_positive());
@@ -299,11 +299,21 @@ pub fn overdue_precommit_test(v: &dyn VM) {
 
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
-    let precommit =
-        precommit_sectors(v, 1, 1, &worker, &id_addr, seal_proof, sector_number, true, None)
-            .get(0)
-            .unwrap()
-            .clone();
+    let precommit = precommit_sectors_v2(
+        v,
+        1,
+        1,
+        vec![],
+        &worker,
+        &id_addr,
+        seal_proof,
+        sector_number,
+        true,
+        None,
+    )
+    .get(0)
+    .unwrap()
+    .clone();
 
     let balances = miner_balance(v, &id_addr);
     assert!(balances.pre_commit_deposit.is_positive());
@@ -407,10 +417,11 @@ pub fn aggregate_bad_sector_number_test(v: &dyn VM) {
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
     let mut precommited_sector_nos = BitField::try_from_bits(
-        precommit_sectors(
+        precommit_sectors_v2(
             v,
             4,
             policy.pre_commit_sector_batch_max_size,
+            vec![],
             &worker,
             &id_addr,
             seal_proof,
@@ -478,10 +489,11 @@ pub fn aggregate_size_limits_test(v: &dyn VM) {
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
     let precommited_sector_nos = BitField::try_from_bits(
-        precommit_sectors(
+        precommit_sectors_v2(
             v,
             oversized_batch,
             policy.pre_commit_sector_batch_max_size,
+            vec![],
             &worker,
             &id_addr,
             seal_proof,
@@ -579,10 +591,11 @@ pub fn aggregate_bad_sender_test(v: &dyn VM) {
     // precommit and advance to prove commit time
     let sector_number: SectorNumber = 100;
     let precommited_sector_nos = BitField::try_from_bits(
-        precommit_sectors(
+        precommit_sectors_v2(
             v,
             4,
             policy.pre_commit_sector_batch_max_size,
+            vec![],
             &worker,
             &id_addr,
             seal_proof,
@@ -648,10 +661,11 @@ pub fn aggregate_one_precommit_expires_test(v: &dyn VM) {
 
     // early precommit
     let early_precommit_time = v.epoch();
-    let early_precommits = precommit_sectors(
+    let early_precommits = precommit_sectors_v2(
         v,
         1,
         policy.pre_commit_sector_batch_max_size,
+        vec![],
         &worker,
         &miner_addr,
         seal_proof,
@@ -667,10 +681,11 @@ pub fn aggregate_one_precommit_expires_test(v: &dyn VM) {
 
     // later precommits
 
-    let later_precommits = precommit_sectors(
+    let later_precommits = precommit_sectors_v2(
         v,
         3,
         policy.pre_commit_sector_batch_max_size,
+        vec![],
         &worker,
         &miner_addr,
         seal_proof,

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -27,8 +27,9 @@ use crate::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
     advance_by_deadline_to_index, advance_to_proving_deadline, bf_all, create_accounts,
     create_miner, cron_tick, expect_invariants, get_deal, invariant_failure_patterns,
-    market_add_balance, market_publish_deal, miner_precommit_sector, miner_prove_sector,
-    sector_deadline, submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
+    market_add_balance, market_publish_deal, miner_precommit_one_sector_v2, miner_prove_sector,
+    precommit_meta_data_from_deals, sector_deadline, submit_windowed_post, verifreg_add_client,
+    verifreg_add_verifier, PrecommitMetadata,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -157,14 +158,14 @@ pub fn extend_legacy_sector_with_deals_test(v: &dyn VM, do_extend2: bool) {
     //
     // Precommit, prove and PoSt empty sector (more fully tested in TestCommitPoStFlow)
     //
-
-    miner_precommit_sector(
+    miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number,
-        deals,
+        precommit_meta_data_from_deals(v, deals, seal_proof),
+        true,
         deal_start + 180 * EPOCHS_IN_DAY,
     );
 
@@ -373,13 +374,14 @@ pub fn commit_sector_with_max_duration_deal_test(v: &dyn VM) {
     //
     // Precommit, prove and PoSt empty sector (more fully tested in TestCommitPoStFlow)
     //
-    miner_precommit_sector(
+    miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number,
-        deals,
+        precommit_meta_data_from_deals(v, deals, seal_proof),
+        true,
         deal_start + deal_lifetime,
     );
 
@@ -436,13 +438,14 @@ pub fn extend_sector_up_to_max_relative_extension_test(v: &dyn VM) {
     let sector_start =
         v.epoch() + max_prove_commit_duration(&Policy::default(), seal_proof).unwrap();
 
-    miner_precommit_sector(
+    miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number,
-        vec![],
+        PrecommitMetadata::default(),
+        true,
         sector_start + 180 * EPOCHS_IN_DAY,
     );
 
@@ -529,7 +532,16 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
 
     let expiration = v.epoch() + 360 * EPOCHS_IN_DAY;
 
-    miner_precommit_sector(v, &worker, &miner_addr, seal_proof, sector_number, vec![], expiration);
+    miner_precommit_one_sector_v2(
+        v,
+        &worker,
+        &miner_addr,
+        seal_proof,
+        sector_number,
+        PrecommitMetadata::default(),
+        true,
+        expiration,
+    );
 
     // advance time by a day and prove the sector
     let prove_epoch = v.epoch() + EPOCHS_IN_DAY;

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -642,6 +642,7 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
             Expect::market_activate_deals(
                 miner_id,
                 deal_ids.clone(),
+                sector_number,
                 initial_sector_info.expiration,
                 initial_sector_info.seal_proof,
                 true,

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -1019,6 +1019,7 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
             Expect::market_activate_deals(
                 miner_id,
                 deal_ids.clone(),
+                sector_number,
                 old_sector_info.expiration,
                 old_sector_info.seal_proof,
                 true,

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -36,7 +36,7 @@ use crate::util::{
     assert_invariants, bf_all, check_sector_active, check_sector_faulty, create_accounts,
     create_miner, deadline_state, declare_recovery, expect_invariants, get_deal, get_network_stats,
     invariant_failure_patterns, make_bitfield, market_publish_deal, miner_balance, miner_power,
-    precommit_sectors, prove_commit_sectors, sector_info, submit_invalid_post,
+    precommit_sectors_v2, prove_commit_sectors, sector_info, submit_invalid_post,
     submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
 };
 
@@ -167,10 +167,11 @@ pub fn prove_replica_update_multi_dline_test(v: &dyn VM) {
     let first_sector_number_p2 = seal_proof.window_post_partitions_sector().unwrap();
     let expiration = v.epoch() + policy.max_sector_expiration_extension;
 
-    let new_precommits = precommit_sectors(
+    let new_precommits = precommit_sectors_v2(
         v,
         more_than_one_partition,
         batch_size,
+        vec![],
         &worker,
         &maddr,
         seal_proof,
@@ -834,10 +835,11 @@ pub fn deal_included_in_multiple_sectors_failure_test(v: &dyn VM) {
     //
     //
     let first_sector_number = 100;
-    let precommits = precommit_sectors(
+    let precommits = precommit_sectors_v2(
         v,
         policy.min_aggregated_sectors as usize,
         policy.pre_commit_sector_batch_max_size,
+        vec![],
         &worker,
         &maddr,
         seal_proof,
@@ -1133,8 +1135,18 @@ pub fn create_sector(
 ) -> (u64, u64) {
     // precommit
     let exp = v.epoch() + Policy::default().max_sector_expiration_extension;
-    let precommits =
-        precommit_sectors(v, 1, 1, &worker, &maddr, seal_proof, sector_number, true, Some(exp));
+    let precommits = precommit_sectors_v2(
+        v,
+        1,
+        1,
+        vec![],
+        &worker,
+        &maddr,
+        seal_proof,
+        sector_number,
+        true,
+        Some(exp),
+    );
     assert_eq!(1, precommits.len());
     assert_eq!(sector_number, precommits[0].info.sector_number);
     let balances = miner_balance(v, &maddr);

--- a/integration_tests/src/tests/terminate_test.rs
+++ b/integration_tests/src/tests/terminate_test.rs
@@ -3,16 +3,16 @@ use fil_actor_market::{
     DealMetaArray, Method as MarketMethod, State as MarketState, WithdrawBalanceParams,
 };
 use fil_actor_miner::{
-    power_for_sector, Method as MinerMethod, PreCommitSectorParams, ProveCommitSectorParams,
-    State as MinerState, TerminateSectorsParams, TerminationDeclaration,
+    power_for_sector, Method as MinerMethod, ProveCommitSectorParams, State as MinerState,
+    TerminateSectorsParams, TerminationDeclaration,
 };
 use fil_actor_power::State as PowerState;
 use fil_actor_verifreg::{Method as VerifregMethod, VerifierParams};
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{
-    test_utils::*, CRON_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ID,
-    STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
+    CRON_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ID, STORAGE_POWER_ACTOR_ADDR,
+    SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
@@ -30,7 +30,8 @@ use crate::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
     advance_to_proving_deadline, create_accounts, create_miner, expect_invariants,
     invariant_failure_patterns, make_bitfield, market_publish_deal, miner_balance,
-    submit_windowed_post, verifreg_add_verifier,
+    miner_precommit_one_sector_v2, precommit_meta_data_from_deals, submit_windowed_post,
+    verifreg_add_verifier,
 };
 
 pub fn terminate_sectors_test(v: &dyn VM) {
@@ -43,7 +44,6 @@ pub fn terminate_sectors_test(v: &dyn VM) {
 
     let m_balance = TokenAmount::from_whole(1_000);
     let sector_number = 100;
-    let sealed_cid = make_sealed_cid(b"s100");
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
 
     let (miner_id_addr, miner_robust_addr) = create_miner(
@@ -165,21 +165,16 @@ pub fn terminate_sectors_test(v: &dyn VM) {
         assert_eq!(None, state);
     }
     //    precommit_sectors(&v, 1, 1, worker, robust_addr, seal_proof, sector_number, true, None);
-    apply_ok(
+
+    miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_robust_addr,
-        &TokenAmount::zero(),
-        MinerMethod::PreCommitSector as u64,
-        Some(PreCommitSectorParams {
-            seal_proof,
-            sector_number,
-            sealed_cid,
-            seal_rand_epoch: v.epoch() - 1,
-            deal_ids: deal_ids.clone(),
-            expiration: v.epoch() + 220 * EPOCHS_IN_DAY,
-            ..Default::default()
-        }),
+        seal_proof,
+        sector_number,
+        precommit_meta_data_from_deals(v, deal_ids.clone(), seal_proof),
+        true,
+        v.epoch() + 220 * EPOCHS_IN_DAY,
     );
     let prove_time = v.epoch() + Policy::default().pre_commit_challenge_delay + 1;
     advance_by_deadline_to_epoch(v, &miner_id_addr, prove_time);

--- a/integration_tests/src/tests/terminate_test.rs
+++ b/integration_tests/src/tests/terminate_test.rs
@@ -270,7 +270,7 @@ pub fn terminate_sectors_test(v: &dyn VM) {
             Expect::power_current_total(miner_id),
             Expect::burn(miner_id, None),
             Expect::power_update_pledge(miner_id, None),
-            Expect::market_sectors_terminate(miner_id, epoch, deal_ids.clone()),
+            Expect::market_sectors_terminate(miner_id, epoch, [sector_number].to_vec()),
             Expect::power_update_claim(miner_id, sector_power.neg()),
         ]),
         ..Default::default()

--- a/integration_tests/src/tests/verified_claim_test.rs
+++ b/integration_tests/src/tests/verified_claim_test.rs
@@ -34,9 +34,9 @@ use crate::util::{
     advance_by_deadline_to_index, advance_to_proving_deadline, assert_invariants, create_accounts,
     create_miner, cron_tick, datacap_extend_claim, datacap_get_balance, expect_invariants,
     invariant_failure_patterns, market_add_balance, market_publish_deal,
-    miner_extend_sector_expiration2, miner_precommit_sector, miner_prove_sector, sector_deadline,
-    submit_windowed_post, verifreg_add_client, verifreg_add_verifier, verifreg_extend_claim_terms,
-    verifreg_remove_expired_allocations,
+    miner_extend_sector_expiration2, miner_precommit_one_sector_v2, miner_prove_sector,
+    precommit_meta_data_from_deals, sector_deadline, submit_windowed_post, verifreg_add_client,
+    verifreg_add_verifier, verifreg_extend_claim_terms, verifreg_remove_expired_allocations,
 };
 
 /// Tests a scenario involving a verified deal from the built-in market, with associated
@@ -91,13 +91,14 @@ pub fn verified_claim_scenario_test(v: &dyn VM) {
 
     // Precommit and prove the sector for the max term allowed by the deal.
     let sector_term = deal_term_min + MARKET_DEFAULT_ALLOCATION_TERM_BUFFER;
-    let _precommit = miner_precommit_sector(
+    let _precommit = miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number,
-        deals.clone(),
+        precommit_meta_data_from_deals(v, deals.clone(), seal_proof),
+        true,
         deal_start + sector_term,
     );
 
@@ -528,23 +529,25 @@ pub fn deal_passes_claim_fails_test(v: &dyn VM) {
         sector_start - max_prove_commit_duration(&Policy::default(), seal_proof).unwrap(),
     );
     let sector_number_a = 0;
-    let _precommit = miner_precommit_sector(
+    let _precommit = miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number_a,
-        vec![deal],
+        precommit_meta_data_from_deals(v, vec![deal], seal_proof),
+        true,
         sector_start + sector_term,
     );
     let sector_number_b = 1;
-    let _precommit = miner_precommit_sector(
+    let _precommit = miner_precommit_one_sector_v2(
         v,
         &worker,
         &miner_id,
         seal_proof,
         sector_number_b,
-        vec![bad_deal],
+        precommit_meta_data_from_deals(v, vec![bad_deal], seal_proof),
+        false,
         sector_start + sector_term,
     );
 

--- a/integration_tests/src/util/workflows.rs
+++ b/integration_tests/src/util/workflows.rs
@@ -258,6 +258,7 @@ pub fn precommit_sectors_v2(
                 });
                 if !sector_meta.deals.is_empty() {
                     sectors_with_deals.push(SectorDeals {
+                        sector_number,
                         sector_type: seal_proof,
                         sector_expiry: expiration,
                         deal_ids: sector_meta.deals.clone(),
@@ -321,6 +322,7 @@ pub fn precommit_sectors_v2(
                 });
                 if !sector_meta.deals.is_empty() {
                     sectors_with_deals.push(SectorDeals {
+                        sector_number,
                         sector_type: seal_proof,
                         sector_expiry: expiration,
                         deal_ids: sector_meta.deals.clone(),

--- a/integration_tests/src/util/workflows.rs
+++ b/integration_tests/src/util/workflows.rs
@@ -16,7 +16,8 @@ use fvm_shared::crypto::signature::Signature;
 use fvm_shared::crypto::signature::SignatureType;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::piece::PaddedPieceSize;
+use fvm_shared::error::ExitCode;
+use fvm_shared::piece::{PaddedPieceSize, PieceInfo};
 use fvm_shared::randomness::Randomness;
 use fvm_shared::sector::PoStProof;
 use fvm_shared::sector::RegisteredPoStProof;
@@ -27,22 +28,17 @@ use num_traits::Zero;
 
 use fil_actor_cron::Method as CronMethod;
 use fil_actor_datacap::Method as DataCapMethod;
-use fil_actor_market::ClientDealProposal;
-use fil_actor_market::DealProposal;
-use fil_actor_market::Label;
-use fil_actor_market::Method as MarketMethod;
-use fil_actor_market::PublishStorageDealsParams;
-use fil_actor_market::PublishStorageDealsReturn;
-use fil_actor_market::SectorDeals;
-use fil_actor_market::MARKET_NOTIFY_DEAL_METHOD;
+use fil_actor_market::{
+    ClientDealProposal, DealProposal, Label, Method as MarketMethod, PublishStorageDealsParams,
+    PublishStorageDealsReturn, SectorDeals, State as MarketState, MARKET_NOTIFY_DEAL_METHOD,
+};
 use fil_actor_miner::{
     aggregate_pre_commit_network_fee, aggregate_prove_commit_network_fee,
     max_prove_commit_duration, ChangeBeneficiaryParams, CompactCommD, DeadlineInfo,
     DeclareFaultsRecoveredParams, ExpirationExtension2, ExtendSectorExpiration2Params,
-    Method as MinerMethod, PoStPartition, PowerPair, PreCommitSectorBatchParams,
-    PreCommitSectorBatchParams2, PreCommitSectorParams, ProveCommitAggregateParams,
-    ProveCommitSectorParams, RecoveryDeclaration, SectorClaim, SectorPreCommitInfo,
-    SectorPreCommitOnChainInfo, State as MinerState, SubmitWindowedPoStParams,
+    Method as MinerMethod, PoStPartition, PowerPair, PreCommitSectorBatchParams2,
+    ProveCommitAggregateParams, ProveCommitSectorParams, RecoveryDeclaration, SectorClaim,
+    SectorPreCommitInfo, SectorPreCommitOnChainInfo, State as MinerState, SubmitWindowedPoStParams,
     WithdrawBalanceParams, WithdrawBalanceReturn,
 };
 use fil_actor_multisig::Method as MultisigMethod;
@@ -73,9 +69,9 @@ use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
 use fil_actors_runtime::VERIFIED_REGISTRY_ACTOR_ADDR;
 use fil_actors_runtime::{DATACAP_TOKEN_ACTOR_ID, VERIFIED_REGISTRY_ACTOR_ID};
 use vm_api::trace::ExpectInvocation;
-use vm_api::util::apply_ok;
 use vm_api::util::get_state;
 use vm_api::util::DynBlockstore;
+use vm_api::util::{apply_code, apply_ok};
 use vm_api::VM;
 
 use crate::expects::Expect;
@@ -130,44 +126,30 @@ pub fn create_miner(
     (res.id_address, res.robust_address)
 }
 
-pub fn miner_precommit_sector(
+#[allow(clippy::too_many_arguments)]
+pub fn miner_precommit_one_sector_v2(
     v: &dyn VM,
     worker: &Address,
-    miner_id: &Address,
+    maddr: &Address,
     seal_proof: RegisteredSealProof,
     sector_number: SectorNumber,
-    deal_ids: Vec<DealID>,
+    meta_data: PrecommitMetadata,
+    expect_cron_enroll: bool,
     expiration: ChainEpoch,
 ) -> SectorPreCommitOnChainInfo {
-    let sealed_cid = make_sealed_cid(b"s100");
-
-    let params = PreCommitSectorParams {
+    precommit_sectors_v2(
+        v,
+        1,
+        1,
+        vec![meta_data],
+        worker,
+        maddr,
         seal_proof,
         sector_number,
-        sealed_cid,
-        seal_rand_epoch: v.epoch() - 1,
-        deal_ids,
-        expiration,
-        replace_capacity: false,
-        replace_sector_deadline: 0,
-        replace_sector_partition: 0,
-        replace_sector_number: 0,
-    };
-
-    apply_ok(
-        v,
-        worker,
-        miner_id,
-        &TokenAmount::zero(),
-        MinerMethod::PreCommitSector as u64,
-        Some(params),
-    );
-
-    let state: MinerState = get_state(v, miner_id).unwrap();
-    state
-        .get_precommitted_sector(&DynBlockstore::wrap(v.blockstore()), sector_number)
-        .unwrap()
-        .unwrap()
+        expect_cron_enroll,
+        Some(expiration),
+    )[0]
+    .clone()
 }
 
 pub fn miner_prove_sector(
@@ -203,9 +185,112 @@ pub fn miner_prove_sector(
     .matches(v.take_invocations().last().unwrap());
 }
 
+#[derive(Default)]
 pub struct PrecommitMetadata {
     pub deals: Vec<DealID>,
     pub commd: CompactCommD,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn precommit_sectors_v2_expect_code(
+    v: &dyn VM,
+    count: usize,
+    batch_size: usize,
+    metadata: Vec<PrecommitMetadata>, // Per-sector deal metadata, or empty vector for no deals.
+    worker: &Address,
+    maddr: &Address,
+    seal_proof: RegisteredSealProof,
+    sector_number_base: SectorNumber,
+    expect_cron_enroll: bool,
+    exp: Option<ChainEpoch>,
+    code: ExitCode,
+) {
+    let miner_id_address = v.resolve_id_address(maddr).unwrap();
+    let miner_id = miner_id_address.id().unwrap();
+    let worker_id = v.resolve_id_address(worker).unwrap().id().unwrap();
+    let expiration = match exp {
+        None => {
+            v.epoch()
+                + Policy::default().min_sector_expiration
+                + max_prove_commit_duration(&Policy::default(), seal_proof).unwrap()
+        }
+        Some(e) => e,
+    };
+
+    let mut sector_idx: usize = 0;
+    let no_deals = PrecommitMetadata::default();
+    let mut sectors_with_deals: Vec<SectorDeals> = vec![];
+    while sector_idx < count {
+        let msg_sector_idx_base = sector_idx;
+        let mut invocs =
+            vec![Expect::reward_this_epoch(miner_id), Expect::power_current_total(miner_id)];
+        let mut param_sectors = Vec::<SectorPreCommitInfo>::new();
+        let mut j = 0;
+        while j < batch_size && sector_idx < count {
+            let sector_number = sector_number_base + sector_idx as u64;
+            let sector_meta = metadata.get(sector_idx).unwrap_or(&no_deals);
+            param_sectors.push(SectorPreCommitInfo {
+                seal_proof,
+                sector_number,
+                sealed_cid: make_sealed_cid(format!("sn: {}", sector_number).as_bytes()),
+                seal_rand_epoch: v.epoch() - 1,
+                deal_ids: sector_meta.deals.clone(),
+                expiration,
+                unsealed_cid: sector_meta.commd.clone(),
+            });
+            if !sector_meta.deals.is_empty() {
+                sectors_with_deals.push(SectorDeals {
+                    sector_number,
+                    sector_type: seal_proof,
+                    sector_expiry: expiration,
+                    deal_ids: sector_meta.deals.clone(),
+                });
+            }
+            sector_idx += 1;
+            j += 1;
+        }
+        if !sectors_with_deals.is_empty() {
+            invocs.push(Expect::market_verify_deals(miner_id, sectors_with_deals.clone()));
+        }
+        if param_sectors.len() > 1 {
+            invocs.push(Expect::burn(
+                miner_id,
+                Some(aggregate_pre_commit_network_fee(
+                    param_sectors.len() as i64,
+                    &TokenAmount::zero(),
+                )),
+            ));
+        }
+        if expect_cron_enroll && msg_sector_idx_base == 0 {
+            invocs.push(Expect::power_enrol_cron(miner_id));
+        }
+
+        apply_code(
+            v,
+            worker,
+            maddr,
+            &TokenAmount::zero(),
+            MinerMethod::PreCommitSectorBatch2 as u64,
+            Some(PreCommitSectorBatchParams2 { sectors: param_sectors.clone() }),
+            code,
+        );
+        if code == ExitCode::OK {
+            let expect = ExpectInvocation {
+                from: worker_id,
+                to: miner_id_address,
+                method: MinerMethod::PreCommitSectorBatch2 as u64,
+                params: Some(
+                    IpldBlock::serialize_cbor(&PreCommitSectorBatchParams2 {
+                        sectors: param_sectors,
+                    })
+                    .unwrap(),
+                ),
+                subinvocs: Some(invocs),
+                ..Default::default()
+            };
+            expect.matches(v.take_invocations().last().unwrap());
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -220,160 +305,24 @@ pub fn precommit_sectors_v2(
     sector_number_base: SectorNumber,
     expect_cron_enroll: bool,
     exp: Option<ChainEpoch>,
-    v2: bool,
 ) -> Vec<SectorPreCommitOnChainInfo> {
-    let miner_id_address = v.resolve_id_address(maddr).unwrap();
-    let miner_id = miner_id_address.id().unwrap();
-    let worker_id = v.resolve_id_address(worker).unwrap().id().unwrap();
-    let expiration = match exp {
-        None => {
-            v.epoch()
-                + Policy::default().min_sector_expiration
-                + max_prove_commit_duration(&Policy::default(), seal_proof).unwrap()
-        }
-        Some(e) => e,
-    };
+    let mid = v.resolve_id_address(maddr).unwrap();
+    precommit_sectors_v2_expect_code(
+        v,
+        count,
+        batch_size,
+        metadata,
+        worker,
+        maddr,
+        seal_proof,
+        sector_number_base,
+        expect_cron_enroll,
+        exp,
+        ExitCode::OK,
+    );
 
-    let mut sector_idx: usize = 0;
-    let no_deals = PrecommitMetadata { deals: vec![], commd: CompactCommD::default() };
-    let mut sectors_with_deals: Vec<SectorDeals> = vec![];
-    while sector_idx < count {
-        let msg_sector_idx_base = sector_idx;
-        let mut invocs =
-            vec![Expect::reward_this_epoch(miner_id), Expect::power_current_total(miner_id)];
-        if !v2 {
-            let mut param_sectors = Vec::<PreCommitSectorParams>::new();
-            let mut j = 0;
-            while j < batch_size && sector_idx < count {
-                let sector_number = sector_number_base + sector_idx as u64;
-                let sector_meta = metadata.get(sector_idx).unwrap_or(&no_deals);
-                param_sectors.push(PreCommitSectorParams {
-                    seal_proof,
-                    sector_number,
-                    sealed_cid: make_sealed_cid(format!("sn: {}", sector_number).as_bytes()),
-                    seal_rand_epoch: v.epoch() - 1,
-                    deal_ids: sector_meta.deals.clone().clone(),
-                    expiration,
-                    ..Default::default()
-                });
-                if !sector_meta.deals.is_empty() {
-                    sectors_with_deals.push(SectorDeals {
-                        sector_number,
-                        sector_type: seal_proof,
-                        sector_expiry: expiration,
-                        deal_ids: sector_meta.deals.clone(),
-                    });
-                }
-                sector_idx += 1;
-                j += 1;
-            }
-            if !sectors_with_deals.is_empty() {
-                invocs.push(Expect::market_verify_deals(miner_id, sectors_with_deals.clone()));
-            }
-            if param_sectors.len() > 1 {
-                invocs.push(Expect::burn(
-                    miner_id,
-                    Some(aggregate_pre_commit_network_fee(
-                        param_sectors.len() as i64,
-                        &TokenAmount::zero(),
-                    )),
-                ));
-            }
-            if expect_cron_enroll && msg_sector_idx_base == 0 {
-                invocs.push(Expect::power_enrol_cron(miner_id));
-            }
-
-            apply_ok(
-                v,
-                worker,
-                maddr,
-                &TokenAmount::zero(),
-                MinerMethod::PreCommitSectorBatch as u64,
-                Some(PreCommitSectorBatchParams { sectors: param_sectors.clone() }),
-            );
-            let expect = ExpectInvocation {
-                from: worker_id,
-                to: miner_id_address,
-                method: MinerMethod::PreCommitSectorBatch as u64,
-                params: Some(
-                    IpldBlock::serialize_cbor(&PreCommitSectorBatchParams {
-                        sectors: param_sectors,
-                    })
-                    .unwrap(),
-                ),
-                subinvocs: Some(invocs),
-                ..Default::default()
-            };
-            expect.matches(v.take_invocations().last().unwrap())
-        } else {
-            let mut param_sectors = Vec::<SectorPreCommitInfo>::new();
-            let mut j = 0;
-            while j < batch_size && sector_idx < count {
-                let sector_number = sector_number_base + sector_idx as u64;
-                let sector_meta = metadata.get(sector_idx).unwrap_or(&no_deals);
-                param_sectors.push(SectorPreCommitInfo {
-                    seal_proof,
-                    sector_number,
-                    sealed_cid: make_sealed_cid(format!("sn: {}", sector_number).as_bytes()),
-                    seal_rand_epoch: v.epoch() - 1,
-                    deal_ids: sector_meta.deals.clone(),
-                    expiration,
-                    unsealed_cid: sector_meta.commd.clone(),
-                });
-                if !sector_meta.deals.is_empty() {
-                    sectors_with_deals.push(SectorDeals {
-                        sector_number,
-                        sector_type: seal_proof,
-                        sector_expiry: expiration,
-                        deal_ids: sector_meta.deals.clone(),
-                    });
-                }
-                sector_idx += 1;
-                j += 1;
-            }
-            if !sectors_with_deals.is_empty() {
-                invocs.push(Expect::market_verify_deals(miner_id, sectors_with_deals.clone()));
-            }
-            if param_sectors.len() > 1 {
-                invocs.push(Expect::burn(
-                    miner_id,
-                    Some(aggregate_pre_commit_network_fee(
-                        param_sectors.len() as i64,
-                        &TokenAmount::zero(),
-                    )),
-                ));
-            }
-            if expect_cron_enroll && msg_sector_idx_base == 0 {
-                invocs.push(Expect::power_enrol_cron(miner_id));
-            }
-
-            apply_ok(
-                v,
-                worker,
-                maddr,
-                &TokenAmount::zero(),
-                MinerMethod::PreCommitSectorBatch2 as u64,
-                Some(PreCommitSectorBatchParams2 { sectors: param_sectors.clone() }),
-            );
-
-            let expect = ExpectInvocation {
-                from: worker_id,
-                to: miner_id_address,
-                method: MinerMethod::PreCommitSectorBatch2 as u64,
-                params: Some(
-                    IpldBlock::serialize_cbor(&PreCommitSectorBatchParams2 {
-                        sectors: param_sectors,
-                    })
-                    .unwrap(),
-                ),
-                subinvocs: Some(invocs),
-                ..Default::default()
-            };
-            expect.matches(v.take_invocations().last().unwrap())
-        }
-    }
     // extract chain state
-    let mstate: MinerState = get_state(v, &miner_id_address).unwrap();
+    let mstate: MinerState = get_state(v, &mid).unwrap();
     (0..count)
         .map(|i| {
             mstate
@@ -387,31 +336,27 @@ pub fn precommit_sectors_v2(
         .collect()
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn precommit_sectors(
+pub fn precommit_meta_data_from_deals(
     v: &dyn VM,
-    count: usize,
-    batch_size: usize,
-    worker: &Address,
-    maddr: &Address,
+    deal_ids: Vec<u64>,
     seal_proof: RegisteredSealProof,
-    sector_number_base: SectorNumber,
-    expect_cron_enroll: bool,
-    exp: Option<ChainEpoch>,
-) -> Vec<SectorPreCommitOnChainInfo> {
-    precommit_sectors_v2(
-        v,
-        count,
-        batch_size,
-        vec![], // no deals
-        worker,
-        maddr,
-        seal_proof,
-        sector_number_base,
-        expect_cron_enroll,
-        exp,
-        false,
-    )
+) -> PrecommitMetadata {
+    let state: MarketState = get_state(v, &STORAGE_MARKET_ACTOR_ADDR).unwrap();
+    let pieces: Vec<PieceInfo> = deal_ids
+        .clone()
+        .into_iter()
+        .map(|id: u64| {
+            let deal = state.get_proposal(&DynBlockstore::wrap(v.blockstore()), id).unwrap();
+            PieceInfo { size: deal.piece_size, cid: deal.piece_cid }
+        })
+        .collect();
+
+    PrecommitMetadata {
+        deals: deal_ids,
+        commd: CompactCommD::of(
+            v.primitives().compute_unsealed_sector_cid(seal_proof, &pieces).unwrap(),
+        ),
+    }
 }
 
 pub fn prove_commit_sectors(

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -66,7 +66,10 @@ pub struct Policy {
     /// Maximum number of unique "declarations" in batch operations.
     pub declarations_max: u64,
 
-    /// The maximum number of sector infos that may be required to be loaded in a single invocation.
+    /// The maximum number of sector numbers addressable in a single invocation
+    /// (which implies also the max infos that may be loaded at once).
+    /// One upper bound on this is the max size of a storage block: 1MiB supports 130k at 8 bytes each,
+    /// though bitfields can compress this.
     pub addressed_sectors_max: u64,
 
     pub max_pre_commit_randomness_lookback: ChainEpoch,

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -1143,12 +1143,32 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
 
         let expected_msg = self.expectations.borrow_mut().expect_sends.pop_front().unwrap();
 
-        assert_eq!(expected_msg.to, *to);
-        assert_eq!(expected_msg.method, method);
-        assert_eq!(expected_msg.params, params);
-        assert_eq!(expected_msg.value, value);
-        assert_eq!(expected_msg.gas_limit, gas_limit, "gas limit did not match expectation");
-        assert_eq!(expected_msg.send_flags, send_flags, "send flags did not match expectation");
+        assert_eq!(expected_msg.to, *to, "expected message to {}, was {}", expected_msg.to, to);
+        assert_eq!(
+            expected_msg.method, method,
+            "expected method {}, was {}",
+            expected_msg.method, method
+        );
+        assert_eq!(
+            expected_msg.params, params,
+            "expected params {:?}, was {:?}",
+            expected_msg.params, params,
+        );
+        assert_eq!(
+            expected_msg.value, value,
+            "expected value {:?}, was {:?}",
+            expected_msg.value, value,
+        );
+        assert_eq!(
+            expected_msg.gas_limit, gas_limit,
+            "expected gas limit {:?}, was {:?}",
+            expected_msg.gas_limit, gas_limit
+        );
+        assert_eq!(
+            expected_msg.send_flags, send_flags,
+            "expected send flags {:?}, was {:?}",
+            expected_msg.send_flags, send_flags
+        );
 
         if let Some(e) = expected_msg.send_error {
             return Err(SendError(e));

--- a/runtime/src/util/map.rs
+++ b/runtime/src/util/map.rs
@@ -87,6 +87,11 @@ where
         })
     }
 
+    /// Returns whether the map is empty.
+    pub fn is_empty(&self) -> bool {
+        self.hamt.is_empty()
+    }
+
     /// Returns a reference to the value associated with a key, if present.
     pub fn get(&self, key: &K) -> Result<Option<&V>, ActorError> {
         let k = key.to_bytes().context_code(ExitCode::USR_ASSERTION_FAILED, "invalid key")?;

--- a/test_vm/tests/batch_onboarding.rs
+++ b/test_vm/tests/batch_onboarding.rs
@@ -1,14 +1,12 @@
 use fil_actors_integration_tests::tests::batch_onboarding_test;
 use fvm_ipld_blockstore::MemoryBlockstore;
-use test_case::test_case;
 use test_vm::TestVM;
 
 // Test for batch pre-commit and aggregate prove-commit onboarding sectors (no deals).
-#[test_case(false; "v1")]
-#[test_case(true; "v2")]
-fn batch_onboarding(v2: bool) {
+#[test]
+fn batch_onboarding() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
 
-    batch_onboarding_test(&v, v2);
+    batch_onboarding_test(&v);
 }

--- a/test_vm/tests/batch_onboarding_deals_test.rs
+++ b/test_vm/tests/batch_onboarding_deals_test.rs
@@ -1,4 +1,6 @@
-use fil_actors_integration_tests::tests::batch_onboarding_deals_test;
+use fil_actors_integration_tests::tests::{
+    batch_onboarding_deals_test, pre_commit_requires_commd_test,
+};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use test_vm::TestVM;
 
@@ -7,4 +9,11 @@ fn batch_onboarding_deals() {
     let store = MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
     batch_onboarding_deals_test(&v);
+}
+
+#[test]
+fn pre_commit_requires_commd() {
+    let store = MemoryBlockstore::new();
+    let v = TestVM::<MemoryBlockstore>::new_with_singletons(&store);
+    pre_commit_requires_commd_test(&v);
 }

--- a/test_vm/tests/power_scenario_tests.rs
+++ b/test_vm/tests/power_scenario_tests.rs
@@ -1,5 +1,6 @@
-use fil_actors_integration_tests::tests::{cron_tick_test, power_create_miner_test};
 use fvm_ipld_blockstore::MemoryBlockstore;
+
+use fil_actors_integration_tests::tests::{cron_tick_test, power_create_miner_test};
 use test_vm::TestVM;
 
 #[test]


### PR DESCRIPTION
This PR extracts functionality shared between ProveCommit and ProveCommitAggregate to be used in the new ProveCommitV2 message(s).

The new method takes a vector of precommits, validates that they are ok for committing and creates a general precursor to the inputs needed by PoRep and snark pack PoRep