### PR TITLE
Add GetDealSector exported API method to market actor

### DIFF
--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -1086,6 +1086,7 @@ pub fn get_proposal<BS: Blockstore>(
             // If the deal ID has been used, it must have been cleaned up.
             ActorError::unchecked(EX_DEAL_EXPIRED, format!("deal {} expired", id))
         } else {
+            // Never been published.
             ActorError::not_found(format!("no such deal {}", id))
         }
     })?;

--- a/actors/market/src/types.rs
+++ b/actors/market/src/types.rs
@@ -242,6 +242,15 @@ pub struct GetDealActivationReturn {
     pub terminated: ChainEpoch,
 }
 
+pub type GetDealSectorParams = DealQueryParams;
+
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct GetDealSectorReturn {
+    /// Sector number with the provider that has committed the deal.
+    pub sector: SectorNumber,
+}
+
 // Interface market clients can implement to receive notifications from builtin market
 pub const MARKET_NOTIFY_DEAL_METHOD: u64 = frc42_dispatch::method_hash!("MarketNotifyDeal");
 


### PR DESCRIPTION
Exposes the new deal->sector mapping in the market actor to smart contracts.

@alexytsu this demonstrates the hiding of whether cron has cleaned up async terminated sectors re #1441 – I think that should follow a similar pattern though they're unfortunately on different integration branches.

Note that there is one other internal state still revealed to callers. After a deal is published and passes its start epoch without being activated, there is some delay until cron cleans it up (and this will remain after FIP-0074). The GetDealSector exit code will change from EX_DEAL_NOT_ACTIVATED to EX_DEAL_EXPIRED when the proposal is cleaned up. We could inspect the proposal's start epoch and simulate EX_DEAL_EXPIRED if the proposal is eligible for clean-up. (In GetDealActivation, the change is from returning a sentinel value for unactivated sectors, to aborting with EX_DEAL_EXPIRED).

I will update FIP-0076 after we settle on this implementation. Edit: https://github.com/filecoin-project/FIPs/pull/852