### PR TITLE
doc(miner): minor correction to aggregate fee comment in PCS3

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1924,7 +1924,8 @@ impl Actor {
 
         if !params.aggregate_proof.is_empty() {
             // Aggregate fee is paid on the sectors successfully proven,
-            // but without regard to data activation success.
+            // but without regard to data activation which may have subsequently failed
+            // and prevented sector activation.
             pay_aggregate_seal_proof_fee(rt, proven_activation_inputs.len())?;
         }
 

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1924,8 +1924,7 @@ impl Actor {
 
         if !params.aggregate_proof.is_empty() {
             // Aggregate fee is paid on the sectors successfully proven,
-            // but without regard to data activation which could subsequently fail
-            // and prevent sector activation.
+            // but without regard to data activation success.
             pay_aggregate_seal_proof_fee(rt, proven_activation_inputs.len())?;
         }
 


### PR DESCRIPTION
@NemanjaLu92 pointed out that aggregate fee is paid _after_ activations while discussing the need for this for the NI-PoRep method, so this comment was likely incorrect in `prove_commit_sectors3`. I thought this was worth checking with a isolated PR since it should be relatively straightforward to clarify.