### PR TITLE
fip-0100: type changes and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,9 +1751,9 @@ checksum = "0d762194228a2f1c11063e46e32e5acb96e66e906382b9eb5441f2e0504bbd5a"
 
 [[package]]
 name = "ipld-core"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ede82a79e134f179f4b29b5fdb1eb92bd1b38c4dfea394c539051150a21b9b"
+checksum = "104718b1cc124d92a6d01ca9c9258a7df311405debb3408c445a36452f9bf8db"
 dependencies = [
  "cid",
  "serde",
@@ -2410,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "serde_ipld_dagcbor"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded35fbe4ab8fdec1f1d14b4daff2206b1eada4d6e708cb451d464d2d965f493"
+checksum = "6851dcd54a7271dd9013195fdccbdaba70c8e71014364e396d4b938d0e67f324"
 dependencies = [
  "cbor4ii",
  "ipld-core",

--- a/actors/miner/src/deadline_state.rs
+++ b/actors/miner/src/deadline_state.rs
@@ -107,7 +107,7 @@ impl Deadlines {
 }
 
 /// Deadline holds the state for all sectors due at a specific deadline.
-#[derive(Debug, Default, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Default, Serialize_tuple, Deserialize_tuple, PartialEq)]
 pub struct Deadline {
     /// Partitions in this deadline, in order.
     /// The keys of this AMT are always sequential integers beginning with zero.
@@ -163,6 +163,14 @@ pub struct Deadline {
     // These proofs may be disputed via DisputeWindowedPoSt. Successfully
     // disputed window PoSts are removed from the snapshot.
     pub optimistic_post_submissions_snapshot: Cid,
+
+    /// Memoized sum of active power in partitions, including faulty. Used to
+    /// cap the daily fee as a proportion of expected block reward.
+    pub total_power: PowerPair,
+
+    /// Memoized sum of daily fee payable to the network for the active sectors
+    /// in this deadline.
+    pub daily_fee: TokenAmount,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
@@ -233,6 +241,8 @@ impl Deadline {
             partitions_snapshot: empty_partitions_array,
             sectors_snapshot: empty_sectors_array,
             optimistic_post_submissions_snapshot: empty_post_submissions_array,
+            total_power: PowerPair::zero(),
+            daily_fee: TokenAmount::zero(),
         })
     }
 
@@ -401,6 +411,7 @@ impl Deadline {
             on_time_pledge: all_on_time_pledge,
             active_power: all_active_power,
             faulty_power: all_faulty_power,
+            fee_deduction: TokenAmount::zero(),
         })
     }
 

--- a/actors/miner/src/expiration_queue.rs
+++ b/actors/miner/src/expiration_queue.rs
@@ -31,7 +31,7 @@ const ENTRY_SECTORS_MAX: u64 = 10_000;
 /// Note that there is not a direct correspondence between on-time sectors and active power;
 /// a sector may be faulty but expiring on-time if it faults just prior to expected termination.
 /// Early sectors are always faulty, and active power always represents on-time sectors.
-#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug, Default)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug, Default, PartialEq)]
 pub struct ExpirationSet {
     /// Sectors expiring "on time" at the end of their committed life
     pub on_time_sectors: BitField,
@@ -43,6 +43,10 @@ pub struct ExpirationSet {
     pub active_power: PowerPair,
     /// Power that is currently faulty
     pub faulty_power: PowerPair,
+    /// Adjustment to the daily fee recorded for the deadline associated with this expiration set
+    /// to account for expiring sectors.
+    #[serde(default)]
+    pub fee_deduction: TokenAmount,
 }
 
 impl ExpirationSet {
@@ -620,6 +624,7 @@ impl<'db, BS: Blockstore> ExpirationQueue<'db, BS> {
             on_time_pledge,
             active_power,
             faulty_power,
+            fee_deduction: TokenAmount::zero(),
         })
     }
 

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -2145,6 +2145,7 @@ impl Actor {
                 replaced_day_reward: TokenAmount::zero(),
                 sector_key_cid: None,
                 flags: SectorOnChainInfoFlags::SIMPLE_QA_POWER,
+                daily_fee: TokenAmount::zero(),
             })
             .collect::<Vec<SectorOnChainInfo>>();
 
