### PR TITLE
test: correctly handle cron vesting in tests

### DIFF
--- a/actors/miner/tests/deadline_cron.rs
+++ b/actors/miner/tests/deadline_cron.rs
@@ -5,7 +5,7 @@ use fil_actor_miner::{
 };
 use fil_actors_runtime::runtime::RuntimePolicy;
 use fil_actors_runtime::test_utils::MockRuntime;
-use fil_actors_runtime::{MessageAccumulator, EPOCHS_IN_DAY};
+use fil_actors_runtime::{MessageAccumulator, EPOCHS_IN_DAY, EPOCHS_IN_HOUR};
 use fvm_ipld_bitfield::BitField;
 use fvm_shared::bigint::Zero;
 use fvm_shared::clock::ChainEpoch;
@@ -91,16 +91,17 @@ fn test_vesting_on_cron() {
         }
     };
 
-    // move current epoch by a day so funds get vested
-    let new_epoch = q.quantize_up(current_epoch + EPOCHS_IN_DAY + 10);
+    // move current epoch by a day so funds get vested. +1 because rewards are vested at the end of
+    // an epoch.
+    let new_epoch = q.quantize_up(current_epoch + 12 * EPOCHS_IN_HOUR) + 1;
     assert_locked_fn(new_epoch, true);
 
     // no funds get vested if epoch moves by <12 hours
-    let new_epoch = new_epoch + (EPOCHS_IN_DAY / 2) - 100;
+    let new_epoch = new_epoch + (12 * EPOCHS_IN_HOUR) - 100;
     assert_locked_fn(new_epoch, false);
 
     // funds get vested again if epoch is quantised
-    let new_epoch = q.quantize_up(new_epoch);
+    let new_epoch = q.quantize_up(new_epoch) + 1;
     assert_locked_fn(new_epoch, true);
 
     h.check_state(&rt);

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -78,7 +78,7 @@ use fil_actor_miner::{
     SectorReturn, SectorUpdateManifest, Sectors, State, SubmitWindowedPoStParams,
     TerminateSectorsParams, TerminationDeclaration, VerifiedAllocationKey, VestingFunds,
     WindowedPoSt, WithdrawBalanceParams, WithdrawBalanceReturn, CRON_EVENT_PROVING_DEADLINE,
-    NI_AGGREGATE_FEE_BASE_SECTOR_COUNT, NO_QUANTIZATION, REWARD_VESTING_SPEC, SECTORS_AMT_BITWIDTH,
+    NI_AGGREGATE_FEE_BASE_SECTOR_COUNT, NO_QUANTIZATION, SECTORS_AMT_BITWIDTH,
     SECTOR_CONTENT_CHANGED,
 };
 use fil_actor_miner::{
@@ -3307,13 +3307,6 @@ enum MhCode {
 
 fn immediately_vesting_funds(rt: &MockRuntime, state: &State) -> TokenAmount {
     let curr_epoch = *rt.epoch.borrow();
-
-    let q =
-        QuantSpec { unit: REWARD_VESTING_SPEC.quantization, offset: state.proving_period_start };
-    if q.quantize_up(curr_epoch) != curr_epoch {
-        return TokenAmount::zero();
-    }
-
     let vesting = rt.store.get_cbor::<VestingFunds>(&state.vesting_funds).unwrap().unwrap();
     let mut sum = TokenAmount::zero();
     for vf in vesting.funds {


### PR DESCRIPTION
1. In the test harness, check if we should vest every epoch. The queue should already be quantized.
2. Correctly handle the fact that we vest at the _end_ of an epoch in the cron vesting test.