### PR TITLE
fix(market): clean up provider_sectors when empty

### DIFF
--- a/actors/market/tests/activate_deal_failures.rs
+++ b/actors/market/tests/activate_deal_failures.rs
@@ -107,7 +107,7 @@ fn reject_proposal_expired() {
         ExitCode::OK,
     );
     cron_tick(&rt);
-    assert_deal_deleted(&rt, deal_id, &deal, 0);
+    assert_deal_deleted(&rt, deal_id, &deal, 0, true);
 
     assert_activation_failure(&rt, deal_id, &deal, 1, sector_expiry, EX_DEAL_EXPIRED);
 }

--- a/actors/market/tests/batch_activate_deals.rs
+++ b/actors/market/tests/batch_activate_deals.rs
@@ -46,7 +46,7 @@ fn activate_deals_one_sector() {
     assert!(res.activation_results.all_ok());
 
     // Deal IDs are stored under the sector, in correct order.
-    assert_eq!(deal_ids, get_sector_deal_ids(&rt, PROVIDER_ID, &[1]));
+    assert_eq!(deal_ids, get_sector_deal_ids(&rt, PROVIDER_ID, &[1]).unwrap());
 
     for id in deal_ids.iter() {
         let state = get_deal_state(&rt, *id);
@@ -392,7 +392,7 @@ fn activate_new_deals_in_existing_sector() {
     assert_eq!(0, get_deal_state(&rt, deal_ids[2]).sector_start_epoch);
 
     // All deals stored under the sector, in order.
-    assert_eq!(deal_ids, get_sector_deal_ids(&rt, PROVIDER_ID, &[sector_number]));
+    assert_eq!(deal_ids, get_sector_deal_ids(&rt, PROVIDER_ID, &[sector_number]).unwrap());
     check_state(&rt);
 }
 

--- a/actors/market/tests/cron_tick_deal_expiry.rs
+++ b/actors/market/tests/cron_tick_deal_expiry.rs
@@ -49,7 +49,7 @@ fn deal_is_correctly_processed_if_first_cron_after_expiry() {
     assert!(slashed.is_zero());
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number, true);
     check_state(&rt);
 }
 
@@ -124,7 +124,7 @@ fn regular_payments_till_deal_expires_and_then_locked_funds_are_unlocked() {
     assert!(slashed.is_zero());
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number, true);
     check_state(&rt);
 }
 
@@ -154,7 +154,7 @@ fn payment_for_a_deal_if_deal_is_already_expired_before_a_cron_tick() {
     assert_eq!((end - start) * &deal_proposal.storage_price_per_epoch, pay);
     assert!(slashed.is_zero());
 
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number, true);
 
     // running cron tick again doesn't do anything
     cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
@@ -203,7 +203,7 @@ fn expired_deal_should_unlock_the_remaining_client_and_provider_locked_balance_a
     assert!(provider_acct.locked.is_zero());
 
     // deal should be deleted
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number, true);
     check_state(&rt);
 }
 

--- a/actors/market/tests/cron_tick_deal_slashing.rs
+++ b/actors/market/tests/cron_tick_deal_slashing.rs
@@ -102,7 +102,7 @@ fn deal_is_slashed() {
         rt.set_epoch(cron_tick_epoch);
         cron_tick(&rt);
 
-        assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
+        assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number, true);
 
         check_state(&rt);
     }
@@ -142,7 +142,7 @@ fn deal_is_slashed_at_the_end_epoch_should_not_be_slashed_and_should_be_consider
     assert!(slashed.is_zero());
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER, true);
 
     check_state(&rt);
 }
@@ -192,7 +192,7 @@ fn deal_payment_and_slashing_correctly_processed_in_same_crontick() {
     cron_tick(&rt);
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number, true);
     check_state(&rt);
 }
 
@@ -249,9 +249,9 @@ fn slash_multiple_deals_in_the_same_epoch() {
     rt.set_epoch(epoch + 1);
     cron_tick(&rt);
 
-    assert_deal_deleted(&rt, deal_id1, &deal_proposal1, SECTOR_NUMBER);
-    assert_deal_deleted(&rt, deal_id2, &deal_proposal2, SECTOR_NUMBER);
-    assert_deal_deleted(&rt, deal_id3, &deal_proposal3, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id1, &deal_proposal1, SECTOR_NUMBER, true);
+    assert_deal_deleted(&rt, deal_id2, &deal_proposal2, SECTOR_NUMBER, true);
+    assert_deal_deleted(&rt, deal_id3, &deal_proposal3, SECTOR_NUMBER, true);
     check_state(&rt);
 }
 
