### PR TITLE
Serialise bigint as idiomatic Filecoin form

### DIFF
--- a/actors/verifreg/src/emit.rs
+++ b/actors/verifreg/src/emit.rs
@@ -4,6 +4,7 @@ use crate::{ActorError, AllocationID};
 use crate::{ClaimID, DataCap};
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::EventBuilder;
+use fvm_shared::bigint::bigint_ser::BigIntSer;
 use fvm_shared::ActorID;
 
 /// Indicates a new value for a verifier's datacap balance.
@@ -18,7 +19,7 @@ pub fn verifier_balance(
         &EventBuilder::new()
             .typ("verifier-balance")
             .field_indexed("verifier", &verifier)
-            .field("balance", new_balance)
+            .field("balance", &BigIntSer(new_balance))
             .build()?,
     )
 }

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -143,7 +143,7 @@ impl Harness {
             EventBuilder::new()
                 .typ("verifier-balance")
                 .field_indexed("verifier", &verifier_resolved.id().unwrap())
-                .field("balance", &allowance)
+                .field("balance", &BigIntSer(allowance))
                 .build()?,
         );
 
@@ -166,7 +166,7 @@ impl Harness {
             EventBuilder::new()
                 .typ("verifier-balance")
                 .field_indexed("verifier", &verifier.id().unwrap())
-                .field("balance", &DataCap::zero())
+                .field("balance", &BigIntSer(&DataCap::zero()))
                 .build()?,
         );
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.root);
@@ -234,7 +234,7 @@ impl Harness {
             EventBuilder::new()
                 .typ("verifier-balance")
                 .field_indexed("verifier", &verifier.id().unwrap())
-                .field("balance", &(verifier_balance - allowance))
+                .field("balance", &BigIntSer(&(verifier_balance - allowance)))
                 .build()?,
         );
         let ret = rt.call::<VerifregActor>(

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -1,4 +1,5 @@
 use fvm_shared::address::Address;
+use fvm_shared::bigint::bigint_ser::BigIntSer;
 use lazy_static::lazy_static;
 
 mod harness;
@@ -447,7 +448,7 @@ mod clients {
             EventBuilder::new()
                 .typ("verifier-balance")
                 .field_indexed("verifier", &VERIFIER.id().unwrap())
-                .field("balance", &(allowance_verifier - allowance_client))
+                .field("balance", &BigIntSer(&(allowance_verifier - allowance_client)))
                 .build()
                 .unwrap(),
         );

--- a/integration_tests/src/util/workflows.rs
+++ b/integration_tests/src/util/workflows.rs
@@ -14,6 +14,7 @@ use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::BytesDe;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
+use fvm_shared::bigint::bigint_ser::BigIntSer;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::crypto::signature::SignatureType;
@@ -764,7 +765,7 @@ pub fn verifier_balance_event(verifier: ActorID, data_cap: DataCap) -> EmittedEv
         event: EventBuilder::new()
             .typ("verifier-balance")
             .field_indexed("verifier", &verifier)
-            .field("balance", &data_cap)
+            .field("balance", &BigIntSer(&data_cap))
             .build()
             .unwrap(),
     }


### PR DESCRIPTION
Without this it naively serialises using the underlying Rust BigInt representation:

	[sign,[data,data,...]]

BigInts are going to be a footgun for these events, any time we encounter a `DataCap`, `TokenAmount` or some other `BigInt` wrapper since we need this explicit serde callout. I'll follow up tomorrow with a PR to the FIP-0083 doc to add some clarification around what "bigint" means for serialising this field, then hopefully future FIP authors will take note of that.

---

Example field value from this event without this fix: `8201821a4876e80017` which is `[1,[1215752192,23]]`, or specifically:

```
82                                                # array(2)
  01                                              #   uint(1)
  82                                              #   array(2)
    1a 4876e800                                   #     uint(1215752192)
    17                                            #     uint(23)
```

With this fix we get: `4600174876e800`, or:

```
46                                                # bytes(6)
  00174876e800                                    #   "\x00\x17Hvè\x00"
```

Which decodes with `github.com/filecoin-project/go-state-types/big.Big#UnmarshalCBOR` as what I fed in to it: `100000000000`.