### PR TITLE
Return error if success count for proof validation or data activations is 0

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1814,6 +1814,9 @@ impl Actor {
             proven_batch_gen.add_successes(validation_batch.size());
         }
         let proven_batch = proven_batch_gen.gen();
+        if proven_batch.success_count == 0 {
+            return Err(actor_error!(illegal_argument, "no valid proofs specified"));
+        }
 
         // Activate data and verify CommD matches the declared one.
         let data_activation_inputs = proven_activation_inputs
@@ -1832,6 +1835,9 @@ impl Actor {
         // Activate data for proven sectors.
         let (data_batch, data_activations) =
             activate_sectors_pieces(rt, data_activation_inputs, params.require_activation_success)?;
+        if data_batch.success_count == 0 {
+            return Err(actor_error!(illegal_argument, "all data activations failed"));
+        }
 
         // Successful data activation is required for sector activation.
         let successful_sector_activations = data_batch.successes(&proven_activation_inputs);

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1123,6 +1123,9 @@ impl Actor {
             return Err(actor_error!(illegal_argument, "no valid updates"));
         }
         let proven_batch = proven_batch_gen.gen();
+        if proven_batch.success_count == 0 {
+            return Err(actor_error!(illegal_argument, "no valid proofs specified"));
+        }
 
         // Activate data.
         let data_activation_inputs: Vec<SectorPiecesActivationInput> = proven_manifests
@@ -1139,6 +1142,9 @@ impl Actor {
         // Activate data for proven updates.
         let (data_batch, data_activations) =
             activate_sectors_pieces(rt, data_activation_inputs, params.require_activation_success)?;
+        if data_batch.success_count == 0 {
+            return Err(actor_error!(illegal_argument, "all data activations failed"));
+        }
 
         // Successful data activation is required for sector activation.
         let successful_manifests = data_batch.successes(&proven_manifests);


### PR DESCRIPTION
The existing logic suppresses any errors if multiple sector validations fail. Return an error if none of the sectors are able to be validated, specifically in the proof validation and data activation stages