### PR TITLE
Actor events for the verified registry

### DIFF
--- a/actors/verifreg/src/emit.rs
+++ b/actors/verifreg/src/emit.rs
@@ -1,6 +1,6 @@
 // A namespace for helpers that build and emit verified registry events.
 
-use crate::{ActorError, Allocation, AllocationID, Claim};
+use crate::{ActorError, AllocationID};
 use crate::{ClaimID, DataCap};
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::EventBuilder;
@@ -16,7 +16,7 @@ pub fn verifier_balance(
 ) -> Result<(), ActorError> {
     rt.emit_event(
         &EventBuilder::new()
-            .event_type("verifier-balance")
+            .typ("verifier-balance")
             .field_indexed("verifier", &verifier)
             .field("balance", new_balance)
             .build()?,
@@ -24,63 +24,26 @@ pub fn verifier_balance(
 }
 
 /// Indicates a new allocation has been made.
-pub fn allocation(
-    rt: &impl Runtime,
-    id: AllocationID,
-    alloc: &Allocation,
-) -> Result<(), ActorError> {
-    rt.emit_event(&EventBuilder::new().event_type("allocation").with_allocation(id, alloc).build()?)
+pub fn allocation(rt: &impl Runtime, id: AllocationID) -> Result<(), ActorError> {
+    rt.emit_event(&EventBuilder::new().typ("allocation").field_indexed("id", &id).build()?)
 }
 
 /// Indicates an expired allocation has been removed.
-pub fn allocation_removed(
-    rt: &impl Runtime,
-    id: AllocationID,
-    alloc: &Allocation,
-) -> Result<(), ActorError> {
-    rt.emit_event(
-        &EventBuilder::new().event_type("allocation-removed").with_allocation(id, alloc).build()?,
-    )
+pub fn allocation_removed(rt: &impl Runtime, id: AllocationID) -> Result<(), ActorError> {
+    rt.emit_event(&EventBuilder::new().typ("allocation-removed").field_indexed("id", &id).build()?)
 }
 
 /// Indicates an allocation has been claimed.
-pub fn claim(rt: &impl Runtime, id: ClaimID, claim: &Claim) -> Result<(), ActorError> {
-    rt.emit_event(&EventBuilder::new().event_type("claim").with_claim(id, claim).build()?)
+pub fn claim(rt: &impl Runtime, id: ClaimID) -> Result<(), ActorError> {
+    rt.emit_event(&EventBuilder::new().typ("claim").field_indexed("id", &id).build()?)
 }
 
 /// Indicates an existing claim has been updated (e.g. with a longer term).
-pub fn claim_updated(rt: &impl Runtime, id: ClaimID, claim: &Claim) -> Result<(), ActorError> {
-    rt.emit_event(&EventBuilder::new().event_type("claim-updated").with_claim(id, claim).build()?)
+pub fn claim_updated(rt: &impl Runtime, id: ClaimID) -> Result<(), ActorError> {
+    rt.emit_event(&EventBuilder::new().typ("claim-updated").field_indexed("id", &id).build()?)
 }
 
 /// Indicates an expired claim has been removed.
-pub fn claim_removed(rt: &impl Runtime, id: ClaimID, claim: &Claim) -> Result<(), ActorError> {
-    rt.emit_event(&EventBuilder::new().event_type("claim-removed").with_claim(id, claim).build()?)
-}
-
-// Private helpers //
-trait WithAllocation {
-    fn with_allocation(self, id: AllocationID, alloc: &Allocation) -> EventBuilder;
-}
-
-impl WithAllocation for EventBuilder {
-    fn with_allocation(self, id: AllocationID, alloc: &Allocation) -> EventBuilder {
-        self.field_indexed("id", &id)
-            .field_indexed("client", &alloc.client)
-            .field_indexed("provider", &alloc.provider)
-            .field_indexed("data-cid", &alloc.data)
-    }
-}
-
-trait WithClaim {
-    fn with_claim(self, id: ClaimID, claim: &Claim) -> EventBuilder;
-}
-
-impl WithClaim for EventBuilder {
-    fn with_claim(self, id: ClaimID, claim: &Claim) -> EventBuilder {
-        self.field_indexed("id", &id)
-            .field_indexed("provider", &claim.provider)
-            .field_indexed("client", &claim.client)
-            .field_indexed("data-cid", &claim.data)
-    }
+pub fn claim_removed(rt: &impl Runtime, id: ClaimID) -> Result<(), ActorError> {
+    rt.emit_event(&EventBuilder::new().typ("claim-removed").field_indexed("id", &id).build()?)
 }

--- a/actors/verifreg/src/emit.rs
+++ b/actors/verifreg/src/emit.rs
@@ -1,7 +1,7 @@
 // A namespace for helpers that build and emit verified registry events.
 
-use crate::ActorError;
 use crate::DataCap;
+use crate::{ActorError, AllocationID};
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::EventBuilder;
 use fvm_shared::ActorID;
@@ -20,5 +20,17 @@ pub fn verifier_balance(
             .field_indexed("verifier", &verifier)
             .field("balance", new_balance)
             .build()?,
+    )
+}
+
+/// Indicates a new allocation has been made.
+pub fn allocation(rt: &impl Runtime, id: AllocationID) -> Result<(), ActorError> {
+    rt.emit_event(&EventBuilder::new().event_type("allocation").field_indexed("id", &id).build()?)
+}
+
+/// Indicates an expired allocation has been removed.
+pub fn allocation_removed(rt: &impl Runtime, id: AllocationID) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new().event_type("allocation-removed").field_indexed("id", &id).build()?,
     )
 }

--- a/actors/verifreg/src/emit.rs
+++ b/actors/verifreg/src/emit.rs
@@ -1,7 +1,7 @@
 // A namespace for helpers that build and emit verified registry events.
 
-use crate::DataCap;
-use crate::{ActorError, AllocationID};
+use crate::{ActorError, Allocation, AllocationID, Claim};
+use crate::{ClaimID, DataCap};
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::EventBuilder;
 use fvm_shared::ActorID;
@@ -24,13 +24,53 @@ pub fn verifier_balance(
 }
 
 /// Indicates a new allocation has been made.
-pub fn allocation(rt: &impl Runtime, id: AllocationID) -> Result<(), ActorError> {
-    rt.emit_event(&EventBuilder::new().event_type("allocation").field_indexed("id", &id).build()?)
+pub fn allocation(
+    rt: &impl Runtime,
+    id: AllocationID,
+    alloc: &Allocation,
+) -> Result<(), ActorError> {
+    rt.emit_event(&EventBuilder::new().event_type("allocation").with_allocation(id, alloc).build()?)
 }
 
 /// Indicates an expired allocation has been removed.
-pub fn allocation_removed(rt: &impl Runtime, id: AllocationID) -> Result<(), ActorError> {
+pub fn allocation_removed(
+    rt: &impl Runtime,
+    id: AllocationID,
+    alloc: &Allocation,
+) -> Result<(), ActorError> {
     rt.emit_event(
-        &EventBuilder::new().event_type("allocation-removed").field_indexed("id", &id).build()?,
+        &EventBuilder::new().event_type("allocation-removed").with_allocation(id, alloc).build()?,
     )
+}
+
+/// Indicates an allocation has been claimed.
+pub fn claim(rt: &impl Runtime, id: ClaimID, claim: &Claim) -> Result<(), ActorError> {
+    rt.emit_event(&EventBuilder::new().event_type("claim").with_claim(id, claim).build()?)
+}
+
+// Private helpers //
+trait WithAllocation {
+    fn with_allocation(self, id: AllocationID, alloc: &Allocation) -> EventBuilder;
+}
+
+impl WithAllocation for EventBuilder {
+    fn with_allocation(self, id: AllocationID, alloc: &Allocation) -> EventBuilder {
+        self.field_indexed("id", &id)
+            .field_indexed("client", &alloc.client)
+            .field_indexed("provider", &alloc.provider)
+            .field_indexed("data-cid", &alloc.data)
+    }
+}
+
+trait WithClaim {
+    fn with_claim(self, id: ClaimID, claim: &Claim) -> EventBuilder;
+}
+
+impl WithClaim for EventBuilder {
+    fn with_claim(self, id: ClaimID, claim: &Claim) -> EventBuilder {
+        self.field_indexed("id", &id)
+            .field_indexed("provider", &claim.provider)
+            .field_indexed("client", &claim.client)
+            .field_indexed("data-cid", &claim.data)
+    }
 }

--- a/actors/verifreg/src/emit.rs
+++ b/actors/verifreg/src/emit.rs
@@ -1,0 +1,24 @@
+// A namespace for helpers that build and emit verified registry events.
+
+use crate::ActorError;
+use crate::DataCap;
+use fil_actors_runtime::runtime::Runtime;
+use fil_actors_runtime::EventBuilder;
+use fvm_shared::ActorID;
+
+/// Indicates a new value for a verifier's datacap balance.
+/// Note that receiving this event does not necessarily mean the balance has changed.
+/// The value is in datacap whole units (not TokenAmount).
+pub fn verifier_balance(
+    rt: &impl Runtime,
+    verifier: ActorID,
+    new_balance: &DataCap,
+) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new()
+            .event_type("verifier-balance")
+            .field_indexed("verifier", &verifier)
+            .field("balance", new_balance)
+            .build()?,
+    )
+}

--- a/actors/verifreg/src/emit.rs
+++ b/actors/verifreg/src/emit.rs
@@ -48,6 +48,16 @@ pub fn claim(rt: &impl Runtime, id: ClaimID, claim: &Claim) -> Result<(), ActorE
     rt.emit_event(&EventBuilder::new().event_type("claim").with_claim(id, claim).build()?)
 }
 
+/// Indicates an existing claim has been updated (e.g. with a longer term).
+pub fn claim_updated(rt: &impl Runtime, id: ClaimID, claim: &Claim) -> Result<(), ActorError> {
+    rt.emit_event(&EventBuilder::new().event_type("claim-updated").with_claim(id, claim).build()?)
+}
+
+/// Indicates an expired claim has been removed.
+pub fn claim_removed(rt: &impl Runtime, id: ClaimID, claim: &Claim) -> Result<(), ActorError> {
+    rt.emit_event(&EventBuilder::new().event_type("claim-removed").with_claim(id, claim).build()?)
+}
+
 // Private helpers //
 trait WithAllocation {
     fn with_allocation(self, id: AllocationID, alloc: &Allocation) -> EventBuilder;

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -341,11 +341,10 @@ impl Actor {
                             ExitCode::USR_ILLEGAL_STATE,
                             format!("failed to remove allocation {}", id),
                         )?
-                        .unwrap();
+                        .unwrap(); // Unwrapping here as both paths to here should ensure the allocation exists.
 
                     emit::allocation_removed(rt, *id)?;
 
-                    // Unwrapping here as both paths to here should ensure the allocation exists.
                     recovered_datacap += existing.size.0;
                 }
 
@@ -558,7 +557,7 @@ impl Actor {
                     }
 
                     let new_claim = Claim { term_max: term.term_max, ..*claim };
-                    st_claims.put(term.provider, term.claim_id, new_claim.clone()).context_code(
+                    st_claims.put(term.provider, term.claim_id, new_claim).context_code(
                         ExitCode::USR_ILLEGAL_STATE,
                         "HAMT put failure storing new claims",
                     )?;

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -1256,7 +1256,7 @@ impl Runtime for MockRuntime {
             .borrow_mut()
             .expect_emitted_events
             .pop_front()
-            .expect("unexpected call to emit_evit");
+            .expect("unexpected call to emit_event");
 
         assert_eq!(*event, expected);
 

--- a/runtime/src/util/events.rs
+++ b/runtime/src/util/events.rs
@@ -20,8 +20,8 @@ impl EventBuilder {
     }
 
     /// Initialise the "type" of the event i.e. Actor event type.
-    pub fn event_type(self, _type: &str) -> Self {
-        self.push_entry(EVENT_TYPE_KEY, _type, Flags::FLAG_INDEXED_KEY)
+    pub fn typ(self, _type: &str) -> Self {
+        self.push_entry(EVENT_TYPE_KEY, _type, Flags::FLAG_INDEXED_ALL)
     }
 
     /// Pushes an entry with an indexed key and an un-indexed, IPLD-CBOR-serialized value.
@@ -75,25 +75,25 @@ mod test {
 
     #[test]
     fn event_type() {
-        let e = EventBuilder::new().event_type("l1").event_type("l2").build().unwrap();
+        let e = EventBuilder::new().typ("l1").field_indexed("v1", "abc").build().unwrap();
 
         let l1_cbor = serialize_vec("l1", "event value").unwrap();
-        let l2_cbor = serialize_vec("l2", "event value").unwrap();
+        let v_cbor = serialize_vec("abc", "event value").unwrap();
 
         assert_eq!(
             ActorEvent {
                 entries: vec![
                     Entry {
-                        flags: Flags::FLAG_INDEXED_KEY,
+                        flags: Flags::FLAG_INDEXED_ALL,
                         key: EVENT_TYPE_KEY.to_string(),
                         codec: IPLD_CBOR,
                         value: l1_cbor, // CBOR for "l1"
                     },
                     Entry {
-                        flags: Flags::FLAG_INDEXED_KEY,
-                        key: EVENT_TYPE_KEY.to_string(),
+                        flags: Flags::FLAG_INDEXED_ALL,
+                        key: "v1".to_string(),
                         codec: IPLD_CBOR,
-                        value: l2_cbor, // CBOR for "l2"
+                        value: v_cbor, // CBOR for "abc"
                     },
                 ]
             },

--- a/runtime/src/util/events.rs
+++ b/runtime/src/util/events.rs
@@ -1,0 +1,127 @@
+use crate::cbor::serialize_vec;
+use crate::ActorError;
+use fvm_shared::event::{ActorEvent, Entry, Flags};
+use serde::ser;
+
+// Codec identifier for CBOR-encoded data.
+const IPLD_CBOR: u64 = 0x51;
+
+const EVENT_TYPE_KEY: &str = "$type";
+
+/// Builder for ActorEvent objects, accumulating key/value pairs.
+pub struct EventBuilder {
+    entries: Result<Vec<Entry>, ActorError>,
+}
+
+impl EventBuilder {
+    /// Creates a new builder with no values.
+    pub fn new() -> Self {
+        Self { entries: Ok(Vec::new()) }
+    }
+
+    /// Initialise the "type" of the event i.e. Actor event type.
+    pub fn event_type(self, _type: &str) -> Self {
+        self.push_entry(EVENT_TYPE_KEY, _type, Flags::FLAG_INDEXED_KEY)
+    }
+
+    /// Pushes an entry with an indexed key and an un-indexed, IPLD-CBOR-serialized value.
+    pub fn field<T: ser::Serialize + ?Sized>(self, name: &str, value: &T) -> Self {
+        self.push_entry(name, value, Flags::FLAG_INDEXED_KEY)
+    }
+
+    /// Pushes an entry with an indexed key and indexed, IPLD-CBOR-serialized value.
+    pub fn field_indexed<T: ser::Serialize + ?Sized>(self, name: &str, value: &T) -> Self {
+        self.push_entry(name, value, Flags::FLAG_INDEXED_ALL)
+    }
+
+    /// Returns an actor event ready to emit (consuming self).
+    pub fn build(self) -> Result<ActorEvent, ActorError> {
+        Ok(ActorEvent { entries: self.entries? })
+    }
+
+    /// Pushes an entry with an IPLD-CBOR-serialized value.
+    fn push_entry<T: ser::Serialize + ?Sized>(
+        mut self,
+        key: &str,
+        value: &T,
+        flags: Flags,
+    ) -> Self {
+        if let Ok(ref mut entries) = self.entries {
+            match serialize_vec(&value, "event value") {
+                Ok(value) => {
+                    entries.push(Entry { flags, key: key.to_string(), codec: IPLD_CBOR, value })
+                }
+                Err(e) => {
+                    self.entries = Err(e);
+                }
+            }
+        }
+        self
+    }
+}
+
+impl Default for EventBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::cbor::serialize_vec;
+    use crate::util::events::{EVENT_TYPE_KEY, IPLD_CBOR};
+    use crate::EventBuilder;
+    use fvm_shared::event::{ActorEvent, Entry, Flags};
+
+    #[test]
+    fn event_type() {
+        let e = EventBuilder::new().event_type("l1").event_type("l2").build().unwrap();
+
+        let l1_cbor = serialize_vec("l1", "event value").unwrap();
+        let l2_cbor = serialize_vec("l2", "event value").unwrap();
+
+        assert_eq!(
+            ActorEvent {
+                entries: vec![
+                    Entry {
+                        flags: Flags::FLAG_INDEXED_KEY,
+                        key: EVENT_TYPE_KEY.to_string(),
+                        codec: IPLD_CBOR,
+                        value: l1_cbor, // CBOR for "l1"
+                    },
+                    Entry {
+                        flags: Flags::FLAG_INDEXED_KEY,
+                        key: EVENT_TYPE_KEY.to_string(),
+                        codec: IPLD_CBOR,
+                        value: l2_cbor, // CBOR for "l2"
+                    },
+                ]
+            },
+            e
+        )
+    }
+
+    #[test]
+    fn values() {
+        let e = EventBuilder::new().field("v1", &3).field_indexed("v2", "abc").build().unwrap();
+        assert_eq!(
+            ActorEvent {
+                entries: vec![
+                    Entry {
+                        flags: Flags::FLAG_INDEXED_KEY,
+                        key: "v1".to_string(),
+                        codec: IPLD_CBOR,
+                        value: vec![0x03],
+                    },
+                    Entry {
+                        flags: Flags::FLAG_INDEXED_ALL,
+                        key: "v2".to_string(),
+                        codec: IPLD_CBOR,
+                        value: vec![0x63, 0x61, 0x62, 0x63], // CBOR for "abc"
+                    },
+                ]
+            },
+            e
+        );
+    }
+}

--- a/runtime/src/util/mod.rs
+++ b/runtime/src/util/mod.rs
@@ -5,16 +5,17 @@ pub use self::batch_return::BatchReturn;
 pub use self::batch_return::BatchReturnGen;
 pub use self::batch_return::FailCode;
 pub use self::downcast::*;
+pub use self::events::*;
 pub use self::map::*;
 pub use self::mapmap::MapMap;
 pub use self::message_accumulator::MessageAccumulator;
 pub use self::multimap::*;
 pub use self::set::Set;
 pub use self::set_multimap::SetMultimap;
-
 mod batch_return;
 pub mod cbor;
 mod downcast;
+mod events;
 mod map;
 mod mapmap;
 mod message_accumulator;

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -328,6 +328,7 @@ impl<'bs> VM for TestVM<'bs> {
             read_only: false,
             policy: &Policy::default(),
             subinvocations: RefCell::new(vec![]),
+            events: RefCell::new(vec![]),
         };
         let res = new_ctx.invoke();
 


### PR DESCRIPTION
Subsumes #1320 .

Based on discussions at #1320, https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0049.md AND https://github.com/filecoin-project/FIPs/discussions/754.

Implements events with minimal payload wherein the client has just enough information to determine whether to query state or not based on the payload of the recieved event.