### PR TITLE
chore: update rust to 1.76.0 and fix new clippy lints

### DIFF
--- a/actors/evm/src/interpreter/instructions/lifecycle.rs
+++ b/actors/evm/src/interpreter/instructions/lifecycle.rs
@@ -216,7 +216,7 @@ mod tests {
                 let create_ret = eam::CreateReturn {
                     actor_id: 12345,
                     eth_address: ret_addr,
-                    robust_address: Some((&ret_addr).try_into().unwrap()),
+                    robust_address: Some(ret_addr.into()),
                 };
 
                 rt.expect_gas_available(10_000_000_000);
@@ -270,7 +270,7 @@ mod tests {
                 let create_ret = eam::CreateReturn {
                     actor_id: 12345,
                     eth_address: ret_addr,
-                    robust_address: Some((&ret_addr).try_into().unwrap()),
+                    robust_address: Some(ret_addr.into()),
                 };
 
                 rt.expect_gas_available(10_000_000_000);

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -175,7 +175,7 @@ fn test_call() {
     let target_id = 0x100;
     let target = FILAddress::new_id(target_id);
     let evm_target = EthAddress(hex_literal::hex!("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"));
-    let f4_target: FILAddress = evm_target.try_into().unwrap();
+    let f4_target: FILAddress = evm_target.into();
     rt.actor_code_cids.borrow_mut().insert(target, *EVM_ACTOR_CODE_ID);
     rt.set_delegated_address(target.id().unwrap(), f4_target);
 
@@ -339,7 +339,7 @@ return
     let cases = [(32, 64), (64, 64), (1024, 1025)];
     for (output_size, return_size) in cases {
         rt.expect_send(
-            (&address).try_into().unwrap(),
+            address.into(),
             Method::InvokeContract as u64,
             None,
             TokenAmount::zero(),
@@ -1071,7 +1071,7 @@ fn call_actor_solidity() {
         log::warn!("new test");
         // EVM actor
         let evm_target = 10101;
-        let evm_del = EthAddress(util::CONTRACT_ADDRESS).try_into().unwrap();
+        let evm_del = EthAddress(util::CONTRACT_ADDRESS).into();
         tester.rt.set_delegated_address(evm_target, evm_del);
 
         let to_address = {
@@ -1168,7 +1168,7 @@ impl ContractTester {
             creator: EthAddress::from_id(EAM_ACTOR_ID),
             initcode: hex::decode(contract_hex).unwrap().into(),
         };
-        rt.add_id_address(addr.try_into().unwrap(), FILAddress::new_id(id));
+        rt.add_id_address(addr.into(), FILAddress::new_id(id));
 
         // invoke constructor
         rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);

--- a/actors/evm/tests/create.rs
+++ b/actors/evm/tests/create.rs
@@ -60,7 +60,7 @@ fn test_create() {
     let fake_ret = eam::CreateReturn {
         actor_id: 12345,
         eth_address: fake_eth_addr,
-        robust_address: Some((&fake_eth_addr).try_into().unwrap()),
+        robust_address: Some((&fake_eth_addr).into()),
     };
 
     let salt =

--- a/actors/evm/tests/delegate_call.rs
+++ b/actors/evm/tests/delegate_call.rs
@@ -67,7 +67,7 @@ fn test_delegate_call_caller() {
     let target_id = 0x100;
     let target = FILAddress::new_id(target_id);
     let evm_target = EthAddress(hex_literal::hex!("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"));
-    let f4_target: FILAddress = evm_target.try_into().unwrap();
+    let f4_target: FILAddress = evm_target.into();
     rt.actor_code_cids.borrow_mut().insert(target, *EVM_ACTOR_CODE_ID);
     rt.set_delegated_address(target.id().unwrap(), f4_target);
     rt.receiver = target;
@@ -75,7 +75,7 @@ fn test_delegate_call_caller() {
     // set caller that is expected to persist through to subcall
     let caller = FILAddress::new_id(0x111);
     let evm_caller = EthAddress(util::CONTRACT_ADDRESS);
-    let f4_caller = evm_caller.try_into().unwrap();
+    let f4_caller = evm_caller.into();
     rt.set_delegated_address(caller.id().unwrap(), f4_caller);
     rt.caller.replace(caller);
 

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -124,7 +124,7 @@ fn test_native_lookup_delegated_address() {
 
     // f0 10101 is an EVM actor
     let evm_target = FILAddress::new_id(10101);
-    let evm_del = EthAddress(util::CONTRACT_ADDRESS).try_into().unwrap();
+    let evm_del = EthAddress(util::CONTRACT_ADDRESS).into();
     rt.set_delegated_address(evm_target.id().unwrap(), evm_del);
 
     // f0 10111 is an actor with a non-evm delegate address
@@ -158,7 +158,7 @@ fn test_resolve_delegated() {
 
     // EVM actor
     let evm_target = FILAddress::new_id(10101);
-    let evm_del = EthAddress(util::CONTRACT_ADDRESS).try_into().unwrap();
+    let evm_del = EthAddress(util::CONTRACT_ADDRESS).into();
     rt.set_delegated_address(evm_target.id().unwrap(), evm_del);
 
     // Actor with a non-evm delegate address

--- a/actors/market/tests/deal_termination.rs
+++ b/actors/market/tests/deal_termination.rs
@@ -187,7 +187,7 @@ fn settle_payments_then_terminate_deal_in_the_same_epoch() {
     let expected_payment = deal_duration * &proposal.storage_price_per_epoch;
     let ret = settle_deal_payments(&rt, PROVIDER_ADDR, &[deal_id], &[], &[]);
     assert_eq!(
-        ret.settlements.get(0).unwrap(),
+        &ret.settlements[0],
         &DealSettlementSummary { completed: false, payment: expected_payment.clone() }
     );
     terminate_deals_and_assert_balances(

--- a/actors/market/tests/settle_deal_payments.rs
+++ b/actors/market/tests/settle_deal_payments.rs
@@ -255,8 +255,8 @@ fn batch_settlement_of_deals_allows_partial_success() {
         * (settlement_epoch - continuing_proposal.start_epoch);
     let finished_payment = &finished_proposal.storage_price_per_epoch
         * (settlement_epoch - finished_proposal.start_epoch);
-    let continuing_summary = ret.settlements.get(0).cloned().unwrap();
-    let finished_summary = ret.settlements.get(1).cloned().unwrap();
+    let continuing_summary = ret.settlements[0].clone();
+    let finished_summary = ret.settlements[1].clone();
 
     // check that the correct payments are reported and that relevant deals are cleaned up
     assert_eq!(

--- a/actors/market/tests/verify_deals_for_activation_test.rs
+++ b/actors/market/tests/verify_deals_for_activation_test.rs
@@ -53,7 +53,7 @@ fn verify_deal_and_activate_to_get_deal_space_for_unverified_deal_proposal() {
     );
     let a_response =
         activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, sector_number, &[deal_id]);
-    let s_response = a_response.activations.get(0).unwrap();
+    let s_response = a_response.activations.first().unwrap();
     assert_eq!(1, v_response.unsealed_cids.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), v_response.unsealed_cids[0]);
     assert_eq!(1, s_response.activated.len());
@@ -64,7 +64,7 @@ fn verify_deal_and_activate_to_get_deal_space_for_unverified_deal_proposal() {
             data: deal_proposal.piece_cid,
             size: deal_proposal.piece_size
         },
-        *s_response.activated.get(0).unwrap()
+        *s_response.activated.first().unwrap()
     );
 
     check_state(&rt);
@@ -98,7 +98,7 @@ fn verify_deal_and_activate_to_get_deal_space_for_verified_deal_proposal() {
 
     let a_response =
         activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, sector_number, &[deal_id]);
-    let s_response = a_response.activations.get(0).unwrap();
+    let s_response = a_response.activations.first().unwrap();
 
     assert_eq!(1, response.unsealed_cids.len());
     assert_eq!(Some(make_piece_cid("1".as_bytes())), response.unsealed_cids[0]);
@@ -155,7 +155,7 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
 
     let a_response =
         activate_deals(&rt, SECTOR_EXPIRY, PROVIDER_ADDR, CURR_EPOCH, sector_number, &deal_ids);
-    let s_response = a_response.activations.get(0).unwrap();
+    let s_response = a_response.activations.first().unwrap();
     assert_eq!(4, s_response.activated.len());
     assert_eq!(
         &ActivatedDeal {
@@ -164,7 +164,7 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
             data: verified_deal_1.piece_cid,
             size: verified_deal_1.piece_size,
         },
-        s_response.activated.get(0).unwrap()
+        &s_response.activated[0],
     );
     assert_eq!(
         &ActivatedDeal {
@@ -173,7 +173,7 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
             data: verified_deal_2.piece_cid,
             size: verified_deal_2.piece_size,
         },
-        s_response.activated.get(1).unwrap()
+        &s_response.activated[1],
     );
     assert_eq!(
         &ActivatedDeal {
@@ -182,7 +182,7 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
             data: unverified_deal_1.piece_cid,
             size: unverified_deal_1.piece_size,
         },
-        s_response.activated.get(2).unwrap()
+        &s_response.activated[2],
     );
     assert_eq!(
         &ActivatedDeal {
@@ -191,7 +191,7 @@ fn verification_and_weights_for_verified_and_unverified_deals() {
             data: unverified_deal_2.piece_cid,
             size: unverified_deal_2.piece_size,
         },
-        s_response.activated.get(3).unwrap()
+        &s_response.activated[3],
     );
 
     check_state(&rt);

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -2271,7 +2271,7 @@ impl Actor {
                     let not_exists = matches!(prev_epoch_partitions, Entry::Vacant(_));
 
                     // Add declaration partition
-                    prev_epoch_partitions.or_insert_with(Vec::new).push(decl.partition);
+                    prev_epoch_partitions.or_default().push(decl.partition);
                     if not_exists {
                         // reschedule epoch if the partition for new epoch didn't already exist
                         epochs_to_reschedule.push(decl.new_expiration);
@@ -4982,11 +4982,11 @@ fn notify_pledge_changed(rt: &impl Runtime, pledge_delta: &TokenAmount) -> Resul
 
 fn get_claims(
     rt: &impl Runtime,
-    ids: &Vec<ext::verifreg::ClaimID>,
+    ids: &[ext::verifreg::ClaimID],
 ) -> Result<Vec<ext::verifreg::Claim>, ActorError> {
     let params = ext::verifreg::GetClaimsParams {
         provider: rt.message().receiver().id().unwrap(),
-        claim_ids: ids.clone(),
+        claim_ids: ids.to_owned(),
     };
     let claims_ret: ext::verifreg::GetClaimsReturn =
         deserialize_block(extract_send_result(rt.send_simple(

--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -628,7 +628,7 @@ fn extend_expiration2_drop_claims() {
     let extension = 42 * rt.policy().wpost_proving_period;
     let new_expiration = old_sector.expiration + extension;
 
-    let claim_ids = vec![400, 500];
+    let claim_ids = [400, 500];
     let client = Address::new_id(3000).id().unwrap();
     let second_expiration = new_expiration + 42 * EPOCHS_IN_DAY;
 
@@ -793,7 +793,7 @@ fn update_expiration2_drop_claims_failure_cases() {
     let extension = 42 * rt.policy().wpost_proving_period;
     let new_expiration = old_sector.expiration + extension;
 
-    let claim_ids = vec![400, 500];
+    let claim_ids = [400, 500];
     let client = Address::new_id(3000).id().unwrap();
 
     let claim0 = make_claim(
@@ -890,7 +890,7 @@ fn update_expiration2_drop_claims_failure_cases() {
 }
 
 fn commit_sector_verified_deals(
-    verified_deals: &Vec<ActivatedDeal>,
+    verified_deals: &[ActivatedDeal],
     h: &mut ActorHarness,
     rt: &MockRuntime,
 ) -> SectorOnChainInfo {
@@ -898,7 +898,7 @@ fn commit_sector_verified_deals(
     assert!(!verified_deals.is_empty());
 
     let mut pcc = ProveCommitConfig::empty();
-    pcc.add_activated_deals(h.next_sector_no, verified_deals.clone());
+    pcc.add_activated_deals(h.next_sector_no, verified_deals.to_owned());
 
     let mut deal_ids: Vec<DealID> = vec![];
     for i in 0..verified_deals.len() {

--- a/actors/multisig/src/lib.rs
+++ b/actors/multisig/src/lib.rs
@@ -222,7 +222,7 @@ impl Actor {
             })?;
 
             // Check to make sure transaction proposer is caller address
-            if tx.approved.get(0) != Some(&caller_addr) {
+            if tx.approved.first() != Some(&caller_addr) {
                 return Err(actor_error!(forbidden; "Cannot cancel another signers transaction"));
             }
 
@@ -534,7 +534,7 @@ where
 /// of the transaction associated with an ID, which might change under chain re-orgs.
 pub fn compute_proposal_hash(txn: &Transaction, sys: &dyn Primitives) -> anyhow::Result<[u8; 32]> {
     let proposal_hash = ProposalHashData {
-        requester: txn.approved.get(0),
+        requester: txn.approved.first(),
         to: &txn.to,
         value: &txn.value,
         method: &txn.method,

--- a/integration_tests/src/tests/commit_post_test.rs
+++ b/integration_tests/src/tests/commit_post_test.rs
@@ -340,7 +340,7 @@ pub fn overdue_precommit_test(v: &dyn VM) {
         true,
         None,
     )
-    .get(0)
+    .first()
     .unwrap()
     .clone();
 

--- a/integration_tests/src/tests/prove_commit3_test.rs
+++ b/integration_tests/src/tests/prove_commit3_test.rs
@@ -112,7 +112,7 @@ pub fn prove_commit_sectors2_test(v: &dyn VM) {
     let mut batcher = DealBatcher::new(v, opts);
     batcher.stage_with_label(client, maddr, "s4p1".to_string());
     let deal_ids_s4 = batcher.publish_ok(worker).ids;
-    let alloc_ids_s4 = vec![alloc_ids_s2[alloc_ids_s2.len() - 1] + 1];
+    let alloc_ids_s4 = [alloc_ids_s2[alloc_ids_s2.len() - 1] + 1];
 
     // Onboard a batch of sectors with a mix of data pieces, claims, and deals.
     let first_sector_number: SectorNumber = 100;

--- a/integration_tests/src/tests/replica_update3_test.rs
+++ b/integration_tests/src/tests/replica_update3_test.rs
@@ -167,7 +167,7 @@ pub fn prove_replica_update2_test(v: &dyn VM) {
     let mut batcher = DealBatcher::new(v, opts);
     batcher.stage_with_label(client, maddr, "s4p1".to_string());
     let deal_ids_s4 = batcher.publish_ok(worker).ids;
-    let alloc_ids_s4 = vec![alloc_ids_s2[alloc_ids_s2.len() - 1] + 1];
+    let alloc_ids_s4 = [alloc_ids_s2[alloc_ids_s2.len() - 1] + 1];
 
     // Update all sectors with a mix of data pieces, claims, and deals.
     let first_sector_number: SectorNumber = 100;

--- a/integration_tests/src/tests/verified_claim_test.rs
+++ b/integration_tests/src/tests/verified_claim_test.rs
@@ -369,7 +369,7 @@ pub fn verified_claim_scenario_test(v: &dyn VM) {
     // provider must process the deals to receive payment and cleanup state
     let ret = provider_settle_deal_payments(v, &miner_id, &deals);
     assert_eq!(
-        ret.settlements.get(0).unwrap(),
+        ret.settlements.first().unwrap(),
         &DealSettlementSummary { payment: proposal.total_storage_fee(), completed: true }
     );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -12,7 +12,6 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use unsigned_varint::decode::Error as UVarintError;
 
-use builtin::HAMT_BIT_WIDTH;
 pub use dispatch::{dispatch, dispatch_default, WithCodec};
 pub use {fvm_ipld_amt, fvm_ipld_hamt};
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.76.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]

--- a/vm_api/src/trace.rs
+++ b/vm_api/src/trace.rs
@@ -157,18 +157,19 @@ impl ExpectInvocation {
     }
 
     pub fn fmt_invocs(&self, invocs: &[InvocationTrace]) -> String {
-        invocs
-            .iter()
-            .enumerate()
-            .map(|(i, invoc)| format!("{}: [{}:{}],\n", i, invoc.to, invoc.method))
-            .collect()
+        invocs.iter().enumerate().fold(String::new(), |mut s, (i, invoc)| {
+            use std::fmt::Write;
+            let _ = writeln!(s, "{}: [{}:{}],", i, invoc.to, invoc.method);
+            s
+        })
     }
 
     pub fn fmt_expect_invocs(&self, exs: &[ExpectInvocation]) -> String {
-        exs.iter()
-            .enumerate()
-            .map(|(i, ex)| format!("{}: [{}:{}],\n", i, ex.to, ex.method))
-            .collect()
+        exs.iter().enumerate().fold(String::new(), |mut s, (i, ex)| {
+            use std::fmt::Write;
+            let _ = writeln!(s, "{}: [{}:{}],", i, ex.to, ex.method);
+            s
+        })
     }
 
     pub fn quick_match(&self, invoc: &InvocationTrace, extra_msg: String) {


### PR DESCRIPTION
Some of the lints were... kind of 🙄, but it's easier to appease the animated paperclip than to argue with it.