### PR TITLE
Market Actor Events

### DIFF
--- a/actors/market/src/emit.rs
+++ b/actors/market/src/emit.rs
@@ -1,0 +1,21 @@
+use fil_actors_runtime::runtime::Runtime;
+use fil_actors_runtime::{ActorError, EventBuilder};
+use fvm_shared::deal::DealID;
+use fvm_shared::ActorID;
+
+/// Indicates a deal has been published.
+pub fn deal_published(
+    rt: &impl Runtime,
+    client: ActorID,
+    provider: ActorID,
+    deal_id: DealID,
+) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new()
+            .typ("deal-published")
+            .field_indexed("client", &client)
+            .field_indexed("provider", &provider)
+            .field_indexed("deal_id", &deal_id)
+            .build()?,
+    )
+}

--- a/actors/market/src/emit.rs
+++ b/actors/market/src/emit.rs
@@ -19,3 +19,10 @@ pub fn deal_published(
             .build()?,
     )
 }
+
+/// Indicates a deal has been activated.
+pub fn deal_activated(rt: &impl Runtime, deal_id: DealID) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new().typ("deal-activated").field_indexed("deal_id", &deal_id).build()?,
+    )
+}

--- a/actors/market/src/emit.rs
+++ b/actors/market/src/emit.rs
@@ -33,3 +33,10 @@ pub fn deal_terminated(rt: &impl Runtime, deal_id: DealID) -> Result<(), ActorEr
         &EventBuilder::new().typ("deal-terminated").field_indexed("deal_id", &deal_id).build()?,
     )
 }
+
+/// Indicates a deal has been completed successfully.
+pub fn deal_completed(rt: &impl Runtime, deal_id: DealID) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new().typ("deal-completed").field_indexed("deal_id", &deal_id).build()?,
+    )
+}

--- a/actors/market/src/emit.rs
+++ b/actors/market/src/emit.rs
@@ -15,28 +15,24 @@ pub fn deal_published(
             .typ("deal-published")
             .field_indexed("client", &client)
             .field_indexed("provider", &provider)
-            .field_indexed("deal_id", &deal_id)
+            .field_indexed("id", &deal_id)
             .build()?,
     )
 }
 
 /// Indicates a deal has been activated.
 pub fn deal_activated(rt: &impl Runtime, deal_id: DealID) -> Result<(), ActorError> {
-    rt.emit_event(
-        &EventBuilder::new().typ("deal-activated").field_indexed("deal_id", &deal_id).build()?,
-    )
+    rt.emit_event(&EventBuilder::new().typ("deal-activated").field_indexed("id", &deal_id).build()?)
 }
 
 /// Indicates a deal has been terminated.
 pub fn deal_terminated(rt: &impl Runtime, deal_id: DealID) -> Result<(), ActorError> {
     rt.emit_event(
-        &EventBuilder::new().typ("deal-terminated").field_indexed("deal_id", &deal_id).build()?,
+        &EventBuilder::new().typ("deal-terminated").field_indexed("id", &deal_id).build()?,
     )
 }
 
 /// Indicates a deal has been completed successfully.
 pub fn deal_completed(rt: &impl Runtime, deal_id: DealID) -> Result<(), ActorError> {
-    rt.emit_event(
-        &EventBuilder::new().typ("deal-completed").field_indexed("deal_id", &deal_id).build()?,
-    )
+    rt.emit_event(&EventBuilder::new().typ("deal-completed").field_indexed("id", &deal_id).build()?)
 }

--- a/actors/market/src/emit.rs
+++ b/actors/market/src/emit.rs
@@ -26,3 +26,10 @@ pub fn deal_activated(rt: &impl Runtime, deal_id: DealID) -> Result<(), ActorErr
         &EventBuilder::new().typ("deal-activated").field_indexed("deal_id", &deal_id).build()?,
     )
 }
+
+/// Indicates a deal has been terminated.
+pub fn deal_terminated(rt: &impl Runtime, deal_id: DealID) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new().typ("deal-terminated").field_indexed("deal_id", &deal_id).build()?,
+    )
+}

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -741,7 +741,6 @@ impl Actor {
 
                 deal_states.push((id, state));
                 emit::deal_terminated(rt, id)?;
-                println!("emitted");
             }
 
             st.put_deal_states(rt.store(), &deal_states)?;
