### PR TITLE
cherry-pick late release/v13 commits onto master

### DIFF
--- a/actors/verifreg/src/emit.rs
+++ b/actors/verifreg/src/emit.rs
@@ -16,14 +16,16 @@ pub fn verifier_balance(
     rt: &impl Runtime,
     verifier: ActorID,
     new_balance: &DataCap,
+    client: Option<ActorID>,
 ) -> Result<(), ActorError> {
-    rt.emit_event(
-        &EventBuilder::new()
-            .typ("verifier-balance")
-            .field_indexed("verifier", &verifier)
-            .field("balance", &BigIntSer(new_balance))
-            .build()?,
-    )
+    let mut event: EventBuilder = EventBuilder::new()
+        .typ("verifier-balance")
+        .field_indexed("verifier", &verifier)
+        .field("balance", &BigIntSer(new_balance));
+    if let Some(client) = client {
+        event = event.field_indexed("client", &client);
+    }
+    rt.emit_event(&event.build()?)
 }
 
 /// Indicates a new allocation has been made.

--- a/actors/verifreg/src/emit.rs
+++ b/actors/verifreg/src/emit.rs
@@ -1,10 +1,12 @@
 // A namespace for helpers that build and emit verified registry events.
 
-use crate::{ActorError, AllocationID};
+use crate::{ActorError, Allocation, AllocationID, Claim};
 use crate::{ClaimID, DataCap};
+use cid::Cid;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::EventBuilder;
 use fvm_shared::bigint::bigint_ser::BigIntSer;
+use fvm_shared::clock::ChainEpoch;
 use fvm_shared::ActorID;
 
 /// Indicates a new value for a verifier's datacap balance.
