### PR TITLE
Deprecate unused Prove Replica update 2

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -122,7 +122,7 @@ pub enum Method {
     ProveCommitAggregate = 26,
     ProveReplicaUpdates = 27,
     PreCommitSectorBatch2 = 28,
-    ProveReplicaUpdatesDeprecated = 29,
+    //ProveReplicaUpdates2 = 29, // Deprecated
     ChangeBeneficiary = 30,
     GetBeneficiary = 31,
     ExtendSectorExpiration2 = 32,
@@ -881,16 +881,6 @@ impl Actor {
             })
             .collect();
         Self::prove_replica_updates_inner(rt, updates)
-    }
-
-    pub fn prove_replica_updates_deprecated(
-        rt: &impl Runtime,
-        _params: ProveReplicaUpdatesParamsDeprecated,
-    ) -> Result<(), ActorError> {
-        rt.validate_immediate_caller_accept_any()?;
-        Err(
-            actor_error!(unhandled_message; "invalid method {}, use {} or {}", Method::ProveReplicaUpdatesDeprecated as u64, Method::ProveReplicaUpdates as u64, Method::ProveReplicaUpdates2 as u64),
-        )
     }
 
     fn prove_replica_updates_inner<RT>(
@@ -5277,13 +5267,6 @@ pub struct DealsActivationInput {
     pub sector_type: RegisteredSealProof,
 }
 
-// Inputs for activating builtin market deals for one sector
-// and optionally confirming CommD for this sector matches expectation
-// struct DataActivationInput {
-//     info: DealsActivationInput,
-//     expected_commd: Option<Cid>,
-// }
-
 impl From<SectorPreCommitOnChainInfo> for DealsActivationInput {
     fn from(pci: SectorPreCommitOnChainInfo) -> DealsActivationInput {
         DealsActivationInput {
@@ -5619,7 +5602,6 @@ impl ActorCode for Actor {
         ProveCommitAggregate => prove_commit_aggregate,
         ProveReplicaUpdates => prove_replica_updates,
         PreCommitSectorBatch2 => pre_commit_sector_batch2,
-        ProveReplicaUpdatesDeprecated => prove_replica_updates_deprecated,
         ChangeBeneficiary|ChangeBeneficiaryExported => change_beneficiary,
         GetBeneficiary|GetBeneficiaryExported => get_beneficiary,
         ExtendSectorExpiration2 => extend_sector_expiration2,

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -467,7 +467,7 @@ pub struct ProveReplicaUpdatesParams {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct ReplicaUpdate2 {
+pub struct ReplicaUpdateDeprecated {
     pub sector_number: SectorNumber,
     pub deadline: u64,
     pub partition: u64,
@@ -479,12 +479,12 @@ pub struct ReplicaUpdate2 {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct ProveReplicaUpdatesParams2 {
-    pub updates: Vec<ReplicaUpdate2>,
+pub struct ProveReplicaUpdatesParamsDeprecated {
+    pub updates: Vec<ReplicaUpdateDeprecated>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct ProveReplicaUpdates3Params {
+pub struct ProveReplicaUpdates2Params {
     pub sector_updates: Vec<SectorUpdateManifest>,
     // Proofs for each sector, parallel to activation manifests.
     // Exactly one of sector_proofs or aggregate_proof must be non-empty.
@@ -516,7 +516,7 @@ pub struct SectorUpdateManifest {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize_tuple, Deserialize_tuple)]
-pub struct ProveReplicaUpdates3Return {
+pub struct ProveReplicaUpdates2Return {
     pub activation_results: BatchReturn,
 }
 

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -467,23 +467,6 @@ pub struct ProveReplicaUpdatesParams {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct ReplicaUpdateDeprecated {
-    pub sector_number: SectorNumber,
-    pub deadline: u64,
-    pub partition: u64,
-    pub new_sealed_cid: Cid,
-    pub new_unsealed_cid: Cid,
-    pub deals: Vec<DealID>,
-    pub update_proof_type: RegisteredUpdateProof,
-    pub replica_proof: RawBytes,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
-pub struct ProveReplicaUpdatesParamsDeprecated {
-    pub updates: Vec<ReplicaUpdateDeprecated>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ProveReplicaUpdates2Params {
     pub sector_updates: Vec<SectorUpdateManifest>,
     // Proofs for each sector, parallel to activation manifests.

--- a/actors/miner/tests/prove_replica_test.rs
+++ b/actors/miner/tests/prove_replica_test.rs
@@ -4,7 +4,7 @@ use fvm_shared::sector::{SectorNumber, StoragePower};
 use fvm_shared::{bigint::Zero, clock::ChainEpoch, econ::TokenAmount, ActorID};
 
 use fil_actor_miner::ext::verifreg::AllocationID;
-use fil_actor_miner::ProveReplicaUpdates3Return;
+use fil_actor_miner::ProveReplicaUpdates2Return;
 use fil_actor_miner::{
     CompactCommD, PieceActivationManifest, SectorOnChainInfo, SectorPreCommitInfo,
     SectorPreCommitOnChainInfo, SectorUpdateManifest, State,
@@ -45,9 +45,9 @@ fn prove_basic_updates() {
         make_update_manifest(&st, store, &sectors[3], &[(piece_size, client_id, 1001, 2001)]), // Alloc and deal
     ];
 
-    let result = h.prove_replica_updates3_batch(&rt, &sector_updates, true, true).unwrap();
+    let result = h.prove_replica_updates2_batch(&rt, &sector_updates, true, true).unwrap();
     assert_eq!(
-        ProveReplicaUpdates3Return { activation_results: BatchReturn::ok(sectors.len() as u32) },
+        ProveReplicaUpdates2Return { activation_results: BatchReturn::ok(sectors.len() as u32) },
         result
     );
 

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -75,7 +75,7 @@ use fil_actor_miner::{
     MinerConstructorParams as ConstructorParams, MinerInfo, Partition, PendingBeneficiaryChange,
     PieceActivationManifest, PieceChange, PieceReturn, PoStPartition, PowerPair,
     PreCommitSectorBatchParams, PreCommitSectorBatchParams2, PreCommitSectorParams,
-    ProveCommitSectorParams, ProveReplicaUpdates3Params, ProveReplicaUpdates3Return,
+    ProveCommitSectorParams, ProveReplicaUpdates2Params, ProveReplicaUpdates2Return,
     RecoveryDeclaration, ReportConsensusFaultParams, SectorChanges, SectorContentChangedParams,
     SectorContentChangedReturn, SectorOnChainInfo, SectorPreCommitInfo, SectorPreCommitOnChainInfo,
     SectorReturn, SectorUpdateManifest, Sectors, State, SubmitWindowedPoStParams,
@@ -1108,18 +1108,18 @@ impl ActorHarness {
         }
     }
 
-    pub fn prove_replica_updates3_batch(
+    pub fn prove_replica_updates2_batch(
         &self,
         rt: &MockRuntime,
         sector_updates: &[SectorUpdateManifest],
         require_activation_success: bool,
         require_notification_success: bool,
-    ) -> Result<ProveReplicaUpdates3Return, ActorError> {
+    ) -> Result<ProveReplicaUpdates2Return, ActorError> {
         fn make_proof(i: u8) -> RawBytes {
             RawBytes::new(vec![i, i, i, i])
         }
 
-        let params = ProveReplicaUpdates3Params {
+        let params = ProveReplicaUpdates2Params {
             sector_updates: sector_updates.into(),
             sector_proofs: sector_updates.iter().map(|su| make_proof(su.sector as u8)).collect(),
             aggregate_proof: RawBytes::default(),
@@ -1236,9 +1236,9 @@ impl ActorHarness {
             ExitCode::OK,
         );
 
-        let result: ProveReplicaUpdates3Return = rt
+        let result: ProveReplicaUpdates2Return = rt
             .call::<Actor>(
-                MinerMethod::ProveReplicaUpdates3 as u64,
+                MinerMethod::ProveReplicaUpdates2 as u64,
                 IpldBlock::serialize_cbor(&params).unwrap(),
             )
             .unwrap()

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -10,7 +10,7 @@ use fil_actor_market::{DealMetaArray, State as MarketState};
 use fil_actor_miner::{
     max_prove_commit_duration, power_for_sector, ExpirationExtension, ExpirationExtension2,
     ExtendSectorExpiration2Params, ExtendSectorExpirationParams, Method as MinerMethod, PowerPair,
-    ProveReplicaUpdatesParams2, ReplicaUpdate2, SectorClaim, Sectors, State as MinerState,
+    ProveReplicaUpdatesParams, ReplicaUpdate, SectorClaim, Sectors, State as MinerState,
 };
 use fil_actor_verifreg::Method as VerifregMethod;
 use fil_actors_runtime::runtime::Policy;
@@ -612,17 +612,17 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
 
     // replica update
     let new_sealed_cid = make_sealed_cid(b"replica1");
-    let deal = get_deal(v, deal_ids[0]);
-    let new_unsealed_cid = v
-        .primitives()
-        .compute_unsealed_sector_cid(
-            seal_proof,
-            &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
-        )
-        .unwrap();
+    //let deal = get_deal(v, deal_ids[0]);
+    // let new_unsealed_cid = v
+    //     .primitives()
+    //     .compute_unsealed_sector_cid(
+    //         seal_proof,
+    //         &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
+    //     )
+    //     .unwrap();
 
     let (d_idx, p_idx) = sector_deadline(v, &miner_addr, sector_number);
-    let replica_update = ReplicaUpdate2 {
+    let replica_update = ReplicaUpdate {
         sector_number,
         deadline: d_idx,
         partition: p_idx,
@@ -630,7 +630,7 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
         deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
         replica_proof: vec![].into(),
-        new_unsealed_cid,
+//        new_unsealed_cid,
     };
     let updated_sectors: BitField = apply_ok(
         v,
@@ -638,7 +638,7 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
         &miner_addr,
         &TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates2 as u64,
-        Some(ProveReplicaUpdatesParams2 { updates: vec![replica_update] }),
+        Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
     )
     .deserialize()
     .unwrap();

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -628,7 +628,7 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
         &worker,
         &miner_addr,
         &TokenAmount::zero(),
-        MinerMethod::ProveReplicaUpdates2 as u64,
+        MinerMethod::ProveReplicaUpdates as u64,
         Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
     )
     .deserialize()
@@ -640,7 +640,7 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
     ExpectInvocation {
         from: worker_id,
         to: miner_addr,
-        method: MinerMethod::ProveReplicaUpdates2 as u64,
+        method: MinerMethod::ProveReplicaUpdates as u64,
         subinvocs: Some(vec![
             Expect::market_activate_deals(
                 miner_id,

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -630,7 +630,7 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
         deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
         replica_proof: vec![].into(),
-//        new_unsealed_cid,
+        //        new_unsealed_cid,
     };
     let updated_sectors: BitField = apply_ok(
         v,

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -26,8 +26,8 @@ use crate::expects::Expect;
 use crate::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
     advance_by_deadline_to_index, advance_to_proving_deadline, bf_all, create_accounts,
-    create_miner, cron_tick, expect_invariants, invariant_failure_patterns,
-    market_add_balance, market_publish_deal, miner_precommit_one_sector_v2, miner_prove_sector,
+    create_miner, cron_tick, expect_invariants, invariant_failure_patterns, market_add_balance,
+    market_publish_deal, miner_precommit_one_sector_v2, miner_prove_sector,
     precommit_meta_data_from_deals, sector_deadline, submit_windowed_post, verifreg_add_client,
     verifreg_add_verifier, PrecommitMetadata,
 };

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -3,7 +3,7 @@ use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::piece::{PaddedPieceSize, PieceInfo};
+use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
 
 use fil_actor_market::{DealMetaArray, State as MarketState};
@@ -26,7 +26,7 @@ use crate::expects::Expect;
 use crate::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_epoch_while_proving,
     advance_by_deadline_to_index, advance_to_proving_deadline, bf_all, create_accounts,
-    create_miner, cron_tick, expect_invariants, get_deal, invariant_failure_patterns,
+    create_miner, cron_tick, expect_invariants, invariant_failure_patterns,
     market_add_balance, market_publish_deal, miner_precommit_one_sector_v2, miner_prove_sector,
     precommit_meta_data_from_deals, sector_deadline, submit_windowed_post, verifreg_add_client,
     verifreg_add_verifier, PrecommitMetadata,
@@ -612,14 +612,6 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
 
     // replica update
     let new_sealed_cid = make_sealed_cid(b"replica1");
-    //let deal = get_deal(v, deal_ids[0]);
-    // let new_unsealed_cid = v
-    //     .primitives()
-    //     .compute_unsealed_sector_cid(
-    //         seal_proof,
-    //         &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
-    //     )
-    //     .unwrap();
 
     let (d_idx, p_idx) = sector_deadline(v, &miner_addr, sector_number);
     let replica_update = ReplicaUpdate {
@@ -630,7 +622,6 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
         deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
         replica_proof: vec![].into(),
-        //        new_unsealed_cid,
     };
     let updated_sectors: BitField = apply_ok(
         v,

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -15,8 +15,8 @@ use fil_actor_cron::Method as CronMethod;
 use fil_actor_market::Method as MarketMethod;
 use fil_actor_miner::{
     power_for_sector, DisputeWindowedPoStParams, ExpirationExtension, ExtendSectorExpirationParams,
-    Method as MinerMethod, PowerPair, ProveCommitSectorParams, ProveReplicaUpdatesParams,
-    ProveReplicaUpdatesParams2, ReplicaUpdate, ReplicaUpdate2, SectorOnChainInfo, Sectors,
+    Method as MinerMethod, PowerPair, ProveCommitSectorParams, 
+    ProveReplicaUpdatesParams, ReplicaUpdate, SectorOnChainInfo, Sectors,
     State as MinerState, TerminateSectorsParams, TerminationDeclaration, SECTORS_AMT_BITWIDTH,
 };
 use fil_actor_verifreg::Method as VerifregMethod;
@@ -982,14 +982,14 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
     // replica update
     let new_sealed_cid = make_sealed_cid(b"replica1");
     let deal = get_deal(v, deal_ids[0]);
-    let new_unsealed_cid = v
-        .primitives()
-        .compute_unsealed_sector_cid(
-            seal_proof,
-            &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
-        )
-        .unwrap();
-    let replica_update = ReplicaUpdate2 {
+    // let new_unsealed_cid = v
+    //     .primitives()
+    //     .compute_unsealed_sector_cid(
+    //         seal_proof,
+    //         &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
+    //     )
+    //     .unwrap();
+    let replica_update = ReplicaUpdate {
         sector_number,
         deadline: d_idx,
         partition: p_idx,
@@ -997,7 +997,7 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
         deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
         replica_proof: vec![].into(),
-        new_unsealed_cid,
+        //new_unsealed_cid,
     };
     let updated_sectors: BitField = apply_ok(
         v,
@@ -1005,7 +1005,7 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
         &robust,
         &TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates2 as u64,
-        Some(ProveReplicaUpdatesParams2 { updates: vec![replica_update] }),
+        Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
     )
     .deserialize()
     .unwrap();
@@ -1092,14 +1092,14 @@ pub fn replica_update_verified_deal_max_term_violated_test(v: &dyn VM) {
     // replica update
     let new_sealed_cid = make_sealed_cid(b"replica1");
     let deal = get_deal(v, deal_ids[0]);
-    let new_unsealed_cid = v
-        .primitives()
-        .compute_unsealed_sector_cid(
-            seal_proof,
-            &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
-        )
-        .unwrap();
-    let replica_update = ReplicaUpdate2 {
+    // let new_unsealed_cid = v
+    //     .primitives()
+    //     .compute_unsealed_sector_cid(
+    //         seal_proof,
+    //         &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
+    //     )
+    //     .unwrap();
+    let replica_update = ReplicaUpdate {
         sector_number,
         deadline: d_idx,
         partition: p_idx,
@@ -1107,7 +1107,7 @@ pub fn replica_update_verified_deal_max_term_violated_test(v: &dyn VM) {
         deals: deal_ids,
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
         replica_proof: vec![].into(),
-        new_unsealed_cid,
+        //new_unsealed_cid,
     };
     apply_code(
         v,
@@ -1115,7 +1115,7 @@ pub fn replica_update_verified_deal_max_term_violated_test(v: &dyn VM) {
         &robust,
         &TokenAmount::zero(),
         MinerMethod::ProveReplicaUpdates2 as u64,
-        Some(ProveReplicaUpdatesParams2 { updates: vec![replica_update] }),
+        Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 }
@@ -1318,14 +1318,14 @@ pub fn create_miner_and_upgrade_sector(
         )
     } else {
         let deal = get_deal(v, deal_ids[0]);
-        let new_unsealed_cid = v
-            .primitives()
-            .compute_unsealed_sector_cid(
-                seal_proof,
-                &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
-            )
-            .unwrap();
-        let replica_update = ReplicaUpdate2 {
+        // let new_unsealed_cid = v
+        //     .primitives()
+        //     .compute_unsealed_sector_cid(
+        //         seal_proof,
+        //         &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
+        //     )
+        //     .unwrap();
+        let replica_update = ReplicaUpdate {
             sector_number,
             deadline: d_idx,
             partition: p_idx,
@@ -1333,7 +1333,7 @@ pub fn create_miner_and_upgrade_sector(
             deals: deal_ids.clone(),
             update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
             replica_proof: vec![].into(),
-            new_unsealed_cid,
+            //new_unsealed_cid,
         };
         apply_ok(
             v,
@@ -1341,7 +1341,7 @@ pub fn create_miner_and_upgrade_sector(
             &robust,
             &TokenAmount::zero(),
             MinerMethod::ProveReplicaUpdates2 as u64,
-            Some(ProveReplicaUpdatesParams2 { updates: vec![replica_update] }),
+            Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         )
     }
     .deserialize()

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -6,7 +6,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::piece::{PaddedPieceSize, PieceInfo};
+use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::SectorSize;
 use fvm_shared::sector::StoragePower;
 use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
@@ -34,7 +34,7 @@ use crate::expects::Expect;
 use crate::util::{
     advance_by_deadline_to_epoch, advance_by_deadline_to_index, advance_to_proving_deadline,
     assert_invariants, bf_all, check_sector_active, check_sector_faulty, create_accounts,
-    create_miner, deadline_state, declare_recovery, expect_invariants, get_deal, get_network_stats,
+    create_miner, deadline_state, declare_recovery, expect_invariants, get_network_stats,
     invariant_failure_patterns, make_bitfield, market_publish_deal, miner_balance, miner_power,
     precommit_sectors_v2, prove_commit_sectors, sector_info, submit_invalid_post,
     submit_windowed_post, verifreg_add_client, verifreg_add_verifier,
@@ -981,14 +981,7 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
 
     // replica update
     let new_sealed_cid = make_sealed_cid(b"replica1");
-    let deal = get_deal(v, deal_ids[0]);
-    // let new_unsealed_cid = v
-    //     .primitives()
-    //     .compute_unsealed_sector_cid(
-    //         seal_proof,
-    //         &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
-    //     )
-    //     .unwrap();
+
     let replica_update = ReplicaUpdate {
         sector_number,
         deadline: d_idx,
@@ -997,7 +990,6 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
         deals: deal_ids.clone(),
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
         replica_proof: vec![].into(),
-        //new_unsealed_cid,
     };
     let updated_sectors: BitField = apply_ok(
         v,
@@ -1091,14 +1083,6 @@ pub fn replica_update_verified_deal_max_term_violated_test(v: &dyn VM) {
 
     // replica update
     let new_sealed_cid = make_sealed_cid(b"replica1");
-    let deal = get_deal(v, deal_ids[0]);
-    // let new_unsealed_cid = v
-    //     .primitives()
-    //     .compute_unsealed_sector_cid(
-    //         seal_proof,
-    //         &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
-    //     )
-    //     .unwrap();
     let replica_update = ReplicaUpdate {
         sector_number,
         deadline: d_idx,
@@ -1107,7 +1091,6 @@ pub fn replica_update_verified_deal_max_term_violated_test(v: &dyn VM) {
         deals: deal_ids,
         update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
         replica_proof: vec![].into(),
-        //new_unsealed_cid,
     };
     apply_code(
         v,
@@ -1317,14 +1300,6 @@ pub fn create_miner_and_upgrade_sector(
             Some(ProveReplicaUpdatesParams { updates: vec![replica_update] }),
         )
     } else {
-        let deal = get_deal(v, deal_ids[0]);
-        // let new_unsealed_cid = v
-        //     .primitives()
-        //     .compute_unsealed_sector_cid(
-        //         seal_proof,
-        //         &[PieceInfo { size: deal.piece_size, cid: deal.piece_cid }],
-        //     )
-        //     .unwrap();
         let replica_update = ReplicaUpdate {
             sector_number,
             deadline: d_idx,
@@ -1333,7 +1308,6 @@ pub fn create_miner_and_upgrade_sector(
             deals: deal_ids.clone(),
             update_proof_type: fvm_shared::sector::RegisteredUpdateProof::StackedDRG32GiBV1,
             replica_proof: vec![].into(),
-            //new_unsealed_cid,
         };
         apply_ok(
             v,

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -15,9 +15,9 @@ use fil_actor_cron::Method as CronMethod;
 use fil_actor_market::Method as MarketMethod;
 use fil_actor_miner::{
     power_for_sector, DisputeWindowedPoStParams, ExpirationExtension, ExtendSectorExpirationParams,
-    Method as MinerMethod, PowerPair, ProveCommitSectorParams, 
-    ProveReplicaUpdatesParams, ReplicaUpdate, SectorOnChainInfo, Sectors,
-    State as MinerState, TerminateSectorsParams, TerminationDeclaration, SECTORS_AMT_BITWIDTH,
+    Method as MinerMethod, PowerPair, ProveCommitSectorParams, ProveReplicaUpdatesParams,
+    ReplicaUpdate, SectorOnChainInfo, Sectors, State as MinerState, TerminateSectorsParams,
+    TerminationDeclaration, SECTORS_AMT_BITWIDTH,
 };
 use fil_actor_verifreg::Method as VerifregMethod;
 use fil_actors_runtime::runtime::Policy;

--- a/test_vm/tests/replica_update_test.rs
+++ b/test_vm/tests/replica_update_test.rs
@@ -1,7 +1,6 @@
 use fil_actors_integration_tests::tests::create_miner_and_upgrade_sector;
 use fil_actors_runtime::runtime::Policy;
 use fvm_ipld_blockstore::MemoryBlockstore;
-use test_case::test_case;
 use test_vm::TestVM;
 
 use fil_actors_integration_tests::tests::{
@@ -18,30 +17,27 @@ use fil_actors_integration_tests::util::assert_invariants;
 
 // ---- Success cases ----
 // Tests that an active CC sector can be correctly upgraded, and the expected state changes occur
-#[test_case(false; "v1")]
-#[test_case(true; "v2")]
-fn replica_update_simple_path_success(v2: bool) {
+#[test]
+fn replica_update_simple_path_success() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    create_miner_and_upgrade_sector(&v, v2);
+    create_miner_and_upgrade_sector(&v);
     assert_invariants(&v, &Policy::default());
 }
 
 // Tests a successful upgrade, followed by the sector going faulty and recovering
-#[test_case(false; "v1")]
-#[test_case(true; "v2")]
-fn replica_update_full_path_success(v2: bool) {
+#[test]
+fn replica_update_full_path_success() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    replica_update_full_path_success_test(&v, v2);
+    replica_update_full_path_success_test(&v);
 }
 
-#[test_case(false; "v1")]
-#[test_case(true; "v2")]
-fn upgrade_and_miss_post(v2: bool) {
+#[test]
+fn upgrade_and_miss_post() {
     let store = &MemoryBlockstore::new();
     let v = TestVM::<MemoryBlockstore>::new_with_singletons(store);
-    upgrade_and_miss_post_test(&v, v2);
+    upgrade_and_miss_post_test(&v);
 }
 
 #[test]


### PR DESCRIPTION
- Remove code for unused PRU2 replacing with a stub that always fails 
- Remove most code from sector_activate_deals which existed only for the benefit of the PRU2 flow
- Claim the prove_replica_updates2 name for the DDO flow introduced in this integration branch
- Remove PRU2 from tests



Related PR: https://github.com/filecoin-project/go-state-types/pull/214

