### PR TITLE
Move some constants & types out of fvm_shared

### DIFF
--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -31,6 +31,7 @@ log = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
+lazy_static = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
@@ -41,7 +42,6 @@ fvm_ipld_amt = { workspace = true }
 multihash = { workspace = true }
 regex = { workspace = true }
 itertools = { workspace = true }
-lazy_static = { workspace = true }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/market/src/policy.rs
+++ b/actors/market/src/policy.rs
@@ -10,12 +10,18 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::sector::StoragePower;
-use fvm_shared::TOTAL_FILECOIN;
+use lazy_static::lazy_static;
 use num_traits::Zero;
 
 pub mod detail {
     /// Maximum length of a deal label.
     pub const DEAL_MAX_LABEL_SIZE: usize = 256;
+}
+
+lazy_static! {
+    /// Total (assumed) Filecoin available to the network. This is only used to bound the maximum
+    /// deal collateral and price.
+    pub static ref TOTAL_FILECOIN: TokenAmount = TokenAmount::from_whole(2_000_000_000);
 }
 
 /// Bounds (inclusive) on deal duration.

--- a/actors/market/tests/publish_storage_deals_failures.rs
+++ b/actors/market/tests/publish_storage_deals_failures.rs
@@ -18,10 +18,9 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::piece::PaddedPieceSize;
 
-use fvm_shared::TOTAL_FILECOIN;
-
 use cid::Cid;
 use fil_actor_market::ext::account::{AuthenticateMessageParams, AUTHENTICATE_MESSAGE_METHOD};
+use fil_actor_market::policy::TOTAL_FILECOIN;
 
 mod harness;
 use fvm_ipld_encoding::ipld_block::IpldBlock;

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -11,6 +11,7 @@ use anyhow::{anyhow, Error};
 use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
 use cid::multihash::Code::Blake2b256;
 use cid::Cid;
+use fil_actors_runtime::runtime::policy_constants::MAX_SECTOR_NUMBER;
 use fvm_ipld_bitfield::{BitField, Validate};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
@@ -24,7 +25,12 @@ use fvm_shared::error::*;
 use fvm_shared::piece::PieceInfo;
 use fvm_shared::randomness::*;
 use fvm_shared::reward::ThisEpochRewardReturn;
-use fvm_shared::sector::*;
+use fvm_shared::sector::{
+    AggregateSealVerifyInfo, AggregateSealVerifyProofAndInfos, InteractiveSealRandomness,
+    PoStProof, RegisteredAggregateProof, RegisteredPoStProof, RegisteredSealProof,
+    RegisteredUpdateProof, ReplicaUpdateInfo, SealRandomness, SealVerifyInfo, SectorID, SectorInfo,
+    SectorNumber, SectorSize, StoragePower, WindowPoStVerifyInfo,
+};
 use fvm_shared::smooth::FilterEstimate;
 use fvm_shared::{ActorID, MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND};
 use itertools::Itertools;

--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -11,9 +11,7 @@ use fvm_shared::bigint::{BigInt, Integer};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::commcid::{FIL_COMMITMENT_SEALED, POSEIDON_BLS12_381_A1_FC1};
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::sector::{
-    RegisteredPoStProof, RegisteredSealProof, SectorQuality, SectorSize, StoragePower,
-};
+use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof, SectorSize, StoragePower};
 use lazy_static::lazy_static;
 
 use super::types::SectorOnChainInfo;
@@ -110,16 +108,16 @@ pub const MIN_SECTOR_EXPIRATION: i64 = 180 * EPOCHS_IN_DAY;
 
 /// DealWeight and VerifiedDealWeight are spacetime occupied by regular deals and verified deals in a sector.
 /// Sum of DealWeight and VerifiedDealWeight should be less than or equal to total SpaceTime of a sector.