@@ -824,7 +823,7 @@ impl Actor {
                         })?;
                     }
 
-                    let (slash_amount, remove_deal) =
+                    let (slash_amount, remove_deal, complete_success) =
                         st.process_deal_update(rt.store(), &state, &deal, curr_epoch)?;
 
                     if slash_amount.is_negative() {
@@ -855,6 +854,10 @@ impl Actor {
                                 illegal_state,
                                 "failed to delete deal proposal: does not exist"
                             ));
+                        }
+
+                        if complete_success {
+                            emit::deal_completed(rt, deal_id)?;
                         }
                     } else {
                         if !slash_amount.is_zero() {

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -665,6 +665,9 @@ impl Actor {
                             unsealed_cid: data_commitment,
                         });
                         batch_gen.add_success();
+                        for d in p.deal_ids {
+                            emit::deal_activated(rt, d)?;
+                        }
                     }
                     Err(e) => {
                         log::warn!("failed to activate deals {:?}: {}", p.deal_ids, e);

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -57,6 +57,8 @@ mod deal;
 mod state;
 mod types;
 
+pub mod emit;
+
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
 
@@ -478,6 +480,13 @@ impl Actor {
             .with_context_code(ExitCode::USR_ILLEGAL_ARGUMENT, || {
                 format!("failed to notify deal with proposal cid {}", valid_deal.cid)
             })?;
+
+            emit::deal_published(
+                rt,
+                valid_deal.proposal.client.id().unwrap(),
+                valid_deal.proposal.provider.id().unwrap(),
+                new_deal_ids[i],
+            )?;
         }
 
         Ok(PublishStorageDealsReturn { ids: new_deal_ids, valid_deals: valid_input_bf })

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -740,6 +740,8 @@ impl Actor {
                 state.slash_epoch = params.epoch;
 
                 deal_states.push((id, state));
+                emit::deal_terminated(rt, id)?;
+                println!("emitted");
             }
 
             st.put_deal_states(rt.store(), &deal_states)?;

--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -576,7 +576,7 @@ impl State {
         state: &DealState,
         deal: &DealProposal,
         epoch: ChainEpoch,
-    ) -> Result<(TokenAmount, bool), ActorError>
+    ) -> Result<(TokenAmount, bool, bool), ActorError>
     where
         BS: Blockstore,
     {
@@ -595,7 +595,7 @@ impl State {
         // This would be the case that the first callback somehow triggers before it is scheduled to
         // This is expected not to be able to happen
         if deal.start_epoch > epoch {
-            return Ok((TokenAmount::zero(), false));
+            return Ok((TokenAmount::zero(), false, false));
         }
 
         let payment_end_epoch = if ever_slashed {
@@ -654,14 +654,14 @@ impl State {
             self.slash_balance(store, &deal.provider, &slashed, Reason::ProviderCollateral)
                 .context("slashing balance")?;
 
-            return Ok((slashed, true));
+            return Ok((slashed, true, false));
         }
 
         if epoch >= deal.end_epoch {
             self.process_deal_expired(store, deal, state)?;
-            return Ok((TokenAmount::zero(), true));
+            return Ok((TokenAmount::zero(), true, true));
         }
-        Ok((TokenAmount::zero(), false))
+        Ok((TokenAmount::zero(), false, false))
     }
 
     /// Deal start deadline elapsed without appearing in a proven sector.

--- a/actors/market/tests/activate_deal_failures.rs
+++ b/actors/market/tests/activate_deal_failures.rs
@@ -38,6 +38,7 @@ fn fail_when_caller_is_not_the_provider_of_the_deal() {
             deal_ids: vec![deal_id],
         }],
         false,
+        vec![],
     )
     .unwrap();
     let res: BatchActivateDealsResult =
@@ -87,6 +88,7 @@ fn fail_when_deal_has_not_been_published_before() {
             deal_ids: vec![DealID::from(42u32)],
         }],
         false,
+        vec![],
     )
     .unwrap();
     let res: BatchActivateDealsResult =