@@ -5583,6 +5584,7 @@ fn activate_new_sector_infos(
                 replaced_day_reward: TokenAmount::zero(),
                 sector_key_cid: None,
                 flags: SectorOnChainInfoFlags::SIMPLE_QA_POWER,
+                daily_fee: TokenAmount::zero(),
             };
 
             new_sector_numbers.push(new_sector_info.sector_number);

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -455,6 +455,11 @@ pub struct SectorOnChainInfo {
     pub sector_key_cid: Option<Cid>,
     /// Additional flags, see [`SectorOnChainInfoFlags`]
     pub flags: SectorOnChainInfoFlags,
+    /// Daily fee payable to the network for the sector as long as it is active.
+    /// Not present in the serialized forms of older sectors, but always written for new and updated
+    /// sectors.
+    #[serde(default)]
+    pub daily_fee: TokenAmount,
 }
 
 bitflags::bitflags! {

--- a/actors/miner/tests/types_test.rs
+++ b/actors/miner/tests/types_test.rs
@@ -1,11 +1,21 @@
 // Tests to match with Go github.com/filecoin-project/go-state-types/builtin/*/miner
 mod serialization {
+    use std::iter;
+    use std::ops::Range;
     use std::str::FromStr;
 
     use cid::Cid;
-    use fil_actor_miner::{ProveCommitSectorsNIParams, SectorNIActivationInfo};
+    use fil_actor_miner::{
+        Deadline, ExpirationSet, PowerPair, ProveCommitSectorsNIParams, SectorNIActivationInfo,
+        SectorOnChainInfo, SectorOnChainInfoFlags,
+    };
+    use fvm_ipld_bitfield::iter::Ranges;
+    use fvm_ipld_bitfield::BitField;
     use fvm_ipld_encoding::ipld_block::IpldBlock;
+    use fvm_shared::bigint::BigInt;
+    use fvm_shared::econ::TokenAmount;
     use fvm_shared::sector::{RegisteredAggregateProof, RegisteredSealProof};
+    use num_traits::Zero;
 
     #[test]
     fn prove_commit_sectors_ni_params() {
@@ -76,6 +86,215 @@ mod serialization {
             let encoded = IpldBlock::serialize_cbor(&params).unwrap().unwrap();
             assert_eq!(const_hex::encode(&encoded.data), expected_hex);
             let decoded: ProveCommitSectorsNIParams = IpldBlock::deserialize(&encoded).unwrap();
+            assert_eq!(params, decoded);
+        }
+    }
+
+    #[test]
+    fn sector_on_chain_info() {
+        let test_cases = vec![
+            (
+                SectorOnChainInfo {
+                    ..Default::default()
+                },
+                // [0,-1,{"/":"baeaaaaa"},[],0,0,[],[],[],[],[],0,[],null,0,[]]
+                "900020d82a45000100000080000040404040400040f60040",
+                // same on write as read
+                "900020d82a45000100000080000040404040400040f60040",
+            ),
+            (
+                SectorOnChainInfo {
+                    sector_number: 1,
+                    seal_proof: RegisteredSealProof::StackedDRG32GiBV1P1,
+                    sealed_cid: Cid::from_str("bagboea4seaaqa").unwrap(),
+                    deprecated_deal_ids: vec![],
+                    activation: 2,
+                    expiration: 3,
+                    deal_weight: 4.into(),
+                    verified_deal_weight: 5.into(),
+                    initial_pledge: TokenAmount::from_whole(6),
+                    expected_day_reward: TokenAmount::from_whole(7),
+                    expected_storage_pledge: TokenAmount::from_whole(8),
+                    power_base_epoch: 9,
+                    replaced_day_reward: TokenAmount::from_whole(10),
+                    sector_key_cid: None,
+                    flags: Default::default(),
+                    daily_fee: TokenAmount::from_whole(11),
+                },
+                // '[1,8,{"/":"bagboea4seaaqa"},[],2,3,[AAQ],[AAU],[AFNESDXsWAAA],[AGEk/umTvAAA],[AG8FtZ07IAAA],9,[AIrHIwSJ6AAA],null,0,[AJin2bgxTAAA]]'
+                "900108d82a49000182e20392200100800203420004420005490053444835ec58000049006124fee993bc000049006f05b59d3b2000000949008ac7230489e80000f600490098a7d9b8314c0000",
+                // same on write as read
+                "900108d82a49000182e20392200100800203420004420005490053444835ec58000049006124fee993bc000049006f05b59d3b2000000949008ac7230489e80000f600490098a7d9b8314c0000",
+            ),
+            (
+                SectorOnChainInfo {
+                    sector_number: 1,
+                    seal_proof: RegisteredSealProof::StackedDRG32GiBV1P1,
+                    sealed_cid: Cid::from_str("bagboea4seaaqa").unwrap(),
+                    deprecated_deal_ids: vec![],
+                    activation: 2,
+                    expiration: 3,
+                    deal_weight: 4.into(),
+                    verified_deal_weight: 5.into(),
+                    initial_pledge: TokenAmount::from_whole(6),
+                    expected_day_reward: TokenAmount::from_whole(7),
+                    expected_storage_pledge: TokenAmount::from_whole(8),
+                    power_base_epoch: 9,
+                    replaced_day_reward: TokenAmount::from_whole(10),
+                    sector_key_cid: Some(Cid::from_str("baga6ea4seaaqc").unwrap()),
+                    flags: SectorOnChainInfoFlags::SIMPLE_QA_POWER,
+                    daily_fee: TokenAmount::from_whole(11),
+                },
+                // [1,8,{"/":"bagboea4seaaqa"},[],2,3,[AAQ],[AAU],[AFNESDXsWAAA],[AGEk/umTvAAA],[AG8FtZ07IAAA],9,[AIrHIwSJ6AAA],{"/":"baga6ea4seaaqc"},1,[AJin2bgxTAAA]]
+                "900108d82a49000182e20392200100800203420004420005490053444835ec58000049006124fee993bc000049006f05b59d3b2000000949008ac7230489e80000d82a49000181e2039220010101490098a7d9b8314c0000",
+                // same on write as read
+                "900108d82a49000182e20392200100800203420004420005490053444835ec58000049006124fee993bc000049006f05b59d3b2000000949008ac7230489e80000d82a49000181e2039220010101490098a7d9b8314c0000",
+            ),
+            (
+                // old format stored on chain but materialised as the new format with a default value at the end
+                SectorOnChainInfo {
+                    sector_number: 1,
+                    seal_proof: RegisteredSealProof::StackedDRG64GiBV1P1,
+                    sealed_cid: Cid::from_str("bagboea4seaaqa").unwrap(),
+                    deprecated_deal_ids: vec![],
+                    activation: 2,
+                    expiration: 3,
+                    deal_weight: 4.into(),
+                    verified_deal_weight: 5.into(),
+                    initial_pledge: TokenAmount::from_whole(6),
+                    expected_day_reward: TokenAmount::from_whole(7),
+                    expected_storage_pledge: TokenAmount::from_whole(8),
+                    power_base_epoch: 9,
+                    replaced_day_reward: TokenAmount::from_whole(10),
+                    sector_key_cid: None,
+                    flags: SectorOnChainInfoFlags::SIMPLE_QA_POWER,
+                    daily_fee: TokenAmount::zero(), // default, not present in the binary
+                },
+                // [1,9,{"/":"bagboea4seaaqa"},[],2,3,[AAQ],[AAU],[AFNESDXsWAAA],[AGEk/umTvAAA],[AG8FtZ07IAAA],9,[AIrHIwSJ6AAA],null,1]
+                "8f0109d82a49000182e20392200100800203420004420005490053444835ec58000049006124fee993bc000049006f05b59d3b2000000949008ac7230489e80000f601",
+                // extra field at the end on write, zero BigInt (bytes) for daily_fee
+                // [1,9,{"/":"bagboea4seaaqa"},[],2,3,[AAQ],[AAU],[AFNESDXsWAAA],[AGEk/umTvAAA],[AG8FtZ07IAAA],9,[AIrHIwSJ6AAA],null,1,[]]
+                "900109d82a49000182e20392200100800203420004420005490053444835ec58000049006124fee993bc000049006f05b59d3b2000000949008ac7230489e80000f60140",
+            ),
+        ];
+
+        for (idx, (params, read_hex, write_hex)) in test_cases.into_iter().enumerate() {
+            let encoded = IpldBlock::serialize_cbor(&params).unwrap().unwrap();
+            assert_eq!(
+                const_hex::encode(&encoded.data),
+                write_hex,
+                "Test case {} encoding failed",
+                idx
+            );
+
+            let data = const_hex::decode(read_hex).unwrap();
+            let decoded: SectorOnChainInfo =
+                IpldBlock::deserialize(&IpldBlock { codec: 0x71, data }).unwrap();
+            assert_eq!(params, decoded, "Test case {} decoding failed", idx);
+        }
+    }
+
+    #[test]
+    fn expiration_set() {
+        // ExpirationSet's fields are all bytes or byte tuples
+        let test_cases = vec![
+            (
+                ExpirationSet { ..Default::default() },
+                // [[],[],[],[[],[]],[[],[]],[]]
+                "8640404082404082404040",
+                // same on write as read
+                "8640404082404082404040",
+            ),
+            (
+                ExpirationSet {
+                    on_time_sectors: BitField::from_ranges(Ranges::new(
+                        iter::once(0..1).collect::<Vec<Range<u64>>>(),
+                    )),
+                    early_sectors: BitField::from_ranges(Ranges::new(
+                        iter::once(1..2).collect::<Vec<Range<u64>>>(),
+                    )),
+                    on_time_pledge: TokenAmount::from_whole(2),
+                    active_power: PowerPair::new(BigInt::from(3), BigInt::from(4)),
+                    faulty_power: PowerPair::new(BigInt::from(5), BigInt::from(6)),
+                    fee_deduction: TokenAmount::from_whole(7),
+                },
+                // [[DA],[GA],[ABvBbWdOyAAA],[[AAM],[AAQ]],[[AAU],[AAY]],[AGEk/umTvAAA]]
+                "86410c411849001bc16d674ec80000824200034200048242000542000649006124fee993bc0000",
+                // same on write as read
+                "86410c411849001bc16d674ec80000824200034200048242000542000649006124fee993bc0000",
+            ),
+            (
+                ExpirationSet {
+                    on_time_sectors: BitField::from_ranges(Ranges::new(
+                        iter::once(0..1).collect::<Vec<Range<u64>>>(),
+                    )),
+                    early_sectors: BitField::from_ranges(Ranges::new(
+                        iter::once(1..2).collect::<Vec<Range<u64>>>(),
+                    )),
+                    on_time_pledge: TokenAmount::from_whole(2),
+                    active_power: PowerPair::new(BigInt::from(3), BigInt::from(4)),
+                    faulty_power: PowerPair::new(BigInt::from(5), BigInt::from(6)),
+                    fee_deduction: TokenAmount::zero(),
+                },
+                // [[DA],[GA],[ABvBbWdOyAAA],[[AAM],[AAQ]],[[AAU],[AAY]]]
+                "85410c411849001bc16d674ec800008242000342000482420005420006",
+                // [[DA],[GA],[ABvBbWdOyAAA],[[AAM],[AAQ]],[[AAU],[AAY]],[]]
+                "86410c411849001bc16d674ec80000824200034200048242000542000640",
+            ),
+        ];
+
+        for (idx, (params, read_hex, write_hex)) in test_cases.into_iter().enumerate() {
+            let encoded = IpldBlock::serialize_cbor(&params).unwrap().unwrap();
+            assert_eq!(
+                const_hex::encode(&encoded.data),
+                write_hex,
+                "Test case {} encoding failed",
+                idx
+            );
+
+            let data = const_hex::decode(read_hex).unwrap();
+            let decoded: ExpirationSet =
+                IpldBlock::deserialize(&IpldBlock { codec: 0x71, data }).unwrap();
+            assert_eq!(params, decoded, "Test case {} decoding failed", idx);
+        }
+    }
+
+    #[test]
+    fn deadline() {
+        let test_cases = vec![(
+            Deadline { ..Default::default() },
+            // [baeaaaaa,baeaaaaa,[],[],0,0,[[],[]],baeaaaaa,baeaaaaa,baeaaaaa,baeaaaaa,[[],[]],[]]
+            "8dd82a450001000000d82a45000100000040400000824040d82a450001000000d82a450001000000d82a450001000000d82a45000100000082404040",
+        ),
+        (
+            Deadline{
+                partitions: Cid::from_str("bagboea4seaaqa").unwrap(),
+                expirations_epochs: Cid::from_str("bagboea4seaaqc").unwrap(),
+                partitions_posted: BitField::from_ranges(Ranges::new(
+                    iter::once(0..1).collect::<Vec<Range<u64>>>(),
+                )),
+                early_terminations: BitField::from_ranges(Ranges::new(
+                    iter::once(1..2).collect::<Vec<Range<u64>>>(),
+                )),
+                live_sectors: 2,
+                total_sectors: 3,
+                faulty_power: PowerPair::new(BigInt::from(4), BigInt::from(5)),
+                optimistic_post_submissions: Cid::from_str("bagboea4seaaqe").unwrap(),
+                sectors_snapshot: Cid::from_str("bagboea4seaaqg").unwrap(),
+                partitions_snapshot: Cid::from_str("bagboea4seaaqi").unwrap(),
+                optimistic_post_submissions_snapshot: Cid::from_str("bagboea4seaaqk").unwrap(),
+                total_power: PowerPair::new(BigInt::from(6), BigInt::from(7)),
+                daily_fee: TokenAmount::from_whole(8),
+            },
+            // [bagboea4seaaqa,bagboea4seaaqc,[DA],[GA],2,3,[[AAQ],[AAU]],bagboea4seaaqe,bagboea4seaaqg,bagboea4seaaqi,bagboea4seaaqk,[[AAY],[AAc]],[AG8FtZ07IAAA]]
+            "8dd82a49000182e20392200100d82a49000182e20392200101410c4118020382420004420005d82a49000182e20392200102d82a49000182e20392200103d82a49000182e20392200104d82a49000182e203922001058242000642000749006f05b59d3b200000",
+        ),
+        ];
+
+        for (params, expected_hex) in test_cases {
+            let encoded = IpldBlock::serialize_cbor(&params).unwrap().unwrap();
+            assert_eq!(const_hex::encode(&encoded.data), expected_hex);
+            let decoded: Deadline = IpldBlock::deserialize(&encoded).unwrap();
             assert_eq!(params, decoded);
         }
     }


### PR DESCRIPTION
PR against feature branch `feat/fip-0100` so we can review incrementally.

Closes: https://github.com/filecoin-project/builtin-actors/issues/1613
Closes: https://github.com/filecoin-project/builtin-actors/issues/1614
Closes: https://github.com/filecoin-project/builtin-actors/issues/1615

Just type changes and tests for their serialization forms so far.

* `Deadline`
  - Add `total_power: PowerPair`
  - Add `daily_fee: TokenAmount`
* `SectorOnChainInfo`
  - Add `daily_fee: TokenAmount` as an optional field
  - Tests that it can load both 15 and 16 field forms but always saves 16 field form
* `ExpirationSet`
  - Add `fee_deduction: TokenAmount` as an optional field
  - Tests that it can load both 5 and 6 field forms but always save 6 field form