### PR TITLE
fip-0100: 50%24hBR cap on payable daily_fee

### DIFF
--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -215,3 +215,15 @@ pub fn daily_proof_fee(policy: &Policy, circulating_supply: &TokenAmount) -> Tok
     let fee = (num * circulating_supply.atto()).div_floor(&denom);
     TokenAmount::from_atto(fee)
 }
+
+// Given a daily fee payable and an estimated BR for the sector(s) the fee is being paid for,
+// calculate the fee payable for the sector(s) by applying the appropriate BR cap.
+pub fn daily_proof_fee_payable(
+    policy: &Policy,
+    daily_fee: &TokenAmount,
+    estimated_day_reward: &TokenAmount,
+) -> TokenAmount {
+    let cap_denom = BigInt::from(policy.daily_fee_block_reward_cap_denom);
+    let cap = estimated_day_reward.div_floor(cap_denom);
+    std::cmp::min(&cap, daily_fee).clone()
+}

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -1122,6 +1122,7 @@ impl State {
                 detected_faulty_power: PowerPair::zero(),
                 total_faulty_power: PowerPair::zero(),
                 daily_fee: TokenAmount::zero(),
+                live_power: PowerPair::zero(),
             });
         }
 
@@ -1144,6 +1145,7 @@ impl State {
                 detected_faulty_power: PowerPair::zero(),
                 total_faulty_power: deadline.faulty_power,
                 daily_fee: TokenAmount::zero(),
+                live_power: PowerPair::zero(),
             });
         }
 
@@ -1188,6 +1190,7 @@ impl State {
             detected_faulty_power,
             total_faulty_power,
             daily_fee: deadline.daily_fee,
+            live_power: deadline.live_power,
         })
     }
 
@@ -1228,6 +1231,8 @@ pub struct AdvanceDeadlineResult {
     pub total_faulty_power: PowerPair,
     /// Fee payable for the sectors in the deadline being advanced
     pub daily_fee: TokenAmount,
+    /// Total power for the deadline, including active, faulty, and unproven
+    pub live_power: PowerPair,
 }
 
 /// Static information about miner

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -455,9 +455,14 @@ pub struct SectorOnChainInfo {
     pub sector_key_cid: Option<Cid>,
     /// Additional flags, see [`SectorOnChainInfoFlags`]
     pub flags: SectorOnChainInfoFlags,
-    /// Daily fee payable to the network for the sector as long as it is active.
-    /// Not present in the serialized forms of older sectors, but always written for new and updated
-    /// sectors.
+    /// The total fee payable per day for this sector. The value of this field is set at the time of
+    /// sector activation, extension and whenever a sector's QAP is changed. This fee is payable for
+    /// the lifetime of the sector and is aggregated in the deadline's `daily_fee` field.
+    ///
+    /// This field is not included in the serialised form of the struct prior to the activation of
+    /// FIP-0100, and is added as the 16th element of the array after that point only for new sectors
+    /// or sectors that are updated after that point. For old sectors, the value of this field will
+    /// always be zero.
     #[serde(default)]
     pub daily_fee: TokenAmount,
 }

--- a/actors/miner/tests/daily_fees_test.rs
+++ b/actors/miner/tests/daily_fees_test.rs
@@ -1,13 +1,14 @@
 use std::ops::Neg;
 
 use fil_actor_miner::{
-    daily_fee_for_sectors, expected_reward_for_power, power_for_sectors, Actor, ApplyRewardParams,
-    Method, PoStPartition,
+    daily_fee_for_sectors, expected_reward_for_power, pledge_penalty_for_termination,
+    power_for_sectors, qa_power_for_sector, Actor, ApplyRewardParams, DeadlineInfo, Method,
+    PoStPartition, SectorOnChainInfo,
 };
 use fil_actors_runtime::reward::FilterEstimate;
 use fil_actors_runtime::test_utils::{MockRuntime, REWARD_ACTOR_CODE_ID};
 
-use fil_actors_runtime::{BURNT_FUNDS_ACTOR_ADDR, REWARD_ACTOR_ADDR};
+use fil_actors_runtime::{BURNT_FUNDS_ACTOR_ADDR, EPOCHS_IN_DAY, REWARD_ACTOR_ADDR};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::bigint::{BigInt, Zero};
 use fvm_shared::error::ExitCode;