@@ -123,6 +125,7 @@ fn fail_when_deal_has_already_been_activated() {
             deal_ids: vec![deal_id],
         }],
         false,
+        vec![],
     )
     .unwrap();
     let res: BatchActivateDealsResult =
@@ -169,6 +172,6 @@ fn fail_when_deal_has_already_been_expired() {
     let mut st: State = rt.get_state::<State>();
     st.next_id = deal_id + 1;
 
-    let res = activate_deals(&rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id]);
+    let res = activate_deals_for(&rt, sector_expiry, PROVIDER_ADDR, 0, &[deal_id], vec![]);
     assert_eq!(res.activation_results.codes(), vec![EX_DEAL_EXPIRED])
 }

--- a/actors/market/tests/batch_activate_deals.rs
+++ b/actors/market/tests/batch_activate_deals.rs
@@ -121,7 +121,8 @@ fn sectors_fail_and_succeed_independently_during_batch_activation() {
         SectorDeals { deal_ids: vec![id_4], sector_type, sector_expiry: END_EPOCH + 2 }, // sector succeeds
     ];
 
-    let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals, false).unwrap();
+    let res =
+        batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals, false, vec![id_4]).unwrap();
     let res: BatchActivateDealsResult =
         res.unwrap().deserialize().expect("VerifyDealsForActivation failed!");
 
@@ -172,7 +173,8 @@ fn handles_sectors_empty_of_deals_gracefully() {
         SectorDeals { deal_ids: vec![], sector_type, sector_expiry: END_EPOCH + 2 }, // empty sector
     ];
 
-    let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals, false).unwrap();
+    let res =
+        batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals, false, vec![id_1]).unwrap();
     let res: BatchActivateDealsResult =
         res.unwrap().deserialize().expect("VerifyDealsForActivation failed!");
 
@@ -221,7 +223,8 @@ fn fails_to_activate_sectors_containing_duplicate_deals() {
         SectorDeals { deal_ids: vec![id_3], sector_type, sector_expiry: END_EPOCH },
     ];
 
-    let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals, false).unwrap();
+    let res = batch_activate_deals_raw(&rt, PROVIDER_ADDR, sectors_deals, false, vec![id_1, id_3])
+        .unwrap();
     let res: BatchActivateDealsResult =
         res.unwrap().deserialize().expect("VerifyDealsForActivation failed!");
 

--- a/actors/market/tests/cron_tick_deal_expiry.rs
+++ b/actors/market/tests/cron_tick_deal_expiry.rs
@@ -171,11 +171,7 @@ fn expired_deal_should_unlock_the_remaining_client_and_provider_locked_balance_a
 
     // move the current epoch so that deal is expired
     rt.expect_emitted_event(
-        EventBuilder::new()
-            .typ("deal-completed")
-            .field_indexed("deal_id", &deal_id)
-            .build()
-            .unwrap(),
+        EventBuilder::new().typ("deal-completed").field_indexed("id", &deal_id).build().unwrap(),
     );
     rt.set_epoch(END_EPOCH + 1000);
     cron_tick(&rt);
@@ -213,11 +209,7 @@ fn all_payments_are_made_for_a_deal_client_withdraws_collateral_and_client_accou
     // move the current epoch so that deal is expired
     rt.set_epoch(END_EPOCH + 100);
     rt.expect_emitted_event(
-        EventBuilder::new()
-            .typ("deal-completed")
-            .field_indexed("deal_id", &deal_id)
-            .build()
-            .unwrap(),
+        EventBuilder::new().typ("deal-completed").field_indexed("id", &deal_id).build().unwrap(),
     );
     cron_tick(&rt);
     assert_eq!(deal_proposal.client_collateral, get_balance(&rt, &CLIENT_ADDR).balance);

--- a/actors/market/tests/cron_tick_deal_expiry.rs
+++ b/actors/market/tests/cron_tick_deal_expiry.rs
@@ -3,6 +3,7 @@
 
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::Policy;
+use fil_actors_runtime::EventBuilder;
 use fvm_shared::clock::ChainEpoch;
 
 mod harness;
