### PR TITLE
feat: miner: max prove commit sector batch size

### DIFF
--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -24,6 +24,8 @@ pub struct Policy {
     pub pre_commit_sector_batch_max_size: usize,
     /// The maximum number of sector replica updates in a single batch.
     pub prove_replica_updates_max_size: usize,
+    /// The maximum number of sector prove commits in a single batch.
+    pub prove_commit_sector_batch_max_size: usize,
 
     /// The delay between pre commit expiration and clean up from state. This enforces that expired pre-commits
     /// stay in state for a period of time creating a grace period during which a late-running aggregated prove-commit
@@ -165,6 +167,8 @@ impl Default for Policy {
             max_replica_update_proof_size: policy_constants::MAX_REPLICA_UPDATE_PROOF_SIZE,
             pre_commit_sector_batch_max_size: policy_constants::PRE_COMMIT_SECTOR_BATCH_MAX_SIZE,
             prove_replica_updates_max_size: policy_constants::PROVE_REPLICA_UPDATES_MAX_SIZE,
+            prove_commit_sector_batch_max_size:
+                policy_constants::PROVE_COMMIT_SECTOR_BATCH_MAX_SIZE,
             expired_pre_commit_clean_up_delay: policy_constants::EXPIRED_PRE_COMMIT_CLEAN_UP_DELAY,
             wpost_proving_period: policy_constants::WPOST_PROVING_PERIOD,
             wpost_challenge_window: policy_constants::WPOST_CHALLENGE_WINDOW,
@@ -243,6 +247,9 @@ pub mod policy_constants {
 
     // Same as PRE_COMMIT_SECTOR_BATCH_MAX_SIZE for consistency.
     pub const PROVE_REPLICA_UPDATES_MAX_SIZE: usize = PRE_COMMIT_SECTOR_BATCH_MAX_SIZE;
+
+    // Same as PRE_COMMIT_SECTOR_BATCH_MAX_SIZE for consistency.
+    pub const PROVE_COMMIT_SECTOR_BATCH_MAX_SIZE: usize = PRE_COMMIT_SECTOR_BATCH_MAX_SIZE;
 
     pub const EXPIRED_PRE_COMMIT_CLEAN_UP_DELAY: i64 = 8 * EPOCHS_IN_HOUR;
 


### PR DESCRIPTION
The lack of a batch max size for the NI-PoRep method @ #1537 came up during an audit yesterday given that one is applied to precommit batches and it was noted that there's no max applied on prove_commit_sectors3, although there is one applied on aggregate proof size.

This may not be necessary here since I suppose it's already limited by the precommit limit, but I wanted to check whether that's correct or not. Perhaps the limitation imposed in this PR should only be added to #1537 for the reason documented @ https://github.com/filecoin-project/builtin-actors/blob/2899d1bf059a87d8f80ad0da9162eacc48f2f914/runtime/src/runtime/policy.rs#L241-L242