### PR TITLE
Charge gas correctly in prove_commit2

### DIFF
--- a/actors/power/src/lib.rs
+++ b/actors/power/src/lib.rs
@@ -42,12 +42,6 @@ mod types;
 
 // * Updated to specs-actors commit: 999e57a151cc7ada020ca2844b651499ab8c0dec (v3.0.1)
 
-/// GasOnSubmitVerifySeal is amount of gas charged for SubmitPoRepForBulkVerify
-/// This number is empirically determined
-pub mod detail {
-    pub const GAS_ON_SUBMIT_VERIFY_SEAL: i64 = 34721049;
-}
-
 /// Storage power actor methods available
 #[derive(FromPrimitive)]
 #[repr(u64)]
@@ -304,12 +298,13 @@ impl Actor {
                 )
             })?;
             if let Some(arr) = arr {
-                if arr.count() >= MAX_MINER_PROVE_COMMITS_PER_EPOCH {
+                if arr.count() >= rt.policy().max_miner_prove_commits_per_epoch {
                     return Err(ActorError::unchecked(
                         ERR_TOO_MANY_PROVE_COMMITS,
                         format!(
                             "miner {} attempting to prove commit over {} sectors in epoch",
-                            miner_addr, MAX_MINER_PROVE_COMMITS_PER_EPOCH
+                            miner_addr,
+                            rt.policy().max_miner_prove_commits_per_epoch
                         ),
                     ));
                 }
@@ -323,7 +318,7 @@ impl Actor {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to flush proofs batch map")
             })?;
 
-            rt.charge_gas("OnSubmitVerifySeal", detail::GAS_ON_SUBMIT_VERIFY_SEAL);
+            rt.charge_gas("OnSubmitVerifySeal", rt.policy().gas_on_submit_verify_seal);
             st.proof_validation_batch = Some(mmrc);
             Ok(())
         })?;

--- a/actors/power/src/policy.rs
+++ b/actors/power/src/policy.rs
@@ -3,11 +3,3 @@
 
 /// Minimum power of an individual miner to meet the threshold for leader election.
 pub const CONSENSUS_MINER_MIN_MINERS: i64 = 4;
-
-/// Maximum number of prove commits a miner can submit in one epoch
-///
-/// We bound this to 200 to limit the number of prove partitions we may need to update in a
-/// given epoch to 200.
-///
-/// To support onboarding 1EiB/year, we need to allow at least 32 prove commits per epoch.
-pub const MAX_MINER_PROVE_COMMITS_PER_EPOCH: u64 = 200;

--- a/actors/power/src/testing.rs
+++ b/actors/power/src/testing.rs
@@ -14,8 +14,7 @@ use fil_actors_runtime::{parse_uint_key, runtime::Policy, MessageAccumulator, Mu
 
 use crate::{
     consensus_miner_min_power, Claim, ClaimsMap, CronEvent, State, CLAIMS_CONFIG,
-    CRON_QUEUE_AMT_BITWIDTH, CRON_QUEUE_HAMT_BITWIDTH, MAX_MINER_PROVE_COMMITS_PER_EPOCH,
-    PROOF_VALIDATION_BATCH_AMT_BITWIDTH,
+    CRON_QUEUE_AMT_BITWIDTH, CRON_QUEUE_HAMT_BITWIDTH, PROOF_VALIDATION_BATCH_AMT_BITWIDTH,
 };
 
 pub struct MinerCronEvent {
@@ -251,7 +250,7 @@ fn check_proofs_invariants<BS: Blockstore>(
                     return ret.map_err(|e| anyhow::anyhow!("error iterating proof validation batch for address {}: {}", address, e));
                 }
 
-                acc.require(proofs_by_address.len() as u64 <= MAX_MINER_PROVE_COMMITS_PER_EPOCH, format!("miner {address} has submitted too many proofs ({}) for batch verification", proofs_by_address.len()));
+                acc.require(proofs_by_address.len() as u64 <= Policy::default().max_miner_prove_commits_per_epoch, format!("miner {address} has submitted too many proofs ({}) for batch verification", proofs_by_address.len()));
                 Ok(())
             });
             acc.require_no_error(ret, "error iterating proof validation queue");

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -21,7 +21,6 @@ use num_traits::Zero;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use fil_actor_power::detail::GAS_ON_SUBMIT_VERIFY_SEAL;
 use fil_actor_power::ext::init::ExecParams;
 use fil_actor_power::ext::miner::ConfirmSectorProofsParams;
 use fil_actor_power::ext::miner::MinerConstructorParams;
