### PR TITLE
replace total_supply with circulating_supply

### DIFF
--- a/integration_tests/src/tests/batch_onboarding.rs
+++ b/integration_tests/src/tests/batch_onboarding.rs
@@ -163,6 +163,7 @@ pub fn batch_onboarding_test(v: &dyn VM, v2: bool) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }
 

--- a/integration_tests/src/tests/change_beneficiary_test.rs
+++ b/integration_tests/src/tests/change_beneficiary_test.rs
@@ -67,7 +67,7 @@ pub fn change_beneficiary_success_test(v: &dyn VM) {
     get_beneficiary_return = get_beneficiary(v, &query_addr, &miner_id);
     assert!(get_beneficiary_return.proposed.is_none());
     assert_active(&change_another_beneificiary_proposal, &get_beneficiary_return.active);
-    assert_invariants(v, &Policy::default());
+    assert_invariants(v, &Policy::default(), None);
 }
 
 #[vm_test]
@@ -218,7 +218,7 @@ pub fn change_beneficiary_fail_test(v: &dyn VM) {
     change_beneficiary(v, &owner, &miner_id, &back_owner_proposal);
     change_beneficiary(v, &beneficiary, &miner_id, &back_owner_proposal);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 fn assert_pending(

--- a/integration_tests/src/tests/change_owner_test.rs
+++ b/integration_tests/src/tests/change_owner_test.rs
@@ -45,7 +45,7 @@ pub fn change_owner_success_test(v: &dyn VM) {
     assert_eq!(new_owner, minfo.owner);
     assert_eq!(new_owner, minfo.beneficiary);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -85,7 +85,7 @@ pub fn keep_beneficiary_when_owner_changed_test(v: &dyn VM) {
     assert_eq!(new_owner, minfo.owner);
     assert_eq!(beneficiary, minfo.beneficiary);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 pub fn change_owner_fail_test(v: &dyn VM) {
@@ -155,5 +155,5 @@ pub fn change_owner_fail_test(v: &dyn VM) {
     assert_eq!(addr, minfo.owner);
     assert_eq!(addr, minfo.beneficiary);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }

--- a/integration_tests/src/tests/commit_post_test.rs
+++ b/integration_tests/src/tests/commit_post_test.rs
@@ -180,7 +180,7 @@ pub fn submit_post_succeeds_test(v: &dyn VM) {
     let p_st: PowerState = get_state(v, &STORAGE_POWER_ACTOR_ADDR).unwrap();
     assert_eq!(sector_power.raw, p_st.total_bytes_committed);
 
-    assert_invariants(v, &Policy::default());
+    assert_invariants(v, &Policy::default(), None);
 }
 
 #[vm_test]
@@ -220,7 +220,7 @@ pub fn skip_sector_test(v: &dyn VM) {
     let network_stats = get_network_stats(v);
     assert!(network_stats.total_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_positive());
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -283,6 +283,7 @@ pub fn missed_first_post_deadline_test(v: &dyn VM) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }
 
@@ -388,6 +389,7 @@ pub fn overdue_precommit_test(v: &dyn VM) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }
 
@@ -459,6 +461,7 @@ pub fn aggregate_bad_sector_number_test(v: &dyn VM) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }
 
@@ -562,6 +565,7 @@ pub fn aggregate_size_limits_test(v: &dyn VM) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }
 
@@ -629,6 +633,7 @@ pub fn aggregate_bad_sender_test(v: &dyn VM) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }
 
@@ -748,5 +753,6 @@ pub fn aggregate_one_precommit_expires_test(v: &dyn VM) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -321,6 +321,7 @@ pub fn extend_legacy_sector_with_deals_test(v: &dyn VM, do_extend2: bool) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }
 

