### PR TITLE
fix: correctly assert the state at the end of the paychan test

### DIFF
--- a/actors/paych/tests/paych_actor_test.rs
+++ b/actors/paych/tests/paych_actor_test.rs
@@ -929,14 +929,16 @@ mod actor_collect {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, st.from);
         rt.expect_validate_caller_addr(vec![st.from, st.to]);
         call(&rt, Method::Settle as u64, None);
+        check_state(&rt);
 
         let st: PState = rt.get_state();
         assert_eq!(st.settling_at, SETTLE_DELAY + curr_epoch);
-        rt.expect_validate_caller_addr(vec![st.from, st.to]);
 
         // wait for settlingat epoch
         rt.epoch.replace(st.settling_at + 1);
 
+        // Collect.
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, st.to);
         rt.expect_send_simple(
             st.to,
             METHOD_SEND,
@@ -946,8 +948,6 @@ mod actor_collect {
             ExitCode::OK,
         );
 
-        // Collect.
-        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, st.to);
         rt.expect_validate_caller_addr(vec![st.from, st.to]);
         rt.expect_send_simple(
             st.from,
@@ -960,7 +960,7 @@ mod actor_collect {
         rt.expect_delete_actor();
         let res = call(&rt, Method::Collect as u64, None);
         assert!(res.is_none());
-        check_state(&rt);
+        assert!(rt.is_deleted());
     }
 
     #[test]

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -473,6 +473,10 @@ impl<BS: Blockstore> MockRuntime<BS> {
         self.policy = policy;
     }
 
+    pub fn is_deleted(&self) -> bool {
+        self.state.borrow().is_none()
+    }
+
     pub fn get_state<T: DeserializeOwned>(&self) -> T {
         self.store_get(self.state.borrow().as_ref().unwrap())
     }
@@ -1186,6 +1190,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         if *self.in_transaction.borrow() {
             return Err(actor_error!(assertion_failed; "side-effect within transaction"));
         }
+        *self.state.borrow_mut() = None;
         let mut exp = self.expectations.borrow_mut();
         assert!(exp.expect_delete_actor, "unexpected call to delete actor");
         exp.expect_delete_actor = false;


### PR DESCRIPTION
The actor has been deleted so the assertions should reflect that. By removing the state from the mock runtime, this change will also let us catch any other testing bugs (and let's us assert that the actor was actually deleted).