### PR TITLE
feat(events): split up verifier_balance event into 4

### DIFF
--- a/actors/miner/src/emit.rs
+++ b/actors/miner/src/emit.rs
@@ -1,6 +1,7 @@
 use cid::Cid;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::{ActorError, EventBuilder};
+use fvm_shared::clock::ChainEpoch;
 use fvm_shared::sector::SectorNumber;
 
 /// Indicates a sector has been pre-committed.
@@ -16,11 +17,13 @@ pub fn sector_activated(
     sector: SectorNumber,
     unsealed_cid: Option<Cid>,
     pieces: &[(Cid, u64)],
+    expiration: &ChainEpoch,
 ) -> Result<(), ActorError> {
     rt.emit_event(
         &EventBuilder::new()
             .typ("sector-activated")
             .with_sector_info(sector, unsealed_cid, pieces)
+            .field("expiration", expiration)
             .build()?,
     )
 }
@@ -31,11 +34,13 @@ pub fn sector_updated(
     sector: SectorNumber,
     unsealed_cid: Option<Cid>,
     pieces: &[(Cid, u64)],
+    expiration: &ChainEpoch,
 ) -> Result<(), ActorError> {
     rt.emit_event(
         &EventBuilder::new()
             .typ("sector-updated")
             .with_sector_info(sector, unsealed_cid, pieces)
+            .field("expiration", expiration)
             .build()?,
     )
 }

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -837,7 +837,13 @@ impl Actor {
 
         for (pc, data) in activated_precommits.iter().zip(activated_data.iter()) {
             let unsealed_cid = pc.info.unsealed_cid.0;
-            emit::sector_activated(rt, pc.info.sector_number, unsealed_cid, &data.pieces)?;
+            emit::sector_activated(
+                rt,
+                pc.info.sector_number,
+                unsealed_cid,
+                &data.pieces,
+                &pc.info.expiration,
+            )?;
         }
 
         // The aggregate fee is paid on the sectors successfully proven.
@@ -984,6 +990,7 @@ impl Actor {
                 usi.update.sector_number,
                 data_activation.unsealed_cid,
                 &data_activation.pieces,
+                &usi.sector_info.expiration,
             )?;
         }
 
@@ -1225,6 +1232,7 @@ impl Actor {
                 update.sector,
                 sector_commds.get(&update.sector).unwrap().0,
                 &pieces,
+                &sector_info.expiration,
             )?;
         }
         notify_data_consumers(rt, &notifications, params.require_notification_success)?;
@@ -1940,7 +1948,13 @@ impl Actor {
                 activations.pieces.iter().map(|p| (p.cid, p.size.0)).collect();
             let unsealed_cid = sector.info.unsealed_cid.0;
 
-            emit::sector_activated(rt, sector.info.sector_number, unsealed_cid, &pieces)?;
+            emit::sector_activated(
+                rt,
+                sector.info.sector_number,
+                unsealed_cid,
+                &pieces,
+                &sector.info.expiration,
+            )?;
         }
         notify_data_consumers(rt, &notifications, params.require_notification_success)?;
 