@@ -40,6 +41,7 @@ fn deal_is_correctly_processed_if_first_cron_after_expiry() {
     // total payment = (end - start)
     let current = END_EPOCH + 5;
     rt.set_epoch(current);
+
     let (pay, slashed) =
         cron_tick_and_assert_balances(&rt, CLIENT_ADDR, PROVIDER_ADDR, current, deal_id);
     let duration = END_EPOCH - START_EPOCH;
@@ -168,6 +170,13 @@ fn expired_deal_should_unlock_the_remaining_client_and_provider_locked_balance_a
     let p_escrow = get_balance(&rt, &PROVIDER_ADDR).balance;
 
     // move the current epoch so that deal is expired
+    rt.expect_emitted_event(
+        EventBuilder::new()
+            .typ("deal-completed")
+            .field_indexed("deal_id", &deal_id)
+            .build()
+            .unwrap(),
+    );
     rt.set_epoch(END_EPOCH + 1000);
     cron_tick(&rt);
 
@@ -203,6 +212,13 @@ fn all_payments_are_made_for_a_deal_client_withdraws_collateral_and_client_accou
 
     // move the current epoch so that deal is expired
     rt.set_epoch(END_EPOCH + 100);
+    rt.expect_emitted_event(
+        EventBuilder::new()
+            .typ("deal-completed")
+            .field_indexed("deal_id", &deal_id)
+            .build()
+            .unwrap(),
+    );
     cron_tick(&rt);
     assert_eq!(deal_proposal.client_collateral, get_balance(&rt, &CLIENT_ADDR).balance);
 

--- a/actors/market/tests/cron_tick_deal_slashing.rs
+++ b/actors/market/tests/cron_tick_deal_slashing.rs
@@ -130,7 +130,7 @@ fn deal_is_slashed_at_the_end_epoch_should_not_be_slashed_and_should_be_consider
     // as deal is considered to be expired.
 
     rt.set_epoch(END_EPOCH);
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id]);
+    terminate_deals_for(&rt, PROVIDER_ADDR, &[deal_id], vec![]);
 
     // on the next cron tick, it will be processed as expired
     let current = END_EPOCH + 300;
@@ -352,7 +352,7 @@ fn regular_payments_till_deal_expires_and_then_we_attempt_to_slash_it_but_it_wil
     // as deal is considered to be expired.
     let duration = END_EPOCH - current;
     rt.set_epoch(END_EPOCH);