@@ -28,11 +30,16 @@ pub fn verifier_balance(
 pub fn allocation(
     rt: &impl Runtime,
     id: AllocationID,
-    client: ActorID,
-    provider: ActorID,
+    alloc: &Allocation,
 ) -> Result<(), ActorError> {
     rt.emit_event(
-        &EventBuilder::new().typ("allocation").with_parties(id, client, provider).build()?,
+        &EventBuilder::new()
+            .typ("allocation")
+            .with_parties(id, alloc.client, alloc.provider)
+            .with_piece(&alloc.data, alloc.size.0)
+            .with_term(alloc.term_min, alloc.term_max)
+            .field("expiration", &alloc.expiration)
+            .build()?,
     )
 }
 
@@ -40,48 +47,58 @@ pub fn allocation(
 pub fn allocation_removed(
     rt: &impl Runtime,
     id: AllocationID,
-    client: ActorID,
-    provider: ActorID,
+    alloc: &Allocation,
 ) -> Result<(), ActorError> {
     rt.emit_event(
         &EventBuilder::new()
             .typ("allocation-removed")
-            .with_parties(id, client, provider)
+            .with_parties(id, alloc.client, alloc.provider)
+            .with_piece(&alloc.data, alloc.size.0)
+            .with_term(alloc.term_min, alloc.term_max)
+            .field("expiration", &alloc.expiration)
             .build()?,
     )
 }
 
 /// Indicates an allocation has been claimed.
-pub fn claim(
-    rt: &impl Runtime,
-    id: ClaimID,
-    client: ActorID,
-    provider: ActorID,
-) -> Result<(), ActorError> {
-    rt.emit_event(&EventBuilder::new().typ("claim").with_parties(id, client, provider).build()?)
+pub fn claim(rt: &impl Runtime, id: ClaimID, claim: &Claim) -> Result<(), ActorError> {
+    rt.emit_event(
+        &EventBuilder::new()
+            .typ("claim")
+            .with_parties(id, claim.client, claim.provider)
+            .with_piece(&claim.data, claim.size.0)
+            .with_term(claim.term_min, claim.term_max)
+            .field("term-start", &claim.term_start)
+            .field_indexed("sector", &claim.sector)
+            .build()?,
+    )
 }
 
 /// Indicates an existing claim has been updated (e.g. with a longer term).
-pub fn claim_updated(
-    rt: &impl Runtime,
-    id: ClaimID,
-    client: ActorID,
-    provider: ActorID,
-) -> Result<(), ActorError> {
+pub fn claim_updated(rt: &impl Runtime, id: ClaimID, claim: &Claim) -> Result<(), ActorError> {
     rt.emit_event(
-        &EventBuilder::new().typ("claim-updated").with_parties(id, client, provider).build()?,
+        &EventBuilder::new()
+            .typ("claim-updated")
+            .with_parties(id, claim.client, claim.provider)
+            .with_piece(&claim.data, claim.size.0)
+            .with_term(claim.term_min, claim.term_max)
+            .field("term-start", &claim.term_start)
+            .field_indexed("sector", &claim.sector)
+            .build()?,
     )
 }
 
 /// Indicates an expired claim has been removed.
-pub fn claim_removed(
-    rt: &impl Runtime,
-    id: ClaimID,
-    client: ActorID,
-    provider: ActorID,
-) -> Result<(), ActorError> {
+pub fn claim_removed(rt: &impl Runtime, id: ClaimID, claim: &Claim) -> Result<(), ActorError> {
     rt.emit_event(
-        &EventBuilder::new().typ("claim-removed").with_parties(id, client, provider).build()?,
+        &EventBuilder::new()
+            .typ("claim-removed")
+            .with_parties(id, claim.client, claim.provider)
+            .with_piece(&claim.data, claim.size.0)
+            .with_term(claim.term_min, claim.term_max)
+            .field("term-start", &claim.term_start)
+            .field_indexed("sector", &claim.sector)
+            .build()?,
     )
 }
 
@@ -95,5 +112,25 @@ impl WithParties for EventBuilder {
         self.field_indexed("id", &id)
             .field_indexed("client", &client)
             .field_indexed("provider", &provider)
+    }
+}
+
+trait WithPiece {
+    fn with_piece(self, piece_cid: &Cid, piece_size: u64) -> EventBuilder;
+}
+
+impl crate::emit::WithPiece for EventBuilder {
+    fn with_piece(self, piece_cid: &Cid, piece_size: u64) -> EventBuilder {
+        self.field_indexed("piece-cid", &piece_cid).field("piece-size", &piece_size)
+    }
+}
+
+trait WithTerm {
+    fn with_term(self, term_min: ChainEpoch, term_max: ChainEpoch) -> EventBuilder;
+}
+
+impl crate::emit::WithTerm for EventBuilder {
+    fn with_term(self, term_min: ChainEpoch, term_max: ChainEpoch) -> EventBuilder {
+        self.field("term-min", &term_min).field("term-max", &term_max)
     }
 }

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -165,8 +165,8 @@ impl Actor {
             ));
         }
 
-        let client = resolve_to_actor_id(rt, &params.address, true)?;
-        let client = Address::new_id(client);
+        let client_id = resolve_to_actor_id(rt, &params.address, true)?;
+        let client = Address::new_id(client_id);
 
         rt.transaction(|st: &mut State, rt| {
             if client == st.root_key {
@@ -345,7 +345,7 @@ impl Actor {
                         )?
                         .unwrap(); // Unwrapping here as both paths to here should ensure the allocation exists.
 
-                    emit::allocation_removed(rt, *id, existing.client, existing.provider)?;
+                    emit::allocation_removed(rt, *id, &existing)?;
 
                     // Unwrapping here as both paths to here should ensure the allocation exists.
                     recovered_datacap += existing.size.0;
@@ -448,7 +448,8 @@ impl Actor {
                         return Err(actor_error!(illegal_argument, "claim {} already exists", id));
                     }
 
-                    emit::claim(rt, id, new_claim.client, new_claim.provider)?;
+                    // Emit a claim event below
+                    emit::claim(rt, id, &new_claim)?;
 
                     allocs.remove(new_claim.client, id).context_code(
                         ExitCode::USR_ILLEGAL_STATE,
@@ -565,7 +566,7 @@ impl Actor {
                         "HAMT put failure storing new claims",
                     )?;
                     batch_gen.add_success();
-                    emit::claim_updated(rt, term.claim_id, new_claim.client, new_claim.provider)?;
+                    emit::claim_updated(rt, term.claim_id, &new_claim)?;
                 } else {
                     batch_gen.add_fail(ExitCode::USR_NOT_FOUND);
                     info!("no claim {} for provider {}", term.claim_id, term.provider);
@@ -617,7 +618,7 @@ impl Actor {
                     )?
                     .unwrap();
 
-                emit::claim_removed(rt, *id, removed.client, removed.provider)?;
+                emit::claim_removed(rt, *id, &removed)?;
             }
 
             st.save_claims(&mut claims)?;
@@ -717,13 +718,13 @@ impl Actor {
             let ids = st.insert_allocations(rt.store(), client, new_allocs.clone())?;
 
             for (id, alloc) in ids.iter().zip(new_allocs.iter()) {
-                emit::allocation(rt, *id, alloc.client, alloc.provider)?;
+                emit::allocation(rt, *id, alloc)?;
             }
 
             st.put_claims(rt.store(), updated_claims.clone())?;
 
             for (id, claim) in updated_claims {
-                emit::claim_updated(rt, id, claim.client, claim.provider)?;
+                emit::claim_updated(rt, id, &claim)?;
             }
 
             Ok(ids)

--- a/actors/verifreg/src/lib.rs
+++ b/actors/verifreg/src/lib.rs
@@ -131,7 +131,7 @@ impl Actor {
                 .context("failed to add verifier")
         })?;
 
-        emit::verifier_balance(rt, verifier, &params.allowance)
+        emit::verifier_balance(rt, verifier, &params.allowance, None)
     }
 
     pub fn remove_verifier(
@@ -146,7 +146,7 @@ impl Actor {
             st.remove_verifier(rt.store(), &verifier_addr).context("failed to remove verifier")
         })?;
 
-        emit::verifier_balance(rt, verifier, &DataCap::zero())
+        emit::verifier_balance(rt, verifier, &DataCap::zero(), None)
     }
 
     pub fn add_verified_client(
@@ -204,7 +204,12 @@ impl Actor {
             st.put_verifier(rt.store(), &verifier_addr, &new_verifier_cap)
                 .context("failed to update verifier allowance")?;
 
-            emit::verifier_balance(rt, verifier_addr.id().unwrap(), &new_verifier_cap)
+            emit::verifier_balance(
+                rt,
+                verifier_addr.id().unwrap(),
+                &new_verifier_cap,
+                Some(client.id().unwrap()),
+            )
         })?;
 
         // Credit client token allowance.

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -1,6 +1,8 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
+use cid::Cid;
+
 use frc46_token::receiver::{FRC46TokenReceived, FRC46_TOKEN_TYPE};
 use frc46_token::token::types::{BurnParams, BurnReturn, TransferParams};
 use frc46_token::token::TOKEN_PRECISION;
@@ -290,13 +292,25 @@ impl Harness {
         claim_allocs: Vec<SectorAllocationClaims>,
         datacap_burnt: u64,
         all_or_nothing: bool,
-        expect_claimed: Vec<(AllocationID, Allocation)>,
+        expect_claimed: Vec<(AllocationID, Allocation, SectorNumber)>,
     ) -> Result<ClaimAllocationsReturn, ActorError> {
         rt.expect_validate_caller_type(vec![Type::Miner]);
         rt.set_caller(*MINER_ACTOR_CODE_ID, Address::new_id(provider));
 
-        for (id, alloc) in expect_claimed.iter() {
-            expect_emitted(rt, "claim", id, alloc.client, alloc.provider);
+        for (id, alloc, sector) in expect_claimed.iter() {
+            expect_claim_emitted(
+                rt,
+                "claim",
+                *id,
+                alloc.client,
+                alloc.provider,
+                &alloc.data,
+                alloc.size.0,
+                *sector,
+                alloc.term_min,
+                alloc.term_max,
+                0,
+            )
         }
 
         if datacap_burnt > 0 {
@@ -339,8 +353,18 @@ impl Harness {
         let mut expected_datacap = 0u64;
         for (id, alloc) in expect_removed {
             expected_datacap += alloc.size.0;
-
-            expect_emitted(rt, "allocation-removed", &id, alloc.client, alloc.provider);
+            expect_allocation_emitted(
+                rt,
+                "allocation-removed",
+                id,
+                alloc.client,
+                alloc.provider,
+                &alloc.data,
+                alloc.size.0,
+                alloc.term_min,
+                alloc.term_max,
+                alloc.expiration,
+            )
         }
         rt.expect_send_simple(
             DATACAP_TOKEN_ACTOR_ADDR,
@@ -380,8 +404,21 @@ impl Harness {
         rt.expect_validate_caller_any();
 
         for (id, claim) in expect_removed {
-            expect_emitted(rt, "claim-removed", &id, claim.client, claim.provider);
+            expect_claim_emitted(
+                rt,
+                "claim-removed",
+                id,
+                claim.client,
+                claim.provider,
+                &claim.data,
+                claim.size.0,
+                claim.sector,
+                claim.term_min,
+                claim.term_max,
+                claim.term_start,
+            )
         }
+
         let params = RemoveExpiredClaimsParams { provider, claim_ids };
         let ret = rt
             .call::<VerifregActor>(
@@ -432,12 +469,36 @@ impl Harness {
 
         let allocs_req: AllocationRequests = payload.operator_data.deserialize().unwrap();
         for (alloc, id) in allocs_req.allocations.iter().zip(expected_alloc_ids.iter()) {
-            expect_emitted(rt, "allocation", id, payload.from, alloc.provider);
+            expect_allocation_emitted(
+                rt,
+                "allocation",
+                *id,
+                payload.from,
+                alloc.provider,
+                &alloc.data,
+                alloc.size.0,
+                alloc.term_min,
+                alloc.term_max,
+                alloc.expiration,
+            )
         }
 
         for ext in allocs_req.extensions {
-            let claim = self.load_claim(rt, ext.provider, ext.claim).unwrap();
-            expect_emitted(rt, "claim-updated", &ext.claim, claim.client, claim.provider);
+            let mut claim = self.load_claim(rt, ext.provider, ext.claim).unwrap();
+            claim.term_max = ext.term_max;
+            expect_claim_emitted(
+                rt,
+                "claim-updated",
+                ext.claim,
+                claim.client,
+                claim.provider,
+                &claim.data,
+                claim.size.0,
+                claim.sector,
+                claim.term_min,
+                claim.term_max,
+                claim.term_start,
+            )
         }
 
         rt.expect_validate_caller_addr(vec![DATACAP_TOKEN_ACTOR_ADDR]);
@@ -497,8 +558,22 @@ impl Harness {
         params: &ExtendClaimTermsParams,
         expected: Vec<(ClaimID, Claim)>,
     ) -> Result<ExtendClaimTermsReturn, ActorError> {
-        for (id, new_claim) in expected.iter() {
-            expect_emitted(rt, "claim-updated", id, new_claim.client, new_claim.provider);
+        for (id, mut new_claim) in expected {
+            let ext = params.terms.iter().find(|c| c.claim_id == id).unwrap();
+            new_claim.term_max = ext.term_max;
+            expect_claim_emitted(
+                rt,
+                "claim-updated",
+                id,
+                new_claim.client,
+                new_claim.provider,
+                &new_claim.data,
+                new_claim.size.0,
+                new_claim.sector,
+                new_claim.term_min,
+                new_claim.term_max,
+                new_claim.term_start,
+            )
         }
 
         rt.expect_validate_caller_any();
@@ -513,6 +588,66 @@ impl Harness {
         rt.verify();
         Ok(ret)
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn expect_allocation_emitted(
+    rt: &MockRuntime,
+    typ: &str,
+    id: u64,
+    client: ActorID,
+    provider: ActorID,
+    piece_cid: &Cid,
+    piece_size: u64,
+    term_min: ChainEpoch,
+    term_max: ChainEpoch,
+    expiration: ChainEpoch,
+) {
+    rt.expect_emitted_event(
+        EventBuilder::new()
+            .typ(typ)
+            .field_indexed("id", &id)
+            .field_indexed("client", &client)
+            .field_indexed("provider", &provider)
+            .field_indexed("piece-cid", piece_cid)
+            .field("piece-size", &piece_size)
+            .field("term-min", &term_min)
+            .field("term-max", &term_max)
+            .field("expiration", &expiration)
+            .build()
+            .unwrap(),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn expect_claim_emitted(
+    rt: &MockRuntime,
+    typ: &str,
+    id: u64,
+    client: ActorID,
+    provider: ActorID,
+    piece_cid: &Cid,
+    piece_size: u64,
+    sector: SectorNumber,
+    term_min: ChainEpoch,
+    term_max: ChainEpoch,
+    term_start: ChainEpoch,
+) {
+    rt.expect_emitted_event(
+        EventBuilder::new()
+            .typ(typ)
+            .field_indexed("id", &id)
+            .field_indexed("client", &client)
+            .field_indexed("provider", &provider)
+            .field_indexed("piece-cid", piece_cid)
+            .field("piece-size", &piece_size)
+            .field("term-min", &term_min)
+            .field("term-max", &term_max)
+            .field("term-start", &term_start)
+            .field_indexed("sector", &sector)
+            .build()
+            .unwrap(),
+    );
 }
 
 pub fn make_alloc(data_id: &str, client: ActorID, provider: ActorID, size: u64) -> Allocation {
@@ -537,18 +672,6 @@ pub fn make_alloc_req(rt: &MockRuntime, provider: ActorID, size: u64) -> Allocat
         term_max: MAXIMUM_VERIFIED_ALLOCATION_TERM,
         expiration: *rt.epoch.borrow() + 100,
     }
-}
-
-pub fn expect_emitted(rt: &MockRuntime, typ: &str, id: &u64, client: ActorID, provider: ActorID) {
-    rt.expect_emitted_event(
-        EventBuilder::new()
-            .typ(typ)
-            .field_indexed("id", &id)
-            .field_indexed("client", &client)
-            .field_indexed("provider", &provider)
-            .build()
-            .unwrap(),
-    );
 }
 
 pub fn make_extension_req(

--- a/actors/verifreg/tests/harness/mod.rs
+++ b/actors/verifreg/tests/harness/mod.rs
@@ -233,13 +233,17 @@ impl Harness {
         );
 
         let params = AddVerifiedClientParams { address: *client, allowance: allowance.clone() };
-        rt.expect_emitted_event(
-            EventBuilder::new()
-                .typ("verifier-balance")
-                .field_indexed("verifier", &verifier.id().unwrap())
-                .field("balance", &BigIntSer(&(verifier_balance - allowance)))
-                .build()?,
-        );
+        if client_resolved.id().is_ok() {
+            // if the client isn't resolved, we don't expect an event because the call should abort
+            rt.expect_emitted_event(
+                EventBuilder::new()
+                    .typ("verifier-balance")
+                    .field_indexed("verifier", &verifier.id().unwrap())
+                    .field("balance", &BigIntSer(&(verifier_balance - allowance)))
+                    .field_indexed("client", &client_resolved.id().unwrap())
+                    .build()?,
+            );
+        }
         let ret = rt.call::<VerifregActor>(
             Method::AddVerifiedClient as MethodNum,
             IpldBlock::serialize_cbor(&params).unwrap(),

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -449,6 +449,7 @@ mod clients {
                 .typ("verifier-balance")
                 .field_indexed("verifier", &VERIFIER.id().unwrap())
                 .field("balance", &BigIntSer(&(allowance_verifier - allowance_client)))
+                .field_indexed("client", &CLIENT.id().unwrap())
                 .build()
                 .unwrap(),
         );

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -680,7 +680,7 @@ mod allocs_claims {
                     reqs,
                     size * 2,
                     false,
-                    vec![(id1, alloc1.clone()), (id2, alloc2.clone())],
+                    vec![(id1, alloc1.clone(), sector), (id2, alloc2.clone(), sector)],
                 )
                 .unwrap();
 
@@ -700,7 +700,14 @@ mod allocs_claims {
             ];
             reqs[1].claims[0].client = CLIENT1;
             let ret = h
-                .claim_allocations(&rt, PROVIDER1, reqs, size, false, vec![(id1, alloc1.clone())])
+                .claim_allocations(
+                    &rt,
+                    PROVIDER1,
+                    reqs,
+                    size,
+                    false,
+                    vec![(id1, alloc1.clone(), sector)],
+                )
                 .unwrap();
             assert_eq!(ret.sector_results.codes(), vec![ExitCode::OK, ExitCode::USR_NOT_FOUND]);
             assert_eq!(ret.sector_claims[0].claimed_space, BigInt::from(size));
@@ -726,7 +733,14 @@ mod allocs_claims {
             let reqs = vec![make_claim_reqs(sector, expiry, &[(id1, &alloc1), (id1, &alloc1)])];
             expect_abort(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
-                h.claim_allocations(&rt, PROVIDER1, reqs, size, false, vec![(id1, alloc1.clone())]),
+                h.claim_allocations(
+                    &rt,
+                    PROVIDER1,
+                    reqs,
+                    size,
+                    false,
+                    vec![(id1, alloc1.clone(), sector)],
+                ),
             );
             rt.reset();
 
@@ -736,7 +750,14 @@ mod allocs_claims {
                 make_claim_reqs(sector, expiry, &[(id1, &alloc1)]),
             ];
             let ret = h
-                .claim_allocations(&rt, PROVIDER1, reqs, size, false, vec![(id1, alloc1.clone())])
+                .claim_allocations(
+                    &rt,
+                    PROVIDER1,
+                    reqs,
+                    size,
+                    false,
+                    vec![(id1, alloc1.clone(), sector)],
+                )
                 .unwrap();
             assert_eq!(ret.sector_results.codes(), vec![ExitCode::OK, ExitCode::USR_NOT_FOUND]);
             assert_eq!(ret.sector_claims[0].claimed_space, BigInt::from(size));
@@ -797,7 +818,14 @@ mod allocs_claims {
             ];
             reqs[0].claims[1].size = PaddedPieceSize(0);
             let ret = h
-                .claim_allocations(&rt, PROVIDER1, reqs, size, false, vec![(id3, alloc3.clone())])
+                .claim_allocations(
+                    &rt,
+                    PROVIDER1,
+                    reqs,
+                    size,
+                    false,
+                    vec![(id3, alloc3.clone(), sector)],
+                )
                 .unwrap();
             assert_eq!(ret.sector_results.codes(), vec![ExitCode::USR_FORBIDDEN, ExitCode::OK]);
             assert_eq!(ret.sector_claims[0].claimed_space, BigInt::from(size));
@@ -831,7 +859,7 @@ mod allocs_claims {
             reqs[0].claims[1].size = PaddedPieceSize(0);
             expect_abort(
                 ExitCode::USR_ILLEGAL_ARGUMENT,
-                h.claim_allocations(&rt, PROVIDER1, reqs, 0, true, vec![(id3, alloc3)]),
+                h.claim_allocations(&rt, PROVIDER1, reqs, 0, true, vec![(id3, alloc3, sector)]),
             );
             rt.reset();
         }

--- a/integration_tests/src/expects.rs
+++ b/integration_tests/src/expects.rs
@@ -357,11 +357,17 @@ impl Expect {
         }
     }
 
-    pub fn build_verifreg_event(
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_verifreg_allocation_event(
         typ: &str,
         id: u64,
         client: ActorID,
         provider: ActorID,
+        piece_cid: &Cid,
+        piece_size: u64,
+        term_min: ChainEpoch,
+        term_max: ChainEpoch,
+        expiration: ChainEpoch,
     ) -> EmittedEvent {
         EmittedEvent {
             emitter: VERIFIED_REGISTRY_ACTOR_ID,
@@ -370,11 +376,47 @@ impl Expect {
                 .field_indexed("id", &id)
                 .field_indexed("client", &client)
                 .field_indexed("provider", &provider)
+                .field_indexed("piece-cid", piece_cid)
+                .field("piece-size", &piece_size)
+                .field("term-min", &term_min)
+                .field("term-max", &term_max)
+                .field("expiration", &expiration)
                 .build()
                 .unwrap(),
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_verifreg_claim_event(
+        typ: &str,
+        id: u64,
+        client: ActorID,
+        provider: ActorID,
+        piece_cid: &Cid,
+        piece_size: u64,
+        term_min: ChainEpoch,
+        term_max: ChainEpoch,
+        term_start: ChainEpoch,
+        sector: SectorNumber,
+    ) -> EmittedEvent {
+        EmittedEvent {
+            emitter: VERIFIED_REGISTRY_ACTOR_ID,
+            event: EventBuilder::new()
+                .typ(typ)
+                .field_indexed("id", &id)
+                .field_indexed("client", &client)
+                .field_indexed("provider", &provider)
+                .field_indexed("piece-cid", piece_cid)
+                .field("piece-size", &piece_size)
+                .field("term-min", &term_min)
+                .field("term-max", &term_max)
+                .field("term-start", &term_start)
+                .field_indexed("sector", &sector)
+                .build()
+                .unwrap(),
+        }
+    }
+    #[allow(clippy::too_many_arguments)]
     pub fn build_market_event(
         typ: &str,
         deal_id: DealID,

--- a/integration_tests/src/tests/extend_sectors_test.rs
+++ b/integration_tests/src/tests/extend_sectors_test.rs
@@ -18,6 +18,7 @@ use fil_actor_miner::{
     ProveReplicaUpdatesParams, ReplicaUpdate, SectorClaim, SectorOnChainInfoFlags, Sectors,
     State as MinerState,
 };
+use fil_actors_runtime::runtime::policy_constants::MARKET_DEFAULT_ALLOCATION_TERM_BUFFER;
 use vm_api::trace::ExpectInvocation;
 use vm_api::util::{apply_ok, get_state, mutate_state, DynBlockstore};
 use vm_api::VM;
@@ -629,6 +630,7 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
 
     // create 1 verified deal for total sector capacity
     let deal_start = v.epoch() + EPOCHS_IN_DAY;
+    let deal_lifetime = 340 * EPOCHS_IN_DAY;
     let deal_ids = market_publish_deal(
         v,
         &worker,
@@ -638,7 +640,7 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
         piece_size,
         true,
         deal_start,
-        340 * EPOCHS_IN_DAY,
+        deal_lifetime,
     )
     .ids;
 
@@ -675,6 +677,10 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
     let pis: Vec<PieceInfo> = vec![PieceInfo { cid: piece_cid, size: piece_size }];
     let unsealed_cid = v.primitives().compute_unsealed_sector_cid(seal_proof, &pis).unwrap();
 
+    let start_epoch = deal_start;
+    let end_epoch = deal_start + deal_lifetime;
+    let claim_term = end_epoch - start_epoch;
+
     // check for the expected subcalls
     ExpectInvocation {
         from: worker_id,
@@ -694,11 +700,17 @@ pub fn extend_updated_sector_with_claims_test(v: &dyn VM) {
                 from: miner_id,
                 to: VERIFIED_REGISTRY_ACTOR_ADDR,
                 method: VerifregMethod::ClaimAllocations as u64,
-                events: Some(vec![Expect::build_verifreg_event(
+                events: Some(vec![Expect::build_verifreg_claim_event(
                     "claim",
                     claim_id,
                     verified_client.id().unwrap(),
                     miner_id,
+                    &piece_cid,
+                    piece_size.0,
+                    claim_term,
+                    claim_term + MARKET_DEFAULT_ALLOCATION_TERM_BUFFER,
+                    v.epoch(),
+                    sector_number,
                 )]),
                 ..Default::default()
             },

--- a/integration_tests/src/tests/prove_commit3_test.rs
+++ b/integration_tests/src/tests/prove_commit3_test.rs
@@ -239,6 +239,45 @@ pub fn prove_commit_sectors2_test(v: &dyn VM) {
         })
         .collect();
 
+    let claim_event_1 = Expect::build_verifreg_claim_event(
+        "claim",
+        alloc_ids_s2[0],
+        client_id,
+        miner_id,
+        &allocs[0].data,
+        allocs[0].size.0,
+        claim_term_min,
+        claim_term_max,
+        v.epoch(),
+        first_sector_number + 2,
+    );
+
+    let claim_event_2 = Expect::build_verifreg_claim_event(
+        "claim",
+        alloc_ids_s2[1],
+        client_id,
+        miner_id,
+        &allocs[1].data,
+        allocs[1].size.0,
+        claim_term_min,
+        claim_term_max,
+        v.epoch(),
+        first_sector_number + 2,
+    );
+
+    let claim_event_3 = Expect::build_verifreg_claim_event(
+        "claim",
+        alloc_ids_s4[0],
+        client_id,
+        miner_id,
+        &manifests[4].pieces[0].cid,
+        manifests[4].pieces[0].size.0,
+        claim_term_min,
+        claim_term_max,
+        v.epoch(),
+        first_sector_number + 4,
+    );
+
     ExpectInvocation {
         from: worker_id,
         to: maddr,
@@ -289,11 +328,7 @@ pub fn prove_commit_sectors2_test(v: &dyn VM) {
                     })
                     .unwrap(),
                 ),
-                events: Some(vec![
-                    Expect::build_verifreg_event("claim", alloc_ids_s2[0], client_id, miner_id),
-                    Expect::build_verifreg_event("claim", alloc_ids_s2[1], client_id, miner_id),
-                    Expect::build_verifreg_event("claim", alloc_ids_s4[0], client_id, miner_id),
-                ]),
+                events: Some(vec![claim_event_1, claim_event_2, claim_event_3]),
                 ..Default::default()
             },
             Expect::reward_this_epoch(miner_id),

--- a/integration_tests/src/tests/replica_update3_test.rs
+++ b/integration_tests/src/tests/replica_update3_test.rs
@@ -250,6 +250,43 @@ pub fn prove_replica_update2_test(v: &dyn VM) {
         },
     ];
 
+    let claim_event_1 = Expect::build_verifreg_claim_event(
+        "claim",
+        alloc_ids_s2[0],
+        client_id,
+        miner_id,
+        &allocs[0].data,
+        allocs[0].size.0,
+        claim_term_min,
+        claim_term_max,
+        v.epoch(),
+        first_sector_number + 2,
+    );
+    let claim_event_2 = Expect::build_verifreg_claim_event(
+        "claim",
+        alloc_ids_s2[1],
+        client_id,
+        miner_id,
+        &allocs[1].data,
+        allocs[1].size.0,
+        claim_term_min,
+        claim_term_max,
+        v.epoch(),
+        first_sector_number + 2,
+    );
+    let claim_event_3 = Expect::build_verifreg_claim_event(
+        "claim",
+        alloc_ids_s4[0],
+        client_id,
+        miner_id,
+        &manifests[4].pieces[0].cid,
+        manifests[4].pieces[0].size.0,
+        claim_term_min,
+        claim_term_max,
+        v.epoch(),
+        first_sector_number + 4,
+    );
+
     // Replica update
     let update_proof = seal_proof.registered_update_proof().unwrap();
     let proofs = vec![RawBytes::new(vec![1, 2, 3, 4]); manifests.len()];
@@ -352,11 +389,7 @@ pub fn prove_replica_update2_test(v: &dyn VM) {
                     })
                     .unwrap(),
                 ),
-                events: Some(vec![
-                    Expect::build_verifreg_event("claim", alloc_ids_s2[0], client_id, miner_id),
-                    Expect::build_verifreg_event("claim", alloc_ids_s2[1], client_id, miner_id),
-                    Expect::build_verifreg_event("claim", alloc_ids_s4[0], client_id, miner_id),
-                ]),
+                events: Some(vec![claim_event_1, claim_event_2, claim_event_3]),
                 ..Default::default()
             },
             Expect::reward_this_epoch(miner_id),

--- a/integration_tests/src/tests/replica_update_test.rs
+++ b/integration_tests/src/tests/replica_update_test.rs
@@ -21,6 +21,7 @@ use fil_actor_miner::{
     TerminationDeclaration, SECTORS_AMT_BITWIDTH,
 };
 use fil_actor_verifreg::Method as VerifregMethod;
+use fil_actors_runtime::runtime::policy_constants::MARKET_DEFAULT_ALLOCATION_TERM_BUFFER;
 use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::test_utils::make_sealed_cid;
 use fil_actors_runtime::VERIFIED_REGISTRY_ACTOR_ADDR;
@@ -1032,8 +1033,20 @@ pub fn replica_update_verified_deal_test(v: &dyn VM) {
     assert_eq!(vec![100], bf_all(updated_sectors));
 
     let claim_id = 1_u64;
-    let claim_event =
-        Expect::build_verifreg_event("claim", claim_id, client.id().unwrap(), maddr.id().unwrap());
+    let deal_term = proposal.end_epoch - proposal.start_epoch;
+    let term_max = deal_term + MARKET_DEFAULT_ALLOCATION_TERM_BUFFER;
+    let claim_event = Expect::build_verifreg_claim_event(
+        "claim",
+        claim_id,
+        client.id().unwrap(),
+        maddr.id().unwrap(),
+        &proposal.piece_cid,
+        proposal.piece_size.0,
+        deal_term,
+        term_max,
+        v.epoch(),
+        sector_number,
+    );
     let old_power = power_for_sector(seal_proof.sector_size().unwrap(), &old_sector_info);
 
     let pieces: Vec<(Cid, u64)> = vec![(proposal.piece_cid, proposal.piece_size.0)];

--- a/integration_tests/src/tests/verified_claim_test.rs
+++ b/integration_tests/src/tests/verified_claim_test.rs
@@ -258,15 +258,7 @@ pub fn verified_claim_scenario_test(v: &dyn VM) {
     let new_max_term = new_claim_expiry_epoch - claim.term_start;
     assert!(new_max_term > original_max_term);
 
-    datacap_extend_claim(
-        v,
-        &verified_client2,
-        &miner_id,
-        claim_id,
-        deal_size,
-        new_max_term,
-        verified_client.id().unwrap(),
-    );
+    datacap_extend_claim(v, &verified_client2, &miner_id, claim_id, deal_size, new_max_term);
 
     // The miner extends the sector into the second year.
     let extended_expiration_2 = extended_expiration_1 + 60 * EPOCHS_IN_DAY;

--- a/integration_tests/src/tests/verifreg_remove_datacap_test.rs
+++ b/integration_tests/src/tests/verifreg_remove_datacap_test.rs
@@ -32,7 +32,7 @@ use vm_api::VM;
 use crate::expects::Expect;
 
 use crate::util::{
-    assert_invariants, create_accounts, verifier_balance_event, verifreg_add_verifier,
+    assert_invariants, create_accounts, verifier_balance_event_with_client, verifreg_add_verifier,
 };
 use crate::{TEST_VERIFREG_ROOT_ADDR, TEST_VERIFREG_ROOT_ID};
 
@@ -84,7 +84,11 @@ pub fn remove_datacap_simple_successful_path_test(v: &dyn VM) {
             subinvocs: None,
             ..Default::default()
         }]),
-        events: Some(vec![verifier_balance_event(verifier1.id().unwrap(), verifier_datacap)]),
+        events: Some(vec![verifier_balance_event_with_client(
+            verifier1.id().unwrap(),
+            verifier_datacap,
+            verified_client.id().unwrap(),
+        )]),
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());

--- a/integration_tests/src/util/workflows.rs
+++ b/integration_tests/src/util/workflows.rs
@@ -51,8 +51,8 @@ use fil_actor_multisig::Method as MultisigMethod;
 use fil_actor_multisig::ProposeParams;
 use fil_actor_power::{CreateMinerParams, CreateMinerReturn, Method as PowerMethod};
 use fil_actor_verifreg::ext::datacap::MintParams;
-use fil_actor_verifreg::AllocationRequests;
 use fil_actor_verifreg::ClaimExtensionRequest;
+use fil_actor_verifreg::{state, AllocationRequests};
 use fil_actor_verifreg::{
     AddVerifiedClientParams, AllocationID, ClaimID, ClaimTerm, ExtendClaimTermsParams,
     Method as VerifregMethod, RemoveExpiredAllocationsParams, State as VerifregState,
@@ -917,11 +917,16 @@ pub fn verifreg_remove_expired_allocations(
         .iter()
         .map(|id| {
             let alloc = allocs.get(client.id().unwrap(), *id).unwrap().unwrap();
-            Expect::build_verifreg_event(
+            Expect::build_verifreg_allocation_event(
                 "allocation-removed",
                 *id,
                 client.id().unwrap(),
                 alloc.provider,
+                &alloc.data,
+                alloc.size.0,
+                alloc.term_min,
+                alloc.term_max,
+                alloc.expiration,
             )
         })
         .collect();
@@ -1014,7 +1019,17 @@ pub fn datacap_create_allocations(
         .iter()
         .enumerate()
         .map(|(i, alloc_id)| {
-            Expect::build_verifreg_event("allocation", *alloc_id, client_id, reqs[i].provider)
+            Expect::build_verifreg_allocation_event(
+                "allocation",
+                *alloc_id,
+                client.id().unwrap(),
+                reqs[i].provider,
+                &reqs[i].data,
+                reqs[i].size.0,
+                reqs[i].term_min,
+                reqs[i].term_max,
+                reqs[i].expiration,
+            )
         })
         .collect::<Vec<EmittedEvent>>();
 
@@ -1037,8 +1052,15 @@ pub fn datacap_extend_claim(
     claim: ClaimID,
     size: u64,
     new_term: ChainEpoch,
-    claim_client: ActorID,
 ) {
+    // read existing claim with claim id from VerifReg state
+    let v_st: fil_actor_verifreg::State = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
+    let store = DynBlockstore::wrap(v.blockstore());
+    let mut claims = v_st.load_claims(&store).unwrap();
+    let mut existing_claim =
+        state::get_claim(&mut claims, provider.id().unwrap(), claim).unwrap().unwrap().clone();
+    existing_claim.term_max = new_term;
+
     let payload = AllocationRequests {
         allocations: vec![],
         extensions: vec![ClaimExtensionRequest {
@@ -1065,17 +1087,25 @@ pub fn datacap_extend_claim(
     );
 
     let client_id = v.resolve_id_address(client).unwrap().id().unwrap();
+    let claim_updated_event = Expect::build_verifreg_claim_event(
+        "claim-updated",
+        claim,
+        existing_claim.client,
+        provider.id().unwrap(),
+        &existing_claim.data,
+        existing_claim.size.0,
+        existing_claim.term_min,
+        existing_claim.term_max,
+        existing_claim.term_start,
+        existing_claim.sector,
+    );
+
     Expect::datacap_transfer_to_verifreg(
         client_id,
         token_amount,
         operator_data,
         true, // Burn
-        vec![Expect::build_verifreg_event(
-            "claim-updated",
-            claim,
-            claim_client,
-            provider.id().unwrap(),
-        )],
+        vec![claim_updated_event],
     )
     .matches(v.take_invocations().last().unwrap());
 }
@@ -1190,6 +1220,18 @@ pub fn market_publish_deal(
 
         let v_st: fil_actor_verifreg::State = get_state(v, &VERIFIED_REGISTRY_ACTOR_ADDR).unwrap();
         let alloc_id = v_st.next_allocation_id - 1;
+        let alloc_req = alloc_reqs.allocations[0].clone();
+        let alloc_event = Expect::build_verifreg_allocation_event(
+            "allocation",
+            alloc_id,
+            deal_client.id().unwrap(),
+            miner_id.id().unwrap(),
+            &proposal.piece_cid,
+            proposal.piece_size.0,
+            alloc_req.term_min,
+            alloc_req.term_max,
+            alloc_req.expiration,
+        );
 
         expect_publish_invocs.push(ExpectInvocation {
             from: STORAGE_MARKET_ACTOR_ID,
@@ -1226,12 +1268,7 @@ pub fn market_publish_deal(
                     })
                     .unwrap(),
                 ),
-                events: Some(vec![Expect::build_verifreg_event(
-                    "allocation",
-                    alloc_id,
-                    deal_client.id().unwrap(),
-                    miner_id.id().unwrap(),
-                )]),
+                events: Some(vec![alloc_event]),
                 ..Default::default()
             }]),
             ..Default::default()

--- a/integration_tests/src/util/workflows.rs
+++ b/integration_tests/src/util/workflows.rs
@@ -777,6 +777,23 @@ pub fn verifier_balance_event(verifier: ActorID, data_cap: DataCap) -> EmittedEv
     }
 }
 
+pub fn verifier_balance_event_with_client(
+    verifier: ActorID,
+    data_cap: DataCap,
+    client: ActorID,
+) -> EmittedEvent {
+    EmittedEvent {
+        emitter: VERIFIED_REGISTRY_ACTOR_ID,
+        event: EventBuilder::new()
+            .typ("verifier-balance")
+            .field_indexed("verifier", &verifier)
+            .field("balance", &BigIntSer(&data_cap))
+            .field_indexed("client", &client)
+            .build()
+            .unwrap(),
+    }
+}
+
 pub fn verifreg_add_verifier(v: &dyn VM, verifier: &Address, data_cap: StoragePower) {
     let add_verifier_params = VerifierParams { address: *verifier, allowance: data_cap.clone() };
     // root address is msig, send proposal from root key
@@ -869,9 +886,10 @@ pub fn verifreg_add_client(
             )]),
             ..Default::default()
         }]),
-        events: Some(vec![verifier_balance_event(
+        events: Some(vec![verifier_balance_event_with_client(
             verifier.id().unwrap(),
             updated_verifier_balance,
+            client.id().unwrap(),
         )]),
         ..Default::default()
     }


### PR DESCRIPTION
These two were late to nv22 and were only merged into the release/v13 branch so are missing from master. I suppose we should have a master-first policy to prevent this!

* [Add client to verifier balance event](https://github.com/filecoin-project/builtin-actors/commit/0f205c378983ac6a08469b9f400cbb908eef64e2) (0f205c378983ac6a08469b9f400cbb908eef64e2)
* [Updates to Actor events based on community feedback for NV22 (#1531)](https://github.com/filecoin-project/builtin-actors/commit/2c7332805b1fb1170895573f7a55e89d6c043a47) (2c7332805b1fb1170895573f7a55e89d6c043a47)

The events assertion in integration tests have become optional since then so these commits didn't quite cleanly apply.
