### PR TITLE
Expose beacon randomness through new EVM precompile via new runtime method (FIP-0095)

### DIFF
--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -220,3 +220,23 @@ pub(super) fn call_actor_shared<RT: Runtime>(
 
     Ok(output)
 }
+
+/// Params:
+///
+/// | Param            | Value                     |
+/// |------------------|---------------------------|
+/// | randomness_epoch | U256 - low i64             |
+///
+/// Errors if unable to fetch randomness
+pub(super) fn get_randomness<RT: Runtime>(
+    system: &mut System<RT>,
+    input: &[u8],
+    _: PrecompileContext,
+) -> PrecompileResult {
+    let mut input_params = ValueReader::new(input);
+
+    let randomness_epoch = input_params.read_value()?;
+
+    let randomness = system.rt.get_beacon_randomness(randomness_epoch);
+    randomness.map(|r| r.to_vec()).map_err(|_| PrecompileError::InvalidInput)
+}

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -225,7 +225,7 @@ pub(super) fn call_actor_shared<RT: Runtime>(
 ///
 /// | Param            | Value                     |
 /// |------------------|---------------------------|
-/// | randomness_epoch | U256 - low i64             |
+/// | epoch            | U256 - low i64            |
 ///
 /// Errors if unable to fetch randomness
 pub(super) fn get_randomness<RT: Runtime>(
@@ -234,9 +234,7 @@ pub(super) fn get_randomness<RT: Runtime>(
     _: PrecompileContext,
 ) -> PrecompileResult {
     let mut input_params = ValueReader::new(input);
-
     let randomness_epoch = input_params.read_value()?;
-
     let randomness = system.rt.get_beacon_randomness(randomness_epoch);
     randomness.map(|r| r.to_vec()).map_err(|_| PrecompileError::InvalidInput)
 }

--- a/actors/evm/src/interpreter/precompiles/mod.rs
+++ b/actors/evm/src/interpreter/precompiles/mod.rs
@@ -13,7 +13,7 @@ mod evm;
 mod fvm;
 
 use evm::{blake2f, ec_add, ec_mul, ec_pairing, ec_recover, identity, modexp, ripemd160, sha256};
-use fvm::{call_actor, call_actor_id, lookup_delegated_address, resolve_address};
+use fvm::{call_actor, call_actor_id, get_randomness, lookup_delegated_address, resolve_address};
 
 type PrecompileFn<RT> = fn(&mut System<RT>, &[u8], PrecompileContext) -> PrecompileResult;
 pub type PrecompileResult = Result<Vec<u8>, PrecompileError>;
@@ -45,7 +45,7 @@ impl<RT: Runtime> Precompiles<RT> {
         Some(resolve_address::<RT>),          // 0xfe00..01
         Some(lookup_delegated_address::<RT>), // 0xfe00..02
         Some(call_actor::<RT>),               // 0xfe00..03
-        None,                                 // 0xfe00..04 DISABLED
+        Some(get_randomness::<RT>),           // 0xfe00..04
         Some(call_actor_id::<RT>),            // 0xfe00..05
     ]);
 

--- a/actors/evm/src/interpreter/precompiles/mod.rs
+++ b/actors/evm/src/interpreter/precompiles/mod.rs
@@ -48,7 +48,6 @@ impl<RT: Runtime> Precompiles<RT> {
         None,                                 // 0xfe00..04 get_actor_type DISABLED
         Some(call_actor_id::<RT>),            // 0xfe00..05
         Some(get_randomness::<RT>),           // 0xfe00..06
-
     ]);
 
     /// EVM specific precompiles