-    terminate_deals(&rt, PROVIDER_ADDR, &[deal_id]);
+    terminate_deals_for(&rt, PROVIDER_ADDR, &[deal_id], vec![]);
 
     // next epoch for cron schedule is endEpoch + 300 ->
     // setting epoch to higher than that will cause deal to be expired, payment will be made

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -404,7 +404,7 @@ pub fn batch_activate_deals_raw(
         rt.expect_emitted_event(
             EventBuilder::new()
                 .typ("deal-activated")
-                .field_indexed("deal_id", &deal_id)
+                .field_indexed("id", &deal_id)
                 .build()
                 .unwrap(),
         );
@@ -528,7 +528,7 @@ pub fn cron_tick_and_assert_balances(
         rt.expect_emitted_event(
             EventBuilder::new()
                 .typ("deal-completed")
-                .field_indexed("deal_id", &deal_id)
+                .field_indexed("id", &deal_id)
                 .build()
                 .unwrap(),
         );
@@ -730,7 +730,7 @@ pub fn publish_deals(
                 .typ("deal-published")
                 .field_indexed("client", &deal.client.id().unwrap())
                 .field_indexed("provider", &deal.provider.id().unwrap())
-                .field_indexed("deal_id", &deal_id)
+                .field_indexed("id", &deal_id)
                 .build()
                 .unwrap(),
         );
@@ -1197,10 +1197,7 @@ pub fn terminate_deals_raw(
 
     for deal_id in terminated_deals {
         rt.expect_emitted_event(
-            EventBuilder::new()
-                .typ("deal-terminated")
-                .field_indexed("deal_id", &deal_id)
-                .build()?,
+            EventBuilder::new().typ("deal-terminated").field_indexed("id", &deal_id).build()?,
         );
     }
 

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -524,6 +524,16 @@ pub fn cron_tick_and_assert_balances(
         updated_provider_locked = TokenAmount::zero();
     }
 
+    if is_deal_expired {
+        rt.expect_emitted_event(
+            EventBuilder::new()
+                .typ("deal-completed")
+                .field_indexed("deal_id", &deal_id)
+                .build()
+                .unwrap(),
+        );
+    }
+
     cron_tick(rt);
 
     let client_acct = get_balance(rt, &client_addr);

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -29,8 +29,8 @@ use fil_actors_runtime::{
     network::EPOCHS_IN_DAY,
     runtime::{builtins::Type, Policy, Runtime},
     test_utils::*,
-    ActorError, BatchReturn, Set, SetMultimap, BURNT_FUNDS_ACTOR_ADDR, CRON_ACTOR_ADDR,
-    DATACAP_TOKEN_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
+    ActorError, BatchReturn, EventBuilder, Set, SetMultimap, BURNT_FUNDS_ACTOR_ADDR,
+    CRON_ACTOR_ADDR, DATACAP_TOKEN_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
     STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use fvm_ipld_encoding::ipld_block::IpldBlock;
@@ -687,6 +687,17 @@ pub fn publish_deals(
             None,
             ExitCode::OK,
         );
+
+        rt.expect_emitted_event(
+            EventBuilder::new()
+                .typ("deal-published")
+                .field_indexed("client", &deal.client.id().unwrap())
+                .field_indexed("provider", &deal.provider.id().unwrap())
+                .field_indexed("deal_id", &deal_id)
+                .build()
+                .unwrap(),
+        );
+
         deal_id += 1;
     }
 

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -15,7 +15,7 @@ use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::{Policy, Runtime, RuntimePolicy};
 use fil_actors_runtime::test_utils::*;
 use fil_actors_runtime::{
-    make_empty_map, ActorError, BatchReturn, SetMultimap, BURNT_FUNDS_ACTOR_ADDR,
+    make_empty_map, ActorError, BatchReturn, EventBuilder, SetMultimap, BURNT_FUNDS_ACTOR_ADDR,
     DATACAP_TOKEN_ACTOR_ADDR, EPOCHS_IN_YEAR, SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use frc46_token::token::types::{TransferFromParams, TransferFromReturn};
@@ -942,6 +942,16 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
         TokenAmount::zero(),
         None,
         ExitCode::OK,
+    );
+
+    rt.expect_emitted_event(
+        EventBuilder::new()
+            .typ("deal-published")
+            .field_indexed("client", &client_resolved.id().unwrap())
+            .field_indexed("provider", &provider_resolved.id().unwrap())
+            .field_indexed("deal_id", &deal_id)
+            .build()
+            .unwrap(),
     );
 
     let ret: PublishStorageDealsReturn = rt
@@ -2132,6 +2142,15 @@ fn insufficient_client_balance_in_a_batch() {
         None,
         ExitCode::OK,
     );
+    rt.expect_emitted_event(
+        EventBuilder::new()
+            .typ("deal-published")
+            .field_indexed("client", &deal2.client.id().unwrap())
+            .field_indexed("provider", &deal2.provider.id().unwrap())
+            .field_indexed("deal_id", &next_deal_id)
+            .build()
+            .unwrap(),
+    );
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
 
@@ -2271,6 +2290,15 @@ fn insufficient_provider_balance_in_a_batch() {
         TokenAmount::zero(),
         None,
         ExitCode::OK,
+    );
+    rt.expect_emitted_event(
+        EventBuilder::new()
+            .typ("deal-published")
+            .field_indexed("client", &deal2.client.id().unwrap())
+            .field_indexed("provider", &deal2.provider.id().unwrap())
+            .field_indexed("deal_id", &next_deal_id)
+            .build()
+            .unwrap(),
     );
 
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, WORKER_ADDR);
@@ -2414,6 +2442,15 @@ fn psd_restricted_correctly() {
         TokenAmount::zero(),
         None,
         ExitCode::OK,
+    );
+    rt.expect_emitted_event(
+        EventBuilder::new()
+            .typ("deal-published")
+            .field_indexed("client", &deal.client.id().unwrap())
+            .field_indexed("provider", &deal.provider.id().unwrap())
+            .field_indexed("deal_id", &next_deal_id)
+            .build()
+            .unwrap(),
     );
 
     let ret: PublishStorageDealsReturn = rt

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -1716,6 +1716,7 @@ fn fail_when_current_epoch_greater_than_start_epoch_of_deal() {
             deal_ids: vec![deal_id],
         }],
         false,
+        vec![],
     )
     .unwrap();
 
