### PR TITLE
Not to merge: rename circulating supply to total supply

### DIFF
--- a/integration_tests/src/util/mod.rs
+++ b/integration_tests/src/util/mod.rs
@@ -58,7 +58,7 @@ pub fn check_invariants(vm: &dyn VM, policy: &Policy) -> anyhow::Result<MessageA
         &vm.actor_manifest(),
         policy,
         Tree::load(&DynBlockstore::wrap(vm.blockstore()), &vm.state_root()).unwrap(),
-        &vm.circulating_supply(),
+        &vm.total_supply(),
         vm.epoch() - 1,
     )
 }

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -87,7 +87,7 @@ impl<'bs> TestVM<'bs> {
         let faucet_total = TokenAmount::from_whole(1_000_000_000i64);
 
         let v = TestVM::<'_>::new(store);
-        v.set_circulating_supply(&reward_total + &faucet_total);
+        v.set_total_supply(&reward_total + &faucet_total);
 
         // system
         let sys_st = SystemState::new(store).unwrap();
@@ -416,11 +416,11 @@ impl<'bs> VM for TestVM<'bs> {
         *self.state_root.borrow()
     }
 
-    fn circulating_supply(&self) -> TokenAmount {
+    fn total_supply(&self) -> TokenAmount {
         self.circulating_supply.borrow().clone()
     }
 
-    fn set_circulating_supply(&self, supply: TokenAmount) {
+    fn set_total_supply(&self, supply: TokenAmount) {
         self.circulating_supply.replace(supply);
     }
 }

--- a/vm_api/src/lib.rs
+++ b/vm_api/src/lib.rs
@@ -76,11 +76,11 @@ pub trait VM {
     /// Take all the invocations that have been made since the last call to this method
     fn take_invocations(&self) -> Vec<InvocationTrace>;
 
-    /// Set the circulating supply constant for the network
-    fn set_circulating_supply(&self, supply: TokenAmount);
+    /// Set the total supply constant for the network
+    fn set_total_supply(&self, supply: TokenAmount);
 
-    /// Get the circulating supply constant for the network
-    fn circulating_supply(&self) -> TokenAmount;
+    /// Get the
+    fn total_supply(&self) -> TokenAmount;
 
     /// Provides access to VM primitives
     fn primitives(&self) -> &dyn Primitives;


### PR DESCRIPTION
For context:

https://github.com/filecoin-project/builtin-actors/issues/1460
https://github.com/anorth/fvm-workbench/pull/33


Total supply should be calculable by summing up all actors' balances. 

```
pub fn check_invariants(vm: &dyn VM, policy: &Policy) -> anyhow::Result<MessageAccumulator> {
    check_state_invariants(
        &vm.actor_manifest(),
        policy,
        Tree::load(&DynBlockstore::wrap(vm.blockstore()), &vm.state_root()).unwrap(),
        &vm.total_supply(),
        vm.epoch() - 1,
    )
}
```

It's current use in check_invariants is probably conceptually wrong. An externally calculated/predetermined total_supply should be passed as a parameter into check_invariants. This raises the question whether `set_total_supply` needs to exist. 

The check_invariants probably doesn't need to do the total_supply check. It should be enforced by the VM. Since the TestVM is implemented here however, there's value in testing its compliance - but that should be in specific unit tests of the TestVM rather than in every integration test (that should target the actors behaviour).

I think the VM should expose:

- set_circulating_supply
- circulating_supply (simply read from set_circulating_supply)
- optionally: a dynamically calculated total_supply method. I don't think this is used in any test bodies at the moment.

