### PR TITLE
chore(power): add CurrentTotalPowerReturn serialization tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,7 @@ version = "14.0.0"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
+ "const-hex",
  "fil_actor_reward",
  "fil_actors_runtime",
  "frc42_dispatch",

--- a/actors/market/src/ext.rs
+++ b/actors/market/src/ext.rs
@@ -155,7 +155,7 @@ pub mod power {
     pub const CURRENT_TOTAL_POWER_METHOD: u64 = 9;
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
-    pub struct CurrentTotalPowerReturnParams {
+    pub struct CurrentTotalPowerReturn {
         #[serde(with = "bigint_ser")]
         pub raw_byte_power: StoragePower,
         #[serde(with = "bigint_ser")]

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -1775,7 +1775,7 @@ fn request_current_baseline_power(rt: &impl Runtime) -> Result<StoragePower, Act
 fn request_current_network_power(
     rt: &impl Runtime,
 ) -> Result<(StoragePower, StoragePower), ActorError> {
-    let ret: ext::power::CurrentTotalPowerReturnParams =
+    let ret: ext::power::CurrentTotalPowerReturn =
         deserialize_block(extract_send_result(rt.send_simple(
             &STORAGE_POWER_ACTOR_ADDR,
             ext::power::CURRENT_TOTAL_POWER_METHOD,

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -33,6 +33,7 @@ fvm_ipld_encoding = { workspace = true }
 [dev-dependencies]
 fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 fil_actor_reward = { workspace = true }
+const-hex = { workspace = true }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/power/tests/types_test.rs
+++ b/actors/power/tests/types_test.rs
@@ -1,0 +1,48 @@
+// Tests to match with Go github.com/filecoin-project/go-state-types/builtin/*/power
+mod serialization {
+    use fil_actor_power::CurrentTotalPowerReturn;
+    use fvm_ipld_encoding::ipld_block::IpldBlock;
+
+    use fil_actors_runtime::reward::FilterEstimate;
+    use fvm_shared::bigint::BigInt;
+    use fvm_shared::econ::TokenAmount;
+    use fvm_shared::sector::StoragePower;
+
+    #[test]
+    fn current_total_power_return() {
+        let test_cases = vec![
+            (
+                CurrentTotalPowerReturn {
+                    raw_byte_power: Default::default(),
+                    quality_adj_power: Default::default(),
+                    pledge_collateral: Default::default(),
+                    quality_adj_power_smoothed: Default::default(),
+                    ramp_start_epoch: Default::default(),
+                    ramp_duration_epochs: Default::default(),
+                },
+                // [byte[],byte[],byte[],[byte[],byte[]],0,0]
+                "864040408240400000",
+            ),
+            (
+                CurrentTotalPowerReturn {
+                    raw_byte_power: StoragePower::from(1 << 20),
+                    quality_adj_power: StoragePower::from(1 << 21),
+                    pledge_collateral: TokenAmount::from_atto(1 << 22),
+                    quality_adj_power_smoothed: FilterEstimate::new(BigInt::from(1 << 23), BigInt::from(1 << 24)),
+                    ramp_start_epoch: 25,
+                    ramp_duration_epochs: 26,
+                },
+                // FilterEstimate BigInts have a precision shift of 128, so they end up larger than the others.
+                // [byte[00100000],byte[00200000],byte[00400000],[byte[0080000000000000000000000000000000000000],byte[000100000000000000000000000000000000000000]],25,26]
+                "8644001000004400200000440040000082540080000000000000000000000000000000000000550001000000000000000000000000000000000000001819181a",
+            ),
+        ];
+
+        for (params, expected_hex) in test_cases {
+            let encoded = IpldBlock::serialize_cbor(&params).unwrap().unwrap();
+            assert_eq!(const_hex::encode(&encoded.data), expected_hex);
+            let decoded: CurrentTotalPowerReturn = IpldBlock::deserialize(&encoded).unwrap();
+            assert_eq!(params, decoded);
+        }
+    }
+}


### PR DESCRIPTION
Plus a minor naming fix I noticed while looking over #1557. The market actor copy of `CurrentTotalPowerReturn` is named `CurrentTotalPowerReturnParams`.

This is on top of #1557, and I'll wait till that's merged before marking this ready for review.