@@ -2057,7 +2071,13 @@ impl Actor {
 
         for (pc, data) in successful_activations.iter().zip(data_activations.iter()) {
             let unsealed_cid = pc.info.unsealed_cid.0;
-            emit::sector_activated(rt, pc.info.sector_number, unsealed_cid, &data.pieces)?;
+            emit::sector_activated(
+                rt,
+                pc.info.sector_number,
+                unsealed_cid,
+                &data.pieces,
+                &pc.info.expiration,
+            )?;
         }
 
         Ok(())

--- a/actors/verifreg/src/emit.rs
+++ b/actors/verifreg/src/emit.rs
@@ -9,23 +9,63 @@ use fvm_shared::bigint::bigint_ser::BigIntSer;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::ActorID;
 
-/// Indicates a new value for a verifier's datacap balance.
-/// Note that receiving this event does not necessarily mean the balance has changed.
+/// Indicates the addition of a new verifier.
 /// The value is in datacap whole units (not TokenAmount).
-pub fn verifier_balance(
+pub fn add_verifier(
     rt: &impl Runtime,
     verifier: ActorID,
-    prev_balance: &DataCap,
-    new_balance: &DataCap,
-    client: Option<ActorID>,
+    balance: &DataCap,
 ) -> Result<(), ActorError> {
     rt.emit_event(
         &EventBuilder::new()
-            .typ("verifier-balance")
+            .typ("add-verifier")
+            .field_indexed("verifier", &verifier)
+            .field("balance", &BigIntSer(balance))
+            .build()?,
+    )
+}
+
+/// Indicates the removal of a verifier.
+pub fn remove_verifier(rt: &impl Runtime, verifier: ActorID) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new().typ("remove-verifier").field_indexed("verifier", &verifier).build()?,
+    )
+}
+
+/// Indicates the transfer of datacap from verifier to a client.
+/// The value is in datacap whole units (not TokenAmount).
+pub fn allocate_datacap(
+    rt: &impl Runtime,
+    verifier: ActorID,
+    client: ActorID,
+    amount: &DataCap,
+) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new()
+            .typ("allocate-datacap")
             .field_indexed("verifier", &verifier)
             .field_indexed("client", &client)
-            .field("prev-balance,", &BigIntSer(prev_balance))
-            .field("balance", &BigIntSer(new_balance))
+            .field("amount", &BigIntSer(amount))
+            .build()?,
+    )
+}
+
+/// Indicates the removal of datacap from a client.
+/// The value is in datacap whole units (not TokenAmount).
+pub fn remove_datacap(
+    rt: &impl Runtime,
+    verifier1: ActorID,
+    verifier2: ActorID,
+    client: ActorID,
+    amount: &DataCap,
+) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new()
+            .typ("remove-datacap")
+            .field_indexed("verifier", &verifier1)
+            .field_indexed("verifier", &verifier2)
+            .field_indexed("client", &client)
+            .field("amount", &BigIntSer(amount))
             .build()?,
     )
 }

--- a/actors/verifreg/src/emit.rs
+++ b/actors/verifreg/src/emit.rs
@@ -2,9 +2,11 @@
 
 use crate::{ActorError, AllocationID};
 use crate::{ClaimID, DataCap};
+use cid::Cid;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::EventBuilder;
 use fvm_shared::bigint::bigint_ser::BigIntSer;
+use fvm_shared::clock::ChainEpoch;
 use fvm_shared::ActorID;
 
 /// Indicates a new value for a verifier's datacap balance.
@@ -13,87 +15,221 @@ use fvm_shared::ActorID;
 pub fn verifier_balance(
     rt: &impl Runtime,
     verifier: ActorID,
+    prev_balance: &DataCap,
     new_balance: &DataCap,
+    client: Option<ActorID>,
 ) -> Result<(), ActorError> {
     rt.emit_event(
         &EventBuilder::new()
             .typ("verifier-balance")
             .field_indexed("verifier", &verifier)
+            .field_indexed("client", &client)
+            .field("prev-balance,", &BigIntSer(prev_balance))
             .field("balance", &BigIntSer(new_balance))
             .build()?,
     )
 }
 
 /// Indicates a new allocation has been made.
