### PR TITLE
Implements new ProveCommit batch+aggregate for direct onboarding

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -129,6 +129,7 @@ pub enum Method {
     ChangeBeneficiary = 30,
     GetBeneficiary = 31,
     ExtendSectorExpiration2 = 32,
+    ProveCommit2 = 33,
     // Method numbers derived from FRC-0042 standards
     ChangeWorkerAddressExported = frc42_dispatch::method_hash!("ChangeWorkerAddress"),
     ChangePeerIDExported = frc42_dispatch::method_hash!("ChangePeerID"),
@@ -5008,7 +5009,7 @@ pub struct PiecesActivationInput {
     pub piece_manifests: Vec<PieceActivationManifest>,
     pub sector_expiry: ChainEpoch,
     pub sector_number: SectorNumber,
-    sector_type: RegisteredSealProof,
+    pub sector_type: RegisteredSealProof,
     pub expected_commd: Option<Cid>,
 }
 
@@ -5416,6 +5417,7 @@ impl ActorCode for Actor {
         GetVestingFundsExported => get_vesting_funds,
         GetPeerIDExported => get_peer_id,
         GetMultiaddrsExported => get_multiaddresses,
+        ProveCommit2 => prove_commit2,
     }
 }
 

--- a/actors/miner/src/monies.rs
+++ b/actors/miner/src/monies.rs
@@ -297,21 +297,21 @@ lazy_static! {
 }
 
 pub fn aggregate_prove_commit_network_fee(
-    aggregate_size: i64,
+    aggregate_size: usize,
     base_fee: &TokenAmount,
 ) -> TokenAmount {
     aggregate_network_fee(aggregate_size, &ESTIMATED_SINGLE_PROVE_COMMIT_GAS_USAGE, base_fee)
 }
 
 pub fn aggregate_pre_commit_network_fee(
-    aggregate_size: i64,
+    aggregate_size: usize,
     base_fee: &TokenAmount,
 ) -> TokenAmount {
     aggregate_network_fee(aggregate_size, &ESTIMATED_SINGLE_PRE_COMMIT_GAS_USAGE, base_fee)
 }
 
 pub fn aggregate_network_fee(
-    aggregate_size: i64,
+    aggregate_size: usize,
     gas_usage: &BigInt,
     base_fee: &TokenAmount,
 ) -> TokenAmount {

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -9,7 +9,10 @@ use anyhow::{anyhow, Error};
 use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_runtime::runtime::Policy;
-use fil_actors_runtime::{actor_error, make_empty_map, make_map_with_root_and_bitwidth, u64_key, ActorDowncast, ActorError, Array, AsActorError};
+use fil_actors_runtime::{
+    actor_error, make_empty_map, make_map_with_root_and_bitwidth, u64_key, ActorDowncast,
+    ActorError, Array, AsActorError,
+};
 use fvm_ipld_amt::Error as AmtError;
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
@@ -1168,20 +1171,20 @@ impl State {
     pub fn get_precommitted_sectors<BS: Blockstore>(
         &self,
         store: &BS,
-        sector_nos: impl IntoIterator<Item = impl Borrow<SectorNumber>>
+        sector_nos: impl IntoIterator<Item = impl Borrow<SectorNumber>>,
     ) -> Result<Vec<SectorPreCommitOnChainInfo>, ActorError> {
         let mut precommits = Vec::new();
         let precommitted =
-            make_map_with_root_and_bitwidth(&self.pre_committed_sectors, store, HAMT_BIT_WIDTH)?;
+            make_map_with_root_and_bitwidth(&self.pre_committed_sectors, store, HAMT_BIT_WIDTH)
+                .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load precommitted sectors")?;
         for sector_no in sector_nos.into_iter() {
             let sector_no = *sector_no.borrow();
             if sector_no > MAX_SECTOR_NUMBER {
-                return Err(
-                    actor_error!(illegal_argument; "sector number greater than maximum").into()
-                );
+                return Err(actor_error!(illegal_argument; "sector number greater than maximum"));
             }
             let info: &SectorPreCommitOnChainInfo = precommitted
-                .get(&u64_key(sector_no)).exit_code(ExitCode::USR_ILLEGAL_STATE)?
+                .get(&u64_key(sector_no))
+                .exit_code(ExitCode::USR_ILLEGAL_STATE)?
                 .ok_or_else(|| actor_error!(not_found, "sector {} not found", sector_no))?;
             precommits.push(info.clone());
         }

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -168,13 +168,13 @@ pub struct SectorDataActivationManifest {
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ProveCommit2Params {
-    sector_data_activations: Vec<SectorDataActivationManifest>,
+    pub sector_data_activations: Vec<SectorDataActivationManifest>,
     // XXX to support aggregate proof here too we just need to make proofs
     // optional and add another optional type for the aggregate proof 
     #[serde(with = "strict_bytes")]
-    proofs: Vec<Vec<u8>>
-    require_activation_success: bool,
-    require_notification_success: bool,
+    pub proofs: Vec<Vec<u8>>
+    pub require_activation_success: bool,
+    pub require_notification_success: bool,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -132,75 +132,96 @@ pub struct SubmitWindowedPoStParams {
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ProveCommitSectorParams {
     pub sector_number: SectorNumber,
-    #[serde(with = "strict_bytes")]
-    pub proof: Vec<u8>,
-}
-
-#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
-pub struct DataActivationNotification {
-    pub address: Address,
-    pub payload: RawBytes,
-}
-
-#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
-pub struct AllocationKey {
-    pub id: AllocationID,
-    pub client: ActorID,
-}
-
-// Data to aci
-#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
-pub struct PieceActivationManifest {
-    pub cid: Cid,
-    pub size: PaddedPieceSize,
-    pub verified_allocation_key: Option<AllocationKey>,
-    pub notify: Vec<DataActivationNotification>,
-}
-
-// Data to activate a commitment to one sector and its data.
-// All non-zero pieces of data must be specified, even those
-// not being notified to a data consumer or claiming a FIL+ activation.
-// XXX: we should consider fast tracking the special case where there is only
-//  one piece not claiming or notifying other actors to allow an empty piece vector.
-//  We could interpret this as a single piece, size == sector size, cid == commD, empty allocation empty notify vector
-#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
-pub struct SectorDataActivationManifest {
-    pub sector_number: SectorNumber,
-    pub pieces: Vec<PieceActivationManifest>,
+    pub proof: RawBytes,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ProveCommit2Params {
-    pub sector_data_activations: Vec<SectorDataActivationManifest>,
-    // XXX to support aggregate proof here too we just need to make proofs
-    // optional and add another optional type for the aggregate proof
-    pub proofs: Vec<RawBytes>,
+    // Activation manifest for each sector being proven.
+    pub sector_activations: Vec<SectorActivationManifest>,
+    // Proofs for each sector, parallel to activation manifests.
+    // Exactly one of sector_proofs or aggregate_proof must be non-empty.
+    pub sector_proofs: Vec<RawBytes>,
+    // Aggregate proof for all sectors.
+    // Exactly one of sector_proofs or aggregate_proof must be non-empty.
+    pub aggregate_proof: RawBytes,
+    // Whether to abort if any sector activation fails.
     pub require_activation_success: bool,
+    // Whether to abort if any notification returns a non-zero exit code.
     pub require_notification_success: bool,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct DataActivationNotificationReturn {
-    code: ExitCode,
-    data: Vec<u8>,
+// Data to activate a commitment to one sector and its data.
+// All pieces of data must be specified, whether or not not claiming a FIL+ activation or being
+// notified to a data consumer.
+// An implicit zero piece fills any remaining sector capacity.
+// XXX: we should consider fast tracking the special case where there is only
+//  one piece not claiming or notifying other actors to allow an empty piece vector.
+//  We could interpret this as a single piece, size == sector size, cid == commD, empty allocation empty notify vector
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+pub struct SectorActivationManifest {
+    // Sector to be activated.
+    pub sector_number: SectorNumber,
+    // Pieces comprising the sector content, in order.
+    pub pieces: Vec<PieceActivationManifest>,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct PieceActivationReturn {
-    claimed: bool,
-    notifications: Vec<DataActivationNotificationReturn>,
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+pub struct PieceActivationManifest {
+    // Piece data commitment.
+    pub cid: Cid,
+    // Piece size.
+    pub size: PaddedPieceSize,
+    // Identifies a verified allocation to be claimed.
+    pub verified_allocation_key: Option<VerifiedAllocationKey>,
+    // Synchronous notifications to be sent to other actors after activation.
+    pub notify: Vec<DataActivationNotification>,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct SectorActivationReturn {
-    activated: bool,
-    power: StoragePower,
-    pieces: Vec<PieceActivationManifest>,
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+pub struct VerifiedAllocationKey {
+    pub client: ActorID,
+    pub id: AllocationID,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+pub struct DataActivationNotification {
+    // Actor to be notified.
+    pub address: Address,
+    // Data to send in the notification.
+    pub payload: RawBytes,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ProveCommit2Return {
+    // Sector activation results, parallel to input sector activation manifests.
     pub sectors: Vec<SectorActivationReturn>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct SectorActivationReturn {
+    // Whether the sector was activated.
+    activated: bool,
+    // Power of the activated sector (or zero).
+    power: StoragePower,
+    // Piece activation results, parallel to input piece activation manifests.
+    pieces: Vec<PieceActivationReturn>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct PieceActivationReturn {
+    // Whether a verified allocation was successfully claimed by the piece.
+    claimed: bool,
+    // Results from notifications of piece activation, parallel to input notification requests.
+    notifications: Vec<DataActivationNotificationReturn>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct DataActivationNotificationReturn {
+    // Exit code from the notified actor.
+    code: ExitCode,
+    // Return value from the notified actor.
+    data: RawBytes,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
@@ -454,8 +475,7 @@ pub struct DisputeWindowedPoStParams {
 #[derive(Debug, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct ProveCommitAggregateParams {
     pub sector_numbers: BitField,
-    #[serde(with = "strict_bytes")]
-    pub aggregate_proof: Vec<u8>,
+    pub aggregate_proof: RawBytes,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
@@ -466,8 +486,7 @@ pub struct ReplicaUpdate {
     pub new_sealed_cid: Cid,
     pub deals: Vec<DealID>,
     pub update_proof_type: RegisteredUpdateProof,
-    #[serde(with = "strict_bytes")]
-    pub replica_proof: Vec<u8>,
+    pub replica_proof: RawBytes,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
@@ -484,8 +503,7 @@ pub struct ReplicaUpdate2 {
     pub new_unsealed_cid: Cid,
     pub deals: Vec<DealID>,
     pub update_proof_type: RegisteredUpdateProof,
-    #[serde(with = "strict_bytes")]
-    pub replica_proof: Vec<u8>,
+    pub replica_proof: RawBytes,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -133,6 +133,75 @@ pub struct ProveCommitSectorParams {
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct DataActivationNotification {
+    pub address: Address,
+    #[serde(with = "strict_bytes")]
+    pub payload: Vec<u8>,    
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct AllocationKey {
+    pub id AllocationID,
+    pub client Address,
+}
+
+// Data to aci
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct PieceActivationManifest {
+    pub cid: Cid,
+    pub size: PaddedPieceSize,
+    pub verified_allocation_key: Option<AllocationKey>,
+    pub notify: Vec<DataActivationNotifictaion>,
+}
+
+// Data to activate a commitment to one sector and its data.
+// All non-zero pieces of data must be specified, even those
+// not being notified to a data consumer or claiming a FIL+ activation.
+// XXX: we should consider fast tracking the special case where there is only
+//  one piece not claiming or notifying other actors to allow an empty piece vector.
+//  We could interpret this as a single piece, size == sector size, cid == commD, empty allocation empty notify vector
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct SectorDataActivationManifest {
+    pub sector_number: SectorNumber,
+    pub pieces: Vec<PieceActivationManifest>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct ProveCommit2Params {
+    sector_data_activations: Vec<SectorDataActivationManifest>,
+    // XXX to support aggregate proof here too we just need to make proofs
+    // optional and add another optional type for the aggregate proof 
+    #[serde(with = "strict_bytes")]
+    proofs: Vec<Vec<u8>>
+    require_activation_success: bool,
+    require_notification_success: bool,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct DataActivationNotificationReturn {
+    code: ExitCode,
+    data: Vec<u8>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct PieceActivationReturn {
+    claimed: bool,
+    notifications: Vec<DataActivationNotificationReturn>
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct SectorActivationReturn {
+    activated: bool,
+    power: StoragePower,
+    pieces: Vec<PieceActivationManifest>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct ProveCommit2Return {
+    pub sectors: Vec<SectorActivationReturn>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct CheckSectorProvenParams {
     pub sector_number: SectorNumber,
 }

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -3,20 +3,24 @@
 
 use cid::Cid;
 use fvm_ipld_bitfield::BitField;
-use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{strict_bytes, BytesDe};
+use fvm_ipld_encoding::{tuple::*, RawBytes};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
+use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::randomness::Randomness;
 use fvm_shared::sector::{
     PoStProof, RegisteredPoStProof, RegisteredSealProof, RegisteredUpdateProof, SectorNumber,
     SectorSize, StoragePower,
 };
 use fvm_shared::smooth::FilterEstimate;
+use fvm_shared::ActorID;
 
+use crate::ext::verifreg::AllocationID;
 use fil_actors_runtime::DealWeight;
 
 use crate::commd::CompactCommD;
@@ -135,14 +139,13 @@ pub struct ProveCommitSectorParams {
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct DataActivationNotification {
     pub address: Address,
-    #[serde(with = "strict_bytes")]
-    pub payload: Vec<u8>,    
+    pub payload: RawBytes,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct AllocationKey {
-    pub id AllocationID,
-    pub client Address,
+    pub id: AllocationID,
+    pub client: ActorID,
 }
 
 // Data to aci
@@ -151,7 +154,7 @@ pub struct PieceActivationManifest {
     pub cid: Cid,
     pub size: PaddedPieceSize,
     pub verified_allocation_key: Option<AllocationKey>,
-    pub notify: Vec<DataActivationNotifictaion>,
+    pub notify: Vec<DataActivationNotification>,
 }
 
 // Data to activate a commitment to one sector and its data.
@@ -170,9 +173,8 @@ pub struct SectorDataActivationManifest {
 pub struct ProveCommit2Params {
     pub sector_data_activations: Vec<SectorDataActivationManifest>,
     // XXX to support aggregate proof here too we just need to make proofs
-    // optional and add another optional type for the aggregate proof 
-    #[serde(with = "strict_bytes")]
-    pub proofs: Vec<Vec<u8>>
+    // optional and add another optional type for the aggregate proof
+    pub proofs: Vec<RawBytes>,
     pub require_activation_success: bool,
     pub require_notification_success: bool,
 }
@@ -186,7 +188,7 @@ pub struct DataActivationNotificationReturn {
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct PieceActivationReturn {
     claimed: bool,
-    notifications: Vec<DataActivationNotificationReturn>
+    notifications: Vec<DataActivationNotificationReturn>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -136,20 +136,20 @@ pub struct ProveCommitSectorParams {
     pub proof: Vec<u8>,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
 pub struct DataActivationNotification {
     pub address: Address,
     pub payload: RawBytes,
 }
 
-#[derive(Serialize_tuple, Deserialize_tuple)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
 pub struct AllocationKey {
     pub id: AllocationID,
     pub client: ActorID,
 }
 
 // Data to aci
-#[derive(Serialize_tuple, Deserialize_tuple)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
 pub struct PieceActivationManifest {
     pub cid: Cid,
     pub size: PaddedPieceSize,
@@ -163,7 +163,7 @@ pub struct PieceActivationManifest {
 // XXX: we should consider fast tracking the special case where there is only
 //  one piece not claiming or notifying other actors to allow an empty piece vector.
 //  We could interpret this as a single piece, size == sector size, cid == commD, empty allocation empty notify vector
-#[derive(Serialize_tuple, Deserialize_tuple)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
 pub struct SectorDataActivationManifest {
     pub sector_number: SectorNumber,
     pub pieces: Vec<PieceActivationManifest>,

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -136,7 +136,7 @@ pub struct ProveCommitSectorParams {
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct ProveCommit2Params {
+pub struct ProveCommitSectors2Params {
     // Activation manifest for each sector being proven.
     pub sector_activations: Vec<SectorActivationManifest>,
     // Proofs for each sector, parallel to activation manifests.

--- a/actors/miner/tests/batch_method_network_fees_test.rs
+++ b/actors/miner/tests/batch_method_network_fees_test.rs
@@ -53,7 +53,7 @@ fn insufficient_funds_for_aggregated_prove_commit_network_fee() {
     rt.set_balance(balance.clone());
     let base_fee = TokenAmount::from_atto(10u64.pow(16));
     rt.base_fee.replace(base_fee.clone());
-    assert!(aggregate_prove_commit_network_fee(precommits.len() as i64, &base_fee) > balance);
+    assert!(aggregate_prove_commit_network_fee(precommits.len(), &base_fee) > balance);
 
     let res = actor.prove_commit_aggregate_sector(
         &rt,
@@ -93,7 +93,7 @@ fn insufficient_funds_for_batch_precommit_network_fee() {
     rt.set_balance(balance.clone());
     let base_fee = TokenAmount::from_atto(10u64.pow(16));
     rt.base_fee.replace(base_fee.clone());
-    assert!(aggregate_pre_commit_network_fee(precommits.len() as i64, &base_fee) > balance);
+    assert!(aggregate_pre_commit_network_fee(precommits.len(), &base_fee) > balance);
 
     let res = actor.pre_commit_sector_batch(
         &rt,
@@ -140,7 +140,7 @@ fn insufficient_funds_for_batch_precommit_in_combination_of_fee_debt_and_network
     // set base fee extremely high so AggregateProveCommitNetworkFee is > 1000 FIL. Set balance to 1000 FIL to easily cover PCD but not network fee
     let base_fee = TokenAmount::from_atto(10u64.pow(16));
     rt.base_fee.replace(base_fee.clone());
-    let net_fee = aggregate_pre_commit_network_fee(precommits.len() as i64, &base_fee);
+    let net_fee = aggregate_pre_commit_network_fee(precommits.len(), &base_fee);
 
     // setup miner to have fee debt equal to net fee
     let mut state: State = rt.get_state();
@@ -196,7 +196,7 @@ fn enough_funds_for_fee_debt_and_network_fee_but_not_for_pcd() {
     // set base fee and fee debt high
     let base_fee = TokenAmount::from_atto(10u64.pow(16));
     rt.base_fee.replace(base_fee.clone());
-    let net_fee = aggregate_pre_commit_network_fee(precommits.len() as i64, &base_fee);
+    let net_fee = aggregate_pre_commit_network_fee(precommits.len(), &base_fee);
     // setup miner to have feed debt equal to net fee
     let mut state: State = rt.get_state();
     state.fee_debt = net_fee.clone();
@@ -251,7 +251,7 @@ fn enough_funds_for_everything() {
     // set base fee extremely high so AggregateProveCommitNetworkFee is > 1000 FIL. Set balance to 1000 FIL to easily cover PCD but not network fee
     let base_fee = TokenAmount::from_atto(10u64.pow(16));
     rt.base_fee.replace(base_fee.clone());
-    let net_fee = aggregate_pre_commit_network_fee(precommits.len() as i64, &base_fee);
+    let net_fee = aggregate_pre_commit_network_fee(precommits.len(), &base_fee);
 
     // setup miner to have fee debt equal to net fee
     let mut state: State = rt.get_state();

--- a/actors/miner/tests/miner_actor_test_precommit_batch.rs
+++ b/actors/miner/tests/miner_actor_test_precommit_batch.rs
@@ -81,7 +81,7 @@ fn assert_simple_batch(
             &pwr_estimate,
         );
     }
-    let net_fee = aggregate_pre_commit_network_fee(batch_size as i64, &base_fee);
+    let net_fee = aggregate_pre_commit_network_fee(batch_size, &base_fee);
     let total_deposit: TokenAmount = deposits.iter().sum();
     let total_balance = net_fee + &total_deposit;
     rt.set_balance(total_balance + balance_surplus);

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -612,8 +612,7 @@ fn verify_proof_does_not_vest_funds() {
     rt.set_epoch(precommit_epoch + rt.policy.pre_commit_challenge_delay + 1);
     rt.balance.replace(TokenAmount::from_whole(1000));
 
-    let mut prove_commit = h.make_prove_commit_params(sector_no);
-    prove_commit.proof.resize(192, 0);
+    let prove_commit = h.make_prove_commit_params(sector_no);
     // The below call expects exactly the pledge delta for the proven sector, zero for any other vesting.
     h.prove_commit_sector_and_confirm(&rt, &precommit, prove_commit, ProveCommitConfig::empty())
         .unwrap();

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -548,7 +548,7 @@ impl ActorHarness {
     }
 
     pub fn make_prove_commit_params(&self, sector_no: u64) -> ProveCommitSectorParams {
-        ProveCommitSectorParams { sector_number: sector_no, proof: vec![0u8; 192] }
+        ProveCommitSectorParams { sector_number: sector_no, proof: vec![0u8; 192].into() }
     }
 
     pub fn pre_commit_sector_batch(
@@ -629,7 +629,7 @@ impl ActorHarness {
 
         let mut expected_network_fee = TokenAmount::zero();
         if sectors.len() > 1 {
-            expected_network_fee = aggregate_pre_commit_network_fee(sectors.len() as i64, base_fee);
+            expected_network_fee = aggregate_pre_commit_network_fee(sectors.len(), base_fee);
         }
         // burn networkFee
         if state.fee_debt.is_positive() || expected_network_fee.is_positive() {
@@ -801,8 +801,8 @@ impl ActorHarness {
             sector_id: SectorID { miner: actor_id, number: pc.info.sector_number },
             sealed_cid: pc.info.sealed_cid,
             registered_proof: pc.info.seal_proof,
-            proof: params.proof.clone(),
-            deal_ids: pc.info.deal_ids.clone(),
+            proof: params.proof.clone().into(),
+            deal_ids: vec![],
             randomness: Randomness(seal_rand.into()),
             interactive_randomness: Randomness(seal_int_rand.into()),
             unsealed_cid: pc.info.unsealed_cid.get_cid(pc.info.seal_proof).unwrap(),
@@ -879,13 +879,13 @@ impl ActorHarness {
                 unsealed_cid: comm_ds[i],
             })
         }
-        rt.expect_aggregate_verify_seals(svis, params.aggregate_proof.clone(), Ok(()));
+        rt.expect_aggregate_verify_seals(svis, params.aggregate_proof.clone().into(), Ok(()));
 
         // confirm sector proofs valid
         self.confirm_sector_proofs_valid_internal(rt, config, &precommits);
 
         // burn network fee
-        let expected_fee = aggregate_prove_commit_network_fee(precommits.len() as i64, base_fee);
+        let expected_fee = aggregate_prove_commit_network_fee(precommits.len(), base_fee);
         assert!(expected_fee.is_positive());
         rt.expect_send_simple(
             BURNT_FUNDS_ACTOR_ADDR,
@@ -2751,7 +2751,7 @@ pub fn get_bitfield(ubf: &UnvalidatedBitField) -> BitField {
 pub fn make_prove_commit_aggregate(sector_nos: &BitField) -> ProveCommitAggregateParams {
     ProveCommitAggregateParams {
         sector_numbers: sector_nos.clone(),
-        aggregate_proof: vec![0; 1024],
+        aggregate_proof: vec![0; 1024].into(),
     }
 }
 

--- a/integration_tests/src/tests/batch_onboarding_deals_test.rs
+++ b/integration_tests/src/tests/batch_onboarding_deals_test.rs
@@ -231,7 +231,7 @@ pub fn prove_commit_aggregate(
     let sector_nos: Vec<u64> = precommits.iter().map(|p| p.info.sector_number).collect();
     let prove_commit_aggregate_params = ProveCommitAggregateParams {
         sector_numbers: make_bitfield(sector_nos.as_slice()),
-        aggregate_proof: vec![],
+        aggregate_proof: vec![].into(),
     };
 
     apply_ok(

--- a/integration_tests/src/tests/commit_post_test.rs
+++ b/integration_tests/src/tests/commit_post_test.rs
@@ -71,7 +71,7 @@ fn setup(v: &dyn VM) -> (MinerInfo, SectorInfo) {
     advance_by_deadline_to_epoch(v, &id_addr, prove_time);
 
     // prove commit, cron, advance to post time
-    let prove_params = ProveCommitSectorParams { sector_number, proof: vec![] };
+    let prove_params = ProveCommitSectorParams { sector_number, proof: vec![].into() };
     let prove_params_ser = IpldBlock::serialize_cbor(&prove_params).unwrap();
     apply_ok(
         v,
@@ -449,7 +449,7 @@ pub fn aggregate_bad_sector_number_test(v: &dyn VM) {
 
     let params = ProveCommitAggregateParams {
         sector_numbers: precommited_sector_nos.clone(),
-        aggregate_proof: vec![],
+        aggregate_proof: vec![].into(),
     };
     apply_code(
         v,
@@ -517,7 +517,7 @@ pub fn aggregate_size_limits_test(v: &dyn VM) {
     // Fail with too many sectors
     let params = ProveCommitAggregateParams {
         sector_numbers: precommited_sector_nos.clone(),
-        aggregate_proof: vec![],
+        aggregate_proof: vec![].into(),
     };
     apply_code(
         v,
@@ -534,7 +534,7 @@ pub fn aggregate_size_limits_test(v: &dyn VM) {
         precommited_sector_nos.slice(0, policy.min_aggregated_sectors - 1).unwrap();
     let params = ProveCommitAggregateParams {
         sector_numbers: too_few_sector_nos_bf,
-        aggregate_proof: vec![],
+        aggregate_proof: vec![].into(),
     };
     apply_code(
         v,
@@ -551,7 +551,7 @@ pub fn aggregate_size_limits_test(v: &dyn VM) {
         precommited_sector_nos.slice(0, policy.max_aggregated_sectors).unwrap();
     let params = ProveCommitAggregateParams {
         sector_numbers: just_right_sectors_no_bf,
-        aggregate_proof: vec![0; policy.max_aggregated_proof_size + 1],
+        aggregate_proof: vec![0; policy.max_aggregated_proof_size + 1].into(),
     };
     apply_code(
         v,
@@ -619,7 +619,7 @@ pub fn aggregate_bad_sender_test(v: &dyn VM) {
 
     let params = ProveCommitAggregateParams {
         sector_numbers: precommited_sector_nos,
-        aggregate_proof: vec![],
+        aggregate_proof: vec![].into(),
     };
     apply_code(
         v,
@@ -720,8 +720,10 @@ pub fn aggregate_one_precommit_expires_test(v: &dyn VM) {
             && agg_setors_count < policy.max_aggregated_sectors
     );
 
-    let prove_params =
-        ProveCommitAggregateParams { sector_numbers: sector_nos_bf, aggregate_proof: vec![] };
+    let prove_params = ProveCommitAggregateParams {
+        sector_numbers: sector_nos_bf,
+        aggregate_proof: vec![].into(),
+    };
     let prove_params_ser = IpldBlock::serialize_cbor(&prove_params).unwrap();
     apply_ok(
         v,

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -629,7 +629,7 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
         new_sealed_cid,
         deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-        replica_proof: vec![],
+        replica_proof: vec![].into(),
         new_unsealed_cid,
     };
     let updated_sectors: BitField = apply_ok(

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -238,7 +238,7 @@ pub fn prove_replica_update_multi_dline_test(v: &dyn VM) {
         new_sealed_cid: new_sealed_cid1,
         deals: deal_ids[0..1].to_vec(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-        replica_proof: vec![],
+        replica_proof: vec![].into(),
     };
 
     let new_sealed_cid2 = make_sealed_cid(b"replica2");
@@ -249,7 +249,7 @@ pub fn prove_replica_update_multi_dline_test(v: &dyn VM) {
         new_sealed_cid: new_sealed_cid2,
         deals: deal_ids[1..].to_vec(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-        replica_proof: vec![],
+        replica_proof: vec![].into(),
     };
 
     let ret_bf: BitField = apply_ok(
@@ -317,7 +317,7 @@ pub fn immutable_deadline_failure_test(v: &dyn VM) {
         new_sealed_cid: new_cid,
         deals: deal_ids,
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-        replica_proof: vec![],
+        replica_proof: vec![].into(),
     };
     apply_code(
         v,
@@ -369,7 +369,7 @@ pub fn unhealthy_sector_failure_test(v: &dyn VM) {
         new_sealed_cid: new_cid,
         deals: deal_ids,
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-        replica_proof: vec![],
+        replica_proof: vec![].into(),
     };
     apply_code(
         v,
@@ -436,7 +436,7 @@ pub fn terminated_sector_failure_test(v: &dyn VM) {
         new_sealed_cid: new_cid,
         deals: deal_ids,
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-        replica_proof: vec![],
+        replica_proof: vec![].into(),
     };
     apply_code(
         v,
@@ -485,7 +485,7 @@ pub fn bad_batch_size_failure_test(v: &dyn VM) {
             new_sealed_cid: new_cid,
             deals: deal_ids.clone(),
             update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-            replica_proof: vec![],
+            replica_proof: vec![].into(),
         });
     }
 
@@ -581,7 +581,7 @@ pub fn bad_post_upgrade_dispute_test(v: &dyn VM) {
         new_sealed_cid: new_cid,
         deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-        replica_proof: vec![],
+        replica_proof: vec![].into(),
     };
 
     let updated_sectors: BitField = apply_ok(
@@ -742,7 +742,7 @@ pub fn wrong_deadline_index_failure_test(v: &dyn VM) {
             new_sealed_cid: new_cid,
             deals: deal_ids.clone(),
             update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-            replica_proof: vec![],
+            replica_proof: vec![].into(),
         });
     }
 
@@ -797,7 +797,7 @@ pub fn wrong_partition_index_failure_test(v: &dyn VM) {
             new_sealed_cid: new_cid,
             deals: deal_ids.clone(),
             update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-            replica_proof: vec![],
+            replica_proof: vec![].into(),
         });
     }
 
@@ -901,7 +901,7 @@ pub fn deal_included_in_multiple_sectors_failure_test(v: &dyn VM) {
         new_sealed_cid: new_sealed_cid1,
         deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-        replica_proof: vec![],
+        replica_proof: vec![].into(),
     };
 
     let new_sealed_cid2 = make_sealed_cid(b"replica2");
@@ -912,7 +912,7 @@ pub fn deal_included_in_multiple_sectors_failure_test(v: &dyn VM) {
         new_sealed_cid: new_sealed_cid2,
         deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-        replica_proof: vec![],
+        replica_proof: vec![].into(),
     };
 
     let ret_bf: BitField = apply_ok(
@@ -996,7 +996,7 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
         new_sealed_cid,
         deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-        replica_proof: vec![],
+        replica_proof: vec![].into(),
         new_unsealed_cid,
     };
     let updated_sectors: BitField = apply_ok(
@@ -1106,7 +1106,7 @@ pub fn replica_update_verified_deal_max_term_violated_test(v: &dyn VM) {
         new_sealed_cid,
         deals: deal_ids,
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-        replica_proof: vec![],
+        replica_proof: vec![].into(),
         new_unsealed_cid,
     };
     apply_code(
@@ -1155,7 +1155,7 @@ pub fn create_sector(
     // prove commit
     let prove_time = v.epoch() + Policy::default().pre_commit_challenge_delay + 1;
     advance_by_deadline_to_epoch(v, &maddr, prove_time);
-    let prove_commit_params = ProveCommitSectorParams { sector_number, proof: vec![] };
+    let prove_commit_params = ProveCommitSectorParams { sector_number, proof: vec![].into() };
     apply_ok(
         v,
         &worker,
@@ -1306,7 +1306,7 @@ pub fn create_miner_and_upgrade_sector(
             new_sealed_cid,
             deals: deal_ids.clone(),
             update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-            replica_proof: vec![],
+            replica_proof: vec![].into(),
         };
         apply_ok(
             v,
@@ -1332,7 +1332,7 @@ pub fn create_miner_and_upgrade_sector(
             new_sealed_cid,
             deals: deal_ids.clone(),
             update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
-            replica_proof: vec![],
+            replica_proof: vec![].into(),
             new_unsealed_cid,
         };
         apply_ok(

--- a/integration_tests/src/tests/terminate_test.rs
+++ b/integration_tests/src/tests/terminate_test.rs
@@ -180,7 +180,7 @@ pub fn terminate_sectors_test(v: &dyn VM) {
     advance_by_deadline_to_epoch(v, &miner_id_addr, prove_time);
 
     // prove commit, cron, advance to post time
-    let prove_params = ProveCommitSectorParams { sector_number, proof: vec![] };
+    let prove_params = ProveCommitSectorParams { sector_number, proof: vec![].into() };
     apply_ok(
         v,
         &worker,

--- a/integration_tests/src/util/workflows.rs
+++ b/integration_tests/src/util/workflows.rs
@@ -158,7 +158,7 @@ pub fn miner_prove_sector(
     miner_id: &Address,
     sector_number: SectorNumber,
 ) {
-    let prove_commit_params = ProveCommitSectorParams { sector_number, proof: vec![] };
+    let prove_commit_params = ProveCommitSectorParams { sector_number, proof: vec![].into() };
     apply_ok(
         v,
         worker,
@@ -255,10 +255,7 @@ pub fn precommit_sectors_v2_expect_code(
         if param_sectors.len() > 1 {
             invocs.push(Expect::burn(
                 miner_id,
-                Some(aggregate_pre_commit_network_fee(
-                    param_sectors.len() as i64,
-                    &TokenAmount::zero(),
-                )),
+                Some(aggregate_pre_commit_network_fee(param_sectors.len(), &TokenAmount::zero())),
             ));
         }
         if expect_cron_enroll && msg_sector_idx_base == 0 {
@@ -377,7 +374,7 @@ pub fn prove_commit_sectors(
 
         let prove_commit_aggregate_params = ProveCommitAggregateParams {
             sector_numbers: make_bitfield(b.as_slice()),
-            aggregate_proof: vec![],
+            aggregate_proof: vec![].into(),
         };
 
         let prove_commit_aggregate_params_ser =
@@ -392,8 +389,7 @@ pub fn prove_commit_sectors(
             Some(prove_commit_aggregate_params),
         );
 
-        let expected_fee =
-            aggregate_prove_commit_network_fee(to_prove.len() as i64, &TokenAmount::zero());
+        let expected_fee = aggregate_prove_commit_network_fee(to_prove.len(), &TokenAmount::zero());
         ExpectInvocation {
             from: worker_id,
             to: *maddr,


### PR DESCRIPTION
- [x] Reject pre-committed deal IDs
- [x] Support both batch and aggregate proofs
- [x] Compute CommD from pieces and check against declared/proven
- [x] Claim allocations, mandatory for activation success
- [x] Sector activations are independent, unless RequireActivationSuccess

Sending of notifications is deferred for a subsequent PR.

Replaces #1379.