-/// Sectors full of VerifiedDeals will have a SectorQuality of VerifiedDealWeightMultiplier/QualityBaseMultiplier.
-/// Sectors full of Deals will have a SectorQuality of DealWeightMultiplier/QualityBaseMultiplier.
-/// Sectors with neither will have a SectorQuality of QualityBaseMultiplier/QualityBaseMultiplier.
-/// SectorQuality of a sector is a weighted average of multipliers based on their proportions.
+/// Sectors full of VerifiedDeals will have a BigInt of VerifiedDealWeightMultiplier/QualityBaseMultiplier.
+/// Sectors full of Deals will have a BigInt of DealWeightMultiplier/QualityBaseMultiplier.
+/// Sectors with neither will have a BigInt of QualityBaseMultiplier/QualityBaseMultiplier.
+/// BigInt of a sector is a weighted average of multipliers based on their proportions.
 pub fn quality_for_weight(
     size: SectorSize,
     duration: ChainEpoch,
     deal_weight: &DealWeight,
     verified_weight: &DealWeight,
-) -> SectorQuality {
+) -> BigInt {
     let sector_space_time = BigInt::from(size as u64) * BigInt::from(duration);
     let total_deal_space_time = deal_weight + verified_weight;
 
@@ -129,7 +127,7 @@ pub fn quality_for_weight(
     let weighted_verified_space_time = verified_weight * &*VERIFIED_DEAL_WEIGHT_MULTIPLIER;
     let weighted_sum_space_time =
         weighted_base_space_time + weighted_deal_space_time + weighted_verified_space_time;
-    let scaled_up_weighted_sum_space_time: SectorQuality =
+    let scaled_up_weighted_sum_space_time: BigInt =
         weighted_sum_space_time << SECTOR_QUALITY_PRECISION;
 
     scaled_up_weighted_sum_space_time

--- a/actors/miner/src/sectors.rs
+++ b/actors/miner/src/sectors.rs
@@ -5,12 +5,13 @@ use std::collections::BTreeSet;
 
 use anyhow::anyhow;
 use cid::Cid;
+use fil_actors_runtime::runtime::policy_constants::MAX_SECTOR_NUMBER;
 use fil_actors_runtime::{actor_error, ActorDowncast, ActorError, Array, AsActorError};
 use fvm_ipld_amt::Error as AmtError;
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::error::ExitCode;
-use fvm_shared::sector::{SectorNumber, MAX_SECTOR_NUMBER};
+use fvm_shared::sector::SectorNumber;
 
 use super::SectorOnChainInfo;
 

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -8,6 +8,7 @@ use std::ops::Neg;
 use anyhow::{anyhow, Error};
 use cid::multihash::Code;
 use cid::Cid;
+use fil_actors_runtime::runtime::policy_constants::MAX_SECTOR_NUMBER;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::{
     actor_error, make_empty_map, make_map_with_root_and_bitwidth, u64_key, ActorDowncast,
@@ -24,7 +25,7 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, SectorSize, MAX_SECTOR_NUMBER};
+use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, SectorSize};
 use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
 use itertools::Itertools;
 use num_traits::Zero;

--- a/actors/miner/tests/compact_sector_numbers_tests.rs
+++ b/actors/miner/tests/compact_sector_numbers_tests.rs
@@ -1,6 +1,5 @@
 use fil_actors_runtime::test_utils::{expect_abort, MockRuntime};
 use fvm_shared::address::Address;
-use fvm_shared::sector::MAX_SECTOR_NUMBER;
 use fvm_shared::{clock::ChainEpoch, error::ExitCode};
 
 mod util;
@@ -18,6 +17,8 @@ fn setup() -> (ActorHarness, MockRuntime) {
 }
 
 mod compact_sector_numbers_test {
+    use fil_actors_runtime::runtime::policy_constants::MAX_SECTOR_NUMBER;
+
     use super::*;
 
     #[test]

--- a/actors/miner/tests/exported_getters.rs
+++ b/actors/miner/tests/exported_getters.rs
@@ -2,11 +2,12 @@ use fil_actor_miner::{
     Actor, GetAvailableBalanceReturn, GetOwnerReturn, GetSectorSizeReturn,
     IsControllingAddressParam, IsControllingAddressReturn, Method,
 };
+use fil_actors_runtime::runtime::policy_constants::MAX_SECTOR_NUMBER;
 use fil_actors_runtime::test_utils::EVM_ACTOR_CODE_ID;
 use fil_actors_runtime::INIT_ACTOR_ADDR;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
-use fvm_shared::{clock::ChainEpoch, econ::TokenAmount, sector::MAX_SECTOR_NUMBER};
+use fvm_shared::{clock::ChainEpoch, econ::TokenAmount};
 use std::ops::Sub;
 
 mod util;

--- a/actors/miner/tests/miner_actor_test_commitment.rs
+++ b/actors/miner/tests/miner_actor_test_commitment.rs
@@ -3,6 +3,7 @@ use fil_actor_miner::{
     VestSpec,
 };
 use fil_actors_runtime::network::EPOCHS_IN_DAY;
+use fil_actors_runtime::runtime::policy_constants::MAX_SECTOR_NUMBER;
 use fil_actors_runtime::test_utils::*;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
@@ -10,7 +11,7 @@ use fvm_shared::consensus::{ConsensusFault, ConsensusFaultType};
 use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::sector::{RegisteredSealProof, SectorNumber, MAX_SECTOR_NUMBER};
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
 
 use num_traits::Zero;
 

--- a/actors/miner/tests/prove_commit.rs
+++ b/actors/miner/tests/prove_commit.rs
@@ -3,7 +3,7 @@ use fvm_shared::{
     clock::ChainEpoch,
     econ::TokenAmount,
     error::ExitCode,
-    sector::{StoragePower, MAX_SECTOR_NUMBER},
+    sector::StoragePower,
     smooth::FilterEstimate,
 };
 use std::collections::HashMap;
@@ -13,7 +13,9 @@ use fil_actor_miner::{
     initial_pledge_for_power, max_prove_commit_duration, pre_commit_deposit_for_power,
     qa_power_for_weight, qa_power_max, PowerPair, PreCommitSectorBatchParams, VestSpec,
 };
-use fil_actors_runtime::test_utils::make_piece_cid;
+use fil_actors_runtime::{
+    runtime::policy_constants::MAX_SECTOR_NUMBER, test_utils::make_piece_cid,
+};
 use fil_actors_runtime::{runtime::Runtime, test_utils::expect_abort, DealWeight};
 use util::*;
 

--- a/actors/miner/tests/sector_number_allocation.rs
+++ b/actors/miner/tests/sector_number_allocation.rs
@@ -5,7 +5,6 @@ use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::test_utils::*;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::error::ExitCode;
-use fvm_shared::sector::MAX_SECTOR_NUMBER;
 
 mod util;
 use util::*;
@@ -16,6 +15,8 @@ use state_harness::*;
 const PERIOD_OFFSET: ChainEpoch = 0;
 
 mod sector_number_allocation {
+    use fil_actors_runtime::runtime::policy_constants::MAX_SECTOR_NUMBER;
+
     use super::*;
 
     #[test]

--- a/actors/reward/src/state.rs
+++ b/actors/reward/src/state.rs
@@ -4,13 +4,17 @@
 use fvm_ipld_encoding::repr::*;
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::bigint::bigint_ser;
+use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::{ChainEpoch, EPOCH_UNDEFINED};
 use fvm_shared::econ::TokenAmount;
 
-use fvm_shared::sector::{Spacetime, StoragePower};
+use fvm_shared::sector::StoragePower;
 use fvm_shared::smooth::{AlphaBetaFilter, FilterEstimate, DEFAULT_ALPHA, DEFAULT_BETA};
 use lazy_static::lazy_static;
 use num_derive::FromPrimitive;
+
+/// The unit of spacetime committed to the network
+pub type Spacetime = BigInt;
 
 use super::logic::*;
 

--- a/integration_tests/src/tests/commit_post_test.rs
+++ b/integration_tests/src/tests/commit_post_test.rs
@@ -1,5 +1,6 @@
 use cid::Cid;
 use export_macro::vm_test;
+use fil_actors_runtime::runtime::policy_constants::MAX_SECTOR_NUMBER;
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::RawBytes;
@@ -8,7 +9,7 @@ use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::randomness::Randomness;
-use fvm_shared::sector::{PoStProof, RegisteredSealProof, SectorNumber, MAX_SECTOR_NUMBER};
+use fvm_shared::sector::{PoStProof, RegisteredSealProof, SectorNumber};
 
 use crate::expects::Expect;
 use crate::util::{

--- a/runtime/src/builtin/network.rs
+++ b/runtime/src/builtin/network.rs
@@ -1,8 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_shared::clock::EPOCH_DURATION_SECONDS;
-pub use fvm_shared::BLOCKS_PER_EPOCH as EXPECTED_LEADERS_PER_EPOCH;
+/// Assumed epoch duration. If this changes, a large state-migration will need to be run to update
+/// expirations, etc.
+pub const EPOCH_DURATION_SECONDS: i64 = 30;
 
 pub const SECONDS_IN_HOUR: i64 = 3600;
 pub const SECONDS_IN_DAY: i64 = 86400;
@@ -10,3 +11,8 @@ pub const SECONDS_IN_YEAR: i64 = 31556925;
 pub const EPOCHS_IN_HOUR: i64 = SECONDS_IN_HOUR / EPOCH_DURATION_SECONDS;
 pub const EPOCHS_IN_DAY: i64 = SECONDS_IN_DAY / EPOCH_DURATION_SECONDS;
 pub const EPOCHS_IN_YEAR: i64 = SECONDS_IN_YEAR / EPOCH_DURATION_SECONDS;
+
+/// This is a protocol constant from Filecoin and depends on expected consensus. Here it is used to
+/// determine expected rewards, fault penalties, etc. This will need to be changed if expected
+/// consensus ever changes (and, likely, so will pledge, etc.).
+pub const EXPECTED_LEADERS_PER_EPOCH: u64 = 5;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -8,7 +8,6 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_hamt::Sha256;
 use fvm_ipld_hamt::{BytesKey, Error as HamtError, Hamt};
 use fvm_shared::bigint::BigInt;
-pub use fvm_shared::BLOCKS_PER_EPOCH as EXPECTED_LEADERS_PER_EPOCH;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use unsigned_varint::decode::Error as UVarintError;

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -221,7 +221,6 @@ impl Default for Policy {
 
 pub mod policy_constants {
     use fvm_shared::clock::ChainEpoch;
-    use fvm_shared::clock::EPOCH_DURATION_SECONDS;
     use fvm_shared::sector::SectorNumber;
 
     use crate::builtin::*;

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -222,8 +222,13 @@ impl Default for Policy {
 pub mod policy_constants {
     use fvm_shared::clock::ChainEpoch;
     use fvm_shared::clock::EPOCH_DURATION_SECONDS;
+    use fvm_shared::sector::SectorNumber;
 
     use crate::builtin::*;
+
+    /// The maximum assignable sector number.
+    /// Raising this would require modifying our AMT implementation.
+    pub const MAX_SECTOR_NUMBER: SectorNumber = i64::MAX as u64;
 
     // See comments on Policy struct.
     pub const MAX_AGGREGATED_SECTORS: u64 = 819;


### PR DESCRIPTION
Specifically:

- `MAX_SECTOR_NUMBER`
- `Spacetime`
- `SectorQuality`
- `TOTAL_FILECOIN`
- `EPOCH_DURATION_SECONDS`
- `BLOCKS_PER_EPOCH`