### PR TITLE
dispatch: improve dispatch macro and allow specifying codecs

### DIFF
--- a/actors/account/src/lib.rs
+++ b/actors/account/src/lib.rs
@@ -118,6 +118,6 @@ impl ActorCode for Actor {
         Constructor => constructor,
         PubkeyAddress => pubkey_address,
         AuthenticateMessageExported => authenticate_message,
-        _ => fallback [raw],
+        _ => fallback,
     }
 }

--- a/actors/ethaccount/src/lib.rs
+++ b/actors/ethaccount/src/lib.rs
@@ -74,6 +74,6 @@ impl ActorCode for EthAccountActor {
 
     actor_dispatch! {
         Constructor => constructor,
-        _ => fallback [raw],
+        _ => fallback,
     }
 }

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -420,6 +420,6 @@ impl ActorCode for EvmContractActor {
         GetStorageAt => storage_at,
         InvokeContractDelegate => invoke_contract_delegate,
         Resurrect => resurrect,
-        _ => handle_filecoin_method [raw],
+        _ => handle_filecoin_method,
     }
 }

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -558,6 +558,6 @@ impl ActorCode for Actor {
       ChangeNumApprovalsThreshold => change_num_approvals_threshold,
       LockBalance => lock_balance,
       UniversalReceiverHook => universal_receiver_hook,
-      _ => fallback [raw],
+      _ => fallback,
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 use unsigned_varint::decode::Error as UVarintError;
 
 use builtin::HAMT_BIT_WIDTH;
-pub use dispatch::{dispatch, dispatch_default};
+pub use dispatch::{dispatch, dispatch_default, WithCodec};
 pub use {fvm_ipld_amt, fvm_ipld_hamt};
 
 #[cfg(feature = "fil-actor")]


### PR DESCRIPTION
FIP-0071 (Deterministic State Access) requires the use of the `DAG_CBOR` codec, instead of the `CBOR` codec, where internal links (cids) should be considered "reachable". We use `CBOR` by default for method parameters as we don't _usually_ pass references by CID in methods (and using `CBOR` here will save us some gas).

However, there are two exceptions:

1. `EVM::bytecode` needs to return a reference to the contained bytecode. This reference needs to be considered "reachable".
2. `EVM::invoke_contract_delegate` needs to be passed a reference to some bytecode, so the parameters need to be `DAG_CBOR`.

This patch augments the dispatch system to allow specifying codecs in method signatures and fixes the EVM case. Specifically, an actor method may specify (either or both):

- Parameters: `WithCodec<ParamType, CODEC>` to restrict inputs to the specified codec.
- Return: `WithCodec<ParamType, CODEC>` to encode outputs with the specified codec, instead of the default `CBOR`.

There are three commits in this PR:

1. The first implements the change described above.
2. The second cleans up the dispatch logic to remove the need to specify `[raw]` using the same mechanism we used in the first patch. I'm happy to move this to a new PR if desired.
3. Tests.

Eventually, I'd like to remove the need for `[default_params]` as well, but that's something to do in the future.

---

Alternatives:

1. I _could_ have just used `[raw]` dispatch where necessary, and checked the codec.
2. Instead of specifying the codec at the _type_ level, I could have specified it at the value level. E.g., `fn my_method(rt &RT, WithCodec(params, codec): WithCodec<ParamsType>)`.