### PR TITLE
fix: restore ConfirmSectorProofsValid

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -119,7 +119,7 @@ pub enum Method {
     ApplyRewards = 14,
     ReportConsensusFault = 15,
     WithdrawBalance = 16,
-    //ConfirmSectorProofsValid = 17, // Deprecated
+    ConfirmSectorProofsValid = 17,
     ChangeMultiaddrs = 18,
     CompactPartitions = 19,
     CompactSectorNumbers = 20,
@@ -1948,6 +1948,70 @@ impl Actor {
 
         let result = util::stack(&[validation_batch, proven_batch, data_batch]);
         Ok(ProveCommitSectors3Return { activation_results: result })
+    }
+
+    fn confirm_sector_proofs_valid(
+        rt: &impl Runtime,
+        params: ConfirmSectorProofsParams,
+    ) -> Result<(), ActorError> {
+        rt.validate_immediate_caller_is(std::iter::once(&STORAGE_POWER_ACTOR_ADDR))?;
+
+        /* validate params */
+        // This should be enforced by the power actor. We log here just in case
+        // something goes wrong.
+        if params.sectors.len() > ext::power::MAX_MINER_PROVE_COMMITS_PER_EPOCH {
+            warn!(
+                "confirmed more prove commits in an epoch than permitted: {} > {}",
+                params.sectors.len(),
+                ext::power::MAX_MINER_PROVE_COMMITS_PER_EPOCH
+            );
+        }
+        let st: State = rt.state()?;
+        let store = rt.store();
+        // This skips missing pre-commits.
+        let precommited_sectors =
+            st.find_precommitted_sectors(store, &params.sectors).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::USR_ILLEGAL_STATE,
+                    "failed to load pre-committed sectors",
+                )
+            })?;
+
+        let data_activations: Vec<DealsActivationInput> =
+            precommited_sectors.iter().map(|x| x.clone().into()).collect();
+        let info = get_miner_info(rt.store(), &st)?;
+
+        /*
+            For all sectors
+            - CommD was specified at precommit
+            - If deal IDs were specified at precommit the CommD was checked against them
+            Therefore CommD on precommit has already been provided and checked so no further processing needed
+        */
+        let compute_commd = false;
+        let (batch_return, data_activations) =
+            activate_sectors_deals(rt, &data_activations, compute_commd)?;
+        let successful_activations = batch_return.successes(&precommited_sectors);
+
+        let pledge_inputs = NetworkPledgeInputs {
+            network_qap: params.quality_adj_power_smoothed,
+            network_baseline: params.reward_baseline_power,
+            circulating_supply: rt.total_fil_circ_supply(),
+            epoch_reward: params.reward_smoothed,
+        };
+        activate_new_sector_infos(
+            rt,
+            successful_activations.clone(),
+            data_activations.clone(),
+            &pledge_inputs,
+            &info,
+        )?;
+
+        for (pc, data) in successful_activations.iter().zip(data_activations.iter()) {
+            let unsealed_cid = pc.info.unsealed_cid.0;
+            emit::sector_activated(rt, pc.info.sector_number, unsealed_cid, &data.pieces)?;
+        }
+
+        Ok(())
     }
 
     fn check_sector_proven(
@@ -5610,6 +5674,7 @@ impl ActorCode for Actor {
         ApplyRewards => apply_rewards,
         ReportConsensusFault => report_consensus_fault,
         WithdrawBalance|WithdrawBalanceExported => withdraw_balance,
+        ConfirmSectorProofsValid => confirm_sector_proofs_valid,
         ChangeMultiaddrs|ChangeMultiaddrsExported => change_multiaddresses,
         CompactPartitions => compact_partitions,
         CompactSectorNumbers => compact_sector_numbers,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -1955,7 +1955,6 @@ impl Actor {
         params: InternalSectorSetupForPresealParams,
     ) -> Result<(), ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
-        
         let st: State = rt.state()?;
         let store = rt.store();
         // This skips missing pre-commits.

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -119,7 +119,7 @@ pub enum Method {
     ApplyRewards = 14,
     ReportConsensusFault = 15,
     WithdrawBalance = 16,
-    ConfirmSectorProofsValid = 17,
+    InternalSectorSetupForPreseal = 17,
     ChangeMultiaddrs = 18,
     CompactPartitions = 19,
     CompactSectorNumbers = 20,
@@ -1950,22 +1950,12 @@ impl Actor {
         Ok(ProveCommitSectors3Return { activation_results: result })
     }
 
-    fn confirm_sector_proofs_valid(
+    fn internal_sector_setup_preseal(
         rt: &impl Runtime,
-        params: ConfirmSectorProofsParams,
+        params: InternalSectorSetupForPresealParams,
     ) -> Result<(), ActorError> {
-        rt.validate_immediate_caller_is(std::iter::once(&STORAGE_POWER_ACTOR_ADDR))?;
-
-        /* validate params */
-        // This should be enforced by the power actor. We log here just in case
-        // something goes wrong.
-        if params.sectors.len() > ext::power::MAX_MINER_PROVE_COMMITS_PER_EPOCH {
-            warn!(
-                "confirmed more prove commits in an epoch than permitted: {} > {}",
-                params.sectors.len(),
-                ext::power::MAX_MINER_PROVE_COMMITS_PER_EPOCH
-            );
-        }
+        rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
+        
         let st: State = rt.state()?;
         let store = rt.store();
         // This skips missing pre-commits.
@@ -5674,7 +5664,7 @@ impl ActorCode for Actor {
         ApplyRewards => apply_rewards,
         ReportConsensusFault => report_consensus_fault,
         WithdrawBalance|WithdrawBalanceExported => withdraw_balance,
-        ConfirmSectorProofsValid => confirm_sector_proofs_valid,
+        InternalSectorSetupForPreseal => internal_sector_setup_preseal,
         ChangeMultiaddrs|ChangeMultiaddrsExported => change_multiaddresses,
         CompactPartitions => compact_partitions,
         CompactSectorNumbers => compact_sector_numbers,

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -14,7 +14,7 @@ use fvm_shared::piece::PaddedPieceSize;
 use fvm_shared::randomness::Randomness;
 use fvm_shared::sector::{
     PoStProof, RegisteredAggregateProof, RegisteredPoStProof, RegisteredSealProof,
-    RegisteredUpdateProof, SectorNumber, SectorSize,
+    RegisteredUpdateProof, SectorNumber, SectorSize, StoragePower,
 };
 use fvm_shared::ActorID;
 use serde::{Deserialize, Serialize};
@@ -86,6 +86,15 @@ pub struct ChangePeerIDParams {
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ChangeMultiaddrsParams {
     pub new_multi_addrs: Vec<BytesDe>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct ConfirmSectorProofsParams {
+    pub sectors: Vec<SectorNumber>,
+    pub reward_smoothed: FilterEstimate,
+    #[serde(with = "bigint_ser")]
+    pub reward_baseline_power: StoragePower,
+    pub quality_adj_power_smoothed: FilterEstimate,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -89,7 +89,7 @@ pub struct ChangeMultiaddrsParams {
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct ConfirmSectorProofsParams {
+pub struct InternalSectorSetupForPresealParams {
     pub sectors: Vec<SectorNumber>,
     pub reward_smoothed: FilterEstimate,
     #[serde(with = "bigint_ser")]

--- a/actors/power/src/ext.rs
+++ b/actors/power/src/ext.rs
@@ -3,8 +3,7 @@ use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{strict_bytes, BytesDe};
 
 use fvm_shared::address::Address;
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, StoragePower};
+use fvm_shared::sector::RegisteredPoStProof;
 use fvm_shared::METHOD_CONSTRUCTOR;
 use num_derive::FromPrimitive;
 
@@ -36,17 +35,7 @@ pub mod init {
 pub mod miner {
     use super::*;
 
-    pub const CONFIRM_SECTOR_PROOFS_VALID_METHOD: u64 = 17;
     pub const ON_DEFERRED_CRON_EVENT_METHOD: u64 = 12;
-
-    #[derive(Serialize_tuple, Deserialize_tuple)]
-    pub struct ConfirmSectorProofsParams {
-        pub sectors: Vec<SectorNumber>,
-        pub reward_smoothed: FilterEstimate,
-        #[serde(with = "bigint_ser")]
-        pub reward_baseline_power: StoragePower,
-        pub quality_adj_power_smoothed: FilterEstimate,
-    }
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct MinerConstructorParams {

--- a/actors/power/src/ext.rs
+++ b/actors/power/src/ext.rs
@@ -3,7 +3,8 @@ use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{strict_bytes, BytesDe};
 
 use fvm_shared::address::Address;
-use fvm_shared::sector::RegisteredPoStProof;
+use fvm_shared::bigint::bigint_ser;
+use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, StoragePower};
 use fvm_shared::METHOD_CONSTRUCTOR;
 use num_derive::FromPrimitive;
 
@@ -35,7 +36,17 @@ pub mod init {
 pub mod miner {
     use super::*;
 
+    pub const CONFIRM_SECTOR_PROOFS_VALID_METHOD: u64 = 17;
     pub const ON_DEFERRED_CRON_EVENT_METHOD: u64 = 12;
+
+    #[derive(Serialize_tuple, Deserialize_tuple)]
+    pub struct ConfirmSectorProofsParams {
+        pub sectors: Vec<SectorNumber>,
+        pub reward_smoothed: FilterEstimate,
+        #[serde(with = "bigint_ser")]
+        pub reward_baseline_power: StoragePower,
+        pub quality_adj_power_smoothed: FilterEstimate,
+    }
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
     pub struct MinerConstructorParams {


### PR DESCRIPTION
Removed in https://github.com/filecoin-project/builtin-actors/pull/1540 but I believe it's still needed to activate preseals; unless there's an alternative route to this?

Ref: https://github.com/filecoin-project/lotus/blob/b73d4e0481517b395a0e9aa9af5dab8bedc18285/chain/gen/genesis/miners.go#L494-L509

Tests for this were tangled up in the prove commit + cron stuff that was removed, this probably needs new tests if it's going back, but I'm not sure yet what that would entail.