### PR TITLE
Deprecate Deal IDs

### DIFF
--- a/actors/market/src/testing.rs
+++ b/actors/market/src/testing.rs
@@ -224,6 +224,7 @@ pub fn check_state_invariants<BS: Blockstore>(
 
     // pending proposals
     let mut pending_proposal_count = 0;
+    // XXX this is invalid, proposals are AMT not HAMT
     match make_map_with_root_and_bitwidth::<_, ()>(
         &state.pending_proposals,
         store,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -978,7 +978,6 @@ impl Actor {
 
             let activated_data = ReplicaUpdateActivatedData {
                 seal_cid: usi.update.new_sealed_cid,
-                deals: usi.update.deals.clone(),
                 unverified_space: data_activation.unverified_space.clone(),
                 verified_space: data_activation.verified_space.clone(),
             };
@@ -1150,7 +1149,6 @@ impl Actor {
         {
             let activated_data = ReplicaUpdateActivatedData {
                 seal_cid: update.new_sealed_cid,
-                deals: vec![],
                 unverified_space: data_activation.unverified_space.clone(),
                 verified_space: data_activation.verified_space.clone(),
             };
@@ -4023,7 +4021,6 @@ fn update_existing_sector_info(
         Some(x) => Some(x),
     };
 
-    new_sector_info.deal_ids = activated_data.deals.clone();
     new_sector_info.power_base_epoch = curr_epoch;
 
     let duration = new_sector_info.expiration - new_sector_info.power_base_epoch;
@@ -5175,7 +5172,7 @@ fn activate_new_sector_infos(
                 sector_number: pci.info.sector_number,
                 seal_proof: pci.info.seal_proof,
                 sealed_cid: pci.info.sealed_cid,
-                deal_ids: pci.info.deal_ids.clone(),
+                deprecated_deal_ids: vec![], // deal ids field deprecated
                 expiration: pci.info.expiration,
                 activation: activation_epoch,
                 deal_weight,
@@ -5316,7 +5313,6 @@ struct ReplicaUpdateStateInputs<'a> {
 // Summary of activated data for a replica update.
 struct ReplicaUpdateActivatedData {
     seal_cid: Cid,
-    deals: Vec<DealID>,
     unverified_space: BigInt,
     verified_space: BigInt,
 }

--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -9,7 +9,6 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
 use fvm_shared::address::Protocol;
 use fvm_shared::clock::{ChainEpoch, QuantSpec, NO_QUANTIZATION};
-use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, SectorSize};
 use num_traits::Zero;
@@ -75,17 +74,14 @@ pub fn check_state_invariants<BS: Blockstore>(
                         "on chain sector's sector number has not been allocated {sector_number}"
                     ),
                 );
-                sector.deal_ids.iter().for_each(|&deal| {
-                    miner_summary.deals.insert(
-                        deal,
+                if !sector.deal_weight.is_zero() || !sector.verified_deal_weight.is_zero() {
+                    miner_summary.live_data_sectors.insert(
+                        sector_number,
                         DealSummary {
                             sector_start: sector.activation,
                             sector_expiration: sector.expiration,
                         },
                     );
-                });
-                if !sector.deal_ids.is_empty() {
-                    miner_summary.sectors_with_deals.insert(sector_number);
                 }
                 acc.require(
                     sector.activation <= sector.power_base_epoch,
@@ -151,10 +147,10 @@ pub struct StateSummary {
     pub live_power: PowerPair,
     pub active_power: PowerPair,
     pub faulty_power: PowerPair,
-    pub deals: BTreeMap<DealID, DealSummary>,
     pub window_post_proof_type: RegisteredPoStProof,
     pub deadline_cron_active: bool,
-    pub sectors_with_deals: BTreeSet<SectorNumber>,
+    // sectors with non zero (verified) deal weight that may carry deals
+    pub live_data_sectors: BTreeMap<SectorNumber, DealSummary>,
 }
 
 impl Default for StateSummary {
@@ -165,8 +161,7 @@ impl Default for StateSummary {
             faulty_power: PowerPair::zero(),
             window_post_proof_type: RegisteredPoStProof::Invalid(0),
             deadline_cron_active: false,
-            deals: BTreeMap::new(),
-            sectors_with_deals: BTreeSet::new(),
+            live_data_sectors: BTreeMap::new(),
         }
     }
 }

--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -3,7 +3,9 @@ use crate::{
     SectorOnChainInfo, SectorPreCommitOnChainInfo, Sectors, State,
 };
 use fil_actors_runtime::runtime::Policy;
-use fil_actors_runtime::{parse_uint_key, Map, MessageAccumulator, DEFAULT_HAMT_CONFIG};
+use fil_actors_runtime::{
+    parse_uint_key, DealWeight, Map, MessageAccumulator, DEFAULT_HAMT_CONFIG,
+};
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
@@ -80,6 +82,8 @@ pub fn check_state_invariants<BS: Blockstore>(
                         DealSummary {
                             sector_start: sector.activation,
                             sector_expiration: sector.expiration,
+                            deal_weight: sector.deal_weight.clone(),
+                            verified_deal_weight: sector.verified_deal_weight.clone(),
                         },
                     );
                 }
@@ -141,6 +145,8 @@ pub fn check_state_invariants<BS: Blockstore>(
 pub struct DealSummary {
     pub sector_start: ChainEpoch,
     pub sector_expiration: ChainEpoch,
+    pub deal_weight: DealWeight,
+    pub verified_deal_weight: DealWeight,
 }
 
 pub struct StateSummary {

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -398,7 +398,7 @@ pub struct SectorOnChainInfo {
     pub seal_proof: RegisteredSealProof,
     /// CommR
     pub sealed_cid: Cid,
-    pub deal_ids: Vec<DealID>,
+    pub deprecated_deal_ids: Vec<DealID>,
     /// Epoch during which the sector proof was accepted
     pub activation: ChainEpoch,
     /// Epoch during which the sector expires

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -85,8 +85,6 @@ fn prove_single_sector() {
 
     assert_eq!(precommit.info.seal_proof, sector.seal_proof);
     assert_eq!(precommit.info.sealed_cid, sector.sealed_cid);
-    assert_eq!(verified_deal_space, sector.verified_deal_weight);
-    assert_eq!(deal_space, sector.deal_weight);
     assert_eq!(*rt.epoch.borrow(), sector.activation);
     assert_eq!(precommit.info.expiration, sector.expiration);
 

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -85,7 +85,8 @@ fn prove_single_sector() {
 
     assert_eq!(precommit.info.seal_proof, sector.seal_proof);
     assert_eq!(precommit.info.sealed_cid, sector.sealed_cid);
-    assert_eq!(vec![], sector.deprecated_deal_idsdeal_ids); // deal_ids no longer set
+    assert_eq!(verified_deal_space, sector.verified_deal_weight);
+    assert_eq!(deal_space, sector.deal_weight);
     assert_eq!(*rt.epoch.borrow(), sector.activation);
     assert_eq!(precommit.info.expiration, sector.expiration);
 

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -85,7 +85,7 @@ fn prove_single_sector() {
 
     assert_eq!(precommit.info.seal_proof, sector.seal_proof);
     assert_eq!(precommit.info.sealed_cid, sector.sealed_cid);
-    assert_eq!(precommit.info.deal_ids, sector.deal_ids);
+    assert_eq!(vec![], sector.deprecated_deal_idsdeal_ids); // deal_ids no longer set
     assert_eq!(*rt.epoch.borrow(), sector.activation);
     assert_eq!(precommit.info.expiration, sector.expiration);
 

--- a/actors/miner/tests/prove_replica_test.rs
+++ b/actors/miner/tests/prove_replica_test.rs
@@ -158,7 +158,7 @@ fn verify_weights(
 ) {
     let s = h.get_sector(rt, sno);
     // Deal IDs are deprecated and never set.
-    assert!(s.deal_ids.is_empty());
+    assert!(s.deprecated_deal_ids.is_empty());
     assert_eq!(data_weight, &s.deal_weight);
     assert_eq!(verified_weight, &s.verified_deal_weight);
     assert_eq!(pledge, &s.initial_pledge);

--- a/actors/miner/tests/sectors_stores_test.rs
+++ b/actors/miner/tests/sectors_stores_test.rs
@@ -107,7 +107,7 @@ fn new_sector_on_chain_info(
         sector_number: sector_no,
         seal_proof: RegisteredSealProof::StackedDRG32GiBV1,
         sealed_cid,
-        deal_ids: vec![],
+        deprecated_deal_ids: vec![],
         activation,
         power_base_epoch: activation,
         expiration: ChainEpoch::from(1),

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -267,9 +267,10 @@ pub fn prove_replica_update_multi_dline_test(v: &dyn VM) {
     assert!(ret_bf.get(first_sector_number_p1));
     assert!(ret_bf.get(first_sector_number_p2));
 
-    let deal_weights1 = get_deal_weights(v, deal_ids[0]);
-    let deal_weights2 = get_deal_weights(v, deal_ids[1]);
     let new_sector_info_p1 = sector_info(v, &maddr, first_sector_number_p1);
+    let duration = new_sector_info_p1.expiration - new_sector_info_p1.power_base_epoch;
+    let deal_weights1 = get_deal_weights(v, deal_ids[0], duration);
+    let deal_weights2 = get_deal_weights(v, deal_ids[1], duration);
     assert_eq!(deal_weights1.0, new_sector_info_p1.deal_weight);
     assert_eq!(deal_weights1.1, new_sector_info_p1.verified_deal_weight);
     assert_eq!(old_sector_commr_p1, new_sector_info_p1.sector_key_cid.unwrap());
@@ -599,8 +600,9 @@ pub fn bad_post_upgrade_dispute_test(v: &dyn VM) {
     assert_eq!(vec![100], bf_all(updated_sectors));
 
     // sanity check the sector after update
-    let weights = get_deal_weights(v, deal_ids[0]);
     let new_sector_info = sector_info(v, &maddr, sector_number);
+    let duration = new_sector_info.expiration - new_sector_info.power_base_epoch;
+    let weights = get_deal_weights(v, deal_ids[0], duration);
     assert_eq!(weights.0, new_sector_info.deal_weight);
     assert_eq!(weights.1, new_sector_info.verified_deal_weight);
     assert_eq!(old_sector_info.sealed_cid, new_sector_info.sector_key_cid.unwrap());
@@ -933,9 +935,10 @@ pub fn deal_included_in_multiple_sectors_failure_test(v: &dyn VM) {
     assert!(ret_bf.get(first_sector_number));
     assert!(!ret_bf.get(first_sector_number + 1));
 
-    let weights1 = get_deal_weights(v, deal_ids[0]);
-    let weights2 = get_deal_weights(v, deal_ids[1]);
     let new_sector_info_p1 = sector_info(v, &maddr, first_sector_number);
+    let duration = new_sector_info_p1.expiration - new_sector_info_p1.power_base_epoch;
+    let weights1 = get_deal_weights(v, deal_ids[0], duration);
+    let weights2 = get_deal_weights(v, deal_ids[1], duration);
     assert_eq!(weights1.0 + weights2.0, new_sector_info_p1.deal_weight);
     assert_eq!(weights1.1 + weights2.1, new_sector_info_p1.verified_deal_weight);
     assert_eq!(new_sealed_cid1, new_sector_info_p1.sealed_cid);
@@ -1045,8 +1048,9 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
     .matches(v.take_invocations().last().unwrap());
 
     // sanity check the sector after update
-    let weights = get_deal_weights(v, deal_ids[0]);
     let new_sector_info = sector_info(v, &maddr, sector_number);
+    let duration = new_sector_info.expiration - new_sector_info.power_base_epoch;
+    let weights = get_deal_weights(v, deal_ids[0], duration);
     assert_eq!(weights.0, new_sector_info.deal_weight);
     assert_eq!(weights.1, new_sector_info.verified_deal_weight);
     assert_eq!(old_sector_info.sealed_cid, new_sector_info.sector_key_cid.unwrap());
@@ -1313,8 +1317,9 @@ pub fn create_miner_and_upgrade_sector(
     assert_eq!(vec![100], bf_all(updated_sectors));
 
     // sanity check the sector after update
-    let weights = get_deal_weights(v, deal_ids[0]);
     let new_sector_info = sector_info(v, &maddr, sector_number);
+    let duration = new_sector_info.expiration - new_sector_info.power_base_epoch;
+    let weights = get_deal_weights(v, deal_ids[0], duration);
     assert_eq!(weights.0, new_sector_info.deal_weight);
     assert_eq!(weights.1, new_sector_info.verified_deal_weight);
     assert_eq!(old_sector_info.sealed_cid, new_sector_info.sector_key_cid.unwrap());

--- a/integration_tests/src/util/workflows.rs
+++ b/integration_tests/src/util/workflows.rs
@@ -52,7 +52,6 @@ use fil_actor_verifreg::{
     AddVerifiedClientParams, AllocationID, ClaimID, ClaimTerm, ExtendClaimTermsParams,
     Method as VerifregMethod, RemoveExpiredAllocationsParams, VerifierParams,
 };
-use fil_actors_runtime::DealWeight;
 use fil_actors_runtime::cbor::deserialize;
 use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::runtime::policy_constants::{
@@ -61,6 +60,7 @@ use fil_actors_runtime::runtime::policy_constants::{
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::test_utils::make_piece_cid;
 use fil_actors_runtime::test_utils::make_sealed_cid;
+use fil_actors_runtime::DealWeight;
 use fil_actors_runtime::CRON_ACTOR_ADDR;
 use fil_actors_runtime::DATACAP_TOKEN_ACTOR_ADDR;
 use fil_actors_runtime::STORAGE_MARKET_ACTOR_ADDR;
@@ -1152,7 +1152,7 @@ pub fn get_deal(v: &dyn VM, deal_id: DealID) -> DealProposal {
 pub fn get_deal_weights(v: &dyn VM, deal_id: DealID) -> (DealWeight, DealWeight) {
     let deal = get_deal(v, deal_id);
     if deal.verified_deal {
-        return (DealWeight::zero(), deal.piece_size)
+        return (DealWeight::zero(), DealWeight::from(deal.piece_size.0));
     }
-    return (deal.piece_size, DealWeight::zero())
+    (DealWeight::from(deal.piece_size.0), DealWeight::zero())
 }

--- a/integration_tests/src/util/workflows.rs
+++ b/integration_tests/src/util/workflows.rs
@@ -1149,10 +1149,14 @@ pub fn get_deal(v: &dyn VM, deal_id: DealID) -> DealProposal {
 }
 
 // return (deal_weight, verified_deal_weight)
-pub fn get_deal_weights(v: &dyn VM, deal_id: DealID) -> (DealWeight, DealWeight) {
+pub fn get_deal_weights(
+    v: &dyn VM,
+    deal_id: DealID,
+    duration: ChainEpoch,
+) -> (DealWeight, DealWeight) {
     let deal = get_deal(v, deal_id);
     if deal.verified_deal {
-        return (DealWeight::zero(), DealWeight::from(deal.piece_size.0));
+        return (DealWeight::zero(), DealWeight::from(deal.piece_size.0 * duration as u64));
     }
-    (DealWeight::from(deal.piece_size.0), DealWeight::zero())
+    (DealWeight::from(deal.piece_size.0 * duration as u64), DealWeight::zero())
 }

--- a/integration_tests/src/util/workflows.rs
+++ b/integration_tests/src/util/workflows.rs
@@ -52,6 +52,7 @@ use fil_actor_verifreg::{
     AddVerifiedClientParams, AllocationID, ClaimID, ClaimTerm, ExtendClaimTermsParams,
     Method as VerifregMethod, RemoveExpiredAllocationsParams, VerifierParams,
 };
+use fil_actors_runtime::DealWeight;
 use fil_actors_runtime::cbor::deserialize;
 use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::runtime::policy_constants::{
@@ -1145,4 +1146,13 @@ pub fn get_deal(v: &dyn VM, deal_id: DealID) -> DealProposal {
     let state: fil_actor_market::State =
         RawBytes::new(bs.get(&actor.state).unwrap().unwrap()).deserialize().unwrap();
     state.get_proposal(&bs, deal_id).unwrap()
+}
+
+// return (deal_weight, verified_deal_weight)
+pub fn get_deal_weights(v: &dyn VM, deal_id: DealID) -> (DealWeight, DealWeight) {
+    let deal = get_deal(v, deal_id);
+    if deal.verified_deal {
+        return (DealWeight::zero(), deal.piece_size)
+    }
+    return (deal.piece_size, DealWeight::zero())
 }

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -341,7 +341,7 @@ fn check_deal_states_against_sectors(
             continue;
         }
 
-        let miner_summary = if let Some(miner_summary) = miner_summaries.get(&deal.provider) {
+        let _miner_summary = if let Some(miner_summary) = miner_summaries.get(&deal.provider) {
             miner_summary
         } else {
             acc.add(format!(
@@ -350,51 +350,6 @@ fn check_deal_states_against_sectors(
             ));
             continue;
         };
-
-        let sector_deal = if let Some(sector_deal) = miner_summary.deals.get(deal_id) {
-            sector_deal
-        } else {
-            acc.require(
-                deal.slash_epoch >= 0,
-                format!(
-                    "un-slashed deal {deal_id} not referenced in active sectors of miner {}",
-                    deal.provider
-                ),
-            );
-            continue;
-        };
-
-        acc.require(
-            deal.sector_start_epoch >= sector_deal.sector_start,
-            format!(
-                "deal state start {} does not match sector start {} for miner {}",
-                deal.sector_start_epoch, sector_deal.sector_start, deal.provider
-            ),
-        );
-
-        acc.require(
-            deal.sector_start_epoch <= sector_deal.sector_expiration,
-            format!(
-                "deal state start {} activated after sector expiration {} for miner {}",
-                deal.sector_start_epoch, sector_deal.sector_expiration, deal.provider
-            ),
-        );
-
-        acc.require(
-            deal.last_update_epoch <= sector_deal.sector_expiration,
-            format!(
-                "deal state update at {} after sector expiration {} for miner {}",
-                deal.last_update_epoch, sector_deal.sector_expiration, deal.provider
-            ),
-        );
-
-        acc.require(
-            deal.slash_epoch <= sector_deal.sector_expiration,
-            format!(
-                "deal state slashed at {} after sector expiration {} for miner {}",
-                deal.slash_epoch, sector_deal.sector_expiration, deal.provider
-            ),
-        );
     }
 }
 
@@ -536,7 +491,7 @@ fn check_verifreg_against_miners(
     for claim in verifreg_summary.claims.values() {
         // all claims are indexed by valid providers
         let maddr = Address::new_id(claim.provider);
-        let miner_summary = match miner_summaries.get(&maddr) {
+        let _miner_summary = match miner_summaries.get(&maddr) {
             None => {
                 acc.add(format!("claim provider {} is not found in miner summaries", maddr));
                 continue;
@@ -544,13 +499,6 @@ fn check_verifreg_against_miners(
             Some(summary) => summary,
         };
 
-        // all claims are linked to a valid sector number
-        acc.require(
-            miner_summary.sectors_with_deals.get(&claim.sector).is_some(),
-            format!(
-                "claim sector number {} not recorded as a sector with deals for miner {}",
-                claim.sector, maddr
-            ),
-        );
+        // XXX all claims are linked to a valid sector number
     }
 }


### PR DESCRIPTION
Stop writing deal ids into sector info upon commit
Improve the miner state check/summary framework to better work with cross market / miner check in the future 
- not yet following through on implementing the new market check, we need to construct the sector => deal index in market summary and then we can check the new live_data_sectors_map for inclusion of all sector numbers in the market index.