### PR TITLE
fip-0100: add daily_proof_fee() and fee constants

### DIFF
--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -206,3 +206,12 @@ pub fn reward_for_disputed_window_post(
     // This is currently just the base. In the future, the fee may scale based on the disputed power.
     BASE_REWARD_FOR_DISPUTED_WINDOW_POST.clone()
 }
+
+// The daily fee payable per sector.
+pub fn daily_proof_fee(policy: &Policy, circulating_supply: &TokenAmount) -> TokenAmount {
+    let num = BigInt::from(policy.daily_fee_circulating_supply_multiplier_num);
+    let denom = BigInt::from(policy.daily_fee_circulating_supply_multiplier_denom);
+
+    let fee = (num * circulating_supply.atto()).div_floor(&denom);
+    TokenAmount::from_atto(fee)
+}

--- a/actors/miner/tests/policy_test.rs
+++ b/actors/miner/tests/policy_test.rs
@@ -1,11 +1,13 @@
-use fil_actor_miner::{qa_power_for_weight, quality_for_weight};
+use fil_actor_miner::{daily_proof_fee, qa_power_for_weight, quality_for_weight};
 use fil_actor_miner::{
     QUALITY_BASE_MULTIPLIER, SECTOR_QUALITY_PRECISION, VERIFIED_DEAL_WEIGHT_MULTIPLIER,
 };
+use fil_actors_runtime::runtime::Policy;
 use fil_actors_runtime::DealWeight;
 use fil_actors_runtime::{EPOCHS_IN_DAY, SECONDS_IN_DAY};
 use fvm_shared::bigint::{BigInt, Integer, Zero};
 use fvm_shared::clock::ChainEpoch;
+use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::SectorSize;
 
 #[test]
