### PR TITLE
Send SectorContentChanged from new onboarding methods

### DIFF
--- a/actors/market/src/ext.rs
+++ b/actors/market/src/ext.rs
@@ -27,13 +27,15 @@ pub mod miner {
     use cid::Cid;
     use fvm_ipld_encoding::RawBytes;
     use fvm_shared::clock::ChainEpoch;
-    use fvm_shared::error::ExitCode;
     use fvm_shared::piece::PaddedPieceSize;
     use fvm_shared::sector::SectorNumber;
+    use fvm_shared::MethodNum;
 
     pub const CONTROL_ADDRESSES_METHOD: u64 = 2;
     pub const IS_CONTROLLING_ADDRESS_EXPORTED: u64 =
         frc42_dispatch::method_hash!("IsControllingAddress");
+    pub const SECTOR_CONTENT_CHANGED: MethodNum =
+        frc42_dispatch::method_hash!("SectorContentChanged");
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct GetControlAddressesReturnParams {
@@ -54,63 +56,42 @@ pub mod miner {
         pub address: Address,
     }
 
-    // Notification of change committed to one or more sectors.
-    // The relevant state must be already committed so the receiver can observe any impacts
-    // at the sending miner actor.
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
     #[serde(transparent)]
     pub struct SectorContentChangedParams {
-        // Distinct sectors with changed content.
         pub sectors: Vec<SectorChanges>,
     }
 
-    // Description of changes to one sector's content.
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
     pub struct SectorChanges {
-        // Identifier of sector being updated.
         pub sector: SectorNumber,
-        // Minimum epoch until which the data is committed to the sector.
-        // Note the sector may later be extended without necessarily another notification.
         pub minimum_commitment_epoch: ChainEpoch,
-        // Information about some pieces added to (or retained in) the sector.
-        // This may be only a subset of sector content.
-        // Inclusion here does not mean the piece was definitely absent previously.
-        // Exclusion here does not mean a piece has been removed since a prior notification.
-        pub added: Vec<PieceInfo>,
+        pub added: Vec<PieceChange>,
     }
 
-    // Description of a piece of data committed to a sector.
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-    pub struct PieceInfo {
+    pub struct PieceChange {
         pub data: Cid,
         pub size: PaddedPieceSize,
-        // A receiver-specific identifier.
-        // E.g. an encoded deal ID which the provider claims this piece satisfies.
         pub payload: RawBytes,
     }
 
-    // For each piece in each sector, the notifee returns an exit code and
-    // (possibly-empty) result data.
-    // The miner actor will pass through results to its caller.
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
     #[serde(transparent)]
     pub struct SectorContentChangedReturn {
-        // A result for each sector that was notified, in the same order.
         pub sectors: Vec<SectorReturn>,
     }
+
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
     #[serde(transparent)]
     pub struct SectorReturn {
-        // A result for each piece for the sector that was notified, in the same order.
         pub added: Vec<PieceReturn>,
     }
+
     #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+    #[serde(transparent)]
     pub struct PieceReturn {
-        // Indicates whether the receiver accepted the notification.
-        // The caller is free to ignore this, but may chose to abort and roll back.
-        pub code: ExitCode,
-        // Receiver-specific result data about the piece, to be passed back to top level caller.
-        pub data: Vec<u8>,
+        pub accepted: bool,
     }
 }
 

--- a/actors/market/tests/activate_deal_failures.rs
+++ b/actors/market/tests/activate_deal_failures.rs
@@ -144,5 +144,5 @@ fn assert_activation_failure(
         added: vec![piece],
     }];
     let ret = sector_content_changed(rt, PROVIDER_ADDR, changes).unwrap();
-    assert_eq!(vec![PieceReturn { code: exit, data: vec![] }], ret.sectors[0].added);
+    assert_eq!(vec![PieceReturn { accepted: false }], ret.sectors[0].added);
 }

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -16,7 +16,7 @@ use std::{cell::RefCell, collections::HashMap};
 
 use fil_actor_market::ext::account::{AuthenticateMessageParams, AUTHENTICATE_MESSAGE_METHOD};
 use fil_actor_market::ext::miner::{
-    PieceInfo, SectorChanges, SectorContentChangedParams, SectorContentChangedReturn,
+    PieceChange, SectorChanges, SectorContentChangedParams, SectorContentChangedReturn,
 };
 use fil_actor_market::ext::verifreg::{AllocationID, AllocationRequest, AllocationsResponse};
 use fil_actor_market::{
@@ -1255,8 +1255,8 @@ where
     ret
 }
 