--- a/actors/evm/src/interpreter/precompiles/mod.rs
+++ b/actors/evm/src/interpreter/precompiles/mod.rs
@@ -41,12 +41,14 @@ pub struct Precompiles<RT>(PhantomData<RT>);
 
 impl<RT: Runtime> Precompiles<RT> {
     /// FEVM specific precompiles (0xfe prefix)
-    const NATIVE_PRECOMPILES: PrecompileTable<RT, 5> = PrecompileTable([
+    const NATIVE_PRECOMPILES: PrecompileTable<RT, 6> = PrecompileTable([
         Some(resolve_address::<RT>),          // 0xfe00..01
         Some(lookup_delegated_address::<RT>), // 0xfe00..02
         Some(call_actor::<RT>),               // 0xfe00..03
-        Some(get_randomness::<RT>),           // 0xfe00..04
+        None,                                 // 0xfe00..04 get_actor_type DISABLED
         Some(call_actor_id::<RT>),            // 0xfe00..05
+        Some(get_randomness::<RT>),           // 0xfe00..06
+
     ]);
 
     /// EVM specific precompiles

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -112,8 +112,9 @@ pub enum NativePrecompile {
     ResolveAddress = 1,
     LookupDelegatedAddress = 2,
     CallActor = 3,
-    GetActorType = 4,
+    GetActorTypeDISABLED = 4,
     CallActorId = 5,
+    GetRandomness = 6,
 }
 
 #[allow(dead_code)]

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -234,8 +234,8 @@ where
     ) -> Result<[u8; RANDOMNESS_LENGTH], ActorError> {
         let digest = fvm::rand::get_chain_randomness(rand_epoch).map_err(|e| {
             match e {
-                ErrorNumber::LimitExceeded => {
-                    actor_error!(illegal_argument; "randomness lookback exceeded: {}", e)
+                ErrorNumber::LimitExceeded | ErrorNumber::IllegalArgument => {
+                    actor_error!(illegal_argument; "invalid lookback epoch: {}", e)
                 }
                 e => actor_error!(assertion_failed; "get chain randomness failed with an unexpected error: {}", e),
             }
@@ -271,8 +271,8 @@ where
     ) -> Result<[u8; RANDOMNESS_LENGTH], ActorError> {
         fvm::rand::get_beacon_randomness(rand_epoch).map_err(|e| {
             match e {
-                ErrorNumber::LimitExceeded => {
-                    actor_error!(illegal_argument; "randomness lookback exceeded: {}", e)
+                ErrorNumber::LimitExceeded | ErrorNumber::IllegalArgument => {
+                    actor_error!(illegal_argument; "invalid lookback epoch: {}", e)
                 }
                 e => actor_error!(assertion_failed; "get beacon randomness failed with an unexpected error: {}", e),
             }

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -255,14 +255,7 @@ where
         rand_epoch: ChainEpoch,
         entropy: &[u8],
     ) -> Result<[u8; RANDOMNESS_LENGTH], ActorError> {
-        let digest = fvm::rand::get_beacon_randomness(rand_epoch).map_err(|e| {
-            match e {
-                ErrorNumber::LimitExceeded => {
-                    actor_error!(illegal_argument; "randomness lookback exceeded: {}", e)
-                }
-                e => actor_error!(assertion_failed; "get beacon randomness failed with an unexpected error: {}", e),
-            }
-        })?;
+        let digest = self.get_beacon_randomness(rand_epoch)?;
         Ok(draw_randomness(
             fvm::crypto::hash_blake2b,
             &digest,
@@ -270,6 +263,20 @@ where
             rand_epoch,
             entropy,
         ))
+    }
+
+    fn get_beacon_randomness(
+        &self,
+        rand_epoch: ChainEpoch,
+    ) -> Result<[u8; RANDOMNESS_LENGTH], ActorError> {
+        fvm::rand::get_beacon_randomness(rand_epoch).map_err(|e| {
+            match e {
+                ErrorNumber::LimitExceeded => {
+                    actor_error!(illegal_argument; "randomness lookback exceeded: {}", e)
+                }
+                e => actor_error!(assertion_failed; "get beacon randomness failed with an unexpected error: {}", e),
+            }
+        })
     }
 
     fn get_state_root(&self) -> Result<Cid, ActorError> {

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -117,6 +117,14 @@ pub trait Runtime: Primitives + RuntimePolicy {
         entropy: &[u8],
     ) -> Result<[u8; RANDOMNESS_LENGTH], ActorError>;
 
+    /// Returns a (pseudo)random byte array drawing from the latest
+    /// beacon from a given epoch.
+    /// This randomness is not tied to any fork of the chain, and is unbiasable.
+    fn get_beacon_randomness(
+        &self,
+        rand_epoch: ChainEpoch,
+    ) -> Result<[u8; RANDOMNESS_LENGTH], ActorError>;
+
     /// Initializes the state object.
     /// This is only valid when the state has not yet been initialized.
     /// NOTE: we should also limit this to being invoked during the constructor method

--- a/test_vm/src/messaging.rs
+++ b/test_vm/src/messaging.rs
@@ -549,6 +549,13 @@ impl<'invocation> Runtime for InvocationCtx<'invocation> {
         Ok(TEST_VM_RAND_ARRAY)
     }
 
+    fn get_beacon_randomness(
+        &self,
+        _rand_epoch: ChainEpoch,
+    ) -> Result<[u8; RANDOMNESS_LENGTH], ActorError> {
+        Ok(TEST_VM_RAND_ARRAY)
+    }
+
     fn get_state_root(&self) -> Result<Cid, ActorError> {
         Ok(self.v.actor(&self.to()).unwrap().state)
     }


### PR DESCRIPTION
Adds a runtime method for fetching drand beacon randomness without necessarily mixing in additional entropy. Expose beacon randomness through new EVM precompile.

There is some redundancy in the runtime methods here. The mixing of entropy could be factored out of the existing runtime beacon randomness method and into a wrapper function. I have code for this, but it has moderate impact on existing tests, which check randomness values assuming this mixing happened inside the runtime layer.

This is an alternative to #1576.

- [x] Tests for the EVM precompile