### PR TITLE
fix(market): load proposals and states roots once in on_miner_sectors_terminate

### DIFF
--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -813,7 +813,7 @@ impl Actor {
                 let deal =
                     proposals.get(id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
                         format!("failed to load deal proposal {}", id)
-                    })?;
+                    })?.cloned();
                 // The deal may have expired and been deleted before the sector is terminated.
                 // Nothing to do, but continue execution for the other deals.
                 if deal.is_none() {
@@ -838,11 +838,11 @@ impl Actor {
                     continue;
                 }
 
-                let mut state: DealState = *states
+                let mut state: DealState = states
                     .get(id)
                     .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
                         format!("failed to load deal state {}", id)
-                    })?
+                    })?.cloned()
                     .ok_or_else(|| actor_error!(illegal_argument, "no state for deal {}", id))?;
 
                 // If a deal is already slashed, there should be no existing state for it

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -794,7 +794,6 @@ impl Actor {
         let miner_addr = rt.message().caller();
 
         let burn_amount = rt.transaction(|st: &mut State, rt| {
-
             // Load the deal proposals and deal states once
             let proposals = st.load_proposals(rt.store())?;
             let states = st.load_deal_states(rt.store())?;
@@ -811,9 +810,10 @@ impl Actor {
 
             let mut total_slashed = TokenAmount::zero();
             for id in all_deal_ids {
-                let deal = proposals.get(id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
-                    format!("failed to load deal proposal {}", id)
-                })?;
+                let deal =
+                    proposals.get(id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+                        format!("failed to load deal proposal {}", id)
+                    })?;
                 // The deal may have expired and been deleted before the sector is terminated.
                 // Nothing to do, but continue execution for the other deals.
                 if deal.is_none() {
@@ -838,9 +838,12 @@ impl Actor {
                     continue;
                 }
 
-                let mut state: DealState = *states.get(id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
-                                    format!("failed to load deal state {}", id)
-                                })?.ok_or_else(|| actor_error!(illegal_argument, "no state for deal {}", id))?;
+                let mut state: DealState = *states
+                    .get(id)
+                    .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+                        format!("failed to load deal state {}", id)
+                    })?
+                    .ok_or_else(|| actor_error!(illegal_argument, "no state for deal {}", id))?;
 
                 // If a deal is already slashed, there should be no existing state for it
                 // but we process it here for deletion anyway

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -794,6 +794,11 @@ impl Actor {
         let miner_addr = rt.message().caller();
 
         let burn_amount = rt.transaction(|st: &mut State, rt| {
+
+            // Load the deal proposals and deal states once
+            let proposals = st.load_proposals(rt.store())?;
+            let states = st.load_deal_states(rt.store())?;
+
             // The sector deals mapping is removed all at once.
             // Note there may be some deal states that are not removed here,
             // despite deletion of this mapping, e.g. for expired but not-yet-settled deals.
@@ -806,7 +811,7 @@ impl Actor {
 
             let mut total_slashed = TokenAmount::zero();
             for id in all_deal_ids {
-                let deal = st.find_proposal(rt.store(), id)?;
+                let deal = st.find_proposal_from_cache(&proposals, id)?;
                 // The deal may have expired and been deleted before the sector is terminated.
                 // Nothing to do, but continue execution for the other deals.
                 if deal.is_none() {
@@ -832,7 +837,7 @@ impl Actor {
                 }
 
                 let mut state: DealState = st
-                    .find_deal_state(rt.store(), id)?
+                    .find_deal_state_from_cache(&states, id)?
                     // A deal with a proposal but no state is not activated, but then it should not be
                     // part of a sector that is terminating.
                     .ok_or_else(|| actor_error!(illegal_argument, "no state for deal {}", id))?;

--- a/actors/market/src/lib.rs
+++ b/actors/market/src/lib.rs
@@ -810,10 +810,12 @@ impl Actor {
 
             let mut total_slashed = TokenAmount::zero();
             for id in all_deal_ids {
-                let deal =
-                    proposals.get(id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+                let deal = proposals
+                    .get(id)
+                    .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
                         format!("failed to load deal proposal {}", id)
-                    })?.cloned();
+                    })?
+                    .cloned();
                 // The deal may have expired and been deleted before the sector is terminated.
                 // Nothing to do, but continue execution for the other deals.
                 if deal.is_none() {
@@ -842,7 +844,8 @@ impl Actor {
                     .get(id)
                     .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
                         format!("failed to load deal state {}", id)
-                    })?.cloned()
+                    })?
+                    .cloned()
                     .ok_or_else(|| actor_error!(illegal_argument, "no state for deal {}", id))?;
 
                 // If a deal is already slashed, there should be no existing state for it

--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -255,6 +255,26 @@ impl State {
         find_proposal(&self.load_proposals(store)?, deal_id)
     }
 
+    pub fn find_proposal_from_cache<BS: Blockstore>(
+        &self,
+        proposals: &DealArray<BS>,
+        deal_id: DealID,
+    ) -> Result<Option<DealProposal>, ActorError> {
+        proposals.get(deal_id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+            format!("failed to load deal proposal {}", deal_id)
+        }).map(|opt| opt.cloned())
+    }
+
+    pub fn find_deal_state_from_cache<BS: Blockstore>(
+        &self,
+        states: &DealMetaArray<BS>,
+        deal_id: DealID,
+    ) -> Result<Option<DealState>, ActorError> {
+        states.get(deal_id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+            format!("failed to load deal state {}", deal_id)
+        }).map(|opt| opt.cloned())
+    }
+
     pub fn remove_proposal<BS>(
         &mut self,
         store: &BS,

--- a/actors/market/src/state.rs
+++ b/actors/market/src/state.rs
@@ -255,26 +255,6 @@ impl State {
         find_proposal(&self.load_proposals(store)?, deal_id)
     }
 
-    pub fn find_proposal_from_cache<BS: Blockstore>(
-        &self,
-        proposals: &DealArray<BS>,
-        deal_id: DealID,
-    ) -> Result<Option<DealProposal>, ActorError> {
-        proposals.get(deal_id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
-            format!("failed to load deal proposal {}", deal_id)
-        }).map(|opt| opt.cloned())
-    }
-
-    pub fn find_deal_state_from_cache<BS: Blockstore>(
-        &self,
-        states: &DealMetaArray<BS>,
-        deal_id: DealID,
-    ) -> Result<Option<DealState>, ActorError> {
-        states.get(deal_id).with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
-            format!("failed to load deal state {}", deal_id)
-        }).map(|opt| opt.cloned())
-    }
-
     pub fn remove_proposal<BS>(
         &mut self,
         store: &BS,


### PR DESCRIPTION
Fixes #1498  

Changes made:

1. Caching proposals and states before iterating through deals.

2. Helper functions to query deal proposal and deal state from cached data.