@@ -1751,6 +1752,7 @@ fn fail_when_end_epoch_of_deal_greater_than_sector_expiry() {
             deal_ids: vec![deal_id],
         }],
         false,
+        vec![],
     )
     .unwrap();
 
@@ -1797,6 +1799,7 @@ fn fail_to_activate_all_deals_if_one_deal_fails() {
             deal_ids: vec![deal_id1, deal_id2],
         }],
         false,
+        vec![],
     )
     .unwrap();
     let res: BatchActivateDealsResult =

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -949,7 +949,7 @@ fn provider_and_client_addresses_are_resolved_before_persisting_state_and_sent_t
             .typ("deal-published")
             .field_indexed("client", &client_resolved.id().unwrap())
             .field_indexed("provider", &provider_resolved.id().unwrap())
-            .field_indexed("deal_id", &deal_id)
+            .field_indexed("id", &deal_id)
             .build()
             .unwrap(),
     );
@@ -1937,11 +1937,7 @@ fn locked_fund_tracking_states() {
     );
 
     rt.expect_emitted_event(
-        EventBuilder::new()
-            .typ("deal-completed")
-            .field_indexed("deal_id", &deal_id2)
-            .build()
-            .unwrap(),
+        EventBuilder::new().typ("deal-completed").field_indexed("id", &deal_id2).build().unwrap(),
     );
     cron_tick(&rt);
     assert_locked_fund_states(&rt, csf, plc, clc);
@@ -2158,7 +2154,7 @@ fn insufficient_client_balance_in_a_batch() {
             .typ("deal-published")
             .field_indexed("client", &deal2.client.id().unwrap())
             .field_indexed("provider", &deal2.provider.id().unwrap())
-            .field_indexed("deal_id", &next_deal_id)
+            .field_indexed("id", &next_deal_id)
             .build()
             .unwrap(),
     );
@@ -2307,7 +2303,7 @@ fn insufficient_provider_balance_in_a_batch() {
             .typ("deal-published")
             .field_indexed("client", &deal2.client.id().unwrap())
             .field_indexed("provider", &deal2.provider.id().unwrap())
-            .field_indexed("deal_id", &next_deal_id)
+            .field_indexed("id", &next_deal_id)
             .build()
             .unwrap(),
     );
@@ -2459,7 +2455,7 @@ fn psd_restricted_correctly() {
             .typ("deal-published")
             .field_indexed("client", &deal.client.id().unwrap())
             .field_indexed("provider", &deal.provider.id().unwrap())
-            .field_indexed("deal_id", &next_deal_id)
+            .field_indexed("id", &next_deal_id)
             .build()
             .unwrap(),
     );

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -1935,6 +1935,14 @@ fn locked_fund_tracking_states() {
         None,
         ExitCode::OK,
     );
+
+    rt.expect_emitted_event(
+        EventBuilder::new()
+            .typ("deal-completed")
+            .field_indexed("deal_id", &deal_id2)
+            .build()
+            .unwrap(),
+    );
     cron_tick(&rt);
     assert_locked_fund_states(&rt, csf, plc, clc);
     check_state(&rt);

--- a/actors/market/tests/on_miner_sectors_terminate.rs
+++ b/actors/market/tests/on_miner_sectors_terminate.rs
@@ -7,6 +7,7 @@ use fil_actor_market::{Actor as MarketActor, Method, OnMinerSectorsTerminatePara
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::test_utils::*;
+use fil_actors_runtime::EventBuilder;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
 use fvm_shared::deal::DealID;
@@ -173,6 +174,13 @@ fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
     assert_eq!(2, deal_ids.len());
     activate_deals(&rt, sector_expiry, PROVIDER_ADDR, current_epoch, &deal_ids);
 
+    rt.expect_emitted_event(
+        EventBuilder::new()
+            .typ("deal-completed")
+            .field_indexed("deal_id", &deal_ids[1])
+            .build()
+            .unwrap(),
+    );
     let new_epoch = end_epoch - 1;
     rt.set_epoch(new_epoch);
     cron_tick(&rt);

--- a/actors/market/tests/on_miner_sectors_terminate.rs
+++ b/actors/market/tests/on_miner_sectors_terminate.rs
@@ -181,6 +181,7 @@ fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
             .build()
             .unwrap(),
     );