@@ -103,13 +104,14 @@ fn fee_capped_by_block_reward_many_sectors_later() {
 }
 
 fn test_fee_capped_by_reward(capped_upfront: bool, num_sectors: usize) {
-    // This tests two cases where half of the the estimated daily block reward for the onboarded sector
-    // is less than the daily fee for the sector. In the first case, the reward is set low before sector
-    // commitment, and in the second case, the reward is set low after sector commitment and before the
-    // next post.
+    // This tests that the miner's daily fee is capped by the reward for the day. We work through
+    // various sector lifecycle scenarios to ensure that the fee is correctly calculated and paid.
+    //  - capped_upfront: whether the capped reward is set before sector commitment
+    //  - num_sectors: number of sectors to commit
 
     let (mut h, rt) = setup();
 
+    let original_epoch_reward_smooth = h.epoch_reward_smooth.clone();
     rt.set_circulating_supply(TokenAmount::from_whole(500_000_000));
 
     if capped_upfront {
@@ -121,64 +123,176 @@ fn test_fee_capped_by_reward(capped_upfront: bool, num_sectors: usize) {
     // make sure we can pay whatever fees we need from rewards
     h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
 
-    let sectors =
+    let mut sectors =
         h.commit_and_prove_sectors(&rt, num_sectors, DEFAULT_SECTOR_EXPIRATION, vec![], true);
     let (dlidx, pidx) = h.get_state(&rt).find_sector(&rt.store, sectors[0].sector_number).unwrap();
-    let sector_power = power_for_sectors(h.sector_size, &sectors);
+    let sectors_power = power_for_sectors(h.sector_size, &sectors);
     let daily_fee = daily_fee_for_sectors(&sectors);
 
-    // in the capped-later case, expect a standard fee payment first, then set the low reward for the next payment
     if !capped_upfront {
+        // Step 0. In the case where the fee is not capped upfront, proceed with a standard PoST and
+        // expect the normal daily_fee to be applied. Change the reward after so we get the cap for
+        // step 1.
+
         h.advance_and_submit_posts(&rt, &sectors);
+
         h.epoch_reward_smooth = FilterEstimate::new(BigInt::from(5e13 as u64), BigInt::zero());
     }
 
-    let reward = h.epoch_reward_smooth.clone();
-    let power = h.epoch_qa_power_smooth.clone();
     let day_reward = expected_reward_for_power(
-        &reward,
-        &power,
+        &h.epoch_reward_smooth,
+        &h.epoch_qa_power_smooth,
         &power_for_sectors(h.sector_size, &sectors).qa,
-        fil_actors_runtime::EPOCHS_IN_DAY,
+        EPOCHS_IN_DAY,
     );
 
     assert!(daily_fee < day_reward); // fee should be less than daily reward
     assert!(daily_fee > day_reward.div_floor(2)); // but greater than 50% of daily reward
 
-    // plenty of funds available to pay fees
-    let miner_balance_before = rt.get_balance();
+    // define various helper functions to keep this terse
 
-    // manual form of h.advance_and_submit_posts to control the cron expectations
+    let advance_to_post_deadline = || -> DeadlineInfo {
+        let mut dlinfo = h.deadline(&rt);
+        while dlinfo.index != dlidx {
+            dlinfo = h.advance_deadline(&rt, CronConfig::empty());
+        }
+        dlinfo
+    };
 
-    // advance to epoch when post is due
-    let mut dlinfo = h.deadline(&rt);
-    while dlinfo.index != dlidx {
-        dlinfo = h.advance_deadline(&rt, CronConfig::empty());
-    }
+    let verify_balance_change = |expected_deduction: &TokenAmount, operation: &dyn Fn()| {
+        let miner_balance_before = rt.get_balance();
+        operation();
+        let miner_balance_after = rt.get_balance();
+        assert_eq!(miner_balance_before - expected_deduction, miner_balance_after);
+    };
 
+    let submit_window_post =
+        |dlinfo: &DeadlineInfo, sectors: &Vec<SectorOnChainInfo>, post_config: PoStConfig| {
+            let partition = PoStPartition { index: pidx, skipped: make_empty_bitfield() };
+            h.submit_window_post(&rt, dlinfo, vec![partition], sectors.clone(), post_config)
+        };
+
+    // Step 1. Normal PoST but capped by reward, not daily_fee
+
+    let dlinfo = advance_to_post_deadline();
     // configure post for power delta in the capped-upfront case
     let cfg = if capped_upfront {
-        PoStConfig::with_expected_power_delta(&sector_power)
+        PoStConfig::with_expected_power_delta(&sectors_power.clone())
     } else {
         PoStConfig::empty() // no power delta, we've had first-post already
     };
-
-    // submit post
-    let partition = PoStPartition { index: pidx, skipped: make_empty_bitfield() };
-    h.submit_window_post(&rt, &dlinfo, vec![partition], sectors.clone(), cfg);
+    submit_window_post(&dlinfo, &sectors, cfg);
 
     let state = h.get_state(&rt);
     let unvested = unvested_vesting_funds(&rt, &state);
     let available = rt.get_balance() + unvested.clone() - &state.initial_pledge;
     let burnt_funds = day_reward.div_floor(2); // i.e. not daily_fee
     assert!(available >= burnt_funds);
-    let pledge_delta = burnt_funds.clone().neg();
 
-    let cfg = CronConfig { burnt_funds: burnt_funds.clone(), pledge_delta, ..Default::default() };
-    h.advance_deadline(&rt, cfg);
+    verify_balance_change(&burnt_funds, &|| {
+        h.advance_deadline(
+            &rt,
+            CronConfig {
+                burnt_funds: burnt_funds.clone(),
+                pledge_delta: burnt_funds.clone().neg(),
+                ..Default::default()
+            },
+        );
+    });
 
-    let miner_balance_after = rt.get_balance();
-    assert_eq!(miner_balance_before - burnt_funds, miner_balance_after);
+    // Step 2. Advance to next deadline, fail to submit post, make sure we have faulty power, and
+    // then assert that the cap is unchanged. i.e. it includes faulty power in its calculation.
+
+    advance_to_post_deadline();
+    verify_balance_change(&burnt_funds, &|| {
+        h.advance_deadline(
+            &rt,
+            CronConfig {
+                burnt_funds: burnt_funds.clone(),
+                pledge_delta: burnt_funds.clone().neg(),
+                power_delta: Some(sectors_power.clone().neg()),
+                ..Default::default()
+            },
+        );
+    });
+
+    // Step 3. Advance to next deadline and submit post, recovering power, and pay the same capped
+    // fee.
+
+    let bf = bitfield_from_slice(&sectors.iter().map(|s| s.sector_number).collect::<Vec<u64>>());
+    h.declare_recoveries(&rt, dlidx, pidx, bf, TokenAmount::zero()).unwrap();
+    let dlinfo = advance_to_post_deadline();
+    submit_window_post(&dlinfo, &sectors, PoStConfig::with_expected_power_delta(&sectors_power));
+    verify_balance_change(&burnt_funds, &|| {
+        h.advance_deadline(
+            &rt,
+            CronConfig {
+                burnt_funds: burnt_funds.clone(),
+                pledge_delta: -burnt_funds.clone(),
+                ..Default::default()
+            },
+        );
+    });
+
+    if num_sectors > 1 {
+        // Step 4 (multiple sectors). Terminate a sector, make sure we pay a capped fee that is
+        // proportional to the power of the remaining sectors.
+
+        let terminated_sector = &sectors[0];
+        let sector_power = qa_power_for_sector(h.sector_size, terminated_sector);
+        let sector_age = *rt.epoch.borrow() - terminated_sector.power_base_epoch;
+        let expected_fee = pledge_penalty_for_termination(
+            &terminated_sector.expected_day_reward,
+            sector_age,
+            &terminated_sector.expected_storage_pledge,
+            &h.epoch_qa_power_smooth,
+            &sector_power,
+            &h.epoch_reward_smooth,
+            &TokenAmount::zero(),
+            0,
+        );
+        h.terminate_sectors(
+            &rt,
+            &bitfield_from_slice(&[terminated_sector.sector_number]),
+            expected_fee,
+        );
+
+        sectors.remove(0);
+
+        let mut dlinfo = h.deadline(&rt);
+        while dlinfo.index != dlidx {
+            dlinfo = h.advance_deadline(&rt, CronConfig::empty());
+        }
+
+        submit_window_post(&dlinfo, &sectors, PoStConfig::empty());
+
+        let day_reward = expected_reward_for_power(
+            &h.epoch_reward_smooth,
+            &h.epoch_qa_power_smooth,
+            &power_for_sectors(h.sector_size, &sectors).qa,
+            EPOCHS_IN_DAY,
+        );
+        let burnt_funds = day_reward.div_floor(2);
+        verify_balance_change(&burnt_funds, &|| {
+            h.advance_deadline(
+                &rt,
+                CronConfig {
+                    burnt_funds: burnt_funds.clone(),
+                    pledge_delta: burnt_funds.clone().neg(),
+                    ..Default::default()
+                },
+            );
+        });
+    }
+
+    // Step 5. Reset the reward to the original value, advance to the next deadline, and submit a
+    // post. We should pay the standard daily_fee with no cap.
+
+    h.epoch_reward_smooth = original_epoch_reward_smooth;
+    let daily_fee = daily_fee_for_sectors(&sectors);
+    verify_balance_change(&daily_fee, &|| {
+        h.advance_and_submit_posts(&rt, &sectors);
+    });
 }
 
 fn setup() -> (ActorHarness, MockRuntime) {

--- a/actors/miner/tests/daily_fees_test.rs
+++ b/actors/miner/tests/daily_fees_test.rs
@@ -1,9 +1,15 @@
-use fil_actor_miner::{daily_fee_for_sectors, Actor, ApplyRewardParams, Method};
+use std::ops::Neg;
+
+use fil_actor_miner::{
+    daily_fee_for_sectors, expected_reward_for_power, power_for_sectors, Actor, ApplyRewardParams,
+    Method, PoStPartition,
+};
+use fil_actors_runtime::reward::FilterEstimate;
 use fil_actors_runtime::test_utils::{MockRuntime, REWARD_ACTOR_CODE_ID};
 
 use fil_actors_runtime::{BURNT_FUNDS_ACTOR_ADDR, REWARD_ACTOR_ADDR};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_shared::bigint::Zero;
+use fvm_shared::bigint::{BigInt, Zero};
 use fvm_shared::error::ExitCode;
 use fvm_shared::METHOD_SEND;
 use fvm_shared::{clock::ChainEpoch, econ::TokenAmount};
@@ -74,6 +80,105 @@ fn fee_paid_at_deadline() {
     assert_eq!(st.fee_debt, *extra); // paid back debt, but added half back
 
     h.check_state(&rt);
+}
+
+#[test]
+fn fee_capped_by_block_reward_first() {
+    test_fee_capped_by_reward(true, 1);
+}
+
+#[test]
+fn fee_capped_by_block_reward_many_sectors_first() {
+    test_fee_capped_by_reward(true, 55);
+}
+
+#[test]
+fn fee_capped_by_block_reward_later() {
+    test_fee_capped_by_reward(false, 1);
+}
+
+#[test]
+fn fee_capped_by_block_reward_many_sectors_later() {
+    test_fee_capped_by_reward(false, 55);
+}
+
+fn test_fee_capped_by_reward(capped_upfront: bool, num_sectors: usize) {
+    // This tests two cases where half of the the estimated daily block reward for the onboarded sector
+    // is less than the daily fee for the sector. In the first case, the reward is set low before sector
+    // commitment, and in the second case, the reward is set low after sector commitment and before the
+    // next post.
+
+    let (mut h, rt) = setup();
+
+    rt.set_circulating_supply(TokenAmount::from_whole(500_000_000));
+
+    if capped_upfront {
+        // set low reward before sector commitment in the capped-upfront case, this value should
+        // leave us with a daily reward that's less than double the daily fee
+        h.epoch_reward_smooth = FilterEstimate::new(BigInt::from(5e13 as u64), BigInt::zero());
+    }
+
+    // make sure we can pay whatever fees we need from rewards
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
+
+    let sectors =
+        h.commit_and_prove_sectors(&rt, num_sectors, DEFAULT_SECTOR_EXPIRATION, vec![], true);
+    let (dlidx, pidx) = h.get_state(&rt).find_sector(&rt.store, sectors[0].sector_number).unwrap();
+    let sector_power = power_for_sectors(h.sector_size, &sectors);
+    let daily_fee = daily_fee_for_sectors(&sectors);
+
+    // in the capped-later case, expect a standard fee payment first, then set the low reward for the next payment
+    if !capped_upfront {
+        h.advance_and_submit_posts(&rt, &sectors);
+        h.epoch_reward_smooth = FilterEstimate::new(BigInt::from(5e13 as u64), BigInt::zero());
+    }
+
+    let reward = h.epoch_reward_smooth.clone();
+    let power = h.epoch_qa_power_smooth.clone();
+    let day_reward = expected_reward_for_power(
+        &reward,
+        &power,
+        &power_for_sectors(h.sector_size, &sectors).qa,
+        fil_actors_runtime::EPOCHS_IN_DAY,
+    );
+
+    assert!(daily_fee < day_reward); // fee should be less than daily reward
+    assert!(daily_fee > day_reward.div_floor(2)); // but greater than 50% of daily reward
+
+    // plenty of funds available to pay fees
+    let miner_balance_before = rt.get_balance();
+
+    // manual form of h.advance_and_submit_posts to control the cron expectations
+
+    // advance to epoch when post is due
+    let mut dlinfo = h.deadline(&rt);
+    while dlinfo.index != dlidx {
+        dlinfo = h.advance_deadline(&rt, CronConfig::empty());
+    }
+
+    // configure post for power delta in the capped-upfront case
+    let cfg = if capped_upfront {
+        PoStConfig::with_expected_power_delta(&sector_power)
+    } else {
+        PoStConfig::empty() // no power delta, we've had first-post already
+    };
+
+    // submit post
+    let partition = PoStPartition { index: pidx, skipped: make_empty_bitfield() };
+    h.submit_window_post(&rt, &dlinfo, vec![partition], sectors.clone(), cfg);
+
+    let state = h.get_state(&rt);
+    let unvested = unvested_vesting_funds(&rt, &state);
+    let available = rt.get_balance() + unvested.clone() - &state.initial_pledge;
+    let burnt_funds = day_reward.div_floor(2); // i.e. not daily_fee
+    assert!(available >= burnt_funds);
+    let pledge_delta = burnt_funds.clone().neg();
+
+    let cfg = CronConfig { burnt_funds: burnt_funds.clone(), pledge_delta, ..Default::default() };
+    h.advance_deadline(&rt, cfg);
+
+    let miner_balance_after = rt.get_balance();
+    assert_eq!(miner_balance_before - burnt_funds, miner_balance_after);
 }
 
 fn setup() -> (ActorHarness, MockRuntime) {

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -144,6 +144,12 @@ pub struct Policy {
     /// the daily fee for new sectors.
     pub daily_fee_circulating_supply_multiplier_denom: i64,
 
+    /// Denominator for the fraction of estimated daily block reward for the sector(s)
+    /// attracting a fee, to be used as a cap for the fees when payable.
+    /// No numerator is provided as the fee is calculated as a fraction of the estimated
+    /// daily block reward.
+    pub daily_fee_block_reward_cap_denom: i64,
+
     //
     // --- verifreg policy ---
     //
@@ -230,6 +236,7 @@ impl Default for Policy {
                 policy_constants::DAILY_FEE_CIRCULATING_SUPPLY_MULTIPLIER_NUM,
             daily_fee_circulating_supply_multiplier_denom:
                 policy_constants::DAILY_FEE_CIRCULATING_SUPPLY_MULTIPLIER_DENOM,
+            daily_fee_block_reward_cap_denom: policy_constants::DAILY_FEE_BLOCK_REWARD_CAP_DENOM,
 
             valid_post_proof_type: ProofSet::default_post_proofs(),
             valid_pre_commit_proof_type: ProofSet::default_precommit_seal_proofs(),
@@ -374,6 +381,9 @@ pub mod policy_constants {
     /// A multiplier of k=7.4e-15, represented as 74/10^16
     pub const DAILY_FEE_CIRCULATING_SUPPLY_MULTIPLIER_NUM: i64 = 74;
     pub const DAILY_FEE_CIRCULATING_SUPPLY_MULTIPLIER_DENOM: i64 = 10_000_000_000_000_000; // 10^16
+
+    // 50% of estimated daily block rewards
+    pub const DAILY_FEE_BLOCK_REWARD_CAP_DENOM: i64 = 2;
 
     //
     // --- verifreg policy ---


### PR DESCRIPTION
This applies the BR cap, adds a constant for the 50% and adds some testing to make sure it's properly applied across various states:

* Single vs multiple sectors
* BR cap happens on first cron vs normal cron with BR cap later
* Miss PoST and see that we still have the same power-based cap
* Recover fault, same payment
* For multiple sectors: terminate a sector and verify that the BR cap is proportional to remaining power
* Reset the network reward and watch the fee payment go back to uncapped

This doesn't go near the new QAP multiplier for FIP-0100, I wanted to get these pieces pushed so I can deal with that separately.