### PR TITLE
feat: refactor vesting funds into a head and a tail

### DIFF
--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -276,10 +276,10 @@ fn check_miner_balances<BS: Blockstore>(
 
     // locked funds must be sum of vesting table and vesting table payments must be quantized
     let mut vesting_sum = TokenAmount::zero();
-    match state.load_vesting_funds(store) {
+    match state.vesting_funds.load(store) {
         Ok(funds) => {
             let quant = state.quant_spec_every_deadline(policy);
-            funds.funds.iter().for_each(|entry| {
+            funds.into_iter().for_each(|entry| {
                 acc.require(
                     entry.amount.is_positive(),
                     format!("non-positive amount in miner vesting table entry {entry:?}"),

--- a/actors/miner/src/vesting_state.rs
+++ b/actors/miner/src/vesting_state.rs
@@ -1,58 +1,125 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::{iter, mem};
+use std::iter;
 
+use cid::Cid;
+use fil_actors_runtime::{ActorError, AsActorError};
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::serde::{Deserialize, Serialize};
 use fvm_ipld_encoding::tuple::*;
+use fvm_ipld_encoding::CborStore;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
-use itertools::{EitherOrBoth, Itertools};
+use fvm_shared::error::ExitCode;
+use itertools::{EitherOrBoth, Itertools, PeekingNext};
+use multihash_codetable::Code;
 use num_traits::Zero;
 
 use super::{QuantSpec, VestSpec};
 
 // Represents miner funds that will vest at the given epoch.
-#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+#[derive(Default, Debug, Serialize_tuple, Deserialize_tuple, Clone)]
 pub struct VestingFund {
     pub epoch: ChainEpoch,
     pub amount: TokenAmount,
 }
 
-/// Represents the vesting table state for the miner.
-/// It is a slice of (VestingEpoch, VestingAmount).
-/// The slice will always be sorted by the VestingEpoch.
-#[derive(Serialize_tuple, Deserialize_tuple, Default)]
-pub struct VestingFunds {
-    pub funds: Vec<VestingFund>,
+/// Represents the vesting table state for the miner. It's composed of a `head` (stored inline) and
+/// a tail (referenced by CID).
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(transparent)]
+pub struct VestingFunds(Option<VestingFundsInner>);
+
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone)]
+struct VestingFundsInner {
+    // The "next" batch of vesting funds.
+    head: VestingFund,
+    // The rest of the vesting funds, if any.
+    tail: Cid, // Vec<VestingFund>
+}
+
+/// Take vested funds from the passed iterator. This assumes the iterator returns `VestingFund`s in
+/// epoch order.
+fn take_vested(
+    iter: &mut impl PeekingNext<Item = VestingFund>,
+    current_epoch: ChainEpoch,
+) -> TokenAmount {
+    iter.peeking_take_while(|fund| fund.epoch < current_epoch).map(|f| f.amount).sum()
 }
 
 impl VestingFunds {
     pub fn new() -> Self {
-        Default::default()
+        Self(None)
     }
 
-    pub fn unlock_vested_funds(&mut self, current_epoch: ChainEpoch) -> TokenAmount {
-        // TODO: the funds are sorted by epoch, so we could do a binary search here
-        let i = self
-            .funds
-            .iter()
-            .position(|fund| fund.epoch >= current_epoch)
-            .unwrap_or(self.funds.len());
+    pub fn load(&self, store: &impl Blockstore) -> Result<Vec<VestingFund>, ActorError> {
+        let Some(this) = &self.0 else { return Ok(Vec::new()) };
+        let mut funds: Vec<_> = store
+            .get_cbor(&this.tail)
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to load the vesting funds")?
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "missing vesting funds state")?;
 
-        self.funds.drain(..i).map(|f| f.amount).sum()
+        // NOTE: we allow head to be drawn down to zero through fees/penalties. However, when
+        // inspecting the vesting table, we never want to see a "zero" entry so we skip it in
+        // that case.
+        if this.head.amount.is_positive() {
+            funds.insert(0, this.head.clone());
+        }
+        Ok(funds)
     }
 
+    fn save(
+        &mut self,
+        store: &impl Blockstore,
+        funds: impl IntoIterator<Item = VestingFund>,
+    ) -> Result<(), ActorError> {
+        let mut funds = funds.into_iter();
+        let Some(head) = funds.next() else {
+            self.0 = None;
+            return Ok(());
+        };
+
+        let tail = store
+            .put_cbor(&funds.collect_vec(), Code::Blake2b256)
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to store the vesting funds")?;
+
+        self.0 = Some(VestingFundsInner { head, tail });
+        Ok(())
+    }
+
+    fn can_vest(&self, current_epoch: ChainEpoch) -> bool {
+        self.0.as_ref().map(|v| v.head.epoch < current_epoch).unwrap_or(false)
+    }
+
+    pub fn unlock_vested_funds(
+        &mut self,
+        store: &impl Blockstore,
+        current_epoch: ChainEpoch,
+    ) -> Result<TokenAmount, ActorError> {
+        if !self.can_vest(current_epoch) {
+            return Ok(TokenAmount::zero());
+        }
+        let mut funds = self.load(store)?.into_iter().peekable();
+        let unlocked = take_vested(&mut funds, current_epoch);
+        self.save(store, funds)?;
+        Ok(unlocked)
+    }
+
+    // Adds locked funds and unlocks everything that has already vested.
     pub fn add_locked_funds(
         &mut self,
+        store: &impl Blockstore,
         current_epoch: ChainEpoch,
         vesting_sum: &TokenAmount,
         proving_period_start: ChainEpoch,
         spec: &VestSpec,
-    ) {
+    ) -> Result<TokenAmount, ActorError> {
         // Quantization is aligned with when regular cron will be invoked, in the last epoch of deadlines.
         let vest_begin = current_epoch + spec.initial_delay; // Nothing unlocks here, this is just the start of the clock.
-        let mut vested_so_far = TokenAmount::zero();
+        let quant = QuantSpec { unit: spec.quantization, offset: proving_period_start };
 
+        let mut vested_so_far = TokenAmount::zero();
         let mut epoch = vest_begin;
 
         // Create an iterator for the vesting schedule we're going to "join" with the current
@@ -64,8 +131,7 @@ impl VestingFunds {
 
             epoch += spec.step_duration;
 
-            let vest_epoch = QuantSpec { unit: spec.quantization, offset: proving_period_start }
-                .quantize_up(epoch);
+            let vest_epoch = quant.quantize_up(epoch);
 
             let elapsed = vest_epoch - vest_begin;
             let target_vest = if elapsed < spec.vest_period {
@@ -81,56 +147,85 @@ impl VestingFunds {
             Some(VestingFund { epoch: vest_epoch, amount: vest_this_time })
         });
 
-        // Take the old funds array and replace it with a new one.
-        let funds_len = self.funds.len();
-        let old_funds = mem::replace(&mut self.funds, Vec::with_capacity(funds_len));
+        let old_funds = self.load(store)?;
 
         // Fill back in the funds array, merging existing and new schedule.
-        self.funds.extend(
-            old_funds.into_iter().merge_join_by(new_funds, |a, b| a.epoch.cmp(&b.epoch)).map(
-                |item| match item {
-                    EitherOrBoth::Left(a) => a,
-                    EitherOrBoth::Right(b) => b,
-                    EitherOrBoth::Both(a, b) => {
-                        VestingFund { epoch: a.epoch, amount: a.amount + b.amount }
-                    }
-                },
-            ),
-        );
+        let mut combined_funds = old_funds
+            .into_iter()
+            .merge_join_by(new_funds, |a, b| a.epoch.cmp(&b.epoch))
+            .map(|item| match item {
+                EitherOrBoth::Left(a) => a,
+                EitherOrBoth::Right(b) => b,
+                EitherOrBoth::Both(a, b) => {
+                    VestingFund { epoch: a.epoch, amount: a.amount + b.amount }
+                }
+            })
+            .peekable();
+
+        // Take any unlocked funds.
+        let unlocked = take_vested(&mut combined_funds, current_epoch);
+
+        // Write back the new value.
+        self.save(store, combined_funds)?;
+
+        Ok(unlocked)
     }
 
-    pub fn unlock_unvested_funds(
+    /// Unlock all vested (first return value) then unlock unvested funds up to at most the
+    /// specified target.
+    pub fn unlock_vested_and_unvested_funds(
         &mut self,
+        store: &impl Blockstore,
         current_epoch: ChainEpoch,
         target: &TokenAmount,
-    ) -> TokenAmount {
-        let mut amount_unlocked = TokenAmount::zero();
-        let mut last = None;
-        let mut start = 0;
-        for (i, vf) in self.funds.iter_mut().enumerate() {
-            if &amount_unlocked >= target {
-                break;
-            }
+    ) -> Result<
+        (
+            TokenAmount, // automatic vested
+            TokenAmount, // unlocked unvested
+        ),
+        ActorError,
+    > {
+        // If our inner value is None, there's nothing to vest.
+        let Some(this) = &mut self.0 else {
+            return Ok(Default::default());
+        };
 
-            if vf.epoch >= current_epoch {
-                let unlock_amount = std::cmp::min(target - &amount_unlocked, vf.amount.clone());
-                amount_unlocked += &unlock_amount;
-                let new_amount = &vf.amount - &unlock_amount;
+        let mut target = target.clone();
 
-                if new_amount.is_zero() {
-                    last = Some(i);
-                } else {
-                    vf.amount = new_amount;
-                }
-            } else {
-                start = i + 1;
-            }
+        // Fast path: take it out of the head and don't touch the tail.
+        if this.head.epoch >= current_epoch && this.head.amount >= target {
+            this.head.amount -= &target;
+            return Ok((TokenAmount::zero(), target));
         }
 
-        if let Some(end) = last {
-            self.funds.drain(start..=end);
-        }
+        // Slow path, take it out of the tail.
 
-        amount_unlocked
+        let mut unvested = TokenAmount::zero();
+        let mut vested = TokenAmount::zero();
+
+        let mut funds = itertools::put_back(self.load(store)?);
+        while let Some(mut vf) = funds.next() {
+            // already vested
+            if vf.epoch < current_epoch {
+                vested += vf.amount;
+                continue;
+            }
+
+            // take all
+            if vf.amount < target {
+                target -= &vf.amount;
+                unvested += &vf.amount;
+                continue;
+            }
+
+            // take some and stop.
+            unvested += &target;
+            vf.amount -= &target;
+            funds.put_back(vf);
+            break;
+        }
+        self.save(store, funds)?;
+
+        Ok((vested, unvested))
     }
 }

--- a/actors/miner/src/vesting_state.rs
+++ b/actors/miner/src/vesting_state.rs
@@ -115,7 +115,17 @@ impl VestingFunds {
         proving_period_start: ChainEpoch,
         spec: &VestSpec,
     ) -> Result<TokenAmount, ActorError> {
-        // Quantization is aligned with when regular cron will be invoked, in the last epoch of deadlines.
+        // Quantization is aligned with the beginning of the next 0th or 23rd deadline, whichever
+        // comes first, and funds vest the epoch _after_ the quantized epoch (vesting_epoch <
+        // current_epoch).
+        //
+        // This means that:
+        //
+        // 1. Vesting funds will become available to withdraw the first epoch after the start of the
+        //    0th or 23rd deadline.
+        // 2. Vesting funds won't automatically vest in cron until the next deadline (the 1st or the
+        //    24th).
+
         let vest_begin = current_epoch + spec.initial_delay; // Nothing unlocks here, this is just the start of the clock.
         let quant = QuantSpec { unit: spec.quantization, offset: proving_period_start };
 

--- a/actors/miner/tests/deadline_cron.rs
+++ b/actors/miner/tests/deadline_cron.rs
@@ -5,7 +5,7 @@ use fil_actor_miner::{
 };
 use fil_actors_runtime::runtime::RuntimePolicy;
 use fil_actors_runtime::test_utils::MockRuntime;
-use fil_actors_runtime::{MessageAccumulator, EPOCHS_IN_DAY};
+use fil_actors_runtime::{MessageAccumulator, EPOCHS_IN_DAY, EPOCHS_IN_HOUR};
 use fvm_ipld_bitfield::BitField;
 use fvm_shared::bigint::Zero;
 use fvm_shared::clock::ChainEpoch;
@@ -98,16 +98,17 @@ fn test_vesting_on_cron() {
         }
     };
 
-    // move current epoch by a day so funds get vested
-    let new_epoch = q.quantize_up(current_epoch + EPOCHS_IN_DAY + 10);
+    // move current epoch by a day so funds get vested. +1 because rewards are vested at the end of
+    // an epoch.
+    let new_epoch = q.quantize_up(current_epoch + 12 * EPOCHS_IN_HOUR) + 1;
     assert_locked_fn(new_epoch, true);
 
     // no funds get vested if epoch moves by <12 hours
-    let new_epoch = new_epoch + (EPOCHS_IN_DAY / 2) - 100;
+    let new_epoch = new_epoch + (12 * EPOCHS_IN_HOUR) - 100;
     assert_locked_fn(new_epoch, false);
 
     // funds get vested again if epoch is quantised
-    let new_epoch = q.quantize_up(new_epoch);
+    let new_epoch = q.quantize_up(new_epoch) + 1;
     assert_locked_fn(new_epoch, true);
 
     h.check_state(&rt);

--- a/actors/miner/tests/deadline_cron.rs
+++ b/actors/miner/tests/deadline_cron.rs
@@ -69,8 +69,8 @@ fn test_vesting_on_cron() {
 
     // --- ASSERT FUNDS TO BE VESTED
     let st = h.get_state(&rt);
-    let vesting_funds = st.load_vesting_funds(&rt.store).unwrap();
-    assert_eq!(360, vesting_funds.funds.len());
+    let vesting_funds = st.vesting_funds.load(&rt.store).unwrap();
+    assert_eq!(360, vesting_funds.len());
 
     let q = QuantSpec { unit: REWARD_VESTING_SPEC.quantization, offset: st.proving_period_start };
 

--- a/actors/miner/tests/repay_debt_test.rs
+++ b/actors/miner/tests/repay_debt_test.rs
@@ -16,8 +16,8 @@ fn repay_debt_in_priority_order() {
 
     let (penalty_from_vesting, penalty_from_balance) =
         h.st.repay_partial_debt_in_priority_order(&h.store, 0, &current_balance).unwrap();
-    assert_eq!(penalty_from_vesting, TokenAmount::zero());
-    assert_eq!(penalty_from_balance, current_balance);
+    assert_eq!(penalty_from_vesting, current_balance);
+    assert_eq!(penalty_from_balance, TokenAmount::zero());
 
     let expected_debt = -(current_balance - fee);
     assert_eq!(expected_debt, h.st.fee_debt);

--- a/actors/miner/tests/state_harness.rs
+++ b/actors/miner/tests/state_harness.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use fil_actor_miner::{
     BitFieldQueue, CollisionPolicy, MinerInfo, QuantSpec, SectorOnChainInfo,
-    SectorPreCommitOnChainInfo, State, VestSpec, VestingFunds,
+    SectorPreCommitOnChainInfo, State, VestSpec,
 };
 use fil_actors_runtime::test_blockstores::MemoryBlockstore;
 use fil_actors_runtime::{runtime::Policy, ActorError};
@@ -120,12 +120,12 @@ impl StateHarness {
     }
 
     #[allow(dead_code)]
-    pub fn unlock_unvested_funds(
+    pub fn unlock_vested_and_unvested_funds(
         &mut self,
         current_epoch: ChainEpoch,
         target: &TokenAmount,
-    ) -> anyhow::Result<TokenAmount> {
-        self.st.unlock_unvested_funds(&self.store, current_epoch, target)
+    ) -> anyhow::Result<(TokenAmount, TokenAmount)> {
+        self.st.unlock_vested_and_unvested_funds(&self.store, current_epoch, target)
     }
 
     pub fn has_sector_number(&self, sector_no: SectorNumber) -> bool {
@@ -142,8 +142,7 @@ impl StateHarness {
 
     #[allow(dead_code)]
     pub fn vesting_funds_store_empty(&self) -> bool {
-        let vesting = self.store.get_cbor::<VestingFunds>(&self.st.vesting_funds).unwrap().unwrap();
-        vesting.funds.is_empty()
+        self.st.vesting_funds.load(&self.store).unwrap().is_empty()
     }
 
     pub fn assign_sectors_to_deadlines(

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -15,7 +15,7 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::de::Deserialize;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::ser::Serialize;
-use fvm_ipld_encoding::{BytesDe, CborStore, RawBytes};
+use fvm_ipld_encoding::{BytesDe, RawBytes};
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::bigint::Zero;
@@ -76,8 +76,8 @@ use fil_actor_miner::{
     SectorActivationManifest, SectorChanges, SectorContentChangedParams,
     SectorContentChangedReturn, SectorOnChainInfo, SectorPreCommitInfo, SectorPreCommitOnChainInfo,
     SectorReturn, SectorUpdateManifest, Sectors, State, SubmitWindowedPoStParams,
-    TerminateSectorsParams, TerminationDeclaration, VerifiedAllocationKey, VestingFunds,
-    WindowedPoSt, WithdrawBalanceParams, WithdrawBalanceReturn, CRON_EVENT_PROVING_DEADLINE,
+    TerminateSectorsParams, TerminationDeclaration, VerifiedAllocationKey, WindowedPoSt,
+    WithdrawBalanceParams, WithdrawBalanceReturn, CRON_EVENT_PROVING_DEADLINE,
     NI_AGGREGATE_FEE_BASE_SECTOR_COUNT, NO_QUANTIZATION, SECTORS_AMT_BITWIDTH,
     SECTOR_CONTENT_CHANGED,
 };
@@ -1707,6 +1707,7 @@ impl ActorHarness {
 
         if state.deadline_cron_active {
             rt.epoch.replace(deadline.last());
+            cfg.pledge_delta -= immediately_vesting_funds(rt, &state);
             cfg.expected_enrollment = deadline.last() + rt.policy.wpost_challenge_window;
             self.on_deadline_cron(rt, cfg);
         }
@@ -2140,15 +2141,32 @@ impl ActorHarness {
                 }
             }
 
+            let state = self.get_state(&rt);
+
+            // Advance to the end of the deadline. We do this manually because we need to be at the
+            // end of the deadline to figure out whether or not we take the fees from vested or
+            // unvested funds.
+            assert!(state.deadline_cron_active, "deadline is active");
+            let deadline = new_deadline_info_from_offset_and_epoch(
+                &rt.policy,
+                state.proving_period_start,
+                *rt.epoch.borrow(),
+            );
+            rt.set_epoch(deadline.last());
+
+            let expected_enrollment = deadline.last() + rt.policy.wpost_challenge_window;
             let unvested = unvested_vesting_funds(rt, &state);
-            let available = rt.get_balance() + unvested.clone() - &state.initial_pledge;
-            let burnt_funds =
-                std::cmp::max(&TokenAmount::zero(), std::cmp::min(&available, &daily_fee)).clone();
-            let pledge_delta = std::cmp::min(&unvested, &daily_fee).neg().clone();
-            let cfg = CronConfig { burnt_funds, pledge_delta, ..Default::default() };
+            let immediately_vesting = immediately_vesting_funds(rt, &state);
+            let available_to_burn = rt.get_balance() - &state.initial_pledge;
+            let burnt_funds = daily_fee.clone().clamp(TokenAmount::zero(), available_to_burn);
+            let pledge_delta = -(std::cmp::min(unvested, daily_fee) + &immediately_vesting);
 
-            self.advance_deadline(rt, cfg);
+            let cfg =
+                CronConfig { burnt_funds, pledge_delta, expected_enrollment, ..Default::default() };
+            self.on_deadline_cron(rt, cfg);
 
+            // Advance to the next deadline.
+            rt.set_epoch(deadline.next_open());
             dlinfo = self.current_deadline(rt);
         }
     }
@@ -3065,7 +3083,7 @@ pub struct ProveCommitSectors3Config {
     pub notification_rejected: bool,    // Whether to reject the notification
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct CronConfig {
     pub no_enrollment: bool, // true if expect not to continue enrollment false otherwise
     pub expected_enrollment: ChainEpoch,
@@ -3175,17 +3193,16 @@ enum MhCode {
 
 fn vesting_funds(rt: &MockRuntime, state: &State, vested: bool) -> TokenAmount {
     let curr_epoch = *rt.epoch.borrow();
-    let vesting = rt.store.get_cbor::<VestingFunds>(&state.vesting_funds).unwrap().unwrap();
-    let mut sum = TokenAmount::zero();
-    for vf in vesting.funds {
-        if (vested && vf.epoch < curr_epoch) || (!vested && vf.epoch >= curr_epoch) {
-            sum += vf.amount;
-        }
-    }
-    sum
+    state
+        .vesting_funds
+        .load(&rt.store)
+        .unwrap()
+        .into_iter()
+        .filter(|vf| vested == (vf.epoch < curr_epoch))
+        .map(|vf| vf.amount)
+        .sum()
 }
 
-#[allow(dead_code)]
 pub fn immediately_vesting_funds(rt: &MockRuntime, state: &State) -> TokenAmount {
     vesting_funds(rt, state, true)
 }

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -78,7 +78,7 @@ use fil_actor_miner::{
     SectorReturn, SectorUpdateManifest, Sectors, State, SubmitWindowedPoStParams,
     TerminateSectorsParams, TerminationDeclaration, VerifiedAllocationKey, VestingFunds,
     WindowedPoSt, WithdrawBalanceParams, WithdrawBalanceReturn, CRON_EVENT_PROVING_DEADLINE,
-    NI_AGGREGATE_FEE_BASE_SECTOR_COUNT, NO_QUANTIZATION, REWARD_VESTING_SPEC, SECTORS_AMT_BITWIDTH,
+    NI_AGGREGATE_FEE_BASE_SECTOR_COUNT, NO_QUANTIZATION, SECTORS_AMT_BITWIDTH,
     SECTOR_CONTENT_CHANGED,
 };
 use fil_actor_miner::{
@@ -3187,14 +3187,6 @@ fn vesting_funds(rt: &MockRuntime, state: &State, vested: bool) -> TokenAmount {
 
 #[allow(dead_code)]
 pub fn immediately_vesting_funds(rt: &MockRuntime, state: &State) -> TokenAmount {
-    let curr_epoch = *rt.epoch.borrow();
-
-    let q =
-        QuantSpec { unit: REWARD_VESTING_SPEC.quantization, offset: state.proving_period_start };
-    if q.quantize_up(curr_epoch) != curr_epoch {
-        return TokenAmount::zero();
-    }
-
     vesting_funds(rt, state, true)
 }
 


### PR DESCRIPTION
This lets us efficiently take fees from vesting funds without loading/storing this object each time. It also lets us check if there are funds to vest without having to load any additional state, because the "next" batch of vesting funds are always stored in the root state object.

If FIP-0100 passes, we'll likely want this change as we'll otherwise read/write the vesting funds queue on every deadline for every miner.

fixes #1594