### PR TITLE
test(niporep): integration test for failing first wdpost

### DIFF
--- a/test_vm/tests/suite/prove_commit_niporep_test.rs
+++ b/test_vm/tests/suite/prove_commit_niporep_test.rs
@@ -1,4 +1,5 @@
 use fil_actors_integration_tests::tests::{
+    prove_commit_ni_next_deadline_post_required_test,
     prove_commit_ni_partial_success_not_required_test, prove_commit_ni_whole_success_test,
 };
 use fil_actors_runtime::test_blockstores::MemoryBlockstore;
@@ -16,4 +17,11 @@ fn prove_commit_ni_partial_success_not_required() {
     let store = MemoryBlockstore::new();
     let v = TestVM::new_with_singletons(store);
     prove_commit_ni_partial_success_not_required_test(&v);
+}
+
+#[test]
+fn prove_commit_ni_next_deadline_post_required() {
+    let store = MemoryBlockstore::new();
+    let v = TestVM::new_with_singletons(store);
+    prove_commit_ni_next_deadline_post_required_test(&v);
 }


### PR DESCRIPTION
The main thing we are looking at here is that the very first proving period after niporep onboarding matters. We can specify which deadline the sector has, we should be required to prove the sector the first time that deadline comes up.

1. Onboard one niporep sector
2. Move past the first proving deadline (that we specified) and fail to submit window post, check
3. Recover sector
4. Move to the next proving deadline and window post
5. Move to next deadline and check sector is active
6. Move to the next proving deadline and window post, then check we have 1 optimistic submission