### PR TITLE
fix(verifreg): make RemovedExpiredClaimsReturn deal with ClaimIDs

### DIFF
--- a/actors/verifreg/src/types.rs
+++ b/actors/verifreg/src/types.rs
@@ -254,7 +254,7 @@ pub struct RemoveExpiredClaimsParams {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct RemoveExpiredClaimsReturn {
     // Ids of the claims that were either specified by the caller or discovered to be expired.
-    pub considered: Vec<AllocationID>,
+    pub considered: Vec<ClaimID>,
     // Results for each processed claim.
     pub results: BatchReturn,
 }


### PR DESCRIPTION
very minor, just noticed this while doing a quick audit for https://github.com/filecoin-project/FIPs/pull/961