### PR TITLE
fix(miner)!: remove DEAL_WEIGHT_MULTIPLIER and its input to QAP calc

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -3892,12 +3892,8 @@ fn extend_simple_qap_sector(
 
         // We only bother updating the expected_day_reward, expected_storage_pledge, and replaced_day_reward
         //  for verified deals, as it can increase power.
-        let qa_pow = qa_power_for_weight(
-            sector_size,
-            new_duration,
-            &new_sector.deal_weight,
-            &new_sector.verified_deal_weight,
-        );
+        let qa_pow =
+            qa_power_for_weight(sector_size, new_duration, &new_sector.verified_deal_weight);
         new_sector.expected_day_reward = expected_reward_for_power(
             &reward_stats.this_epoch_reward_smoothed,
             &power_stats.quality_adj_power_smoothed,
@@ -4283,12 +4279,7 @@ fn update_existing_sector_info(
     new_sector_info.verified_deal_weight = activated_data.verified_space.clone() * duration;
 
     // compute initial pledge
-    let qa_pow = qa_power_for_weight(
-        sector_size,
-        duration,
-        &new_sector_info.deal_weight,
-        &new_sector_info.verified_deal_weight,
-    );
+    let qa_pow = qa_power_for_weight(sector_size, duration, &new_sector_info.verified_deal_weight);
 
     new_sector_info.replaced_day_reward =
         max(&sector_info.expected_day_reward, &sector_info.replaced_day_reward).clone();
@@ -5530,12 +5521,7 @@ fn activate_new_sector_infos(
             let deal_weight = &deal_spaces.unverified_space * duration;
             let verified_deal_weight = &deal_spaces.verified_space * duration;
 
-            let power = qa_power_for_weight(
-                info.sector_size,
-                duration,
-                &deal_weight,
-                &verified_deal_weight,
-            );
+            let power = qa_power_for_weight(info.sector_size, duration, &verified_deal_weight);
 
             let day_reward = expected_reward_for_power(
                 &pledge_inputs.epoch_reward,

--- a/actors/miner/tests/aggregate_prove_commit.rs
+++ b/actors/miner/tests/aggregate_prove_commit.rs
@@ -91,7 +91,6 @@ fn valid_precommits_then_aggregate_provecommit() {
     let qa_power = qa_power_for_weight(
         actor.sector_size,
         expiration - *rt.epoch.borrow(),
-        &deal_weight,
         &verified_deal_weight,
     );
     assert_eq!(expected_power, qa_power);

--- a/actors/miner/tests/policy_test.rs
+++ b/actors/miner/tests/policy_test.rs
@@ -1,10 +1,10 @@
 use fil_actor_miner::{qa_power_for_weight, quality_for_weight};
 use fil_actor_miner::{
-    DEAL_WEIGHT_MULTIPLIER, QUALITY_BASE_MULTIPLIER, SECTOR_QUALITY_PRECISION,
-    VERIFIED_DEAL_WEIGHT_MULTIPLIER,
+    QUALITY_BASE_MULTIPLIER, SECTOR_QUALITY_PRECISION, VERIFIED_DEAL_WEIGHT_MULTIPLIER,
 };
+use fil_actors_runtime::DealWeight;
 use fil_actors_runtime::{EPOCHS_IN_DAY, SECONDS_IN_DAY};
-use fvm_shared::bigint::{BigInt, Zero};
+use fvm_shared::bigint::{BigInt, Integer, Zero};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::sector::SectorSize;
 
@@ -12,12 +12,12 @@ use fvm_shared::sector::SectorSize;
 fn quality_is_independent_of_size_and_duration() {
     // Quality of space with no deals. This doesn't depend on either the sector size or duration.
     let empty_quality = BigInt::from(1 << SECTOR_QUALITY_PRECISION);
-    // Quality space filled with non-verified deals.
-    let deal_quality =
-        &empty_quality * (DEAL_WEIGHT_MULTIPLIER.clone() / QUALITY_BASE_MULTIPLIER.clone());
     // Quality space filled with verified deals.
     let verified_quality = &empty_quality
         * (VERIFIED_DEAL_WEIGHT_MULTIPLIER.clone() / QUALITY_BASE_MULTIPLIER.clone());
+    // Quality space half filled with verified deals.
+    let half_verified_quality =
+        &empty_quality / BigInt::from(2) + &verified_quality / BigInt::from(2);
 
     let size_range: Vec<SectorSize> = vec![
         SectorSize::_2KiB,
@@ -32,21 +32,50 @@ fn quality_is_independent_of_size_and_duration() {
         ChainEpoch::from(1000),
         1000 * EPOCHS_IN_DAY,
     ];
+    let zero = &BigInt::zero();
 
     for size in size_range {
         for duration in &duration_range {
-            let sector_weight = weight(size, *duration);
+            let full_weight = weight(size, *duration);
+            let half_weight = &full_weight.checked_div(&BigInt::from(2)).unwrap();
+
+            assert_eq!(empty_quality, quality_for_weight(size, *duration, zero));
+            assert_eq!(verified_quality, quality_for_weight(size, *duration, &full_weight));
+            assert_eq!(half_verified_quality, quality_for_weight(size, *duration, half_weight));
+
+            // test against old form that takes a deal_weight argument
+            assert_eq!(empty_quality, original_quality_for_weight(size, *duration, zero, zero));
             assert_eq!(
                 empty_quality,
-                quality_for_weight(size, *duration, &BigInt::zero(), &BigInt::zero()),
+                original_quality_for_weight(size, *duration, &full_weight, zero)
             );
             assert_eq!(
-                deal_quality,
-                quality_for_weight(size, *duration, &sector_weight, &BigInt::zero()),
+                empty_quality,
+                original_quality_for_weight(size, *duration, half_weight, zero)
             );
             assert_eq!(
                 verified_quality,
-                quality_for_weight(size, *duration, &BigInt::zero(), &sector_weight),
+                original_quality_for_weight(size, *duration, zero, &full_weight)
+            );
+            assert_eq!(
+                verified_quality,
+                original_quality_for_weight(size, *duration, half_weight, &full_weight)
+            );
+            assert_eq!(
+                verified_quality,
+                original_quality_for_weight(size, *duration, &full_weight, &full_weight)
+            );
+            assert_eq!(
+                half_verified_quality,
+                original_quality_for_weight(size, *duration, zero, half_weight)
+            );
+            assert_eq!(
+                half_verified_quality,
+                original_quality_for_weight(size, *duration, half_weight, half_weight)
+            );
+            assert_eq!(
+                half_verified_quality,
+                original_quality_for_weight(size, *duration, &full_weight, half_weight)
             );
         }
     }
@@ -86,7 +115,7 @@ fn quality_scales_with_verified_weight_proportion() {
         let expected_quality = (eq + vq) / &sector_weight;
         assert_eq!(
             expected_quality,
-            quality_for_weight(sector_size, sector_duration, &BigInt::zero(), &verified_weight),
+            quality_for_weight(sector_size, sector_duration, &verified_weight),
         );
     }
 }
@@ -109,10 +138,7 @@ fn empty_sector_has_power_equal_to_size() {
     for size in size_range {
         for duration in &duration_range {
             let expected_power = BigInt::from(size as i64);
-            assert_eq!(
-                expected_power,
-                qa_power_for_weight(size, *duration, &BigInt::zero(), &BigInt::zero())
-            );
+            assert_eq!(expected_power, qa_power_for_weight(size, *duration, &BigInt::zero()));
         }
     }
 }
@@ -138,10 +164,7 @@ fn verified_sector_has_power_a_multiple_of_size() {
         for duration in &duration_range {
             let verified_weight = weight(size, *duration);
             let expected_power = size as i64 * &verified_multiplier;
-            assert_eq!(
-                expected_power,
-                qa_power_for_weight(size, *duration, &BigInt::zero(), &verified_weight)
-            );
+            assert_eq!(expected_power, qa_power_for_weight(size, *duration, &verified_weight));
         }
     }
 }
@@ -186,12 +209,7 @@ fn verified_weight_adds_proportional_power() {
             let ep = empty_weight * &fully_empty_power;
             let vp = &verified_weight * &fully_verified_power;
             let expected_power = (ep + vp) / &sector_weight;
-            let power = qa_power_for_weight(
-                sector_size,
-                sector_duration,
-                &BigInt::zero(),
-                &verified_weight,
-            );
+            let power = qa_power_for_weight(sector_size, sector_duration, &verified_weight);
             let power_error = expected_power - power;
             assert!(power_error <= max_error);
         }
@@ -209,16 +227,16 @@ fn demonstrate_standard_sectors() {
 
     assert_eq!(
         BigInt::from(sector_size as u64),
-        qa_power_for_weight(sector_size, sector_duration, &BigInt::zero(), &BigInt::zero())
+        qa_power_for_weight(sector_size, sector_duration, &BigInt::zero())
     );
     assert_eq!(
         &vmul * sector_size as u64,
-        qa_power_for_weight(sector_size, sector_duration, &BigInt::zero(), &sector_weight)
+        qa_power_for_weight(sector_size, sector_duration, &sector_weight)
     );
     let half_verified_power = ((sector_size as u64) / 2) + (&vmul * (sector_size as u64) / 2);
     assert_eq!(
         half_verified_power,
-        qa_power_for_weight(sector_size, sector_duration, &BigInt::zero(), &(sector_weight / 2))
+        qa_power_for_weight(sector_size, sector_duration, &(sector_weight / 2))
     );
 
     // 64GiB
@@ -227,16 +245,16 @@ fn demonstrate_standard_sectors() {
 
     assert_eq!(
         BigInt::from(sector_size as u64),
-        qa_power_for_weight(sector_size, sector_duration, &BigInt::zero(), &BigInt::zero())
+        qa_power_for_weight(sector_size, sector_duration, &BigInt::zero())
     );
     assert_eq!(
         &vmul * sector_size as u64,
-        qa_power_for_weight(sector_size, sector_duration, &BigInt::zero(), &sector_weight)
+        qa_power_for_weight(sector_size, sector_duration, &sector_weight)
     );
     let half_verified_power = ((sector_size as u64) / 2) + (&vmul * (sector_size as u64) / 2);
     assert_eq!(
         half_verified_power,
-        qa_power_for_weight(sector_size, sector_duration, &BigInt::zero(), &(sector_weight / 2))
+        qa_power_for_weight(sector_size, sector_duration, &(sector_weight / 2))
     );
 }
 
@@ -246,4 +264,30 @@ fn weight(size: SectorSize, duration: ChainEpoch) -> BigInt {
 
 fn weight_with_size_as_bigint(size: BigInt, duration: ChainEpoch) -> BigInt {
     size * BigInt::from(duration)
+}
+
+// Original form of quality_for_weight prior to removing the deal weight multiplier; retained here
+// for testing purposes. Since the deal weight multipler has remained fixed at the same value as
+// the quality base multiplier (10) it has never had an effect on the result.
+fn original_quality_for_weight(
+    size: SectorSize,
+    duration: ChainEpoch,
+    deal_weight: &DealWeight,
+    verified_weight: &DealWeight,
+) -> BigInt {
+    let sector_space_time = BigInt::from(size as u64) * BigInt::from(duration);
+    let total_deal_space_time = deal_weight + verified_weight;
+
+    let weighted_base_space_time =
+        (&sector_space_time - total_deal_space_time) * &*QUALITY_BASE_MULTIPLIER;
+    let weighted_deal_space_time = deal_weight * BigInt::from(10);
+    let weighted_verified_space_time = verified_weight * &*VERIFIED_DEAL_WEIGHT_MULTIPLIER;
+    let weighted_sum_space_time =
+        weighted_base_space_time + weighted_deal_space_time + weighted_verified_space_time;
+    let scaled_up_weighted_sum_space_time: BigInt =
+        weighted_sum_space_time << SECTOR_QUALITY_PRECISION;
+
+    scaled_up_weighted_sum_space_time
+        .div_floor(&sector_space_time)
+        .div_floor(&QUALITY_BASE_MULTIPLIER)
 }

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1203,19 +1203,12 @@ impl ActorHarness {
             let mut expected_raw_power = BigInt::from(0);
 
             for pc in valid_pcs {
-                let deal_space = cfg.deal_space(pc.info.sector_number);
                 let verified_deal_space = cfg.verified_deal_space(pc.info.sector_number);
-
                 let duration = pc.info.expiration - *rt.epoch.borrow();
-                let deal_weight = deal_space * duration;
                 let verified_deal_weight = verified_deal_space * duration;
                 if duration >= rt.policy.min_sector_expiration {
-                    let qa_power_delta = qa_power_for_weight(
-                        self.sector_size,
-                        duration,
-                        &deal_weight,
-                        &verified_deal_weight,
-                    );
+                    let qa_power_delta =
+                        qa_power_for_weight(self.sector_size, duration, &verified_deal_weight);
                     expected_qa_power += &qa_power_delta;
                     expected_raw_power += self.sector_size as u64;
                     expected_pledge += self.initial_pledge_for_power(rt, &qa_power_delta);
@@ -1382,8 +1375,7 @@ impl ActorHarness {
                     deal_size += piece.size.0 * duration as u64;
                 }
             }
-            let qa_power_delta =
-                qa_power_for_weight(self.sector_size, duration, &deal_size, &verified_size);
+            let qa_power_delta = qa_power_for_weight(self.sector_size, duration, &verified_size);
             expected_qa_power += &qa_power_delta;
             expected_pledge += self.initial_pledge_for_power(rt, &qa_power_delta);
         }
@@ -1596,9 +1588,8 @@ impl ActorHarness {
                 }
             }
 
-            let qa_power_delta =
-                qa_power_for_weight(self.sector_size, duration, &deal_size, &verified_size)
-                    - qa_power_for_sector(self.sector_size, &sector);
+            let qa_power_delta = qa_power_for_weight(self.sector_size, duration, &verified_size)
+                - qa_power_for_sector(self.sector_size, &sector);
             expected_qa_power += &qa_power_delta;
             expected_pledge += self.initial_pledge_for_power(rt, &qa_power_delta);
         }


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/builtin-actors/issues/1573

As outlined in #1573, as long as `QUALITY_BASE_MULTIPLIER` == `DEAL_WEIGHT_MULTIPLIER` then we factor out `deal_space` in QAP calculations. It appears to me from the [language of the spec](https://spec.filecoin.io/#section-systems.filecoin_mining.sector.sector-quality) that it was imagined that the "DealWeightMultiplier (DWM)" was something that could be tuned but unless anyone imagines a world where we tinker with anything other than the "VerifiedDealWeightMultiplier (VDWM)" then we should just do away with deal_weight entirely in the calculations to avoid confusion and overhead.

In terms of what this does to `quality_for_weight`, here's what I see in that code as it is currently. Where `WSS` is `weighted_sum_space_time`, `S` is `size`, `D` is `duration`, `W` is `deal_weight` and `V` is `verified_deal_weight`, we end up doing this:

```
WSS = 10 * (S * D - W - V) + 10 * W + 100 * V
WSS = 10 * S * D - 10 * W - 10 * V + 10 * W + 100 * V
WSS = 10 * S * D - 10 * V + 100 * V
WSS = 10 * S * D + 90 * V
```

Which leads to our QAP result (without precision adjusting):

```
QAP = (S * D + 9 * V) / (S * D)
```

i.e. `W` appears nowhere in the simplified version. We just do lots of unnecessary calculations with it.

You can even see this in the test for the QAP calculation `quality_is_independent_of_size_and_duration`:

```rust
    // Quality of space with no deals. This doesn't depend on either the sector size or duration.
    let empty_quality = BigInt::from(1 << SECTOR_QUALITY_PRECISION);
    // Quality space filled with non-verified deals.
    let deal_quality = &empty_quality * (DEAL_WEIGHT_MULTIPLIER.clone() / QUALITY_BASE_MULTIPLIER.clone());
```

Substitute `* (DEAL_WEIGHT_MULTIPLIER.clone() / QUALITY_BASE_MULTIPLIER.clone())` with `* (10/10)`.

It would be nice to take this simplification further and remove all "unverified space" calculations, but `SectorOnChainInfo` still needs it and I guess we should keep it accurate unless we FIP to remove it or set it to zero.