### PR TITLE
More tests for direct data onboarding

### DIFF
--- a/actors/miner/src/commd.rs
+++ b/actors/miner/src/commd.rs
@@ -25,10 +25,24 @@ impl CompactCommD {
         CompactCommD(Some(c))
     }
 
+    // Whether this represents the zero CID.
+    pub fn is_zero(&self) -> bool {
+        self.0.is_none()
+    }
+
+    // Gets the full, non-compact CID.
     pub fn get_cid(&self, seal_proof: RegisteredSealProof) -> Result<Cid, ActorError> {
         match self.0 {
             Some(ref x) => Ok(*x),
             None => zero_commd(seal_proof),
+        }
+    }
+
+    // Gets the full, non-compact CID, panicking if the CID is zero.
+    pub fn get_nonzero_cid(&self) -> Cid {
+        match self.0 {
+            Some(ref x) => *x,
+            None => panic!("zero commd"),
         }
     }
 }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -5374,7 +5374,7 @@ fn activate_sectors_pieces(
             if !declared_commd.eq(&computed_commd) {
                 return Err(actor_error!(
                     illegal_argument,
-                    "unsealed CID does not match deals for sector {}, computed {:?} declared {:?}",
+                    "unsealed CID does not match pieces for sector {}, computed {:?} declared {:?}",
                     activation_info.sector_number,
                     computed_commd,
                     declared_commd

--- a/actors/miner/tests/prove_commit2_failures_test.rs
+++ b/actors/miner/tests/prove_commit2_failures_test.rs
@@ -1,17 +1,17 @@
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::{ActorID, bigint::Zero, clock::ChainEpoch, econ::TokenAmount};
 use fvm_shared::address::Address;
 use fvm_shared::deal::DealID;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::SectorNumber;
+use fvm_shared::{bigint::Zero, clock::ChainEpoch, econ::TokenAmount, ActorID};
 
-use fil_actor_miner::{
-    ERR_NOTIFICATION_RECEIVER_ABORTED, ERR_NOTIFICATION_REJECTED, ProveCommitSectors2Params,
-    SectorActivationManifest,
-};
 use fil_actor_miner::ext::verifreg::AllocationID;
-use fil_actors_runtime::EPOCHS_IN_DAY;
+use fil_actor_miner::{
+    ProveCommitSectors2Params, SectorActivationManifest, ERR_NOTIFICATION_RECEIVER_ABORTED,
+    ERR_NOTIFICATION_REJECTED,
+};
 use fil_actors_runtime::test_utils::{expect_abort_contains_message, MockRuntime};
+use fil_actors_runtime::EPOCHS_IN_DAY;
 use util::*;
 
 mod util;
@@ -181,7 +181,7 @@ fn reject_required_proof_failure() {
 fn reject_mismatched_commd() {
     let (h, rt, mut activations) = setup_precommits(&[(0, 0, 0); 2]);
     // Set wrong CID for first sector.
-    activations[0].pieces[0].cid = activations[1].pieces[0].cid.clone();
+    activations[0].pieces[0].cid = activations[1].pieces[0].cid;
 
     let cfg = ProveCommitSectors2Config::default();
     expect_abort_contains_message(

--- a/actors/miner/tests/prove_commit2_failures_test.rs
+++ b/actors/miner/tests/prove_commit2_failures_test.rs
@@ -1,17 +1,17 @@
 use fvm_ipld_encoding::RawBytes;
+use fvm_shared::{ActorID, bigint::Zero, clock::ChainEpoch, econ::TokenAmount};
 use fvm_shared::address::Address;
 use fvm_shared::deal::DealID;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::SectorNumber;
-use fvm_shared::{bigint::Zero, clock::ChainEpoch, econ::TokenAmount, ActorID};
 
-use fil_actor_miner::ext::verifreg::AllocationID;
 use fil_actor_miner::{
-    ProveCommitSectors2Params, SectorActivationManifest, ERR_NOTIFICATION_RECEIVER_ABORTED,
-    ERR_NOTIFICATION_REJECTED,
+    ERR_NOTIFICATION_RECEIVER_ABORTED, ERR_NOTIFICATION_REJECTED, ProveCommitSectors2Params,
+    SectorActivationManifest,
 };
-use fil_actors_runtime::test_utils::{expect_abort_contains_message, MockRuntime};
+use fil_actor_miner::ext::verifreg::AllocationID;
 use fil_actors_runtime::EPOCHS_IN_DAY;
+use fil_actors_runtime::test_utils::{expect_abort_contains_message, MockRuntime};
 use util::*;
 
 mod util;
@@ -111,13 +111,18 @@ fn reject_precommit_deals() {
     // Precommit sectors, one with a deal
     let precommit_epoch = *rt.epoch.borrow();
     let sector_expiry = precommit_epoch + DEFAULT_SECTOR_EXPIRATION_DAYS * EPOCHS_IN_DAY;
-    let mut precommits =
-        make_fake_commd_precommits(&h, FIRST_SECTOR_NUMBER, precommit_epoch - 1, sector_expiry, 2);
+    let piece_size = h.sector_size as u64;
+    let mut precommits = make_fake_precommits(
+        &h,
+        FIRST_SECTOR_NUMBER,
+        precommit_epoch - 1,
+        sector_expiry,
+        &[&[piece_size], &[piece_size]],
+    );
     precommits[0].deal_ids.push(1);
     h.pre_commit_sector_batch_v2(&rt, &precommits, true, &TokenAmount::zero()).unwrap();
     rt.set_epoch(precommit_epoch + rt.policy.pre_commit_challenge_delay + 1);
 
-    let piece_size = h.sector_size as u64;
     let manifests: Vec<SectorActivationManifest> = precommits
         .iter()
         .map(|s| make_activation_manifest(s.sector_number, &[(piece_size, 0, 0, 0)]))
@@ -170,6 +175,20 @@ fn reject_required_proof_failure() {
         h.prove_commit_sectors2(&rt, &activations, true, false, false, cfg),
     );
     h.check_state(&rt);
+}
+
+#[test]
+fn reject_mismatched_commd() {
+    let (h, rt, mut activations) = setup_precommits(&[(0, 0, 0); 2]);
+    // Set wrong CID for first sector.
+    activations[0].pieces[0].cid = activations[1].pieces[0].cid.clone();
+
+    let cfg = ProveCommitSectors2Config::default();
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        "unsealed CID does not match pieces",
+        h.prove_commit_sectors2(&rt, &activations, false, false, false, cfg),
+    );
 }
 
 #[test]
@@ -229,19 +248,21 @@ fn setup_precommits(
     let (h, rt) = setup_basic();
 
     // Precommit sectors
+    let piece_size = h.sector_size as u64; // All sectors have a single full-size piece.
     let precommit_epoch = *rt.epoch.borrow();
     let sector_expiry = *rt.epoch.borrow() + DEFAULT_SECTOR_EXPIRATION_DAYS * EPOCHS_IN_DAY;
-    let precommits = make_fake_commd_precommits(
+    let one_sector_piece_sizes = &[piece_size] as &[u64];
+    let piece_sizes = vec![one_sector_piece_sizes; confs.len()];
+    let precommits = make_fake_precommits(
         &h,
         FIRST_SECTOR_NUMBER,
         precommit_epoch - 1,
         sector_expiry,
-        confs.len(),
+        &piece_sizes,
     );
     h.pre_commit_sector_batch_v2(&rt, &precommits, true, &TokenAmount::zero()).unwrap();
     rt.set_epoch(precommit_epoch + rt.policy.pre_commit_challenge_delay + 1);
 
-    let piece_size = h.sector_size as u64;
     let manifests = precommits
         .iter()
         .zip(confs)

--- a/actors/miner/tests/prove_replica_test.rs
+++ b/actors/miner/tests/prove_replica_test.rs
@@ -298,7 +298,15 @@ fn cant_update_nonempty_sector() {
 
     // Onboard a non-empty sector
     let sector_expiry = *rt.epoch.borrow() + DEFAULT_SECTOR_EXPIRATION_DAYS * EPOCHS_IN_DAY;
-    let sectors = onboard_nonempty_sectors(&rt, &h, sector_expiry, FIRST_SECTOR_NUMBER, 1);
+    let challenge = *rt.epoch.borrow();
+    let precommits = make_fake_precommits(
+        &h,
+        FIRST_SECTOR_NUMBER,
+        challenge - 1,
+        sector_expiry,
+        &[&[h.sector_size as u64]],
+    );
+    let sectors = onboard_sectors(&rt, &h, &precommits);
     let snos = sectors.iter().map(|s| s.sector_number).collect::<Vec<_>>();
 
     // Attempt to update

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -424,7 +424,7 @@ impl ActorHarness {
             let pcc = if !has_deals {
                 PreCommitConfig::new(None)
             } else {
-                PreCommitConfig::new(Some(make_piece_cid("1".as_bytes())))
+                PreCommitConfig::new(Some(make_unsealed_cid("1".as_bytes())))
             };
             let precommit = self.pre_commit_sector_and_get(rt, params, pcc, first && i == 0);
             precommits.push(precommit);
@@ -1186,12 +1186,7 @@ impl ActorHarness {
             if cfg.validation_failure.contains(&i) || cfg.proof_failure.contains(&i) {
                 continue;
             }
-            expect_compute_unsealed_cid_from_pieces(
-                rt,
-                sa.sector_number,
-                self.seal_proof_type,
-                &sa.pieces,
-            );
+            expect_compute_unsealed_cid_from_pieces(rt, self.seal_proof_type, &sa.pieces);
             let precommit = self.get_precommit(rt, sa.sector_number);
             sector_allocation_claims.push(SectorAllocationClaims {
                 sector: sa.sector_number,
@@ -1369,12 +1364,8 @@ impl ActorHarness {
         let mut expected_sector_notifications = Vec::new(); // Assuming all to f05
         for (i, sup) in sector_updates.iter().enumerate() {
             let sector = self.get_sector(rt, sup.sector);
-            let unsealed_cid = expect_compute_unsealed_cid_from_pieces(
-                rt,
-                sup.sector,
-                self.seal_proof_type,
-                &sup.pieces,
-            );
+            let unsealed_cid =
+                expect_compute_unsealed_cid_from_pieces(rt, self.seal_proof_type, &sup.pieces);
             if cfg.validation_failure.contains(&i) {
                 continue;
             }
@@ -1384,7 +1375,7 @@ impl ActorHarness {
                     update_proof_type: self.seal_proof_type.registered_update_proof().unwrap(),
                     new_sealed_cid: sup.new_sealed_cid,
                     old_sealed_cid: sector.sealed_cid,
-                    new_unsealed_cid: unsealed_cid,
+                    new_unsealed_cid: unsealed_cid.get_cid(self.seal_proof_type).unwrap(),
                     proof: make_proof(sup.sector as u8).into(),
                 },
                 if proof_ok { Ok(()) } else { Err(anyhow!("invalid replica proof")) },
@@ -2866,7 +2857,7 @@ pub fn test_verified_deal(space: u64) -> VerifiedDealInfo {
     VerifiedDealInfo {
         client: 0,
         allocation_id: 0,
-        data: make_piece_cid("test verified deal".as_bytes()),
+        data: make_unsealed_cid("test verified deal".as_bytes()),
         size: PaddedPieceSize(space),
     }
 }
@@ -3090,9 +3081,14 @@ fn make_sealed_cid(input: &[u8]) -> Cid {
     Cid::new_v1(FIL_COMMITMENT_SEALED, h)
 }
 
-fn make_piece_cid(input: &[u8]) -> Cid {
+fn make_unsealed_cid(input: &[u8]) -> Cid {
     let h = MhCode::Sha256TruncPaddedFake.digest(input);
     Cid::new_v1(FIL_COMMITMENT_UNSEALED, h)
+}
+
+// Makes a fake piece CID that is unique for sector number, piece index, and piece size.
+fn make_piece_cid(sector_number: SectorNumber, index: usize, size: u64) -> Cid {
+    make_unsealed_cid(format!("piece-{}-{}-{}", sector_number, index, size).as_bytes())
 }
 
 // Pre-commits and then proves a batch of empty sectors, and submits their first Window PoSt.
@@ -3111,25 +3107,8 @@ pub fn onboard_empty_sectors(
     onboard_sectors(rt, h, &precommits)
 }
 
-// Pre-commits and then proves a batch of non-empty sectors, and submits their first Window PoSt.
-// Each sector has a single piece of data occupying its full capacity.
-// The epoch is advanced to when the first window post is submitted.
-#[allow(dead_code)]
-pub fn onboard_nonempty_sectors(
-    rt: &MockRuntime,
-    h: &ActorHarness,
-    expiration: ChainEpoch,
-    first_sector_number: SectorNumber,
-    count: usize,
-) -> Vec<SectorOnChainInfo> {
-    let challenge = *rt.epoch.borrow();
-    let precommits =
-        make_fake_commd_precommits(h, first_sector_number, challenge - 1, expiration, count);
-    onboard_sectors(rt, h, &precommits)
-}
-
 // Pre-commits and then proves a batch of sectors, and submits their first Window PoSt.
-fn onboard_sectors(
+pub fn onboard_sectors(
     rt: &MockRuntime,
     h: &ActorHarness,
     precommits: &[SectorPreCommitInfo],
@@ -3170,41 +3149,56 @@ pub fn make_empty_precommits(
     expiration: ChainEpoch,
     count: usize,
 ) -> Vec<SectorPreCommitInfo> {
-    (0..count)
-        .map(|i| {
+    let mut piece_sizes = Vec::new();
+    for _ in 0..count {
+        piece_sizes.push(&[] as &[u64]); // No pieces in empty sector.
+    }
+    make_fake_precommits(h, first_sector_number, challenge, expiration, &piece_sizes)
+}
+
+// Creates a batch of fake pre-commits for sectors given a list of per-sector list of piece sizes.
+// Each piece is given a fake CID based on the sector number, piece index, and piece size,
+// and the sector's CommD depends on those.
+#[allow(dead_code)]
+pub fn make_fake_precommits(
+    h: &ActorHarness,
+    first_sector_number: SectorNumber,
+    challenge: ChainEpoch,
+    expiration: ChainEpoch,
+    piece_sizes: &[&[u64]], // List of sizes per sector
+) -> Vec<SectorPreCommitInfo> {
+    piece_sizes
+        .iter()
+        .enumerate()
+        .map(|(i, piece_sizes)| {
             let sector_number = first_sector_number + i as u64;
+            let piece_cids = piece_sizes
+                .iter()
+                .enumerate()
+                .map(|(j, sz)| make_piece_cid(sector_number, j, *sz))
+                .collect::<Vec<_>>();
             h.make_pre_commit_params_v2(
                 sector_number,
                 challenge,
                 expiration,
                 vec![],
-                CompactCommD::empty(),
+                sector_commd_from_pieces(&piece_cids),
             )
         })
         .collect()
 }
 
-// Note this matches the faked commD computation in the testing harness
+// Computes a fake sector CommD that depends on all the piece CIDs (or is zero if there are none).
 #[allow(dead_code)]
-pub fn make_fake_commd_precommits(
-    h: &ActorHarness,
-    first_sector_number: SectorNumber,
-    challenge: ChainEpoch,
-    expiration: ChainEpoch,
-    count: usize,
-) -> Vec<SectorPreCommitInfo> {
-    (0..count)
-        .map(|i| {
-            let sector_number = first_sector_number + i as u64;
-            h.make_pre_commit_params_v2(
-                sector_number,
-                challenge,
-                expiration,
-                vec![],
-                CompactCommD(Some(make_sector_commd(sector_number))),
-            )
-        })
-        .collect()
+pub fn sector_commd_from_pieces(pieces: &[Cid]) -> CompactCommD {
+    if pieces.is_empty() {
+        return CompactCommD::empty();
+    }
+    let mut buf = Vec::new();
+    for piece in pieces {
+        buf.extend_from_slice(piece.to_bytes().as_slice());
+    }
+    CompactCommD::of(make_unsealed_cid(buf.as_slice()))
 }
 
 #[allow(dead_code)]
@@ -3251,7 +3245,7 @@ pub fn make_piece_manifest(
     deal: DealID,
 ) -> PieceActivationManifest {
     PieceActivationManifest {
-        cid: make_piece_cid(format!("piece-{}-{}", sector, seq).as_bytes()),
+        cid: make_piece_cid(sector, seq, size),
         size: PaddedPieceSize(size),
         verified_allocation_key: if alloc_id != NO_ALLOCATION_ID {
             Some(VerifiedAllocationKey { client: alloc_client, id: alloc_id })
@@ -3297,9 +3291,9 @@ pub fn notifications_from_pieces(pieces: &[PieceActivationManifest]) -> Vec<Piec
         .collect()
 }
 
-fn make_sector_commd(sno: SectorNumber) -> Cid {
-    make_piece_cid(format!("unsealed-{}", sno).as_bytes())
-}
+// fn make_sector_commd(sno: SectorNumber) -> Cid {
+//     make_piece_cid(format!("unsealed-{}", sno).as_bytes())
+// }
 
 fn make_sector_commr(sector: SectorNumber) -> Cid {
     make_sealed_cid(format!("sealed-{}", sector).as_bytes())
@@ -3441,22 +3435,24 @@ pub fn sectors_as_map(sectors: &[SectorOnChainInfo]) -> SectorsMap {
 
 fn expect_compute_unsealed_cid_from_pieces(
     rt: &MockRuntime,
-    sno: SectorNumber,
     seal_proof_type: RegisteredSealProof,
     pieces: &[PieceActivationManifest],
-) -> Cid {
-    let expected_unsealed_cid_inputs: Vec<PieceInfo> =
-        pieces.iter().map(|p| PieceInfo { size: p.size, cid: p.cid }).collect();
-    let unsealed_cid = make_sector_commd(sno);
-    if !expected_unsealed_cid_inputs.is_empty() {
+) -> CompactCommD {
+    if !pieces.is_empty() {
+        let expected_inputs: Vec<PieceInfo> =
+            pieces.iter().map(|p| PieceInfo { size: p.size, cid: p.cid }).collect();
+        let unsealed_cid = sector_commd_from_pieces(&pieces.iter().map(|p| p.cid).collect::<Vec<_>>())
+            .get_nonzero_cid();
         rt.expect_compute_unsealed_sector_cid(
             seal_proof_type,
-            expected_unsealed_cid_inputs,
+            expected_inputs,
             unsealed_cid.clone(),
             ExitCode::OK,
         );
+        CompactCommD::of(unsealed_cid)
+    } else {
+        CompactCommD::empty()
     }
-    unsealed_cid
 }
 
 fn expect_validate_precommits(


### PR DESCRIPTION
Tests that CommD computed from pieces must match that declared at precommit. Tests that updating an empty replica to be empty is permitted (later, when we allow updates to non-empty replicas, it won't be a no-op).

- [x] Merge #1437 and rebase this first