-pub fn piece_info_from_deal(id: DealID, deal: &DealProposal) -> PieceInfo {
-    PieceInfo {
+pub fn piece_info_from_deal(id: DealID, deal: &DealProposal) -> PieceChange {
+    PieceChange {
         data: deal.piece_cid,
         size: deal.piece_size,
         payload: serialize(&id, "deal id").unwrap(),

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -24,12 +24,13 @@ use fvm_shared::randomness::*;
 use fvm_shared::reward::ThisEpochRewardReturn;
 use fvm_shared::sector::*;
 use fvm_shared::smooth::FilterEstimate;
-use fvm_shared::{ActorID, METHOD_CONSTRUCTOR, METHOD_SEND};
+use fvm_shared::{ActorID, MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND};
 use itertools::Itertools;
 use log::{error, info, warn};
 use num_derive::FromPrimitive;
 use num_traits::{Signed, Zero};
 
+use crate::notifications::{notify_data_consumers, ActivationNotifications};
 pub use beneficiary::*;
 pub use bitfield_queue::*;
 pub use commd::*;
@@ -48,6 +49,7 @@ use fil_actors_runtime::{
     STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_ipld_encoding::ipld_block::IpldBlock;
+
 use fvm_shared::version::NetworkVersion;
 pub use monies::*;
 pub use partition_state::*;
@@ -77,6 +79,7 @@ mod expiration_queue;
 #[doc(hidden)]
 pub mod ext;
 mod monies;
+mod notifications;
 mod partition_state;
 mod policy;
 mod sector_map;
@@ -144,7 +147,12 @@ pub enum Method {
     GetMultiaddrsExported = frc42_dispatch::method_hash!("GetMultiaddrs"),
 }
 
+pub const SECTOR_CONTENT_CHANGED: MethodNum = frc42_dispatch::method_hash!("SectorContentChanged");
+
 pub const ERR_BALANCE_INVARIANTS_BROKEN: ExitCode = ExitCode::new(1000);
+pub const ERR_NOTIFICATION_SEND_FAILED: ExitCode = ExitCode::new(1001);
+pub const ERR_NOTIFICATION_RESPONSE_INVALID: ExitCode = ExitCode::new(1002);
+pub const ERR_NOTIFICATION_REJECTED: ExitCode = ExitCode::new(1003);
 
 /// Miner Actor
 /// here in order to update the Power Actor to v3.
@@ -1159,19 +1167,20 @@ impl Actor {
         for ((update, sector_info), data_activation) in
             successful_manifests.iter().zip(data_activations)
         {
-            let dl = update.deadline;
             let activated_data = ReplicaUpdateActivatedData {
                 seal_cid: update.new_sealed_cid,
                 deals: vec![],
                 unverified_space: data_activation.unverified_space.clone(),
                 verified_space: data_activation.verified_space.clone(),
             };
-            state_updates_by_dline.entry(dl).or_default().push(ReplicaUpdateStateInputs {
-                deadline: update.deadline,
-                partition: update.partition,
-                sector_info,
-                activated_data,
-            });
+            state_updates_by_dline.entry(update.deadline).or_default().push(
+                ReplicaUpdateStateInputs {
+                    deadline: update.deadline,
+                    partition: update.partition,
+                    sector_info,
+                    activated_data,
+                },
+            );
         }
 
         let (power_delta, pledge_delta) = update_replica_states(
@@ -1185,10 +1194,18 @@ impl Actor {
         notify_pledge_changed(rt, &pledge_delta)?;
         request_update_power(rt, power_delta)?;
 
-        // Notify data consumers (not yet implemented).
-        // notify_data_consumers(rt, successful_sector_activations);
+        // Notify data consumers.
+        let mut notifications: Vec<ActivationNotifications> = vec![];
+        for (update, sector_info) in successful_manifests {
+            notifications.push(ActivationNotifications {
+                sector_number: update.sector,
+                sector_expiration: sector_info.expiration,
+                pieces: &update.pieces,
+            });
+        }
+        notify_data_consumers(rt, &notifications, params.require_notification_success)?;
 
-        Ok(ProveReplicaUpdates3Return { sectors: vec![] })
+        Ok(ProveReplicaUpdates3Return { activation_results: BatchReturn::empty() })
     }
 
     fn dispute_windowed_post(
@@ -1699,7 +1716,7 @@ impl Actor {
     fn prove_commit_sectors2(
         rt: &impl Runtime,
         params: ProveCommitSectors2Params,
-    ) -> Result<(), ActorError> {
+    ) -> Result<ProveCommitSectors2Return, ActorError> {
         let state: State = rt.state()?;
         let store = rt.store();
         let policy = rt.policy();
@@ -1853,16 +1870,25 @@ impl Actor {
             &info,
         )?;
 
-        // Notify data consumers (not yet implemented).
-        // notify_data_consumers(rt, successful_sector_activations);
-
         if !params.aggregate_proof.is_empty() {
             // Aggregate fee is paid on the sectors successfully proven,
             // but without regard to data activation which could subsequently fail
             // and prevent sector activation.
             pay_aggregate_seal_proof_fee(rt, proven_activation_inputs.len())?;
         }
-        Ok(())
+
+        // Notify data consumers.
+        let mut notifications: Vec<ActivationNotifications> = vec![];
+        for (activations, sector) in &successful_sector_activations {
+            notifications.push(ActivationNotifications {
+                sector_number: activations.sector_number,
+                sector_expiration: sector.info.expiration,
+                pieces: &activations.pieces,
+            });
+        }
+        notify_data_consumers(rt, &notifications, params.require_notification_success)?;
+
+        Ok(ProveCommitSectors2Return { activation_results: BatchReturn::empty() })
     }
 
     /// Checks state of the corresponding sector pre-commitment, then schedules the proof to be verified in bulk

--- a/actors/miner/src/notifications.rs
+++ b/actors/miner/src/notifications.rs
@@ -1,0 +1,179 @@
+use crate::{
+    PieceActivationManifest, PieceChange, SectorChanges, SectorContentChangedParams,
+    SectorContentChangedReturn, SECTOR_CONTENT_CHANGED,
+};
+use fil_actors_runtime::runtime::Runtime;
+use fil_actors_runtime::{
+    actor_error, ActorError, AsActorError, SendError, STORAGE_MARKET_ACTOR_ADDR,
+};
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+
+use fvm_shared::address::Address;
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::sector::SectorNumber;
+use fvm_shared::sys::SendFlags;
+use num_traits::Zero;
+use std::collections::BTreeMap;
+
+pub struct ActivationNotifications<'a> {
+    pub sector_number: SectorNumber,
+    pub sector_expiration: ChainEpoch,
+    pub pieces: &'a Vec<PieceActivationManifest>,
+}
+
+/// Sends notifications of sector and piece activation to nominated receiving actors.
+/// Inputs are per-sector, matching parameters provided by external callers.
+/// This method groups inputs by receiving actor and sends a single notification per actor.
+/// Notifications are fire-and-forget, so there is no return value.
+/// If require_success is true, this method will return an error if any of the notifications fail
+/// or are rejected by the receiving actor.
+pub fn notify_data_consumers(
+    rt: &impl Runtime,
+    activations: &[ActivationNotifications],
+    require_success: bool,
+) -> Result<(), ActorError> {
+    // Inputs are grouped by sector -> piece -> notifee+payload
+    // Regroup by notifee -> sector -> piece+payload for sending.
+    let mut activations_by_notifee =
+        BTreeMap::<Address, BTreeMap<SectorNumber, Vec<PieceChange>>>::new();
+    // Collect each sector's expiration for sending to each receiver of a notification.
+    let mut sector_expirations = BTreeMap::<SectorNumber, ChainEpoch>::new();
+    for activation in activations {
+        sector_expirations.insert(activation.sector_number, activation.sector_expiration);
+        for piece in activation.pieces {
+            for notifee in &piece.notify {
+                activations_by_notifee
+                    .entry(notifee.address)
+                    .or_default()
+                    .entry(activation.sector_number)
+                    .or_default()
+                    .push(PieceChange {
+                        data: piece.cid,
+                        size: piece.size,
+                        payload: notifee.payload.clone(),
+                    });
+            }
+        }
+    }
+
+    for (notifee, payloads) in activations_by_notifee {
+        // Reject notifications to any actor other than the built-in market.
+        if notifee != STORAGE_MARKET_ACTOR_ADDR {
+            if require_success {
+                return Err(
+                    actor_error!(illegal_argument; "disallowed notification receiver: {}", notifee),
+                );
+            }
+            continue;
+        }
+        let sectors_changes: Vec<SectorChanges> = payloads
+            .into_iter()
+            .map(|(sector_number, pieces)| SectorChanges {
+                sector: sector_number,
+                minimum_commitment_epoch: *sector_expirations.get(&sector_number).unwrap(),
+                added: pieces,
+            })
+            .collect();
+
+        let response = send_notification(
+            rt,
+            &notifee,
+            SectorContentChangedParams { sectors: sectors_changes.clone() },
+        );
+        if require_success {
+            match response {
+                Ok(response) => {
+                    validate_notification_response(&notifee, &sectors_changes, &response)?;
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// Sends a notification to one receiver and handles errors and syntactically invalid responses.
+fn send_notification(
+    rt: &impl Runtime,
+    notifee: &Address,
+    params: SectorContentChangedParams,
+) -> Result<SectorContentChangedReturn, ActorError> {
+    let gas_limit = None;
+    let send_flags = SendFlags::default();
+    let ret = rt.send(
+        notifee,
+        SECTOR_CONTENT_CHANGED,
+        IpldBlock::serialize_cbor(&params)?,
+        TokenAmount::zero(),
+        gas_limit,
+        send_flags,
+    );
+    match ret {
+        Ok(r) => {
+            if r.exit_code.is_success() {
+                if let Some(data) = r.return_data {
+                    // Success with non-empty return data.
+                    data.deserialize().context_code(
+                        crate::ERR_NOTIFICATION_RESPONSE_INVALID,
+                        "invalid return data serialization",
+                    )
+                } else {
+                    Err(ActorError::checked(
+                        crate::ERR_NOTIFICATION_RESPONSE_INVALID,
+                        "no return data".to_string(),
+                        None,
+                    ))
+                }
+            } else {
+                // Propagate the non-ok exit code from the receiver.
+                Err(ActorError::checked(r.exit_code, "receiver aborted".to_string(), None))
+            }
+        }
+        Err(SendError(e)) => Err(ActorError::checked(
+            crate::ERR_NOTIFICATION_SEND_FAILED,
+            format!("send error {}", e),
+            None,
+        )),
+    }
+}
+
+// Checks that a notification response shape matches the request shape, and that
+// all notifications were accepted.
+fn validate_notification_response(
+    notifee: &Address,
+    request: &[SectorChanges],
+    response: &SectorContentChangedReturn,
+) -> Result<(), ActorError> {
+    if response.sectors.len() != request.len() {
+        return Err(ActorError::checked(
+            crate::ERR_NOTIFICATION_RESPONSE_INVALID,
+            "sector change response mismatched sectors".to_string(),
+            None,
+        ));
+    }
+    for (sreq, sresp) in request.iter().zip(response.sectors.iter()) {
+        if sresp.added.len() != sreq.added.len() {
+            return Err(ActorError::checked(
+                crate::ERR_NOTIFICATION_RESPONSE_INVALID,
+                format!("sector change response mismatched pieces for sector {}", sreq.sector),
+                None,
+            ));
+        }
+        for (nreq, nresp) in sreq.added.iter().zip(sresp.added.iter()) {
+            if !nresp.accepted {
+                return Err(ActorError::checked(
+                    crate::ERR_NOTIFICATION_REJECTED,
+                    format!(
+                        "sector change response rejected by {} for sector {} piece {} payload {:?}",
+                        notifee, sreq.sector, nreq.data, nreq.payload
+                    ),
+                    None,
+                ));
+            }
+        }
+    }
+    Ok(())
+}

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -10,7 +10,6 @@ use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::randomness::Randomness;
 use fvm_shared::sector::{
@@ -21,7 +20,7 @@ use fvm_shared::smooth::FilterEstimate;
 use fvm_shared::ActorID;
 
 use crate::ext::verifreg::AllocationID;
-use fil_actors_runtime::DealWeight;
+use fil_actors_runtime::{BatchReturn, DealWeight};
 
 use crate::commd::CompactCommD;
 use crate::ext::verifreg::ClaimID;
@@ -193,35 +192,8 @@ pub struct DataActivationNotification {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize_tuple, Deserialize_tuple)]
-pub struct ProveCommit2Return {
-    // Sector activation results, parallel to input sector activation manifests.
-    pub sectors: Vec<SectorActivationReturn>,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize_tuple, Deserialize_tuple)]
-pub struct SectorActivationReturn {
-    // Whether the sector was activated.
-    activated: bool,
-    // Power of the activated sector (or zero).
-    power: StoragePower,
-    // Piece activation results, parallel to input piece activation manifests.
-    pieces: Vec<PieceActivationReturn>,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize_tuple, Deserialize_tuple)]
-pub struct PieceActivationReturn {
-    // Whether a verified allocation was successfully claimed by the piece.
-    claimed: bool,
-    // Results from notifications of piece activation, parallel to input notification requests.
-    notifications: Vec<DataActivationNotificationReturn>,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize_tuple, Deserialize_tuple)]
-pub struct DataActivationNotificationReturn {
-    // Exit code from the notified actor.
-    code: ExitCode,
-    // Return value from the notified actor.
-    data: RawBytes,
+pub struct ProveCommitSectors2Return {
+    pub activation_results: BatchReturn,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
@@ -543,7 +515,10 @@ pub struct SectorUpdateManifest {
     pub pieces: Vec<PieceActivationManifest>,
 }
 
-pub type ProveReplicaUpdates3Return = ProveCommit2Return;
+#[derive(Clone, Debug, Eq, PartialEq, Serialize_tuple, Deserialize_tuple)]
+pub struct ProveReplicaUpdates3Return {
+    pub activation_results: BatchReturn,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ChangeBeneficiaryParams {
@@ -618,4 +593,64 @@ pub struct GetPeerIDReturn {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct GetMultiaddrsReturn {
     pub multi_addrs: Vec<BytesDe>,
+}
+
+// Notification of change committed to one or more sectors.
+// The relevant state must be already committed so the receiver can observe any impacts
+// at the sending miner actor.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
+pub struct SectorContentChangedParams {
+    // Distinct sectors with changed content.
+    pub sectors: Vec<SectorChanges>,
+}
+
+// Description of changes to one sector's content.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct SectorChanges {
+    // Identifier of sector being updated.
+    pub sector: SectorNumber,
+    // Minimum epoch until which the data is committed to the sector.
+    // Note the sector may later be extended without necessarily another notification.
+    pub minimum_commitment_epoch: ChainEpoch,
+    // Information about some pieces added to (or retained in) the sector.
+    // This may be only a subset of sector content.
+    // Inclusion here does not mean the piece was definitely absent previously.
+    // Exclusion here does not mean a piece has been removed since a prior notification.
+    pub added: Vec<PieceChange>,
+}
+
+// Description of a piece of data committed to a sector.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct PieceChange {
+    pub data: Cid,
+    pub size: PaddedPieceSize,
+    // A receiver-specific identifier.
+    // E.g. an encoded deal ID which the provider claims this piece satisfies.
+    pub payload: RawBytes,
+}
+
+// For each piece in each sector, the notifee returns an exit code and
+// (possibly-empty) result data.
+// The miner actor will pass through results to its caller.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
+pub struct SectorContentChangedReturn {
+    // A result for each sector that was notified, in the same order.
+    pub sectors: Vec<SectorReturn>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
+pub struct SectorReturn {
+    // A result for each piece for the sector that was notified, in the same order.
+    pub added: Vec<PieceReturn>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
+pub struct PieceReturn {
+    // Indicates whether the receiver accepted the notification.
+    // The caller is free to ignore this, but may chose to abort and roll back.
+    pub accepted: bool,
 }


### PR DESCRIPTION
Also simplifies return values to make notifications fire and forget. Plumbing notification results back through to a structure parallel with the input proved very complex, and of not much value. I intend to emit events for deal activation from the built-in market actor to provide insight into deals that were activated.

Note the return values are not yet populated, deferred for a future PR.

- [ ] Merge #1385 and rebase before landing
