### PR TITLE
ci: change the name of the coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: Continuous integration
+name: Coverage
 
 on: workflow_dispatch
 


### PR DESCRIPTION
Quick follow up on https://github.com/filecoin-project/builtin-actors/pull/1465

This will ensure we have two distinct entries in the Actions tab

I'm pretty sure we'll have to manually clean up the duplicate after this is merged - I'll take care of it