### PR TITLE
replace simple_qa_power with extensible flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 dependencies = [
  "serde",
 ]
@@ -1563,6 +1563,7 @@ name = "fil_actor_miner"
 version = "12.0.0"
 dependencies = [
  "anyhow",
+ "bitflags 2.4.0",
  "byteorder",
  "cid 0.10.1",
  "fil_actor_account",
@@ -2274,7 +2275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8704b912372b9640f625fef1b8af24873e27feba66dcbae3f2a49f486a26589d"
 dependencies = [
  "anyhow",
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "blake2b_simd",
  "cid 0.10.1",
  "data-encoding",
@@ -3577,7 +3578,7 @@ version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
 # Common
 serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.65"
+bitflags = "2.4.0"
 num = { version = "0.4", features = ["serde"] }
 num-derive = "0.3.3"
 num-traits = "0.2.14"

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
+bitflags = { workspace = true }
 fil_actors_runtime = { workspace = true }
 frc42_dispatch = { workspace = true }
 fvm_shared = { workspace = true }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3415,7 +3415,7 @@ fn extend_sector_committment(
     validate_extended_expiration(policy, curr_epoch, new_expiration, sector)?;
 
     // all simple_qa_power sectors with VerifiedDealWeight > 0 MUST check all claims
-    if sector.simple_qa_power {
+    if sector.flags.contains(SectorOnChainInfoFlags::SIMPLE_QA_POWER) {
         extend_simple_qap_sector(
             policy,
             new_expiration,
@@ -3440,7 +3440,7 @@ fn extend_sector_committment_legacy(
     validate_extended_expiration(policy, curr_epoch, new_expiration, sector)?;
 
     // it is an error to do legacy sector expiration on simple-qa power sectors with deal weight
-    if sector.simple_qa_power
+    if sector.flags.contains(SectorOnChainInfoFlags::SIMPLE_QA_POWER)
         && (sector.verified_deal_weight > BigInt::zero() || sector.deal_weight > BigInt::zero())
     {
         return Err(actor_error!(
@@ -3739,7 +3739,7 @@ fn update_existing_sector_info(
 ) -> SectorOnChainInfo {
     let mut new_sector_info = sector_info.clone();
 
-    new_sector_info.simple_qa_power = true;
+    new_sector_info.flags.set(SectorOnChainInfoFlags::SIMPLE_QA_POWER, true);
     new_sector_info.sealed_cid = activated_data.seal_cid;
     new_sector_info.sector_key_cid = match new_sector_info.sector_key_cid {
         None => Some(sector_info.sealed_cid),
@@ -4841,7 +4841,7 @@ fn activate_new_sector_infos(
                 power_base_epoch: activation_epoch,
                 replaced_day_reward: TokenAmount::zero(),
                 sector_key_cid: None,
-                simple_qa_power: true,
+                flags: SectorOnChainInfoFlags::SIMPLE_QA_POWER,
             };
 
             new_sector_numbers.push(new_sector_info.sector_number);

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -365,7 +365,7 @@ pub struct SectorOnChainInfo {
 bitflags::bitflags! {
     #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default, Debug)]
     #[serde(transparent)]
-    pub struct SectorOnChainInfoFlags: u8 {
+    pub struct SectorOnChainInfoFlags: u32 {
         /// QA power mechanism introduced in FIP-0045
         const SIMPLE_QA_POWER = 0x1;
     }

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -18,6 +18,7 @@ use fvm_shared::sector::{
 use fvm_shared::smooth::FilterEstimate;
 
 use fil_actors_runtime::DealWeight;
+use serde::{Deserialize, Serialize};
 
 use crate::commd::CompactCommD;
 use crate::ext::verifreg::ClaimID;
@@ -357,8 +358,17 @@ pub struct SectorOnChainInfo {
     pub replaced_day_reward: TokenAmount,
     /// The original SealedSectorCID, only gets set on the first ReplicaUpdate
     pub sector_key_cid: Option<Cid>,
-    // Flag for QA power mechanism introduced in fip 0045
-    pub simple_qa_power: bool,
+    /// Additional flags, see [`SectorOnChainInfoFlags`]
+    pub flags: SectorOnChainInfoFlags,
+}
+
+bitflags::bitflags! {
+    #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default, Debug)]
+    #[serde(transparent)]
+    pub struct SectorOnChainInfoFlags: u8 {
+        /// QA power mechanism introduced in FIP-0045
+        const SIMPLE_QA_POWER = 0x1;
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize_tuple, Deserialize_tuple)]

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -10,7 +10,8 @@ use fil_actor_market::{DealMetaArray, State as MarketState};
 use fil_actor_miner::{
     max_prove_commit_duration, power_for_sector, ExpirationExtension, ExpirationExtension2,
     ExtendSectorExpiration2Params, ExtendSectorExpirationParams, Method as MinerMethod, PowerPair,
-    ProveReplicaUpdatesParams2, ReplicaUpdate2, SectorClaim, Sectors, State as MinerState,
+    ProveReplicaUpdatesParams2, ReplicaUpdate2, SectorClaim, SectorOnChainInfoFlags, Sectors,
+    State as MinerState,
 };
 use fil_actor_verifreg::Method as VerifregMethod;
 use fil_actors_runtime::runtime::Policy;
@@ -191,7 +192,7 @@ pub fn extend_legacy_sector_with_deals_test(v: &dyn VM, do_extend2: bool) {
     // Note: we don't need to explicitly set verified weight using the legacy method
     // because legacy and simple qa power deal weight calculations line up for fully packed sectors
     // We do need to set simple_qa_power to false
-    sector_info.simple_qa_power = false;
+    sector_info.flags.set(SectorOnChainInfoFlags::SIMPLE_QA_POWER, false);
 
     // Manually craft state to match legacy sectors
     mutate_state(v, &miner_id, |st: &mut MinerState| {

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -16,8 +16,9 @@ use fil_actor_market::Method as MarketMethod;
 use fil_actor_miner::{
     power_for_sector, DisputeWindowedPoStParams, ExpirationExtension, ExtendSectorExpirationParams,
     Method as MinerMethod, PowerPair, ProveCommitSectorParams, ProveReplicaUpdatesParams,
-    ProveReplicaUpdatesParams2, ReplicaUpdate, ReplicaUpdate2, SectorOnChainInfo, Sectors,
-    State as MinerState, TerminateSectorsParams, TerminationDeclaration, SECTORS_AMT_BITWIDTH,
+    ProveReplicaUpdatesParams2, ReplicaUpdate, ReplicaUpdate2, SectorOnChainInfo,
+    SectorOnChainInfoFlags, Sectors, State as MinerState, TerminateSectorsParams,
+    TerminationDeclaration, SECTORS_AMT_BITWIDTH,
 };
 use fil_actor_verifreg::Method as VerifregMethod;
 use fil_actors_runtime::runtime::Policy;
@@ -665,7 +666,7 @@ pub fn extend_after_upgrade_test(v: &dyn VM) {
 
     let sector_number = sector_info.sector_number;
     let mut legacy_sector = sector_info;
-    legacy_sector.simple_qa_power = false;
+    legacy_sector.flags.set(SectorOnChainInfoFlags::SIMPLE_QA_POWER, false);
 
     let blockstore = &DynBlockstore::wrap(v.blockstore());
     mutate_state(v, &miner_id, |st: &mut MinerState| {


### PR DESCRIPTION
See this [discussion](https://github.com/filecoin-project/FIPs/discussions/601) for more details. In short, we want to have an easily extensible flags field for the `SectorOnChainInfo` instead of a field per flag, which is wasteful.

@ZenGround0 Hopefully, I introduced your description correctly. Is the `u8` correct in this context?


Closes https://github.com/filecoin-project/builtin-actors/issues/1275