### PR TITLE
chore(deps): remove const-hex dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,6 @@ dependencies = [
  "bitflags",
  "byteorder",
  "cid",
- "const-hex",
  "fil_actor_account",
  "fil_actor_market",
  "fil_actor_power",
@@ -981,6 +980,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
+ "hex-literal",
  "itertools",
  "lazy_static",
  "log",
@@ -1044,7 +1044,6 @@ version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "cid",
- "const-hex",
  "fil_actor_reward",
  "fil_actors_runtime",
  "frc42_dispatch",
@@ -1052,6 +1051,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
+ "hex-literal",
  "indexmap 2.7.0",
  "integer-encoding",
  "lazy_static",
@@ -1099,7 +1099,6 @@ version = "16.0.0-dev1"
 dependencies = [
  "anyhow",
  "cid",
- "const-hex",
  "fil_actors_runtime",
  "frc42_dispatch",
  "frc46_token",
@@ -1108,6 +1107,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
  "fvm_shared",
+ "hex-literal",
  "lazy_static",
  "log",
  "num-derive",
@@ -1193,7 +1193,6 @@ dependencies = [
  "byteorder",
  "castaway",
  "cid",
- "const-hex",
  "derive_builder",
  "fil_actors_runtime",
  "fvm_ipld_amt",
@@ -1204,6 +1203,7 @@ dependencies = [
  "fvm_sdk",
  "fvm_shared",
  "hex",
+ "hex-literal",
  "integer-encoding",
  "itertools",
  "lazy_static",
@@ -2217,12 +2217,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bitflags",
- "lazy_static",
  "num-traits",
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
  "unarray",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,6 @@ pretty_env_logger = "0.5.0"
 serde_repr = "0.1.8"
 unsigned-varint = "0.8.0"
 rand_chacha = "0.3.1"
-const-hex = "1.11.3"
 
 # Crypto
 libsecp256k1 = { version = "0.7.1", default-features = false }

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -43,7 +43,7 @@ fil_actor_power = { workspace = true }
 fil_actor_market = { workspace = true }
 rand = { workspace = true }
 test-case = { workspace = true }
-const-hex = { workspace = true }
+hex-literal = { workspace = true }
 multihash-derive = { workspace = true }
 
 [features]

--- a/actors/miner/tests/types_test.rs
+++ b/actors/miner/tests/types_test.rs
@@ -3,6 +3,8 @@ mod serialization {
     use std::str::FromStr;
 
     use cid::Cid;
+    use hex_literal::hex;
+
     use fil_actor_miner::{ProveCommitSectorsNIParams, SectorNIActivationInfo};
     use fvm_ipld_encoding::ipld_block::IpldBlock;
     use fvm_shared::sector::{RegisteredAggregateProof, RegisteredSealProof};
@@ -20,7 +22,7 @@ mod serialization {
                     require_activation_success: false,
                 },
                 // [[],byte[],8,1,2,false]
-                 "868040080102f4",
+                &hex!("868040080102f4")[..],
             ),
             (
                 ProveCommitSectorsNIParams {
@@ -39,7 +41,7 @@ mod serialization {
                     require_activation_success: true,
                 },
                 // [[[1,2,bagboea4seaaqa,3,4,5]],byte[deadbeef],18,1,6,true]
-                "8681860102d82a49000182e2039220010003040544deadbeef120106f5",
+                &hex!("8681860102d82a49000182e2039220010003040544deadbeef120106f5"),
             ),
             (
                 ProveCommitSectorsNIParams {
@@ -68,13 +70,13 @@ mod serialization {
                     require_activation_success: false,
                 },
                 // [[[1,2,bagboea4seaaqa,3,4,5],[6,7,bagboea4seaaqc,8,9,10]],byte[deadbeef],18,1,11,false]
-                "8682860102d82a49000182e20392200100030405860607d82a49000182e2039220010108090a44deadbeef12010bf4",
+                &hex!("8682860102d82a49000182e20392200100030405860607d82a49000182e2039220010108090a44deadbeef12010bf4"),
             ),
         ];
 
         for (params, expected_hex) in test_cases {
             let encoded = IpldBlock::serialize_cbor(&params).unwrap().unwrap();
-            assert_eq!(const_hex::encode(&encoded.data), expected_hex);
+            assert_eq!(encoded.data, expected_hex);
             let decoded: ProveCommitSectorsNIParams = IpldBlock::deserialize(&encoded).unwrap();
             assert_eq!(params, decoded);
         }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -33,7 +33,7 @@ fvm_ipld_encoding = { workspace = true }
 [dev-dependencies]
 fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 fil_actor_reward = { workspace = true }
-const-hex = { workspace = true }
+hex-literal = { workspace = true }
 
 [features]
 fil-actor = ["fil_actors_runtime/fil-actor"]

--- a/actors/power/tests/types_test.rs
+++ b/actors/power/tests/types_test.rs
@@ -1,5 +1,7 @@
 // Tests to match with Go github.com/filecoin-project/go-state-types/builtin/*/power
 mod serialization {
+    use hex_literal::hex;
+
     use fil_actor_power::CurrentTotalPowerReturn;
     use fvm_ipld_encoding::ipld_block::IpldBlock;
 
@@ -21,7 +23,7 @@ mod serialization {
                     ramp_duration_epochs: Default::default(),
                 },
                 // [byte[],byte[],byte[],[byte[],byte[]],0,0]
-                "864040408240400000",
+                &hex!("864040408240400000")[..],
             ),
             (
                 CurrentTotalPowerReturn {
@@ -34,13 +36,13 @@ mod serialization {
                 },
                 // FilterEstimate BigInts have a precision shift of 128, so they end up larger than the others.
                 // [byte[00100000],byte[00200000],byte[00400000],[byte[0080000000000000000000000000000000000000],byte[000100000000000000000000000000000000000000]],25,26]
-                "8644001000004400200000440040000082540080000000000000000000000000000000000000550001000000000000000000000000000000000000001819181a",
+                &hex!("8644001000004400200000440040000082540080000000000000000000000000000000000000550001000000000000000000000000000000000000001819181a"),
             ),
         ];
 
         for (params, expected_hex) in test_cases {
             let encoded = IpldBlock::serialize_cbor(&params).unwrap().unwrap();
-            assert_eq!(const_hex::encode(&encoded.data), expected_hex);
+            assert_eq!(encoded.data, expected_hex);
             let decoded: CurrentTotalPowerReturn = IpldBlock::deserialize(&encoded).unwrap();
             assert_eq!(params, decoded);
         }

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -32,7 +32,7 @@ num-traits = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
-const-hex = { workspace = true }
+hex-literal = { workspace = true }
 fil_actors_runtime = { workspace = true, features = ["test_utils", "sector-default"] }
 
 [features]

--- a/actors/verifreg/tests/verifreg_actor_test.rs
+++ b/actors/verifreg/tests/verifreg_actor_test.rs
@@ -1602,6 +1602,8 @@ mod serialization {
     use std::str::FromStr;
 
     use cid::Cid;
+    use hex_literal::hex;
+
     use fil_actor_verifreg::{AllocationClaim, ClaimAllocationsParams, SectorAllocationClaims};
     use fvm_ipld_encoding::ipld_block::IpldBlock;
     use fvm_shared::piece::PaddedPieceSize;
@@ -1612,7 +1614,7 @@ mod serialization {
             (
                 ClaimAllocationsParams { sectors: vec![], all_or_nothing: false },
                 // [[],false]
-                "8280f4",
+                &hex!("8280f4")[..],
             ),
             (
                 ClaimAllocationsParams {
@@ -1624,7 +1626,7 @@ mod serialization {
                     all_or_nothing: true,
                 },
                 // [[[101,202,[]]],true]
-                "828183186518ca80f5",
+                &hex!("828183186518ca80f5"),
             ),
             (
                 ClaimAllocationsParams {
@@ -1652,13 +1654,13 @@ mod serialization {
                     all_or_nothing: true,
                 },
                 // [[[101,202,[[303,404,baga6ea4seaaqa,505],[606,707,baga6ea4seaaqc,808]]],[303,404,[]]],true]
-                "828283186518ca828419012f190194d82a49000181e203922001001901f98419025e1902c3d82a49000181e203922001011903288319012f19019480f5",
+                &hex!("828283186518ca828419012f190194d82a49000181e203922001001901f98419025e1902c3d82a49000181e203922001011903288319012f19019480f5"),
             ),
         ];
 
         for (params, expected_hex) in test_cases {
             let encoded = IpldBlock::serialize_cbor(&params).unwrap().unwrap();
-            assert_eq!(const_hex::encode(&encoded.data), expected_hex);
+            assert_eq!(encoded.data, expected_hex);
             let decoded: ClaimAllocationsParams = IpldBlock::deserialize(&encoded).unwrap();
             assert_eq!(params, decoded);
         }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -56,7 +56,7 @@ base64 = "0.22.1"
 derive_builder = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
-const-hex = { workspace = true }
+hex-literal = { workspace = true }
 # Enable the test_utils feature when testing.
 fil_actors_runtime = { workspace = true, features = ["test_utils"] }
 

--- a/runtime/tests/types_test.rs
+++ b/runtime/tests/types_test.rs
@@ -1,5 +1,7 @@
 // Tests to match with Go github.com/filecoin-project/go-state-types/*/BatchReturn
 mod serialization {
+    use hex_literal::hex;
+
     use fil_actors_runtime::{BatchReturn, BatchReturnGen};
     use fvm_ipld_encoding::ipld_block::IpldBlock;
     use fvm_shared::error::ExitCode;
@@ -12,7 +14,7 @@ mod serialization {
         test_cases.push((
             gen.gen(),
             // [0,[]]
-            "820080",
+            &hex!("820080")[..],
         ));
 
         gen = BatchReturnGen::new(1);
@@ -20,7 +22,7 @@ mod serialization {
         test_cases.push((
             gen.gen(),
             // [1,[]]
-            "820180",
+            &hex!("820180"),
         ));
 
         gen = BatchReturnGen::new(1);
@@ -28,7 +30,7 @@ mod serialization {
         test_cases.push((
             gen.gen(),
             // [0,[[0,16]]]
-            "820081820010",
+            &hex!("820081820010"),
         ));
 
         gen = BatchReturnGen::new(5);
@@ -41,12 +43,12 @@ mod serialization {
         test_cases.push((
             gen.gen(),
             // [2,[[1,7],[2,20],[4,16]]]
-            "820283820107820214820410",
+            &hex!("820283820107820214820410"),
         ));
 
         for (params, expected_hex) in test_cases {
             let encoded = IpldBlock::serialize_cbor(&params).unwrap().unwrap();
-            assert_eq!(const_hex::encode(&encoded.data), expected_hex);
+            assert_eq!(encoded.data, expected_hex);
             let decoded: BatchReturn = IpldBlock::deserialize(&encoded).unwrap();
             assert_eq!(params, decoded);
         }


### PR DESCRIPTION
I was responsible for adding this in the first place but I've since noticed there are already 2 hex libraries in the dependencies list and a macro is fine for this use.