### PR TITLE
Remove go-interop feat from the AMT crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ fvm_ipld_encoding = "0.4.0"
 fvm_ipld_blockstore = "0.2.0"
 fvm_ipld_hamt = "0.7.0"
 fvm_ipld_kamt = "0.3.0"
-fvm_ipld_amt = { version = "0.6.1", features = ["go-interop"] }
+fvm_ipld_amt = { version = "0.6.1" }
 fvm_ipld_bitfield = "0.5.4"
 
 # workspace


### PR DESCRIPTION
Based on the discussion in https://github.com/filecoin-project/ref-fvm/issues/1856, the feature will disappear and should not be used anymore.