### PR TITLE
test: verifreg: add initial cbor encoding forms tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,13 +608,14 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.9.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37be52ef5e3b394db27a2341010685ad5103c72ac15ce2e9420a7e8f93f342c"
+checksum = "5ba00838774b4ab0233e355d26710fbfc8327a05c017f6dc4873f876d1f79f78"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "hex",
+ "proptest",
  "serde",
 ]
 
@@ -1681,6 +1682,7 @@ version = "12.0.0"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
+ "const-hex",
  "fil_actors_runtime",
  "frc42_dispatch",
  "frc46_token",
@@ -2722,6 +2724,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "libsecp256k1"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2975,6 +2983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3330,6 +3339,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+dependencies = [
+ "bitflags 2.4.1",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3378,6 +3403,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -4318,6 +4352,12 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ pretty_env_logger = "0.4.0"
 serde_repr = "0.1.8"
 unsigned-varint = "0.7.1"
 rand_chacha = "0.3.1"
+const-hex = "1.11.3"
 
 # Crypto
 libsecp256k1 = { version = "0.7.1", default-features = false }

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -30,6 +30,7 @@ log = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
+const-hex = { workspace = true }
 
 [dev-dependencies]
 fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -1581,24 +1581,11 @@ mod serialization {
     fn claim_allocations_params() {
         let test_cases = vec![
             (
-                /*
-                 82                                                # array(2)
-                   80                                              #   array(0)
-                   f4                                              #   false
-                */
                 ClaimAllocationsParams { sectors: vec![], all_or_nothing: false },
+                // [[],false]
                 "8280f4",
             ),
             (
-                /*
-                 82                                                # array(2)
-                   81                                              #   array(1)
-                     83                                            #     array(3)
-                       18 65                                       #       uint(101)
-                       18 ca                                       #       uint(202)
-                       80                                          #       array(0)
-                   f5                                              #   true
-                */
                 ClaimAllocationsParams {
                     sectors: vec![SectorAllocationClaims {
                         sector: 101,
@@ -1607,36 +1594,10 @@ mod serialization {
                     }],
                     all_or_nothing: true,
                 },
+                // [[[101,202,[]]],true]
                 "828183186518ca80f5",
             ),
             (
-                /*
-                 82                                                # array(2)
-                   82                                              #   array(2)
-                     83                                            #     array(3)
-                       18 65                                       #       uint(101)
-                       18 ca                                       #       uint(202)
-                       82                                          #       array(2)
-                         84                                        #         array(4)
-                           19 012f                                 #           uint(303)
-                           19 0194                                 #           uint(404)
-                           d8 2a                                   #           tag(42)
-                             49                                    #             bytes(9)
-                               000181e20392200100                  #               "\x00\x01\x81â\x03\x92 \x01\x00"
-                           19 01f9                                 #           uint(505)
-                         84                                        #         array(4)
-                           19 025e                                 #           uint(606)
-                           19 02c3                                 #           uint(707)
-                           d8 2a                                   #           tag(42)
-                             49                                    #             bytes(9)
-                               000181e20392200101                  #               "\x00\x01\x81â\x03\x92 \x01\x01"
-                           19 0328                                 #           uint(808)
-                     83                                            #     array(3)
-                       19 012f                                     #       uint(303)
-                       19 0194                                     #       uint(404)
-                       80                                          #       array(0)
-                   f5                                              #   true
-                */
                 ClaimAllocationsParams {
                     sectors: vec![
                         SectorAllocationClaims {
@@ -1661,6 +1622,7 @@ mod serialization {
                     ],
                     all_or_nothing: true,
                 },
+                // [[[101,202,[[303,404,baga6ea4seaaqa,505],[606,707,baga6ea4seaaqc,808]]],[303,404,[]]],true]
                 "828283186518ca828419012f190194d82a49000181e203922001001901f98419025e1902c3d82a49000181e203922001011903288319012f19019480f5",
             ),
         ];


### PR DESCRIPTION
Starting with ClaimAllocationsParams for now, matching with Go versions of this in go-state-types.

See https://github.com/filecoin-project/go-state-types/pull/263 for the matching PR and a longer description of why/what this is.