@@ -41,6 +40,7 @@ use fil_actor_power::{CronEvent, MinerConsensusCountReturn};
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::runtime::RuntimePolicy;
+use fil_actors_runtime::runtime::policy_constants::GAS_ON_SUBMIT_VERIFY_SEAL;
 use fil_actors_runtime::test_utils::CRON_ACTOR_CODE_ID;
 use fil_actors_runtime::test_utils::{
     MockRuntime, ACCOUNT_ACTOR_CODE_ID, MINER_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID,

--- a/actors/power/tests/harness/mod.rs
+++ b/actors/power/tests/harness/mod.rs
@@ -38,9 +38,9 @@ use fil_actor_power::{
 };
 use fil_actor_power::{CronEvent, MinerConsensusCountReturn};
 use fil_actors_runtime::runtime::builtins::Type;
+use fil_actors_runtime::runtime::policy_constants::GAS_ON_SUBMIT_VERIFY_SEAL;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::runtime::RuntimePolicy;
-use fil_actors_runtime::runtime::policy_constants::GAS_ON_SUBMIT_VERIFY_SEAL;
 use fil_actors_runtime::test_utils::CRON_ACTOR_CODE_ID;
 use fil_actors_runtime::test_utils::{
     MockRuntime, ACCOUNT_ACTOR_CODE_ID, MINER_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID,

--- a/actors/power/tests/power_actor_tests.rs
+++ b/actors/power/tests/power_actor_tests.rs
@@ -1321,11 +1321,10 @@ mod cron_batch_proof_verifies_tests {
 mod submit_porep_for_bulk_verify_tests {
     use super::*;
 
-    use fil_actor_power::{
-        ERR_TOO_MANY_PROVE_COMMITS, MAX_MINER_PROVE_COMMITS_PER_EPOCH,
-        PROOF_VALIDATION_BATCH_AMT_BITWIDTH,
-    };
+    use fil_actor_power::{ERR_TOO_MANY_PROVE_COMMITS, PROOF_VALIDATION_BATCH_AMT_BITWIDTH};
+    use fil_actors_runtime::runtime::policy_constants::MAX_MINER_PROVE_COMMITS_PER_EPOCH;
     use fil_actors_runtime::shared::HAMT_BIT_WIDTH;
+
     use fil_actors_runtime::test_utils::{make_piece_cid, make_sealed_cid};
     use fil_actors_runtime::Multimap;
     use fvm_shared::sector::{InteractiveSealRandomness, SealRandomness, SealVerifyInfo, SectorID};

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -151,6 +151,14 @@ pub struct Policy {
     // --- power ---
     /// Minimum miner consensus power
     pub minimum_consensus_power: StoragePower,
+    /// GasOnSubmitVerifySeal is amount of gas charged for SubmitPoRepForBulkVerify
+    /// This number is empirically determined
+    pub gas_on_submit_verify_seal: i64,
+    /// Maximum number of prove commits a miner can submit in one epoch
+    /// We bound this to 200 to limit the number of prove partitions we may need to update in a
+    /// given epoch to 200.
+    /// To support onboarding 1EiB/year, we need to allow at least 32 prove commits per epoch.
+    pub max_miner_prove_commits_per_epoch: u64,
 }
 
 impl Default for Policy {
@@ -211,6 +219,8 @@ impl Default for Policy {
                 policy_constants::MARKET_DEFAULT_ALLOCATION_TERM_BUFFER,
 
             minimum_consensus_power: StoragePower::from(policy_constants::MINIMUM_CONSENSUS_POWER),
+            gas_on_submit_verify_seal: policy_constants::GAS_ON_SUBMIT_VERIFY_SEAL,
+            max_miner_prove_commits_per_epoch: policy_constants::MAX_MINER_PROVE_COMMITS_PER_EPOCH,
         }
     }
 }
@@ -343,6 +353,8 @@ pub mod policy_constants {
         feature = "min-power-32g"
     )))]
     pub const MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;
+    pub const GAS_ON_SUBMIT_VERIFY_SEAL: i64 = 34721049;
+    pub const MAX_MINER_PROVE_COMMITS_PER_EPOCH: u64 = 200;
 }
 
 /// A set indicating which proofs are considered valid, optimised for lookup of a small number of


### PR DESCRIPTION
When moving batch verify seals over from cron earlier we neglected to properly charge for gas and apply a check on proving batch size.

Since these constants are now shared between miner and power I moved them to the runtime policy.