### PR TITLE
Convert SectorDealIDs to an alias for Vec<DealID>, removing struct

### DIFF
--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -564,7 +564,7 @@ impl Actor {
             let mut batch_gen = BatchReturnGen::new(params.sectors.len());
             let mut activations: Vec<SectorDealActivation> = vec![];
             let mut activated_deals: HashSet<DealID> = HashSet::new();
-            let mut sectors_deals: Vec<(SectorNumber, SectorDealIDs)> = vec![];
+            let mut sectors_deals: Vec<(SectorNumber, Vec<DealID>)> = vec![];
 
             'sector: for sector in params.sectors {
                 let mut sector_deal_ids = sector.deal_ids.clone();
@@ -641,8 +641,7 @@ impl Actor {
                     None
                 };
 
-                sectors_deals
-                    .push((sector.sector_number, SectorDealIDs { deals: sector.deal_ids.clone() }));
+                sectors_deals.push((sector.sector_number, sector.deal_ids.clone()));
                 activations.push(SectorDealActivation { activated, unsealed_cid: data_commitment });
 
                 for (deal_id, proposal) in sector.deal_ids.iter().zip(&validated_proposals) {
@@ -686,7 +685,7 @@ impl Actor {
 
             let mut deal_states: Vec<(DealID, DealState)> = vec![];
             let mut activated_deals: HashSet<DealID> = HashSet::new();
-            let mut sectors_deals: Vec<(SectorNumber, SectorDealIDs)> = vec![];
+            let mut sectors_deals: Vec<(SectorNumber, Vec<DealID>)> = vec![];
             let mut sectors_ret: Vec<ext::miner::SectorReturn> = vec![];
 
             for sector in &params.sectors {
@@ -762,7 +761,7 @@ impl Actor {
                     ret.accepted = true;
                 }
 
-                sectors_deals.push((sector.sector, SectorDealIDs { deals: sector_deal_ids }));
+                sectors_deals.push((sector.sector, sector_deal_ids));
                 assert_eq!(pieces_ret.len(), sector.added.len(), "mismatched piece returns");
                 sectors_ret.push(ext::miner::SectorReturn { added: pieces_ret });
             }

--- a/actors/market/tests/harness.rs
+++ b/actors/market/tests/harness.rs
@@ -31,9 +31,9 @@ use fil_actor_market::ext::miner::{
 use fil_actor_market::ext::verifreg::{AllocationID, AllocationRequest, AllocationsResponse};
 use fil_actor_market::{
     deal_cid, deal_get_payment_remaining, BatchActivateDealsParams, BatchActivateDealsResult,
-    PendingDealAllocationsMap, ProviderSectorsMap, SectorDealIDs, SectorDealsMap,
-    SettleDealPaymentsParams, SettleDealPaymentsReturn, PENDING_ALLOCATIONS_CONFIG,
-    PROVIDER_SECTORS_CONFIG, SECTOR_DEALS_CONFIG,
+    PendingDealAllocationsMap, ProviderSectorsMap, SectorDealsMap, SettleDealPaymentsParams,
+    SettleDealPaymentsReturn, PENDING_ALLOCATIONS_CONFIG, PROVIDER_SECTORS_CONFIG,
+    SECTOR_DEALS_CONFIG,
 };
 use fil_actor_market::{
     ext, ext::miner::GetControlAddressesReturnParams, next_update_epoch,
@@ -567,9 +567,9 @@ pub fn get_sector_deal_ids(
         sector_numbers
             .iter()
             .flat_map(|sector_number| {
-                let deals: Option<&SectorDealIDs> = sector_deals.get(sector_number).unwrap();
+                let deals: Option<&Vec<DealID>> = sector_deals.get(sector_number).unwrap();
                 match deals {
-                    Some(deals) => deals.deals.clone(),
+                    Some(deals) => deals.clone(),
                     None => vec![],
                 }
             })

--- a/integration_tests/src/util/mod.rs
+++ b/integration_tests/src/util/mod.rs
@@ -201,7 +201,7 @@ pub fn market_list_sectors_deals(
     let mut found: HashMap<SectorNumber, Vec<DealID>> = HashMap::new();
     sector_deals
         .for_each(|sno, deal_ids| {
-            found.insert(sno, deal_ids.deals.clone());
+            found.insert(sno, deal_ids.clone());
             Ok(())
         })
         .unwrap();


### PR DESCRIPTION
Continuing on from a question I raised in https://github.com/filecoin-project/FIPs/pull/930 about the wrapping of an array in a struct, this is seeing what it looks like with that done in code.