### PR TITLE
chore: release 16.0.0-dev1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "fil_actors_runtime",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.3.1",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_datacap"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "cid 0.11.1",
  "fil_actors_runtime",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_eam"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "cid 0.11.1",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_ethaccount"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_evm"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "cid 0.11.1",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "cid 0.11.1",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "cid 0.11.1",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "cid 0.11.1",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "cid 0.11.1",
@@ -1657,11 +1657,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_placeholder"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 
 [[package]]
 name = "fil_actor_power"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "cid 0.11.1",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore 0.3.1",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "cid 0.11.1",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "cid 0.11.1",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_evm_shared"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.5.1",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "cid 0.11.1",
  "clap",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_state"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "test_vm"
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "16.0.0-rc1"
+version = "16.0.0-dev1"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/filecoin-project/builtin-actors"


### PR DESCRIPTION
Publish a v16.0.0-dev1 release, so that we can start testing of https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0097.md.