### PR TITLE
Check state invariants in direct onboarding tests

### DIFF
--- a/actors/miner/tests/prove_commit2_test.rs
+++ b/actors/miner/tests/prove_commit2_test.rs
@@ -57,4 +57,5 @@ fn prove_commit2_basic() {
     verify_weights(&rt, &h, snos[2], piece_size, 0);
     // Sector 3: Deal doesn't make a difference to verified weight only set.
     verify_weights(&rt, &h, snos[3], 0, piece_size);
+    h.check_state(&rt);
 }

--- a/actors/miner/tests/prove_replica_failures_test.rs
+++ b/actors/miner/tests/prove_replica_failures_test.rs
@@ -36,6 +36,7 @@ fn reject_unauthorized_caller() {
         "caller",
         h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg),
     );
+    h.check_state(&rt);
 }
 
 #[test]
@@ -53,6 +54,7 @@ fn reject_no_proof_types() {
         "exactly one of sector proofs or aggregate proof must be non-empty",
         h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg),
     );
+    h.check_state(&rt);
 }
 
 #[test]
@@ -70,6 +72,7 @@ fn reject_both_proof_types() {
         "exactly one of sector proofs or aggregate proof must be non-empty",
         h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg),
     );
+    h.check_state(&rt);
 }
 
 #[test]
@@ -86,6 +89,7 @@ fn reject_mismatched_proof_len() {
         "mismatched lengths",
         h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg),
     );
+    h.check_state(&rt);
 }
 
 #[test]
@@ -103,6 +107,7 @@ fn reject_aggregate_proof() {
         "aggregate update proofs not yet supported",
         h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg),
     );
+    h.check_state(&rt);
 }
 
 #[test]
@@ -114,6 +119,7 @@ fn reject_all_proofs_fail() {
         "no valid updates",
         h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg),
     );
+    h.check_state(&rt);
 }
 
 #[test]
@@ -126,6 +132,7 @@ fn reject_invalid_update() {
         "invalid update 1 while requiring activation success",
         h.prove_replica_updates2_batch(&rt, &sector_updates, true, false, cfg),
     );
+    h.check_state(&rt);
 }
 
 #[test]
@@ -137,6 +144,7 @@ fn reject_required_proof_failure() {
         "requiring activation success",
         h.prove_replica_updates2_batch(&rt, &sector_updates, true, false, cfg),
     );
+    h.check_state(&rt);
 }
 
 #[test]
@@ -151,6 +159,7 @@ fn reject_required_claim_failure() {
         "error claiming allocations",
         h.prove_replica_updates2_batch(&rt, &sector_updates, true, false, cfg),
     );
+    h.check_state(&rt);
 }
 
 #[test]
@@ -167,6 +176,7 @@ fn reject_required_notification_abort() {
         "receiver aborted",
         h.prove_replica_updates2_batch(&rt, &sector_updates, false, true, cfg),
     );
+    h.check_state(&rt);
 }
 
 #[test]
@@ -180,6 +190,7 @@ fn reject_required_notification_rejected() {
         "sector change rejected",
         h.prove_replica_updates2_batch(&rt, &sector_updates, false, true, cfg),
     );
+    h.check_state(&rt);
 }
 
 fn setup(

--- a/actors/miner/tests/prove_replica_test.rs
+++ b/actors/miner/tests/prove_replica_test.rs
@@ -107,6 +107,7 @@ fn update_batch() {
     verify_weights(&rt, &h, snos[2], piece_size, 0);
     // Sector 3: Deal doesn't make a difference to verified weight only set.
     verify_weights(&rt, &h, snos[3], 0, piece_size);
+    h.check_state(&rt);
 }
 
 #[test]
@@ -205,6 +206,7 @@ fn multiple_pieces_in_sector() {
 
     verify_weights(&rt, &h, snos[0], 0, piece_size * 2);
     verify_weights(&rt, &h, snos[1], piece_size, piece_size);
+    h.check_state(&rt);
 }
 
 #[test]
@@ -287,6 +289,7 @@ fn multiple_notifs_for_piece() {
 
     verify_weights(&rt, &h, snos[0], piece_size * 2, 0);
     verify_weights(&rt, &h, snos[1], piece_size, 0);
+    h.check_state(&rt);
 }
 
 #[test]
@@ -310,6 +313,7 @@ fn cant_update_nonempty_sector() {
         "cannot update sector with non-zero data",
         h.prove_replica_updates2_batch(&rt, &sector_updates, true, true, cfg),
     );
+    h.check_state(&rt);
 }
 
 // See prove_replica_failures_test.rs for tests where requiring success is set to true,
@@ -336,6 +340,7 @@ fn invalid_update_dropped() {
     verify_weights(&rt, &h, snos[0], 0, 0);
     // Sector 1: verified weight.
     verify_weights(&rt, &h, snos[1], 0, piece_size);
+    h.check_state(&rt);
 }
 
 #[test]
@@ -357,6 +362,7 @@ fn invalid_proof_dropped() {
 
     verify_weights(&rt, &h, snos[0], 0, 0);
     verify_weights(&rt, &h, snos[1], 0, piece_size);
+    h.check_state(&rt);
 }
 
 #[test]
@@ -378,6 +384,7 @@ fn invalid_claim_dropped() {
 
     verify_weights(&rt, &h, snos[0], 0, 0);
     verify_weights(&rt, &h, snos[1], 0, piece_size);
+    h.check_state(&rt);
 }
 
 #[test]
@@ -406,6 +413,7 @@ fn aborted_notification_dropped() {
     verify_weights(&rt, &h, snos[0], piece_size, 0);
     verify_weights(&rt, &h, snos[1], piece_size, 0);
     verify_weights(&rt, &h, snos[2], 0, piece_size);
+    h.check_state(&rt);
 }
 
 #[test]
@@ -431,6 +439,7 @@ fn rejected_notification_dropped() {
     verify_weights(&rt, &h, snos[0], piece_size, 0);
     verify_weights(&rt, &h, snos[1], piece_size, 0);
     verify_weights(&rt, &h, snos[2], 0, piece_size);
+    h.check_state(&rt);
 }
 
 fn setup_basic() -> (ActorHarness, MockRuntime) {


### PR DESCRIPTION
This pattern, common elsewhere, can now be followed by new tests that adapt these.