### PR TITLE
Take the batch builder by-value

### DIFF
--- a/runtime/src/util/batch_return.rs
+++ b/runtime/src/util/batch_return.rs
@@ -170,12 +170,9 @@ impl BatchReturnGen {
         }
     }
 
-    pub fn gen(&self) -> BatchReturn {
+    pub fn gen(self) -> BatchReturn {
         assert_eq!(self.expect_count, self.success_count + self.fail_codes.len(), "programmer error, mismatched batch size {} and processed count {} batch return must include success/fail for all inputs", self.expect_count, self.success_count + self.fail_codes.len());
-        BatchReturn {
-            success_count: self.success_count as u32,
-            fail_codes: self.fail_codes.clone(),
-        }
+        BatchReturn { success_count: self.success_count as u32, fail_codes: self.fail_codes }
     }
 }
 


### PR DESCRIPTION
Small nit, but builders generally take `self` by value to avoid cloning necessarily.