+#[allow(clippy::too_many_arguments)]
 pub fn allocation(
     rt: &impl Runtime,
     id: AllocationID,
     client: ActorID,
     provider: ActorID,
+    piece_cid: &Cid,
+    piece_size: &u64,
+    term_min: &ChainEpoch,
+    term_max: &ChainEpoch,
+    expiration: &ChainEpoch,
 ) -> Result<(), ActorError> {
-    rt.emit_event(
-        &EventBuilder::new().typ("allocation").with_parties(id, client, provider).build()?,
+    let event = build_base_event(
+        "allocation",
+        &id,
+        &client,
+        &provider,
+        piece_cid,
+        piece_size,
+        term_min,
+        term_max,
+        expiration,
     )
+    .build()?;
+    rt.emit_event(&event)
 }
 
 /// Indicates an expired allocation has been removed.
+#[allow(clippy::too_many_arguments)]
 pub fn allocation_removed(
     rt: &impl Runtime,
     id: AllocationID,
     client: ActorID,
     provider: ActorID,
+    piece_cid: &Cid,
+    piece_size: &u64,
+    term_min: &ChainEpoch,
+    term_max: &ChainEpoch,
+    expiration: &ChainEpoch,
 ) -> Result<(), ActorError> {
-    rt.emit_event(
-        &EventBuilder::new()
-            .typ("allocation-removed")
-            .with_parties(id, client, provider)
-            .build()?,
+    let event = build_base_event(
+        "allocation-removed",
+        &id,
+        &client,
+        &provider,
+        piece_cid,
+        piece_size,
+        term_min,
+        term_max,
+        expiration,
     )
+    .build()?;
+    rt.emit_event(&event)
 }
 
 /// Indicates an allocation has been claimed.
+#[allow(clippy::too_many_arguments)]
 pub fn claim(
     rt: &impl Runtime,
     id: ClaimID,
     client: ActorID,
     provider: ActorID,
+    piece_cid: &Cid,
+    piece_size: &u64,
+    term_min: &ChainEpoch,
+    term_max: &ChainEpoch,
+    expiration: &ChainEpoch,
+    sector: &u64,
 ) -> Result<(), ActorError> {
-    rt.emit_event(&EventBuilder::new().typ("claim").with_parties(id, client, provider).build()?)
+    let event = build_base_event(
+        "claim", &id, &client, &provider, piece_cid, piece_size, term_min, term_max, expiration,
+    )
+    .field_indexed("sector", &sector)
+    .build()?;
+    rt.emit_event(&event)
 }
 
 /// Indicates an existing claim has been updated (e.g. with a longer term).
+#[allow(clippy::too_many_arguments)]
 pub fn claim_updated(
     rt: &impl Runtime,
     id: ClaimID,
     client: ActorID,
     provider: ActorID,
+    piece_cid: &Cid,
+    piece_size: &u64,
+    term_min: &ChainEpoch,
+    term_max: &ChainEpoch,
+    expiration: &ChainEpoch,
+    sector: &u64,
+    prev_term_max: &ChainEpoch,
 ) -> Result<(), ActorError> {
-    rt.emit_event(
-        &EventBuilder::new().typ("claim-updated").with_parties(id, client, provider).build()?,
+    let event = build_base_event(
+        "claim-updated",
+        &id,
+        &client,
+        &provider,
+        piece_cid,
+        piece_size,
+        term_min,
+        term_max,
+        expiration,
     )
+    .field_indexed("sector", &sector)
+    .field("prev-term-max", &prev_term_max)
+    .build()?;
+    rt.emit_event(&event)
 }
 
 /// Indicates an expired claim has been removed.
+#[allow(clippy::too_many_arguments)]
 pub fn claim_removed(
     rt: &impl Runtime,
     id: ClaimID,
     client: ActorID,
     provider: ActorID,
+    piece_cid: &Cid,
+    piece_size: &u64,
+    term_min: &ChainEpoch,
+    term_max: &ChainEpoch,
+    expiration: &ChainEpoch,
+    sector: &u64,
 ) -> Result<(), ActorError> {
-    rt.emit_event(
-        &EventBuilder::new().typ("claim-removed").with_parties(id, client, provider).build()?,
+    let event = build_base_event(
+        "claim-removed",
+        &id,
+        &client,
+        &provider,
+        piece_cid,
+        piece_size,
+        term_min,
+        term_max,
+        expiration,
     )
+    .field_indexed("sector", sector)
+    .build()?;
+    rt.emit_event(&event)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_base_event(
+    typ: &str,
+    id: &u64,
+    client: &ActorID,
+    provider: &ActorID,
+    piece_cid: &Cid,
+    piece_size: &u64,
+    term_min: &ChainEpoch,
+    term_max: &ChainEpoch,
+    expiration: &ChainEpoch,
+) -> EventBuilder {
+    EventBuilder::new()
+        .typ(typ)
+        .with_parties(id, client, provider)
+        .with_piece(piece_cid, piece_size)
+        .with_term(term_min, term_max, expiration)
 }
 
 // Private helpers //
-trait WithParties {
-    fn with_parties(self, id: AllocationID, client: ActorID, provider: ActorID) -> EventBuilder;
+pub trait WithParties {
+    fn with_parties(self, id: &AllocationID, client: &ActorID, provider: &ActorID) -> EventBuilder;
 }
 
 impl WithParties for EventBuilder {
-    fn with_parties(self, id: AllocationID, client: ActorID, provider: ActorID) -> EventBuilder {
+    fn with_parties(self, id: &AllocationID, client: &ActorID, provider: &ActorID) -> EventBuilder {
         self.field_indexed("id", &id)
             .field_indexed("client", &client)
             .field_indexed("provider", &provider)
+    }
+}
+
+pub trait WithPiece {
+    fn with_piece(self, piece_cid: &Cid, piece_size: &u64) -> EventBuilder;
+}
+
+impl crate::emit::WithPiece for EventBuilder {
+    fn with_piece(self, piece_cid: &Cid, piece_size: &u64) -> EventBuilder {
+        self.field_indexed("piece-cid", &piece_cid).field("piece-size", &piece_size)
+    }
+}
+
+pub trait WithTerm {
+    fn with_term(
+        self,
+        term_min: &ChainEpoch,
+        term_max: &ChainEpoch,
+        expiration: &ChainEpoch,
+    ) -> EventBuilder;
+}
+
+impl crate::emit::WithTerm for EventBuilder {
+    fn with_term(
+        self,
+        term_min: &ChainEpoch,
+        term_max: &ChainEpoch,
+        expiration: &ChainEpoch,
+    ) -> EventBuilder {
+        self.field("term-min", &term_min)
+            .field("term-max", &term_max)
+            .field("expiration", &expiration)
     }
 }

--- a/integration_tests/src/tests/verifreg_remove_datacap_test.rs
+++ b/integration_tests/src/tests/verifreg_remove_datacap_test.rs
@@ -32,7 +32,8 @@ use vm_api::VM;
 use crate::expects::Expect;
 
 use crate::util::{
-    assert_invariants, create_accounts, verifier_balance_event, verifreg_add_verifier,
+    allocate_datacap_event, assert_invariants, create_accounts, remove_datacap_event,
+    verifreg_add_verifier,
 };
 use crate::{TEST_VERIFREG_ROOT_ADDR, TEST_VERIFREG_ROOT_ID};
 
@@ -69,8 +70,6 @@ pub fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
         Some(add_verified_client_params.clone()),
     );
 
-    let verifier_datacap = DataCap::from(0);
-
     ExpectInvocation {
         from: verifier1_id,
         to: VERIFIED_REGISTRY_ACTOR_ADDR,
@@ -84,7 +83,11 @@ pub fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
             subinvocs: None,
             ..Default::default()
         }]),
-        events: vec![verifier_balance_event(verifier1.id().unwrap(), verifier_datacap)],
+        events: vec![allocate_datacap_event(
+            verifier1.id().unwrap(),
+            verified_client_id_addr.id().unwrap(),
+            verifier_allowance.clone(),
+        )],
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
@@ -435,6 +438,12 @@ fn expect_remove_datacap(
                 ..Default::default()
             },
         ]),
+        events: vec![remove_datacap_event(
+            params.verifier_request_1.verifier.id().unwrap(),
+            params.verifier_request_2.verifier.id().unwrap(),
+            params.verified_client_to_remove.id().unwrap(),
+            params.data_cap_amount_to_remove.clone(),
+        )],
         ..Default::default()
     }
 }


### PR DESCRIPTION
PR against https://github.com/filecoin-project/builtin-actors/pull/1531

Ref: https://github.com/filecoin-project/FIPs/discussions/754#discussioncomment-8833387

* add_verifier
* remove_verifier
* allocate_datacap (client)
* remove_datacap (client, not previously covered)