### PR TITLE
Specify version, license and other metadata in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,28 @@
+[workspace]
+resolver = "2"
+members = [
+     "actors/*",
+     "state",
+     "runtime",
+     "test_vm",
+     "vm_api",
+     "integration_tests"
+]
+
+[workspace.package]
+version = "12.0.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+repository = "https://github.com/filecoin-project/builtin-actors"
+
 [package]
 name = "fil_builtin_actors_bundle"
 description = "Bundle of FVM-compatible Wasm bytecode for Filecoin builtin actors"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 exclude = ["examples", ".github"]
 
@@ -48,17 +65,6 @@ calibrationnet = []
 devnet = []
 testing = []
 testing-fake-proofs = []
-
-[workspace]
-resolver = "2"
-members = [
-     "actors/*",
-     "state",
-     "runtime",
-     "test_vm",
-     "vm_api",
-     "integration_tests"
-]
 
 [workspace.dependencies]
 # Common
@@ -124,28 +130,28 @@ fvm_ipld_amt = { version = "0.6.2" }
 fvm_ipld_bitfield = "0.6.0"
 
 # workspace
-fil_actor_account = { version = "12.0.0", path = "actors/account" }
-fil_actor_cron = { version = "12.0.0", path = "actors/cron" }
-fil_actor_datacap = { version = "12.0.0", path = "actors/datacap" }
-fil_actor_eam = { version = "12.0.0", path = "actors/eam" }
-fil_actor_ethaccount = { version = "12.0.0", path = "actors/ethaccount" }
-fil_actor_evm = { version = "12.0.0", path = "actors/evm" }
-fil_actor_init = { version = "12.0.0", path = "actors/init" }
-fil_actor_market = { version = "12.0.0", path = "actors/market" }
-fil_actor_miner = { version = "12.0.0", path = "actors/miner" }
-fil_actor_multisig = { version = "12.0.0", path = "actors/multisig" }
-fil_actor_paych = { version = "12.0.0", path = "actors/paych" }
-fil_actor_placeholder = { version = "12.0.0", path = "actors/placeholder" }
-fil_actor_power = { version = "12.0.0", path = "actors/power" }
-fil_actor_reward = { version = "12.0.0", path = "actors/reward" }
-fil_actor_system = { version = "12.0.0", path = "actors/system" }
-fil_actor_verifreg = { version = "12.0.0", path = "actors/verifreg" }
-fil_actors_evm_shared = { version = "12.0.0", path = "actors/evm/shared" }
-fil_actors_runtime = { version = "12.0.0", path = "runtime" }
-fil_builtin_actors_state = { version = "12.0.0", path = "state"}
+fil_actor_account = { path = "actors/account" }
+fil_actor_cron = { path = "actors/cron" }
+fil_actor_datacap = { path = "actors/datacap" }
+fil_actor_eam = { path = "actors/eam" }
+fil_actor_ethaccount = { path = "actors/ethaccount" }
+fil_actor_evm = { path = "actors/evm" }
+fil_actor_init = { path = "actors/init" }
+fil_actor_market = { path = "actors/market" }
+fil_actor_miner = { path = "actors/miner" }
+fil_actor_multisig = { path = "actors/multisig" }
+fil_actor_paych = { path = "actors/paych" }
+fil_actor_placeholder = { path = "actors/placeholder" }
+fil_actor_power = { path = "actors/power" }
+fil_actor_reward = { path = "actors/reward" }
+fil_actor_system = { path = "actors/system" }
+fil_actor_verifreg = { path = "actors/verifreg" }
+fil_actors_evm_shared = { path = "actors/evm/shared" }
+fil_actors_runtime = { path = "runtime" }
+fil_builtin_actors_state = { path = "state"}
 fil_actors_integration_tests = { version = "1.0.0", path = "integration_tests" }
 vm_api = { version = "1.0.0", path = "vm_api" }
-test_vm = { version = "12.0.0", path = "test_vm" }
+test_vm = { path = "test_vm" }
 
 [patch.crates-io]
 #fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }

--- a/actors/account/Cargo.toml
+++ b/actors/account/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "fil_actor_account"
 description = "Builtin account actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/cron/Cargo.toml
+++ b/actors/cron/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_cron"
 description = "Builtin cron actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_datacap"
 description = "Builtin data cap actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/eam/Cargo.toml
+++ b/actors/eam/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_eam"
 description = "Builtin Ethereum address manager actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm", "evm"]
 
 [lib]

--- a/actors/ethaccount/Cargo.toml
+++ b/actors/ethaccount/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_ethaccount"
 description = "Builtin Ethereum Externally Owned Address actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm", "evm"]
 
 [lib]

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_evm"
 description = "Builtin EVM actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm", "evm"]
 exclude = ["/precompile-testdata", "/tests/measurements", "/tests/contracts"]
 

--- a/actors/evm/shared/Cargo.toml
+++ b/actors/evm/shared/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actors_evm_shared"
 description = "Shared libraries for the built-in EVM actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm", "evm"]
 
 [dependencies]

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_init"
 description = "Builtin init actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_market"
 description = "Builtin market actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_miner"
 description = "Builtin miner actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_multisig"
 description = "Builtin multisig actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_paych"
 description = "Builtin paych actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/placeholder/Cargo.toml
+++ b/actors/placeholder/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "fil_actor_placeholder"
 description = "Builtin placeholder actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_power"
 description = "Builtin power actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_reward"
 description = "Builtin reward actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_system"
 description = "Builtin system actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actor_verifreg"
 description = "Builtin verifreg actor for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_actors_runtime"
 description = "System actors for the Filecoin protocol"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 
 [dependencies]
 anyhow = { workspace = true }
@@ -33,7 +33,7 @@ serde = { workspace = true }
 serde_repr = { workspace = true }
 thiserror = { workspace = true }
 unsigned-varint = { workspace = true }
-vm_api = { workspace = true } 
+vm_api = { workspace = true }
 
 # A fake-proofs dependency but... we can't select on that feature here because we enable it from
 # build.rs.

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fil_builtin_actors_state"
 description = "Builtin Actor state utils for Filecoin"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 authors = ["ChainSafe Systems <info@chainsafe.io>", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
-repository = "https://github.com/filecoin-project/builtin-actors"
 keywords = ["filecoin", "web3", "wasm"]
 
 [lib]

--- a/test_vm/Cargo.toml
+++ b/test_vm/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "test_vm"
 description = "Reference vm for integration testing builtin actors"
-version = "12.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
 authors = ["Protocol Labs", "Filecoin Core Devs"]
-edition = "2021"
 keywords = ["filecoin", "web3", "wasm"]
 publish = false
 


### PR DESCRIPTION
This PR updates the root workspace to specify version, license, and other metadata which we then refer to in all subcrates.

This means, bumping builtin-actor version now only requires changing the version in one place instead of touching 20+ crates (like in https://github.com/filecoin-project/builtin-actors/pull/1286)