@@ -290,4 +292,15 @@ fn original_quality_for_weight(
     scaled_up_weighted_sum_space_time
         .div_floor(&sector_space_time)
         .div_floor(&QUALITY_BASE_MULTIPLIER)
+}
+
+#[test]
+fn daily_proof_fee_calc() {
+    let policy = Policy::default();
+    // Given a CS of 680M FIL and a fee multiplier of 7.4e-15, the daily proof fee should be 5032 nanoFIL.
+    //   680M * 7.4e-15 = 0.000005032 FIL
+    //   0.000005032 * 1e9 = 5032 nanoFIL
+    let circulating_supply = TokenAmount::from_whole(680_000_000);
+    let fee = daily_proof_fee(&policy, &circulating_supply);
+    assert_eq!(fee, TokenAmount::from_nano(5032));
 }

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -11,6 +11,9 @@ pub trait RuntimePolicy {
 // The policy itself
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Policy {
+    //
+    // --- miner policy ---
+    //
     /// Maximum amount of sectors that can be aggregated.
     pub max_aggregated_sectors: u64,
     /// Minimum amount of sectors that can be aggregated.
@@ -134,7 +137,16 @@ pub struct Policy {
     /// Allowed pre commit proof types for new miners
     pub valid_pre_commit_proof_type: ProofSet,
 
-    // --- verifreg policy
+    /// Numerator of the fraction of circulating supply that will be used to calculate
+    /// the daily fee for new sectors.
+    pub daily_fee_circulating_supply_multiplier_num: i64,
+    /// Denominator of the fraction of circulating supply that will be used to calculate
+    /// the daily fee for new sectors.
+    pub daily_fee_circulating_supply_multiplier_denom: i64,
+
+    //
+    // --- verifreg policy ---
+    //
     /// Minimum verified deal size
     pub minimum_verified_allocation_size: StoragePower,
     /// Minimum term for a verified data allocation (epochs)
@@ -147,7 +159,9 @@ pub struct Policy {
     // Period of time at the end of a sector's life during which claims can be dropped
     pub end_of_life_claim_drop_period: ChainEpoch,
 
+    //
     //  --- market policy ---
+    //
     /// The number of blocks between payouts for deals
     pub deal_updates_interval: i64,
 
@@ -163,7 +177,9 @@ pub struct Policy {
     /// allocation's maximum term.
     pub market_default_allocation_term_buffer: i64,
 
-    // --- power ---
+    //
+    // --- power policy ---
+    //
     /// Minimum miner consensus power
     pub minimum_consensus_power: StoragePower,
 }
@@ -210,6 +226,10 @@ impl Default for Policy {
                 policy_constants::CONSENSUS_FAULT_INELIGIBILITY_DURATION,
             new_sectors_per_period_max: policy_constants::NEW_SECTORS_PER_PERIOD_MAX,
             chain_finality: policy_constants::CHAIN_FINALITY,
+            daily_fee_circulating_supply_multiplier_num:
+                policy_constants::DAILY_FEE_CIRCULATING_SUPPLY_MULTIPLIER_NUM,
+            daily_fee_circulating_supply_multiplier_denom:
+                policy_constants::DAILY_FEE_CIRCULATING_SUPPLY_MULTIPLIER_DENOM,
 
             valid_post_proof_type: ProofSet::default_post_proofs(),
             valid_pre_commit_proof_type: ProofSet::default_precommit_seal_proofs(),
@@ -240,6 +260,10 @@ pub mod policy_constants {
     use fvm_shared::sector::SectorNumber;
 
     use crate::builtin::*;
+
+    //
+    // --- miner policy ---
+    //
 
     /// The maximum assignable sector number.
     /// Raising this would require modifying our AMT implementation.
@@ -347,6 +371,14 @@ pub mod policy_constants {
     /// This is a conservative value that is chosen via simulations of all known attacks.
     pub const CHAIN_FINALITY: ChainEpoch = 900;
 
+    /// A multiplier of k=7.4e-15, represented as 74/10^16
+    pub const DAILY_FEE_CIRCULATING_SUPPLY_MULTIPLIER_NUM: i64 = 74;
+    pub const DAILY_FEE_CIRCULATING_SUPPLY_MULTIPLIER_DENOM: i64 = 10_000_000_000_000_000; // 10^16
+
+    //
+    // --- verifreg policy ---
+    //
+
     #[cfg(not(feature = "small-deals"))]
     pub const MINIMUM_VERIFIED_ALLOCATION_SIZE: i32 = 1 << 20;
     #[cfg(feature = "small-deals")]
@@ -355,6 +387,10 @@ pub mod policy_constants {
     pub const MAXIMUM_VERIFIED_ALLOCATION_TERM: i64 = 5 * EPOCHS_IN_YEAR;
     pub const MAXIMUM_VERIFIED_ALLOCATION_EXPIRATION: i64 = 60 * EPOCHS_IN_DAY;
     pub const END_OF_LIFE_CLAIM_DROP_PERIOD: ChainEpoch = 30 * EPOCHS_IN_DAY;
+
+    //
+    // --- market policy ---
+    //
 
     pub const DEAL_UPDATES_INTERVAL: i64 = 30 * EPOCHS_IN_DAY;
 
@@ -366,6 +402,10 @@ pub mod policy_constants {
     pub const PROV_COLLATERAL_PERCENT_SUPPLY_DENOM: i64 = 100;
 
     pub const MARKET_DEFAULT_ALLOCATION_TERM_BUFFER: i64 = 90 * EPOCHS_IN_DAY;
+
+    //
+    // --- power policy ---
+    //
 
     #[cfg(feature = "min-power-2k")]
     pub const MINIMUM_CONSENSUS_POWER: i64 = 2 << 10;


### PR DESCRIPTION
Stacking a PR here so it's mainly asking for a sanity-check review and checking if anything's out of place or I'm not following convention.

Stacked on #1620 for the `feat/fip-0100` branch.

Closes: https://github.com/filecoin-project/builtin-actors/issues/1612

* Adds a `daily_proof_fee(policy: &Policy, circulating_supply: TokenAmount)` for the miner actor
* Adds `DAILY_FEE_CIRCULATING_SUPPLY_MULTIPLIER_NUM` and `DAILY_FEE_CIRCULATING_SUPPLY_MULTIPLIER_DENOM` for a 7.4e-15 multiplier as per the FIP: https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0100.md#per-sector-fee-added

Added a test to sanity check, it also ~matches what was given as a current-day estimate [here](https://github.com/filecoin-project/FIPs/discussions/1105#discussioncomment-12148441).