@@ -319,7 +319,7 @@ fn regular_payments_till_deal_is_slashed_and_then_slashing_is_processed() {
     cron_tick(&rt);
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER, true);
     check_state(&rt);
 }
 
@@ -372,6 +372,6 @@ fn regular_payments_till_deal_expires_and_then_we_attempt_to_slash_it_but_it_wil
     assert!(slashed.is_zero());
 
     // deal should be deleted as it should have expired
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER, true);
     check_state(&rt);
 }

--- a/actors/market/tests/cron_tick_timedout_deals.rs
+++ b/actors/market/tests/cron_tick_timedout_deals.rs
@@ -55,7 +55,7 @@ fn timed_out_deal_is_slashed_and_deleted() {
     assert_eq!(c_escrow, client_acct.balance);
     assert!(client_acct.locked.is_zero());
     assert_account_zero(&rt, PROVIDER_ADDR);
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, 0);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, 0, true);
     check_state(&rt);
 }
 
@@ -126,7 +126,7 @@ fn publishing_timed_out_deal_again_should_work_after_cron_tick_as_it_should_no_l
         ExitCode::OK,
     );
     cron_tick(&rt);
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, 0);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, 0, true);
 
     // now publishing should work
     generate_and_publish_deal(&rt, CLIENT_ADDR, &MinerAddresses::default(), START_EPOCH, END_EPOCH);
@@ -192,8 +192,8 @@ fn timed_out_and_verified_deals_are_slashed_deleted() {
     cron_tick_no_change(&rt, CLIENT_ADDR, PROVIDER_ADDR);
 
     assert_account_zero(&rt, PROVIDER_ADDR);
-    assert_deal_deleted(&rt, deal_ids[0], &deal1, 0);
-    assert_deal_deleted(&rt, deal_ids[1], &deal2, 0);
-    assert_deal_deleted(&rt, deal_ids[2], &deal3, 0);
+    assert_deal_deleted(&rt, deal_ids[0], &deal1, 0, true);
+    assert_deal_deleted(&rt, deal_ids[1], &deal2, 0, true);
+    assert_deal_deleted(&rt, deal_ids[2], &deal3, 0, true);
     check_state(&rt);
 }

--- a/actors/market/tests/deal_termination.rs
+++ b/actors/market/tests/deal_termination.rs
@@ -106,7 +106,7 @@ fn deal_is_terminated() {
         assert_eq!(tc.termination_payment, pay);
         assert_eq!(deal_proposal.provider_collateral, slashed);
 
-        assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number);
+        assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number, true);
 
         // assert that trying to settle is always a no-op after termination
 
@@ -197,7 +197,7 @@ fn settle_payments_then_terminate_deal_in_the_same_epoch() {
         &[sector_number],
         &[deal_id],
     );
-    assert_deal_deleted(&rt, deal_id, &proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &proposal, sector_number, true);
 
     // end state should be equivalent to only calling termination
     let client_after = get_balance(&rt, &CLIENT_ADDR);
@@ -245,7 +245,7 @@ fn terminate_a_deal_then_settle_it_in_the_same_epoch() {
     );
     let ret = settle_deal_payments(&rt, PROVIDER_ADDR, &[deal_id], &[], &[]);
     assert_eq!(ret.results.codes(), vec![EX_DEAL_EXPIRED]);
-    assert_deal_deleted(&rt, deal_id, &proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &proposal, sector_number, true);
 
     check_state(&rt);
 }