--- a/integration_tests/src/tests/move_partitions_test.rs
+++ b/integration_tests/src/tests/move_partitions_test.rs
@@ -62,7 +62,7 @@ pub fn move_partitions_test(v: &dyn VM) {
 
     cron_tick(v);
     v.set_epoch(v.epoch() + 1);
-    assert_invariants(v, &Policy::default());
+    assert_invariants(v, &Policy::default(), None);
 }
 
 fn submit_post_succeeds_test(v: &dyn VM, miner_info: MinerInfo, sector_info: SectorInfo) {
@@ -84,7 +84,7 @@ fn submit_post_succeeds_test(v: &dyn VM, miner_info: MinerInfo, sector_info: Sec
     let p_st: PowerState = get_state(v, &STORAGE_POWER_ACTOR_ADDR).unwrap();
     assert_eq!(sector_power.raw, p_st.total_bytes_committed);
 
-    assert_invariants(v, &Policy::default());
+    assert_invariants(v, &Policy::default(), None);
 }
 
 struct SectorInfo {

--- a/integration_tests/src/tests/multisig_test.rs
+++ b/integration_tests/src/tests/multisig_test.rs
@@ -105,7 +105,7 @@ pub fn proposal_hash_test(v: &dyn VM) {
     expect.matches(v.take_invocations().last().unwrap());
 
     assert_eq!(sys_act_start_bal + fil_delta, v.actor(&SYSTEM_ACTOR_ADDR).unwrap().balance);
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 pub fn test_delete_self_inner_test(v: &dyn VM, signers: u64, threshold: usize, remove_idx: usize) {
@@ -168,7 +168,7 @@ pub fn test_delete_self_inner_test(v: &dyn VM, signers: u64, threshold: usize, r
     let new_signers: HashSet<Address> = HashSet::from_iter(st.signers);
     let diff: Vec<&Address> = old_signers.symmetric_difference(&new_signers).collect();
     assert_eq!(vec![&(addrs[remove_idx])], diff);
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -194,7 +194,7 @@ pub fn swap_self_1_of_2_test(v: &dyn VM) {
     );
     let st: MsigState = get_state(v, &msig_addr).unwrap();
     assert_eq!(vec![bob, chuck], st.signers);
-    assert_invariants(v, &Policy::default());
+    assert_invariants(v, &Policy::default(), None);
 }
 
 #[vm_test]
@@ -266,7 +266,7 @@ pub fn swap_self_2_of_3_test(v: &dyn VM) {
     let st: MsigState = get_state(v, &msig_addr).unwrap();
     assert_eq!(vec![bob, chuck, alice], st.signers);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 fn create_msig(v: &dyn VM, signers: &[Address], threshold: u64) -> Address {

--- a/integration_tests/src/tests/power_scenario_tests.rs
+++ b/integration_tests/src/tests/power_scenario_tests.rs
@@ -101,7 +101,7 @@ pub fn power_create_miner_test(v: &dyn VM) {
     };
 
     expect.matches(v.take_invocations().last().unwrap());
-    assert_invariants(v, &Policy::default());
+    assert_invariants(v, &Policy::default(), None);
 }
 
 #[vm_test]
@@ -219,5 +219,6 @@ pub fn cron_tick_test(v: &dyn VM) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }

--- a/integration_tests/src/tests/publish_deals_test.rs
+++ b/integration_tests/src/tests/publish_deals_test.rs
@@ -141,7 +141,7 @@ pub fn psd_mismatched_provider_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 2], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -163,7 +163,7 @@ pub fn psd_bad_piece_size_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -180,7 +180,7 @@ pub fn psd_start_time_in_past_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -196,7 +196,7 @@ pub fn psd_client_address_cannot_be_resolved_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -211,7 +211,7 @@ pub fn psd_no_client_lockup_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![1], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -241,7 +241,7 @@ pub fn psd_not_enough_client_lockup_for_batch_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -278,7 +278,7 @@ pub fn psd_not_enough_provider_lockup_for_batch_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -305,7 +305,7 @@ pub fn psd_duplicate_deal_in_batch_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 4], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -330,7 +330,7 @@ pub fn psd_duplicate_deal_in_state_test(v: &dyn VM) {
     let good_inputs2 = bf_all(deal_ret2.valid_deals);
     assert_eq!(vec![1], good_inputs2);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -357,7 +357,7 @@ pub fn psd_verified_deal_fails_getting_datacap_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -416,7 +416,7 @@ pub fn psd_random_assortment_of_failures_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 2, 8], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -441,7 +441,7 @@ pub fn psd_all_deals_are_bad_test(v: &dyn VM) {
     );
 
     batcher.publish_fail(a.worker);
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -517,7 +517,7 @@ pub fn psd_bad_sig_test(v: &dyn VM) {
     }
     .matches(v.take_invocations().last().unwrap());
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -537,7 +537,7 @@ pub fn all_deals_are_good_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 2, 3, 4], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -563,7 +563,7 @@ pub fn psd_valid_deals_with_ones_longer_than_540_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1, 2], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -591,5 +591,5 @@ pub fn psd_deal_duration_too_long_test(v: &dyn VM) {
     let good_inputs = bf_all(deal_ret.valid_deals);
     assert_eq!(vec![0, 1], good_inputs);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -92,7 +92,7 @@ pub fn replica_update_full_path_success_test(v: &dyn VM, v2: bool) {
     assert!(!check_sector_faulty(v, &miner_id, deadline_index, partition_index, sector_number));
     assert_eq!(miner_power(v, &miner_id).raw, BigInt::from(sector_size as i64));
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -152,7 +152,7 @@ pub fn upgrade_and_miss_post_test(v: &dyn VM, v2: bool) {
     assert!(!check_sector_faulty(v, &miner_id, deadline_index, partition_index, sector_number));
     assert_eq!(miner_power(v, &miner_id).raw, BigInt::from(sector_size as i64));
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -299,7 +299,7 @@ pub fn prove_replica_update_multi_dline_test(v: &dyn VM) {
     assert_eq!(old_sector_commr_p2, new_sector_info_p2.sector_key_cid.unwrap());
     assert_eq!(new_sealed_cid2, new_sector_info_p2.sealed_cid);
 
-    assert_invariants(v, &Policy::default());
+    assert_invariants(v, &Policy::default(), None);
 }
 
 // ---- Failure cases ----
@@ -351,7 +351,7 @@ pub fn immutable_deadline_failure_test(v: &dyn VM) {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -408,6 +408,7 @@ pub fn unhealthy_sector_failure_test(v: &dyn VM) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }
 
@@ -472,7 +473,7 @@ pub fn terminated_sector_failure_test(v: &dyn VM) {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -524,7 +525,7 @@ pub fn bad_batch_size_failure_test(v: &dyn VM) {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -542,7 +543,7 @@ pub fn nodispute_after_upgrade_test(v: &dyn VM) {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -567,7 +568,7 @@ pub fn upgrade_bad_post_dispute_test(v: &dyn VM) {
         Some(dispute_params),
     );
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -643,7 +644,7 @@ pub fn bad_post_upgrade_dispute_test(v: &dyn VM) {
         Some(dispute_params),
     );
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 /// Tests that an active CC sector can be correctly upgraded, and then the sector can be terminated
@@ -683,7 +684,7 @@ pub fn terminate_after_upgrade_test(v: &dyn VM) {
     assert!(network_stats.total_qa_bytes_committed.is_zero());
     assert!(network_stats.total_pledge_collateral.is_zero());
 
-    assert_invariants(v, &Policy::default());
+    assert_invariants(v, &Policy::default(), None);
 }
 
 /// Tests that an active CC sector can be correctly upgraded, and then the sector can be extended
@@ -733,7 +734,7 @@ pub fn extend_after_upgrade_test(v: &dyn VM) {
         final_sector_info.expiration - extension_epoch,
     );
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -789,7 +790,7 @@ pub fn wrong_deadline_index_failure_test(v: &dyn VM) {
     let new_sector_info = sector_info(v, &maddr, sector_number);
     assert_eq!(old_sector_info, new_sector_info);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -845,7 +846,7 @@ pub fn wrong_partition_index_failure_test(v: &dyn VM) {
     let new_sector_info = sector_info(v, &maddr, sector_number);
     assert_eq!(old_sector_info, new_sector_info);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -969,7 +970,7 @@ pub fn deal_included_in_multiple_sectors_failure_test(v: &dyn VM) {
     assert!(new_sector_info_p2.deal_ids.len().is_zero());
     assert_ne!(new_sealed_cid2, new_sector_info_p2.sealed_cid);
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]

--- a/integration_tests/src/tests/terminate_test.rs
+++ b/integration_tests/src/tests/terminate_test.rs
@@ -355,5 +355,6 @@ pub fn terminate_sectors_test(v: &dyn VM) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }

--- a/integration_tests/src/tests/verified_claim_test.rs
+++ b/integration_tests/src/tests/verified_claim_test.rs
@@ -362,6 +362,7 @@ pub fn verified_claim_scenario_test(v: &dyn VM) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }
 
@@ -455,6 +456,7 @@ pub fn expired_allocations_test(v: &dyn VM) {
         v,
         &Policy::default(),
         &[invariant_failure_patterns::REWARD_STATE_EPOCH_MISMATCH.to_owned()],
+        None,
     );
 }
 
@@ -584,5 +586,5 @@ pub fn deal_passes_claim_fails_test(v: &dyn VM) {
     assert_eq!(None, sector_info_a);
 
     // run check before last change and confirm that we hit the expected broken state error
-    assert_invariants(v, &Policy::default());
+    assert_invariants(v, &Policy::default(), None);
 }

--- a/integration_tests/src/tests/verifreg_remove_datacap_test.rs
+++ b/integration_tests/src/tests/verifreg_remove_datacap_test.rs
@@ -303,7 +303,7 @@ pub fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
         .unwrap();
 
     assert_eq!(2u64, verifier2_proposal_id.id);
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 #[vm_test]
@@ -359,7 +359,7 @@ pub fn remove_datacap_fails_on_verifreg_test(v: &dyn VM) {
         ExitCode::USR_ILLEGAL_ARGUMENT,
     );
 
-    assert_invariants(v, &Policy::default())
+    assert_invariants(v, &Policy::default(), None)
 }
 
 fn expect_remove_datacap(

--- a/integration_tests/src/util/mod.rs
+++ b/integration_tests/src/util/mod.rs
@@ -53,23 +53,32 @@ pub fn create_accounts_seeded(
     pk_addrs.iter().map(|pk_addr| v.resolve_id_address(pk_addr).unwrap()).collect()
 }
 
-pub fn check_invariants(vm: &dyn VM, policy: &Policy) -> anyhow::Result<MessageAccumulator> {
+pub fn check_invariants(
+    vm: &dyn VM,
+    policy: &Policy,
+    expected_balance_total: Option<TokenAmount>,
+) -> anyhow::Result<MessageAccumulator> {
     check_state_invariants(
         &DynBlockstore::wrap(vm.blockstore()),
         &vm.actor_manifest(),
         policy,
         &vm.actor_states(),
-        &vm.circulating_supply(),
+        expected_balance_total,
         vm.epoch() - 1,
     )
 }
 
-pub fn assert_invariants(v: &dyn VM, policy: &Policy) {
-    check_invariants(v, policy).unwrap().assert_empty()
+pub fn assert_invariants(v: &dyn VM, policy: &Policy, expected_balance_total: Option<TokenAmount>) {
+    check_invariants(v, policy, expected_balance_total).unwrap().assert_empty()
 }
 
-pub fn expect_invariants(v: &dyn VM, policy: &Policy, expected_patterns: &[Regex]) {
-    check_invariants(v, policy).unwrap().assert_expected(expected_patterns)
+pub fn expect_invariants(
+    v: &dyn VM,
+    policy: &Policy,
+    expected_patterns: &[Regex],
+    expected_balance_total: Option<TokenAmount>,
+) {
+    check_invariants(v, policy, expected_balance_total).unwrap().assert_expected(expected_patterns)
 }
 
 pub fn miner_balance(v: &dyn VM, m: &Address) -> MinerBalances {

--- a/state/src/check.rs
+++ b/state/src/check.rs
@@ -63,7 +63,7 @@ pub fn check_state_invariants<BS: Blockstore>(
     manifest: &BTreeMap<Cid, Type>,
     policy: &Policy,
     tree: &BTreeMap<Address, ActorState>,
-    expected_balance_total: &TokenAmount,
+    expected_balance_total: Option<TokenAmount>,
     prior_epoch: ChainEpoch,
 ) -> anyhow::Result<MessageAccumulator> {
     let acc = MessageAccumulator::default();
@@ -191,10 +191,12 @@ pub fn check_state_invariants<BS: Blockstore>(
         check_verifreg_against_miners(&acc, &verifreg_summary, &miner_summaries);
     }
 
-    acc.require(
-        &total_fil == expected_balance_total,
-        format!("total token balance is {total_fil}, expected {expected_balance_total}"),
-    );
+    if let Some(expected_balance_total) = expected_balance_total {
+        acc.require(
+            total_fil == expected_balance_total,
+            format!("total token balance is {total_fil}, expected {expected_balance_total}"),
+        );
+    }
 
     Ok(acc)
 }

--- a/test_vm/tests/suite/replica_update_test.rs
+++ b/test_vm/tests/suite/replica_update_test.rs
@@ -25,7 +25,7 @@ fn replica_update_simple_path_success(v2: bool) {
     let store = MemoryBlockstore::new();
     let v = TestVM::new_with_singletons(store);
     create_miner_and_upgrade_sector(&v, v2);
-    assert_invariants(&v, &Policy::default());
+    assert_invariants(&v, &Policy::default(), None);
 }
 
 // Tests a successful upgrade, followed by the sector going faulty and recovering

--- a/test_vm/tests/suite/test_vm_test.rs
+++ b/test_vm/tests/suite/test_vm_test.rs
@@ -50,7 +50,7 @@ fn state_control() {
     assert_eq!(None, v.actor(&addr2));
     assert_eq!(v.actor(&addr1).unwrap(), a1);
 
-    let invariants_check = check_invariants(&v, &Policy::default());
+    let invariants_check = check_invariants(&v, &Policy::default(), Some(TokenAmount::zero()));
     assert!(invariants_check.is_err());
     assert!(invariants_check.unwrap_err().to_string().contains("AccountState is empty"));
 }
@@ -118,7 +118,7 @@ fn test_sent() {
     assert_account_actor(3, TokenAmount::from_atto(42u8), addr1, &v, expect_id_addr1);
     assert_account_actor(2, TokenAmount::zero(), addr2, &v, expect_id_addr2);
 
-    assert_invariants(&v, &Policy::default())
+    assert_invariants(&v, &Policy::default(), None)
 }
 
 #[test]


### PR DESCRIPTION
Based off discussion in #1461 replacing it
Closes #1460 

- Corrects the name `total_supply` -> `circulating_supply` in the VM api
- Makes total_supply checks optional in `check_state_invariants`

Does not implement total_supply as part of the VM api
- There are no uses of it in the current code
- If tests do require this value, it can be calculated manually from `VM::actor_states` (or implemented as a utility function in _integration_tests/src/util/mod.rs_

