### PR TITLE
Verifreg Actor events should contain client and provider Actor IDs

### DIFF
--- a/actors/verifreg/src/emit.rs
+++ b/actors/verifreg/src/emit.rs
@@ -24,26 +24,75 @@ pub fn verifier_balance(
 }
 
 /// Indicates a new allocation has been made.
-pub fn allocation(rt: &impl Runtime, id: AllocationID) -> Result<(), ActorError> {
-    rt.emit_event(&EventBuilder::new().typ("allocation").field_indexed("id", &id).build()?)
+pub fn allocation(
+    rt: &impl Runtime,
+    id: AllocationID,
+    client: ActorID,
+    provider: ActorID,
+) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new().typ("allocation").with_parties(id, client, provider).build()?,
+    )
 }
 
 /// Indicates an expired allocation has been removed.
-pub fn allocation_removed(rt: &impl Runtime, id: AllocationID) -> Result<(), ActorError> {
-    rt.emit_event(&EventBuilder::new().typ("allocation-removed").field_indexed("id", &id).build()?)
+pub fn allocation_removed(
+    rt: &impl Runtime,
+    id: AllocationID,
+    client: ActorID,
+    provider: ActorID,
+) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new()
+            .typ("allocation-removed")
+            .with_parties(id, client, provider)
+            .build()?,
+    )
 }
 
 /// Indicates an allocation has been claimed.
-pub fn claim(rt: &impl Runtime, id: ClaimID) -> Result<(), ActorError> {
-    rt.emit_event(&EventBuilder::new().typ("claim").field_indexed("id", &id).build()?)
+pub fn claim(
+    rt: &impl Runtime,
+    id: ClaimID,
+    client: ActorID,
+    provider: ActorID,
+) -> Result<(), ActorError> {
+    rt.emit_event(&EventBuilder::new().typ("claim").with_parties(id, client, provider).build()?)
 }
 
 /// Indicates an existing claim has been updated (e.g. with a longer term).
-pub fn claim_updated(rt: &impl Runtime, id: ClaimID) -> Result<(), ActorError> {
-    rt.emit_event(&EventBuilder::new().typ("claim-updated").field_indexed("id", &id).build()?)
+pub fn claim_updated(
+    rt: &impl Runtime,
+    id: ClaimID,
+    client: ActorID,
+    provider: ActorID,
+) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new().typ("claim-updated").with_parties(id, client, provider).build()?,
+    )
 }
 
 /// Indicates an expired claim has been removed.
-pub fn claim_removed(rt: &impl Runtime, id: ClaimID) -> Result<(), ActorError> {
-    rt.emit_event(&EventBuilder::new().typ("claim-removed").field_indexed("id", &id).build()?)
+pub fn claim_removed(
+    rt: &impl Runtime,
+    id: ClaimID,
+    client: ActorID,
+    provider: ActorID,
+) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new().typ("claim-removed").with_parties(id, client, provider).build()?,
+    )
+}
+
+// Private helpers //
+trait WithParties {
+    fn with_parties(self, id: AllocationID, client: ActorID, provider: ActorID) -> EventBuilder;
+}
+
+impl WithParties for EventBuilder {
+    fn with_parties(self, id: AllocationID, client: ActorID, provider: ActorID) -> EventBuilder {
+        self.field_indexed("id", &id)
+            .field_indexed("client", &client)
+            .field_indexed("provider", &provider)
+    }
 }


### PR DESCRIPTION
For #1464.

Based on discussion at https://github.com/filecoin-project/builtin-actors/pull/1471#discussion_r1376888379.