### PR TITLE
fip-0100: move compact_partitions logic into deadline

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -2364,7 +2364,7 @@ impl Actor {
                         .ok_or_else(|| actor_error!(not_found, "no such partition {:?}", key))?;
 
                     let old_sectors = sectors
-                        .load_sector(&decl.sectors)
+                        .load_sectors(&decl.sectors)
                         .map_err(|e| e.wrap("failed to load sectors"))?;
                     let new_sectors: Vec<SectorOnChainInfo> = old_sectors
                         .iter()
@@ -2996,53 +2996,35 @@ impl Actor {
 
             let mut deadline = deadlines.load_deadline(store, params_deadline)?;
 
-            let (live, dead, removed_power) =
-                deadline.remove_partitions(store, partitions, quant).map_err(|e| {
+            let daily_fee_before = deadline.daily_fee.clone();
+
+            let mut sectors = Sectors::load(store, &state.sectors).map_err(|e| {
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load sectors")
+            })?;
+
+            let dead = deadline
+                .compact_partitions(
+                    store,
+                    &mut sectors,
+                    info.sector_size,
+                    info.window_post_partition_sectors,
+                    partitions,
+                    quant,
+                )
+                .map_err(|e| {
                     e.downcast_default(
                         ExitCode::USR_ILLEGAL_STATE,
                         format!("failed to remove partitions from deadline {}", params_deadline),
                     )
                 })?;
 
-            state.delete_sectors(store, &dead).map_err(|e| {
-                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to delete dead sectors")
+            sectors.delete_sectors(&dead).map_err(|e| {
+                e.wrap("failed to delete sectors removed during partition compaction")
             })?;
-
-            let sectors = state.load_sector_infos(store, &live).map_err(|e| {
-                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load moved sectors")
-            })?;
-            let proven = true;
-            let (added_power, added_fee) = deadline
-                .add_sectors(
-                    store,
-                    info.window_post_partition_sectors,
-                    proven,
-                    &sectors,
-                    info.sector_size,
-                    quant,
-                )
-                .map_err(|e| {
-                    e.downcast_default(
-                        ExitCode::USR_ILLEGAL_STATE,
-                        "failed to add back moved sectors",
-                    )
+            state.sectors =
+                sectors.amt.flush().with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
+                    "failed to save sectors after compaction"
                 })?;
-
-            if removed_power != added_power {
-                return Err(actor_error!(
-                    illegal_state,
-                    "power changed when compacting partitions: was {:?}, is now {:?}",
-                    removed_power,
-                    added_power
-                ));
-            }
-
-            // Rebalance the fee:
-            //   * The deadline's total daily_fee already reflected the total daily_fee of all live sectors.
-            //   * remove_partitions() doesn't perform a subtraction of the fee value
-            //   * add_sector() does perform an addition of the fee value
-            // So we've now added the fee for all live sectors in the removed partitions twice.
-            deadline.daily_fee -= added_fee;
 
             deadlines.update_deadline(policy, store, params_deadline, &deadline).map_err(|e| {
                 e.downcast_default(
@@ -3057,6 +3039,14 @@ impl Actor {
                     format!("failed to save deadline {}", params_deadline),
                 )
             })?;
+
+            let daily_fee_after = deadline.daily_fee;
+            if daily_fee_before != daily_fee_after {
+                return Err(actor_error!(
+                    illegal_state,
+                    "unexpected daily fee change during partition compaction"
+                ));
+            }
 
             Ok(())
         })?;
@@ -4398,7 +4388,7 @@ fn process_early_terminations(
 
         for (epoch, sector_numbers) in result.iter() {
             let sectors = sectors
-                .load_sector(sector_numbers)
+                .load_sectors(sector_numbers)
                 .map_err(|e| e.wrap("failed to load sector infos"))?;
 
             for sector in &sectors {

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -5,9 +5,8 @@ use std::borrow::Borrow;
 use std::cmp;
 use std::ops::Neg;
 
-use anyhow::{anyhow, Error};
+use anyhow::anyhow;
 use cid::Cid;
-use fvm_ipld_amt::Error as AmtError;
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
@@ -393,30 +392,6 @@ impl State {
         sectors.get(sector_num)
     }
 
-    pub fn delete_sectors<BS: Blockstore>(
-        &mut self,
-        store: &BS,
-        sector_nos: &BitField,
-    ) -> Result<(), AmtError> {
-        let mut sectors = Sectors::load(store, &self.sectors)?;
-
-        for sector_num in sector_nos.iter() {
-            let deleted_sector = sectors
-                .amt
-                .delete(sector_num)
-                .map_err(|e| e.downcast_wrap("could not delete sector number"))?;
-            if deleted_sector.is_none() {
-                return Err(AmtError::Dynamic(Error::msg(format!(
-                    "sector {} doesn't exist, failed to delete",
-                    sector_num
-                ))));
-            }
-        }
-
-        self.sectors = sectors.amt.flush()?;
-        Ok(())
-    }
-
     pub fn for_each_sector<BS: Blockstore, F>(&self, store: &BS, mut f: F) -> anyhow::Result<()>
     where
         F: FnMut(&SectorOnChainInfo) -> anyhow::Result<()>,
@@ -536,10 +511,13 @@ impl State {
 
             // The power returned from AddSectors is ignored because it's not activated (proven) yet.
             let proven = false;
+            // New sectors, so the deadline has new fees.
+            let new_fees = true;
             deadline.add_sectors(
                 store,
                 partition_size,
                 proven,
+                new_fees,
                 &deadline_sectors,
                 sector_size,
                 quant,
@@ -585,8 +563,9 @@ impl State {
 
         let quant = self.quant_spec_for_deadline(policy, deadline_idx);
         let proven = false;
+        let new_fees = true; // New sectors, so the deadline has new fees.
         deadline
-            .add_sectors(store, partition_size, proven, &sectors, sector_size, quant)
+            .add_sectors(store, partition_size, proven, new_fees, &sectors, sector_size, quant)
             .with_context_code(ExitCode::USR_ILLEGAL_STATE, || {
                 format!("failed to add sectors to deadline {}", deadline_idx)
             })?;
@@ -760,7 +739,7 @@ impl State {
         store: &BS,
         sectors: &BitField,
     ) -> anyhow::Result<Vec<SectorOnChainInfo>> {
-        Ok(Sectors::load(store, &self.sectors)?.load_sector(sectors)?)
+        Ok(Sectors::load(store, &self.sectors)?.load_sectors(sectors)?)
     }
 
     pub fn load_deadlines<BS: Blockstore>(&self, store: &BS) -> Result<Deadlines, ActorError> {

--- a/actors/miner/tests/deadline_state_test.rs
+++ b/actors/miner/tests/deadline_state_test.rs
@@ -63,7 +63,7 @@ fn add_sectors(
     let store = rt.store();
 
     let (activated_power, daily_fee) = deadline
-        .add_sectors(store, PARTITION_SIZE, false, &sectors, SECTOR_SIZE, QUANT_SPEC)
+        .add_sectors(store, PARTITION_SIZE, false, true, &sectors, SECTOR_SIZE, QUANT_SPEC)
         .expect("Couldn't add sectors");
     let expected_power = power_for_sectors(SECTOR_SIZE, &sectors);
     let expected_daily_fee =
@@ -85,13 +85,13 @@ fn add_sectors(
         return (deadline_state, sectors);
     }
 
-    let mut sector_array = sectors_arr(store, sectors.to_owned());
+    let mut sectors_array = sectors_arr(store, sectors.to_owned());
 
     //prove everything
     let result = deadline
         .record_proven_sectors(
             store,
-            &sector_array,
+            &sectors_array,
             SECTOR_SIZE,
             QUANT_SPEC,
             0,
@@ -105,7 +105,7 @@ fn add_sectors(
 
     assert_eq!(result.power_delta, expected_power);
 
-    let sectors_root = sector_array.amt.flush().unwrap();
+    let sectors_root = sectors_array.amt.flush().unwrap();
 
     let (faulty_power, recovery_power) =
         deadline.process_deadline_end(store, QUANT_SPEC, 0, sectors_root).unwrap();
@@ -204,27 +204,24 @@ fn add_then_terminate_then_remove_partition(
 ) -> (ExpectedDeadlineState, Vec<SectorOnChainInfo>) {
     let (deadline_state, sectors) = add_then_terminate_then_pop_early(rt, deadline);
     let store = rt.store();
+    let mut sectors_array = sectors_arr(store, sectors.to_owned());
 
-    let (live, dead, removed_power) = deadline
-        .remove_partitions(store, &bitfield_from_slice(&[0]), QUANT_SPEC)
+    let dead = deadline
+        .compact_partitions(
+            store,
+            &mut sectors_array,
+            SECTOR_SIZE,
+            PARTITION_SIZE,
+            &bitfield_from_slice(&[0]),
+            QUANT_SPEC,
+        )
         .expect("should have removed partitions");
 
-    assert_bitfield_equals(&live, &[2, 4]);
     assert_bitfield_equals(&dead, &[1, 3]);
 
-    // Subtract the fee from removing the partition to satisfy the invariant for this.
-    // This should be taken care of in the deadline when we remove a partition, but we don't
-    // expect remove_partitions to do it because it doesn't have the full sector info.
-    let removed_daily_fee = &select_sectors(&sectors, &live)
-        .iter()
-        .fold(TokenAmount::zero(), |acc, s| acc + s.daily_fee.clone());
-    deadline.daily_fee -= removed_daily_fee;
-
-    let live_power = power_for_sectors(SECTOR_SIZE, &select_sectors(&sectors, &live));
-    assert_eq!(live_power, removed_power);
     let deadline_state = deadline_state
         .with_terminations(&[6])
-        .with_partitions(vec![bitfield_from_slice(&[5, 6, 7, 8]), bitfield_from_slice(&[9])])
+        .with_partitions(vec![bitfield_from_slice(&[5, 6, 7, 8]), bitfield_from_slice(&[2, 4, 9])])
         .assert(store, &sectors, deadline);
 
     (deadline_state, sectors)
@@ -341,10 +338,21 @@ fn cannot_remove_partitions_with_early_terminations() {
     let (_, rt) = setup();
     let mut deadline = Deadline::new(rt.store()).unwrap();
 
-    add_then_terminate(&rt, &mut deadline, false);
+    let (_, sectors) = add_then_terminate(&rt, &mut deadline, false);
 
     let store = rt.store();
-    assert!(deadline.remove_partitions(store, &bitfield_from_slice(&[0]), QUANT_SPEC).is_err());
+    let mut sectors_array = sectors_arr(store, sectors.to_owned());
+
+    assert!(deadline
+        .compact_partitions(
+            store,
+            &mut sectors_array,
+            SECTOR_SIZE,
+            PARTITION_SIZE,
+            &bitfield_from_slice(&[0]),
+            QUANT_SPEC,
+        )
+        .is_err());
 }
 
 #[test]
@@ -394,9 +402,19 @@ fn cannot_remove_missing_partition() {
     let (_, rt) = setup();
     let mut deadline = Deadline::new(rt.store()).unwrap();
 
-    add_then_terminate_then_remove_partition(&rt, &mut deadline);
+    let (_, sectors) = add_then_terminate_then_remove_partition(&rt, &mut deadline);
+    let store = rt.store();
+    let mut sectors_array = sectors_arr(store, sectors.to_owned());
+
     assert!(deadline
-        .remove_partitions(rt.store(), &bitfield_from_slice(&[2]), QUANT_SPEC)
+        .compact_partitions(
+            store,
+            &mut sectors_array,
+            SECTOR_SIZE,
+            PARTITION_SIZE,
+            &bitfield_from_slice(&[2]),
+            QUANT_SPEC,
+        )
         .is_err());
 }
 
@@ -406,12 +424,20 @@ fn removing_no_partitions_does_nothing() {
     let mut deadline = Deadline::new(rt.store()).unwrap();
 
     let (deadline_state, sectors) = add_then_terminate_then_pop_early(&rt, &mut deadline);
-    let (live, dead, removed_power) = deadline
-        .remove_partitions(rt.store(), &bitfield_from_slice(&[]), QUANT_SPEC)
+    let store = rt.store();
+    let mut sectors_array = sectors_arr(store, sectors.to_owned());
+
+    let dead = deadline
+        .compact_partitions(
+            store,
+            &mut sectors_array,
+            SECTOR_SIZE,
+            PARTITION_SIZE,
+            &bitfield_from_slice(&[]),
+            QUANT_SPEC,
+        )
         .expect("should not have failed to remove partitions");
 
-    assert!(removed_power.is_zero());
-    assert!(live.is_empty());
     assert!(dead.is_empty());
 
     // Popping early terminations doesn't affect the terminations bitfield.
@@ -430,11 +456,19 @@ fn fails_to_remove_partitions_with_faulty_sectors() {
     let (_, rt) = setup();
     let mut deadline = Deadline::new(rt.store()).unwrap();
 
-    add_then_mark_faulty(&rt, &mut deadline, false);
+    let (_, sectors) = add_then_mark_faulty(&rt, &mut deadline, false);
+    let store = rt.store();
+    let mut sectors_array = sectors_arr(store, sectors.to_owned());
 
-    // Try to remove a partition with faulty sectors.
     assert!(deadline
-        .remove_partitions(rt.store(), &bitfield_from_slice(&[1]), QUANT_SPEC)
+        .compact_partitions(
+            store,
+            &mut sectors_array,
+            SECTOR_SIZE,
+            PARTITION_SIZE,
+            &bitfield_from_slice(&[1]),
+            QUANT_SPEC,
+        )
         .is_err());
 }
 
@@ -673,7 +707,15 @@ fn post_all_the_things() {
 
     // add an inactive sector
     let (power, daily_fee) = deadline
-        .add_sectors(rt.store(), PARTITION_SIZE, false, &extra_sectors(), SECTOR_SIZE, QUANT_SPEC)
+        .add_sectors(
+            rt.store(),
+            PARTITION_SIZE,
+            false,
+            true,
+            &extra_sectors(),
+            SECTOR_SIZE,
+            QUANT_SPEC,
+        )
         .unwrap();
     let expected_power = power_for_sectors(SECTOR_SIZE, &extra_sectors());
     let expected_daily_fee =
@@ -775,7 +817,15 @@ fn post_with_unproven_faults_recoveries_untracted_recoveries() {
 
     // add an inactive sector
     let (power, daily_fee) = deadline
-        .add_sectors(rt.store(), PARTITION_SIZE, false, &extra_sectors(), SECTOR_SIZE, QUANT_SPEC)
+        .add_sectors(
+            rt.store(),
+            PARTITION_SIZE,
+            false,
+            true,
+            &extra_sectors(),
+            SECTOR_SIZE,
+            QUANT_SPEC,
+        )
         .unwrap();
     let expected_power = power_for_sectors(SECTOR_SIZE, &extra_sectors());
     let expected_daily_fee =
@@ -890,7 +940,15 @@ fn post_with_skipped_unproven() {
 
     // add an inactive sector
     let (power, daily_fee) = deadline
-        .add_sectors(rt.store(), PARTITION_SIZE, false, &extra_sectors(), SECTOR_SIZE, QUANT_SPEC)
+        .add_sectors(
+            rt.store(),
+            PARTITION_SIZE,
+            false,
+            true,
+            &extra_sectors(),
+            SECTOR_SIZE,
+            QUANT_SPEC,
+        )
         .unwrap();
     let expected_power = power_for_sectors(SECTOR_SIZE, &extra_sectors());
     let expected_daily_fee =
@@ -963,7 +1021,15 @@ fn post_missing_partition() {
 
     // add an inactive sector
     let (power, daily_fee) = deadline
-        .add_sectors(rt.store(), PARTITION_SIZE, false, &extra_sectors(), SECTOR_SIZE, QUANT_SPEC)
+        .add_sectors(
+            rt.store(),
+            PARTITION_SIZE,
+            false,
+            true,
+            &extra_sectors(),
+            SECTOR_SIZE,
+            QUANT_SPEC,
+        )
         .unwrap();
     let expected_power = power_for_sectors(SECTOR_SIZE, &extra_sectors());
     let expected_daily_fee =
@@ -1003,7 +1069,15 @@ fn post_partition_twice() {
 
     // add an inactive sector
     let (power, daily_fee) = deadline
-        .add_sectors(rt.store(), PARTITION_SIZE, false, &extra_sectors(), SECTOR_SIZE, QUANT_SPEC)
+        .add_sectors(
+            rt.store(),
+            PARTITION_SIZE,
+            false,
+            true,
+            &extra_sectors(),
+            SECTOR_SIZE,
+            QUANT_SPEC,
+        )
         .unwrap();
     let expected_power = power_for_sectors(SECTOR_SIZE, &extra_sectors());
     let expected_daily_fee =
@@ -1315,7 +1389,11 @@ impl ExpectedDeadlineState {
 
         for (i, partition_sectors) in self.partition_sectors.iter().enumerate() {
             let partitions = partitions.get(i as u64).unwrap().unwrap();
-            assert_eq!(partition_sectors, &partitions.sectors);
+            assert_eq!(
+                partition_sectors, &partitions.sectors,
+                "Partition {} sectors do not match. Expected: {:?}, Found: {:?}",
+                i, partition_sectors, partitions.sectors
+            );
         }
 
         self

--- a/actors/miner/tests/sectors.rs
+++ b/actors/miner/tests/sectors.rs
@@ -35,13 +35,13 @@ fn loads_sectors() {
     let sectors = setup_sectors(&store);
 
     let mut bf = bf_from_vec(vec![0, 5]);
-    let vec_sectors = sectors.load_sector(&bf).unwrap();
+    let vec_sectors = sectors.load_sectors(&bf).unwrap();
     assert_eq!(vec_sectors.len(), 2);
     assert_eq!(make_sector(0), vec_sectors[0]);
     assert_eq!(make_sector(5), vec_sectors[1]);
 
     bf = bf_from_vec(vec![0, 3]);
-    let res = sectors.load_sector(&bf);
+    let res = sectors.load_sectors(&bf);
     assert!(res.is_err());
 }
 
@@ -60,7 +60,7 @@ fn stores_sectors() {
     sectors.store(vec![s3.clone(), s1.clone()]).unwrap();
 
     let bf = bf_from_vec(vec![0, 1, 3, 5]);
-    let vec_sectors = sectors.load_sector(&bf).unwrap();
+    let vec_sectors = sectors.load_sectors(&bf).unwrap();
     assert_eq!(vec_sectors.len(), 4);
     assert_eq!(&s0, &vec_sectors[0]);
     assert_eq!(&s1, &vec_sectors[1]);
@@ -75,7 +75,7 @@ fn loads_and_stores_no_sectors() {
     let mut sectors = setup_sectors(&store);
 
     let bf = bf_from_vec(vec![]);
-    let vec_sectors = sectors.load_sector(&bf).unwrap();
+    let vec_sectors = sectors.load_sectors(&bf).unwrap();
     assert_eq!(vec_sectors.len(), 0);
     sectors.store(vec![]).unwrap();
 }
@@ -147,4 +147,17 @@ fn no_non_faulty_sectors() {
 
     let vec_sectors = sectors.load_for_proof(&bf_from_vec(vec![1]), &bf_from_vec(vec![1])).unwrap();
     assert_eq!(vec_sectors.len(), 0);
+}
+
+#[test]
+fn delete_nonexistent_value_returns_an_error() {
+    let store = MemoryBlockstore::default();
+    let mut sectors = setup_sectors(&store);
+    let mut bf = BitField::new();
+
+    bf.set(100); // doesn't exist
+    assert!(sectors.delete_sectors(&bf).is_err());
+
+    bf.set(0); // does exist but 100 still doesn't
+    assert!(sectors.delete_sectors(&bf).is_err());
 }

--- a/actors/miner/tests/sectors_stores_test.rs
+++ b/actors/miner/tests/sectors_stores_test.rs
@@ -1,7 +1,6 @@
 use cid::Cid;
 use fil_actor_miner::SectorOnChainInfo;
 use fil_actors_runtime::test_utils::*;
-use fvm_ipld_bitfield::BitField;
 use fvm_shared::{
     bigint::BigInt,
     clock::ChainEpoch,
@@ -13,7 +12,7 @@ mod util;
 use state_harness::*;
 
 #[test]
-fn put_get_and_delete() {
+fn put_and_get() {
     let mut h = StateHarness::new(0);
 
     let sector_no = 1u64;
@@ -39,20 +38,6 @@ fn put_get_and_delete() {
     assert!(h.has_sector_number(sector_no));
     let out = h.get_sector(sector_no);
     assert_eq!(sector_info_2, out);
-
-    h.delete_sectors(vec![sector_no]);
-    assert!(!h.has_sector_number(sector_no));
-}
-
-#[test]
-fn delete_nonexistent_value_returns_an_error() {
-    let mut h = StateHarness::new(ChainEpoch::from(0));
-
-    let sector_no = 1u64;
-    let mut bf = BitField::new();
-    bf.set(sector_no);
-
-    assert!(h.st.delete_sectors(&h.store, &bf).is_err());
 }
 
 #[test]
@@ -64,11 +49,11 @@ fn get_nonexistent_value_returns_false() {
 }
 
 #[test]
-fn iterate_and_delete_multiple_sectors() {
+fn iterate_multiple_sectors() {
     let mut h = StateHarness::new(ChainEpoch::from(0));
 
     // set of sectors, the larger numbers here are not significant
-    let sector_nos = vec![100, 200, 300, 400, 500, 600, 700, 800, 900, 1000];
+    let sector_nos = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000];
 
     // put all the sectors in the store
     for (i, s) in sector_nos.iter().enumerate() {
@@ -90,10 +75,6 @@ fn iterate_and_delete_multiple_sectors() {
 
     // ensure we iterated over the expected number of sectors
     assert_eq!(sector_nos.len(), sector_no_idx);
-    h.delete_sectors(sector_nos.clone());
-    for s in sector_nos {
-        assert!(!h.has_sector_number(s));
-    }
 }
 
 // returns a unique SectorOnChainInfo with each invocation with SectorNumber set to `sectorNo`.

--- a/actors/miner/tests/state_harness.rs
+++ b/actors/miner/tests/state_harness.rs
@@ -140,15 +140,6 @@ impl StateHarness {
         self.st.get_sector(&self.store, sector_number).unwrap().unwrap()
     }
 
-    // makes a bit field from the passed sector numbers
-    pub fn delete_sectors(&mut self, sector_numbers: Vec<u64>) {
-        let mut bf = BitField::new();
-        for b in sector_numbers.iter() {
-            bf.set(*b);
-        }
-        self.st.delete_sectors(&self.store, &bf).unwrap();
-    }
-
     #[allow(dead_code)]
     pub fn vesting_funds_store_empty(&self) -> bool {
         let vesting = self.store.get_cbor::<VestingFunds>(&self.st.vesting_funds).unwrap().unwrap();


### PR DESCRIPTION
Redoing #1625, same content, single commit

* fip-0100: move compact_partitions logic into deadline
* fip-0100: remove sectors in AMT not state
* fip-0100: Deadline::add_sectors flag to optionally accumulate fees