### PR TITLE
chore: remove unused targets from the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
 SHELL=/usr/bin/env bash
 
-# How much to "bump" the version by on release.
-BUMP ?= patch
-VERSION ?= $(error VERSION environment variable must be set)
-
 # Run cargo fmt
 rustfmt:
 	cargo fmt --all --check
@@ -19,21 +15,6 @@ check:
 # Run cargo test
 test:
 	cargo test --workspace
-
-# Release a new version. Specify the version "bump" with BUMP
-bump-version: check-clean deps-release check
-	cargo set-version --workspace --bump $(BUMP)
-	cargo update --workspace
-	@echo "Bumped actors to version $$($(MAKE) --quiet version)"
-
-set-version: check-clean deps-release check
-	cargo set-version --workspace $(VERSION)
-	cargo update --workspace
-	@echo "Set actors to version $(VERSION)"
-
-# Publish the current version to crates.io
-publish:
-	cargo workspaces publish --from-git
 
 # Create a bundle in a deterministic location
 bundle:
@@ -61,8 +42,6 @@ bundle-testing:
 	BUILD_FIL_NETWORK=testing cargo run -- -o output/builtin-actors-testing.car
 	BUILD_FIL_NETWORK=testing-fake-proofs cargo run -- -o output/builtin-actors-testing-fake-proofs.car
 
-.PHONY: all-bundles bundle-mainnet bundle-caterpillarnet bundle-butterflynet bundle-calibrationnet bundle-devnet bundle-testing
-
 # Check if the working tree is clean.
 check-clean:
 	@git diff --quiet || { \
@@ -70,15 +49,5 @@ check-clean:
 		exit 1; \
 	}
 
-# Check if we have the required deps.
-deps-release:
-	@which cargo-set-version >/dev/null 2>&1 || { \
-		echo "Please install cargo-edit: 'cargo install cargo-edit'."; \
-		exit 1; \
-	}
-	@which cargo-workspaces >/dev/null 2>&1 || { \
-		echo "Please install cargo-workspaces: 'cargo install cargo-workspaces'."; \
-		exit 1; \
-	}
-
-.PHONY: check check-clean deps deps-release deps-release test publish bump-version set-version bundle
+.PHONY: rustfmt check check-clean test bundle
+.PHONY: all-bundles bundle-mainnet bundle-caterpillarnet bundle-butterflynet bundle-calibrationnet bundle-devnet bundle-testing


### PR DESCRIPTION
We now bump the version by editing the workspace `Cargo.toml`. The README will be fixed in a separate patch.