### PR TITLE
fix: miner: move partitions with expired/terminated sectors

### DIFF
--- a/actors/miner/src/deadline_state.rs
+++ b/actors/miner/src/deadline_state.rs
@@ -145,16 +145,16 @@ impl Deadlines {
 
             let dest_partition_idx = first_dest_partition_idx + i as u64;
 
-            // sector_count is both total sector count and total live sector count, since no sector is faulty here.
             let sector_count = moving_partition.sectors.len();
+            let live_sector_count = sector_count - moving_partition.terminated.len();
 
             // start updating orig/dest `Deadline` here
 
             orig_deadline.total_sectors -= sector_count;
-            orig_deadline.live_sectors -= sector_count;
+            orig_deadline.live_sectors -= live_sector_count;
 
             dest_deadline.total_sectors += sector_count;
-            dest_deadline.live_sectors += sector_count;
+            dest_deadline.live_sectors += live_sector_count;
 
             orig_partitions.set(orig_partition_idx, Partition::new(store)?)?;
             dest_partitions.set(dest_partition_idx, moving_partition)?;


### PR DESCRIPTION
I think the comment `sector_count is both total sector count and total live sector count, since no sector is faulty here.` was wrong. You can have "dead" sectors (terminated or expired) ones. @TippyFlitsUK hit this case when testing moving partitions.

The question is what's the right thing to do. I think it's fine to just move partitions with terminated / expired sectors, and the text of the FIP doesn't disallow this. If so, I think this PR fixes this, and we can land it with a test.

Otherwise, we need to explicitly disallow moving partitions with expired sectors, which the code doesn't currently do.