### PR TITLE
chore: update fvm/helix libraries to to the final released versions (#1475)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "frc42_dispatch"
-version = "5.0.0-alpha.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646103488de23b15af472fd22e81f16eacf821e2b6b921f16961315e192fa34f"
+checksum = "cfe63cf3ff3e332ef15fd19d95cffcb3fd2af14ccb3cb04abc730271c1362c4f"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
@@ -1915,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "frc42_hasher"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19727efce9e1cdd535791c75de2d9813080d2ab39c0434ec9e7a6c858df6a926"
+checksum = "08a35e7214108f81cefc17b0466be01279f384faf913918a12dbc8528bb758a4"
 dependencies = [
  "fvm_sdk",
  "fvm_shared",
@@ -1926,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "frc42_macros"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08689c30919b9706463b63809b6ee02b5a7ca34307ca7afd5fd39da48bfff42"
+checksum = "6f50cd62b077775194bde67eef8076b31f915b9c099f3a7fd1a760363d65f145"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "frc46_token"
-version = "9.0.0-alpha.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9576de352ca5767fcaa7b8bb9ba3cf973b0f1db3afbb44f6a471f2fdc14fa87d"
+checksum = "02d3e91e8d92fcd274d4e56cbbec093c4c7613cd294b6c8a855dacc4f9dfff9c"
 dependencies = [
  "cid 0.10.1",
  "frc42_dispatch",
@@ -2090,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_actor_utils"
-version = "9.0.0-alpha.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bdb80dc2a6e3a6ccefd0c04c762ee96c6f1596367282da437ecb47fa046533d"
+checksum = "1227ae02b9395085d6b4e7e4f5d7ea2fcbfd13197fade8fa8eaba8089b8865d3"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -2218,9 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.0.0-alpha.4"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081816d6e5b7832beca5f906e16108e63a288b8b0c314bacbd47e56348a7fd63"
+checksum = "258cfc9a2e5dcb28ffcadd4abed504893996d31238488a07ef7d2a6a6e80e1ec"
 dependencies = [
  "byteorder",
  "cid 0.10.1",
@@ -2234,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.0.0-alpha.4"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022bdee26d3a256905d6430b66099868ff7a439a8ceb22c0f351843aa7c5f394"
+checksum = "c3a19ef48bbc1b22742002667b82944237cfdebc38e946c216aa8de1192392ea"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,13 +109,13 @@ libipld-core = { version = "0.13.1", features = ["serde-codec"] }
 integer-encoding = { version = "3.0.3", default-features = false }
 
 # helix-onchain
-fvm_actor_utils = "9.0.0-alpha.1"
-frc42_dispatch = "5.0.0-alpha.1"
-frc46_token = "9.0.0-alpha.1"
+fvm_actor_utils = "9.0.0"
+frc42_dispatch = "5.0.0"
+frc46_token = "9.0.0"
 
 # FVM
-fvm_sdk = "4.0.0-alpha.4"
-fvm_shared = "4.0.0-alpha.4"
+fvm_sdk = "~4.0"
+fvm_shared = "~4.0"
 fvm_ipld_encoding = "0.4.0"
 fvm_ipld_blockstore = "0.2.0"
 fvm_ipld_hamt = "0.8.0"


### PR DESCRIPTION
Forward port of #1475.