+    
     let new_epoch = end_epoch - 1;
     rt.set_epoch(new_epoch);
     cron_tick(&rt);

--- a/actors/market/tests/on_miner_sectors_terminate.rs
+++ b/actors/market/tests/on_miner_sectors_terminate.rs
@@ -181,7 +181,7 @@ fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
             .build()
             .unwrap(),
     );
-    
+
     let new_epoch = end_epoch - 1;
     rt.set_epoch(new_epoch);
     cron_tick(&rt);

--- a/actors/market/tests/on_miner_sectors_terminate.rs
+++ b/actors/market/tests/on_miner_sectors_terminate.rs
@@ -177,7 +177,7 @@ fn terminate_valid_deals_along_with_expired_and_cleaned_up_deal() {
     rt.expect_emitted_event(
         EventBuilder::new()
             .typ("deal-completed")
-            .field_indexed("deal_id", &deal_ids[1])
+            .field_indexed("id", &deal_ids[1])
             .build()
             .unwrap(),
     );

--- a/actors/market/tests/publish_storage_deals_failures.rs
+++ b/actors/market/tests/publish_storage_deals_failures.rs
@@ -381,7 +381,7 @@ fn fail_when_deals_have_different_providers() {
             .typ("deal-published")
             .field_indexed("client", &deal1.client.id().unwrap())
             .field_indexed("provider", &deal1.provider.id().unwrap())
-            .field_indexed("deal_id", &next_deal_id)
+            .field_indexed("id", &next_deal_id)
             .build()
             .unwrap(),
     );

--- a/actors/market/tests/publish_storage_deals_failures.rs
+++ b/actors/market/tests/publish_storage_deals_failures.rs
@@ -25,6 +25,7 @@ use fil_actor_market::ext::account::{AuthenticateMessageParams, AUTHENTICATE_MES
 
 mod harness;
 
+use fil_actors_runtime::EventBuilder;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::sys::SendFlags;
 use harness::*;
@@ -374,6 +375,15 @@ fn fail_when_deals_have_different_providers() {
         TokenAmount::zero(),
         None,
         ExitCode::OK,
+    );
+    rt.expect_emitted_event(
+        EventBuilder::new()
+            .typ("deal-published")
+            .field_indexed("client", &deal1.client.id().unwrap())
+            .field_indexed("provider", &deal1.provider.id().unwrap())
+            .field_indexed("deal_id", &next_deal_id)
+            .build()
+            .unwrap(),
     );
 
     let psd_ret: PublishStorageDealsReturn = rt

--- a/actors/market/tests/random_cron_epoch_during_publish.rs
+++ b/actors/market/tests/random_cron_epoch_during_publish.rs
@@ -134,7 +134,7 @@ fn activation_after_deal_start_epoch_but_before_it_is_processed_fails() {
     let curr_epoch = START_EPOCH + 1;
     rt.set_epoch(curr_epoch);
 
-    let res = activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, curr_epoch, &[deal_id]);
+    let res = activate_deals_for(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, curr_epoch, &[deal_id], vec![]);
     assert_eq!(res.activation_results.codes(), vec![ExitCode::USR_ILLEGAL_ARGUMENT]);
     check_state(&rt);
 }


### PR DESCRIPTION
For #1464 .

This PR contains Market Actor events for the following deal lifecycle events:

1. Deal published
2. Deal activated
3. Deal terminated (when a sector is terminated by the Miner -> all deals in the sector get terminated)
4. Deal activated

We do not emit events for expired deals i.e. deals that have been published but not activated by their start epoch as that only ever happens in the cron job.