--- a/actors/market/tests/market_actor_legacy_tests.rs
+++ b/actors/market/tests/market_actor_legacy_tests.rs
@@ -59,7 +59,7 @@ fn slash_a_deal_and_make_payment_for_another_deal_in_the_same_epoch() {
     terminate_deals(&rt, PROVIDER_ADDR, &[sector_1], &[deal_id1]);
     cron_tick(&rt);
 
-    assert_deal_deleted(&rt, deal_id1, &d1, sector_1);
+    assert_deal_deleted(&rt, deal_id1, &d1, sector_1, true);
     let s2 = get_deal_state(&rt, deal_id2);
     assert_eq!(slash_epoch, s2.last_updated_epoch);
     check_state(&rt);

--- a/actors/market/tests/market_actor_test.rs
+++ b/actors/market/tests/market_actor_test.rs
@@ -344,7 +344,7 @@ fn worker_balance_after_withdrawal_must_account_for_slashed_funds() {
     // terminate the deal
     rt.set_epoch(publish_epoch + 1);
     terminate_deals(&rt, PROVIDER_ADDR, &[sector_number], &[deal_id]);
-    assert_deal_deleted(&rt, deal_id, &proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &proposal, sector_number, true);
 
     // provider cannot withdraw any funds since it's been terminated
     let withdraw_amount = TokenAmount::from_atto(1);
@@ -1369,7 +1369,7 @@ fn terminating_a_deal_removes_proposal_synchronously() {
 
     // terminating the deal deletes proposal, state and pending_proposal but leaves deal op in queue
     terminate_deals(&rt, addrs.provider, &[sector_number], &[deal_id]);
-    assert_deal_deleted(&rt, deal_id, &proposal, sector_number);
+    assert_deal_deleted(&rt, deal_id, &proposal, sector_number, true);
     check_state(&rt);
 
     // the next cron_tick will remove the dangling deal op entry

--- a/actors/market/tests/random_cron_epoch_during_publish.rs
+++ b/actors/market/tests/random_cron_epoch_during_publish.rs
@@ -96,7 +96,7 @@ fn deal_is_processed_after_its_end_epoch_should_expire_correctly() {
     assert!(slashed.is_zero());
     let duration = END_EPOCH - START_EPOCH;
     assert_eq!(duration * &deal_proposal.storage_price_per_epoch, pay);
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER, true);
     check_state(&rt);
 }
 
@@ -152,6 +152,6 @@ fn cron_processing_of_deal_after_missed_activation_should_fail_and_slash() {
     );
     cron_tick(&rt);
 
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, SECTOR_NUMBER, true);
     check_state(&rt);
 }

--- a/actors/market/tests/sector_content_changed.rs
+++ b/actors/market/tests/sector_content_changed.rs
@@ -88,7 +88,7 @@ fn simple_one_sector() {
     assert!(ret.sectors[0].added.iter().all(|r| r.accepted));
 
     // Deal IDs are stored under the sector, in correct order.
-    assert_eq!(deal_ids, get_sector_deal_ids(&rt, PROVIDER_ID, &[sno]));
+    assert_eq!(deal_ids, get_sector_deal_ids(&rt, PROVIDER_ID, &[sno]).unwrap());
 
     // Deal states include allocation IDs from when they were published.
     for id in deal_ids.iter() {
@@ -142,8 +142,8 @@ fn simple_multiple_sectors() {
     assert_eq!(vec![PieceReturn { accepted: true }], ret.sectors[2].added);
 
     // Deal IDs are stored under the right sector, in correct order.
-    assert_eq!(deal_ids[0..2], get_sector_deal_ids(&rt, PROVIDER_ID, &[1]));
-    assert_eq!(deal_ids[2..3], get_sector_deal_ids(&rt, PROVIDER_ID, &[2]));
+    assert_eq!(deal_ids[0..2], get_sector_deal_ids(&rt, PROVIDER_ID, &[1]).unwrap());
+    assert_eq!(deal_ids[2..3], get_sector_deal_ids(&rt, PROVIDER_ID, &[2]).unwrap());
 }
 
 #[test]
@@ -188,7 +188,7 @@ fn new_deal_existing_sector() {
     sector_content_changed(&rt, PROVIDER_ADDR, changes).unwrap();
 
     // All deal IDs are stored under the right sector, in correct order.
-    assert_eq!(deal_ids[0..3], get_sector_deal_ids(&rt, PROVIDER_ID, &[1]));
+    assert_eq!(deal_ids[0..3], get_sector_deal_ids(&rt, PROVIDER_ID, &[1]).unwrap());
 }
 
 #[test]
@@ -303,8 +303,8 @@ fn failures_isolated() {
     assert_eq!(vec![PieceReturn { accepted: true }], ret.sectors[2].added);
 
     // Successful deal IDs are stored under the right sector, in correct order.
-    assert_eq!(deal_ids[0..1], get_sector_deal_ids(&rt, PROVIDER_ID, &[1]));
-    assert_eq!(deal_ids[3..4], get_sector_deal_ids(&rt, PROVIDER_ID, &[3]));
+    assert_eq!(deal_ids[0..1], get_sector_deal_ids(&rt, PROVIDER_ID, &[1]).unwrap());
+    assert_eq!(deal_ids[3..4], get_sector_deal_ids(&rt, PROVIDER_ID, &[3]).unwrap());
 }
 
 #[test]
@@ -346,8 +346,8 @@ fn rejects_duplicates_in_same_sector() {
     );
 
     // Deal IDs are stored under the right sector, in correct order.
-    assert_eq!(deal_ids[0..2], get_sector_deal_ids(&rt, PROVIDER_ID, &[1]));
-    assert_eq!(Vec::<DealID>::new(), get_sector_deal_ids(&rt, PROVIDER_ID, &[2]));
+    assert_eq!(deal_ids[0..2], get_sector_deal_ids(&rt, PROVIDER_ID, &[1]).unwrap());
+    assert!(get_sector_deal_ids(&rt, PROVIDER_ID, &[2]).is_none());
 }
 
 #[test]
@@ -407,8 +407,8 @@ fn rejects_duplicates_across_sectors() {
     );
 
     // Deal IDs are stored under the right sector, in correct order.
-    assert_eq!(deal_ids[0..2], get_sector_deal_ids(&rt, PROVIDER_ID, &[1]));
-    assert_eq!(deal_ids[2..3], get_sector_deal_ids(&rt, PROVIDER_ID, &[2]));
+    assert_eq!(deal_ids[0..2], get_sector_deal_ids(&rt, PROVIDER_ID, &[1]).unwrap());
+    assert_eq!(deal_ids[2..3], get_sector_deal_ids(&rt, PROVIDER_ID, &[2]).unwrap());
 }
 
 #[test]

--- a/actors/market/tests/settle_deal_payments.rs
+++ b/actors/market/tests/settle_deal_payments.rs
@@ -43,7 +43,7 @@ fn timedout_deal_is_slashed_and_deleted() {
     assert_eq!(c_escrow, client_acct.balance);
     assert!(client_acct.locked.is_zero());
     assert_account_zero(&rt, PROVIDER_ADDR);
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, 0);
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, 0, true);
 
     check_state(&rt);
 
@@ -112,7 +112,7 @@ fn can_manually_settle_deals_in_the_cron_queue() {
     assert_eq!(&provider_after.balance, &final_provider_escrow);
 
     // cleaned up by cron
-    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number)
+    assert_deal_deleted(&rt, deal_id, &deal_proposal, sector_number, true)
 }
 
 #[test]
@@ -267,9 +267,9 @@ fn batch_settlement_of_deals_allows_partial_success() {
         finished_summary,
         DealSettlementSummary { completed: true, payment: finished_payment.clone() }
     );
-    assert_deal_deleted(&rt, finished_id, &finished_proposal, sector_number);
-    assert_deal_deleted(&rt, terminated_id, &terminated_proposal, sector_number);
-    assert_deal_deleted(&rt, unactivated_id, &unactivated_proposal, sector_number);
+    assert_deal_deleted(&rt, finished_id, &finished_proposal, sector_number, false);
+    assert_deal_deleted(&rt, terminated_id, &terminated_proposal, sector_number, false);
+    assert_deal_deleted(&rt, unactivated_id, &unactivated_proposal, sector_number, false);
 
     // check that the sum total of all payments/slashing has been reflected in the balance table
     let client_end = get_balance(&rt, &CLIENT_ADDR);

--- a/actors/market/tests/transient_marked_for_termination.rs
+++ b/actors/market/tests/transient_marked_for_termination.rs
@@ -102,7 +102,7 @@ fn deal_scheduled_for_termination_cannot_be_settled_manually() {
     cron_tick(&rt);
 
     // assert that the slashed deal was terminated
-    assert_deal_deleted(&rt, slashed_deal, &slashed_prop, sector_number);
+    assert_deal_deleted(&rt, slashed_deal, &slashed_prop, sector_number, false);
 
     // attempt to settle payment for both deals again - partially succeeds because not found deals are ignored
     rt.set_epoch(scheduled_epoch + 1);


### PR DESCRIPTION
We have this invariant complaining with nv22, `no deal ids in sector X` for the new `ProviderSectors` mapping: https://github.com/filecoin-project/go-state-types/blob/ad909a3d6ebef5ebc5688b4310e954e27da2203b/builtin/v13/market/invariants.go#L294

I don't think it's the migration that's the cause of this since it's checking the `len==0` case: https://github.com/filecoin-project/go-state-types/blob/ad909a3d6ebef5ebc5688b4310e954e27da2203b/builtin/v13/migration/miner.go#L76-L78

We have 2 ways that we remove items from `provider_sectors` in actors, `pop_sector_deal_ids` and `remove_sector_deal_ids`. The former does cleanup when empty. But the latter just removes and saves. This PR proposes removing in both cases when we get to an empty `DealID` array.

Before I write any tests for this I want to check if this is correct. Also, if this is correct, should we propose a small cleanup migration for nv23 to get rid of the empty ones?