### PR TITLE
fip-0100: QAP multiplier for daily_fee

### DIFF
--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::cmp;
+use std::ops::Shl;
 
 use cid::{Cid, Version};
 use fil_actors_runtime::network::*;
@@ -204,13 +205,22 @@ pub fn reward_for_disputed_window_post(
     BASE_REWARD_FOR_DISPUTED_WINDOW_POST.clone()
 }
 
-// The daily fee payable per sector.
-pub fn daily_proof_fee(policy: &Policy, circulating_supply: &TokenAmount) -> TokenAmount {
-    let num = BigInt::from(policy.daily_fee_circulating_supply_multiplier_num);
-    let denom = BigInt::from(policy.daily_fee_circulating_supply_multiplier_denom);
+pub fn daily_proof_fee(
+    policy: &Policy,
+    circulating_supply: &TokenAmount,
+    qa_power: &StoragePower,
+) -> TokenAmount {
+    const PRECISION_BITS: u32 = 128; // Use 128 bits of precision for calculations
+    let scale = BigInt::from(1).shl(PRECISION_BITS);
+    let num = BigInt::from(policy.daily_fee_circulating_supply_qap_multiplier_num);
+    let denom = BigInt::from(policy.daily_fee_circulating_supply_qap_multiplier_scale_1)
+        * BigInt::from(policy.daily_fee_circulating_supply_qap_multiplier_scale_2);
 
-    let fee = (num * circulating_supply.atto()).div_floor(&denom);
-    TokenAmount::from_atto(fee)
+    // num/denom gives us the fraction of the circulating supply that should be paid as a fee per
+    // byte of quality-adjusted power.
+
+    let power_multiplier = (num * &scale * qa_power) / denom;
+    TokenAmount::from_atto(power_multiplier * circulating_supply.atto() / scale)
 }
 
 // Given a daily fee payable and an estimated BR for the sector(s) the fee is being paid for,

--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -212,16 +212,13 @@ pub fn daily_proof_fee(
     circulating_supply: &TokenAmount,
     qa_power: &StoragePower,
 ) -> TokenAmount {
-    let num = BigInt::from(policy.daily_fee_circulating_supply_qap_multiplier_num);
-    let denom = BigInt::from(policy.daily_fee_circulating_supply_qap_multiplier_scale_1)
-        * BigInt::from(policy.daily_fee_circulating_supply_qap_multiplier_scale_2);
-
-    // num/denom gives us the fraction of the circulating supply that should be paid as a fee per
-    // byte of quality-adjusted power.
-
-    let power_multiplier = (num * &*DAILY_FEE_PRECISION_SCALE * qa_power) / denom;
+    // daily_fee_circulating_supply_qap_multiplier{num/denom} gives us the fraction of the
+    // circulating supply that should be paid as a fee per byte of quality-adjusted power.
     TokenAmount::from_atto(
-        (power_multiplier * circulating_supply.atto()).div_floor(&*DAILY_FEE_PRECISION_SCALE),
+        (&policy.daily_fee_circulating_supply_qap_multiplier_num
+            * qa_power
+            * circulating_supply.atto())
+        .div_floor(&policy.daily_fee_circulating_supply_qap_multiplier_denom),
     )
 }
 

--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -214,9 +214,9 @@ pub fn daily_proof_fee(
     // circulating supply that should be paid as a fee per byte of quality-adjusted power.
     TokenAmount::from_atto(
         (&policy.daily_fee_circulating_supply_qap_multiplier_num
-            * qa_power
-            * circulating_supply.atto())
-        .div_floor(&policy.daily_fee_circulating_supply_qap_multiplier_denom),
+            * circulating_supply.atto()
+            * qa_power)
+            .div_floor(&policy.daily_fee_circulating_supply_qap_multiplier_denom),
     )
 }
 

--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -26,8 +26,6 @@ lazy_static! {
 
     /// Quality multiplier for verified deals in a sector
     pub static ref VERIFIED_DEAL_WEIGHT_MULTIPLIER: BigInt = BigInt::from(100);
-
-    static ref DAILY_FEE_PRECISION_SCALE: BigInt =  BigInt::from(1) << DAILY_FEE_PRECISION_BITS;
 }
 
 /// The maximum number of partitions that may be required to be loaded in a single invocation,
@@ -231,9 +229,7 @@ pub fn daily_proof_fee_adjust(
     if old_qa_power == new_qa_power {
         return daily_fee.clone();
     }
-    // adjust the daily_fee by the same proportion as the power changed
-    let change = (new_qa_power * &*DAILY_FEE_PRECISION_SCALE) / old_qa_power;
-    TokenAmount::from_atto((daily_fee.atto() * change).div_floor(&*DAILY_FEE_PRECISION_SCALE))
+    TokenAmount::from_atto((daily_fee.atto() * new_qa_power).div_floor(old_qa_power))
 }
 
 // Given a daily fee payable and an estimated BR for the sector(s) the fee is being paid for,

--- a/actors/miner/tests/daily_fees_test.rs
+++ b/actors/miner/tests/daily_fees_test.rs
@@ -137,8 +137,13 @@ fn test_fee_capped_by_reward(capped_upfront: bool, num_sectors: usize) {
         EPOCHS_IN_DAY,
     );
 
-    assert!(daily_fee < day_reward); // fee should be less than daily reward
-    assert!(daily_fee > day_reward.div_floor(2)); // but greater than 50% of daily reward
+    assert!(daily_fee < day_reward, "daily_fee: {} < day_reward: {}", daily_fee, day_reward); // fee should be less than daily reward
+    assert!(
+        daily_fee > day_reward.div_floor(2),
+        "daily_fee: {} <, day_reward/2: {}",
+        daily_fee,
+        day_reward.div_floor(2)
+    ); // but greater than 50% of daily reward
 
     // define various helper functions to keep this terse
 

--- a/actors/miner/tests/policy_test.rs
+++ b/actors/miner/tests/policy_test.rs
@@ -10,6 +10,8 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::SectorSize;
 
+use num_traits::Signed;
+
 #[test]
 fn quality_is_independent_of_size_and_duration() {
     // Quality of space with no deals. This doesn't depend on either the sector size or duration.
@@ -297,10 +299,33 @@ fn original_quality_for_weight(
 #[test]
 fn daily_proof_fee_calc() {
     let policy = Policy::default();
-    // Given a CS of 680M FIL and a fee multiplier of 7.4e-15, the daily proof fee should be 5032 nanoFIL.
+    // Given a CS of 680M FIL, 32GiB QAP, a fee multiplier of 7.4e-15 per 32GiB QAP, the daily proof
+    // fee should be 5032 nanoFIL.
     //   680M * 7.4e-15 = 0.000005032 FIL
     //   0.000005032 * 1e9 = 5032 nanoFIL
+    //   0.000005032 * 1e18 = 5032000000000 attoFIL
+    // As a per-byte multiplier we use 2.1536e-25, a close approximation of 7.4e-15 / 32GiB.
+    //   680M * 32GiB * 2.1536e-25 = 0.000005031805013354 FIL
+    //   0.000005031805013354 * 1e18 = 5031805013354 attoFIL
     let circulating_supply = TokenAmount::from_whole(680_000_000);
-    let fee = daily_proof_fee(&policy, &circulating_supply);
-    assert_eq!(fee, TokenAmount::from_nano(5032));
+
+    let ref_32gib_fee = 5031805013354_u64;
+    [
+        (32_u64, ref_32gib_fee),
+        (64, ref_32gib_fee * 2),
+        (32 * 10, ref_32gib_fee * 10),
+        (32 * 5, ref_32gib_fee * 5),
+        (64 * 10, ref_32gib_fee * 20),
+    ]
+    .iter()
+    .for_each(|(size, expected_fee)| {
+        let power = BigInt::from(*size) << 30; // 32GiB raw QAP
+        let fee = daily_proof_fee(&policy, &circulating_supply, &power);
+        assert!(
+            (fee.atto() - BigInt::from(*expected_fee)).abs() <= BigInt::from(1),
+            "fee: {}, expected_fee: {}",
+            fee.atto(),
+            expected_fee
+        );
+    });
 }

--- a/actors/miner/tests/prove_replica_failures_test.rs
+++ b/actors/miner/tests/prove_replica_failures_test.rs
@@ -19,7 +19,7 @@ use util::*;
 
 mod util;
 
-// Tests for ProveReplicaUpdates2 where the request fails completely
+// Tests for ProveReplicaUpdates3 where the request fails completely
 
 const CLIENT_ID: ActorID = 1000;
 const DEFAULT_SECTOR_EXPIRATION_DAYS: ChainEpoch = 220;
@@ -35,7 +35,7 @@ fn reject_unauthorized_caller() {
     expect_abort_contains_message(
         ExitCode::USR_FORBIDDEN,
         "caller",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, false, cfg),
     );
     h.check_state(&rt);
 }
@@ -53,7 +53,7 @@ fn reject_no_proof_types() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "exactly one of sector proofs or aggregate proof must be non-empty",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, false, cfg),
     );
     h.check_state(&rt);
 }
@@ -71,7 +71,7 @@ fn reject_both_proof_types() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "exactly one of sector proofs or aggregate proof must be non-empty",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, false, cfg),
     );
     h.check_state(&rt);
 }
@@ -88,7 +88,7 @@ fn reject_mismatched_proof_len() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "mismatched lengths",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, false, cfg),
     );
     h.check_state(&rt);
 }
@@ -107,7 +107,7 @@ fn reject_aggregate_proof() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "aggregate update proofs not yet supported",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, false, cfg),
     );
     h.check_state(&rt);
 }
@@ -119,7 +119,7 @@ fn reject_all_proofs_fail() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "no valid updates",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, false, cfg),
     );
     h.check_state(&rt);
 }
@@ -132,7 +132,7 @@ fn reject_invalid_update() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "invalid update 1 while requiring activation success",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, true, false, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, true, false, cfg),
     );
     h.check_state(&rt);
 }
@@ -144,7 +144,7 @@ fn reject_required_proof_failure() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "requiring activation success",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, true, false, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, true, false, cfg),
     );
     h.check_state(&rt);
 }
@@ -156,7 +156,7 @@ fn reject_required_claim_failure() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "error claiming allocations",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, true, false, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, true, false, cfg),
     );
     h.check_state(&rt);
 }
@@ -173,7 +173,7 @@ fn reject_required_notification_abort() {
     expect_abort_contains_message(
         ERR_NOTIFICATION_RECEIVER_ABORTED,
         "receiver aborted",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, true, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, true, cfg),
     );
     h.check_state(&rt);
 }
@@ -187,7 +187,7 @@ fn reject_required_notification_rejected() {
     expect_abort_contains_message(
         ERR_NOTIFICATION_REJECTED,
         "sector change rejected",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, true, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, true, cfg),
     );
     h.check_state(&rt);
 }

--- a/actors/miner/tests/prove_replica_test.rs
+++ b/actors/miner/tests/prove_replica_test.rs
@@ -44,7 +44,7 @@ fn update_batch() {
 
     let cfg = ProveReplicaUpdatesConfig::default();
     let (result, claims, notifications) =
-        h.prove_replica_updates2_batch(&rt, &sector_updates, true, true, cfg).unwrap();
+        h.prove_replica_updates3_batch(&rt, &sector_updates, true, true, cfg).unwrap();
     assert_update_result(&vec![ExitCode::OK; sectors.len()], &result);
 
     // Explicitly verify claims match what we expect.
@@ -109,24 +109,43 @@ fn update_batch() {
         notifications
     );
 
-    // Sector 0: Even though there's no "deal", the data weight is set.
-    verify_weights(&rt, &h, snos[0], piece_size, 0);
-    // Sector 1: With an allocation, the verified weight is set instead.
-    verify_weights(&rt, &h, snos[1], 0, piece_size);
-    // Sector 2: Deal weight is set.
-    verify_weights(&rt, &h, snos[2], piece_size, 0);
-    // Sector 3: Deal doesn't make a difference to verified weight only set.
-    verify_weights(&rt, &h, snos[3], 0, piece_size);
+    let sectors_after = snos.iter().map(|sno| h.get_sector(&rt, *sno)).collect::<Vec<_>>();
+    for i in 0..sectors.len() {
+        // Sectors 1 and 3 are full of verified data, 0 and 2 are not
+        let has_verified = i % 2 == 1;
 
-    // Check that the fees haven't changed.
-    let sectors_after = snos.iter().map(|sno| h.get_sector(&rt, *sno));
-    for (before, after) in std::iter::zip(sectors, sectors_after) {
+        verify_weights(
+            &rt,
+            &h,
+            snos[i],
+            if has_verified { 0 } else { piece_size },
+            if has_verified { piece_size } else { 0 },
+        );
+
+        // Check daily fees - if we added verified data, we expect the fees to be x10
+        let expected_fee = sectors[i].daily_fee.clone() * if has_verified { 10 } else { 1 };
         assert_eq!(
-            before.daily_fee, after.daily_fee,
+            expected_fee, sectors_after[i].daily_fee,
             "daily fees differ for sector {}",
-            before.sector_number
+            sectors[i].sector_number
         );
     }
+
+    let total_fees = sectors_after.iter().map(|s| s.daily_fee.clone()).sum::<TokenAmount>();
+
+    let (deadline_index, partition_index) = st.find_sector(rt.store(), snos[0]).unwrap();
+    // check the deadline and partition state is correct for the replaced sector's fee
+    let (deadline, partition) = h.get_deadline_and_partition(&rt, deadline_index, partition_index);
+
+    // deadline has the total fees for all sectors
+    assert_eq!(total_fees, deadline.daily_fee);
+
+    // partition expiration queue has the total fees for all sectors as a deduction
+    let quant = h.get_state(&rt).quant_spec_for_deadline(&rt.policy, deadline_index);
+    let quantized_expiration = quant.quantize_up(sectors_after[0].expiration);
+    let p_queue = h.collect_partition_expirations(&rt, &partition);
+    let entry = p_queue.get(&quantized_expiration).cloned().unwrap();
+    assert_eq!(total_fees, entry.fee_deduction);
 
     h.check_state(&rt);
 }
@@ -139,7 +158,23 @@ fn update_fee() {
     rt.set_circulating_supply(TokenAmount::zero());
     let sector_expiry = *rt.epoch.borrow() + DEFAULT_SECTOR_EXPIRATION_DAYS * EPOCHS_IN_DAY;
     let sectors = onboard_empty_sectors(&rt, &h, sector_expiry, FIRST_SECTOR_NUMBER, 4);
-    assert!(sectors.iter().all(|s| s.daily_fee.is_zero()), "sectors have zero daily fees");
+    let st: State = h.get_state(&rt);
+    let (deadline_index, partition_index) =
+        st.find_sector(rt.store(), sectors[0].sector_number).unwrap();
+    // check the deadline and partition state is correct for the replaced sector's fee
+    let (deadline, partition) = h.get_deadline_and_partition(&rt, deadline_index, partition_index);
+
+    // sanity check the fee state
+    // 1. sectors have no fees
+    assert!(sectors.iter().all(|s| s.daily_fee.is_zero()));
+    // 2. deadline has no fees
+    assert!(deadline.daily_fee.is_zero());
+    // 3. expiration queue has no fees
+    let quant = h.get_state(&rt).quant_spec_for_deadline(&rt.policy, deadline_index);
+    let quantized_expiration = quant.quantize_up(sectors[0].expiration);
+    let p_queue = h.collect_partition_expirations(&rt, &partition);
+    let entry = p_queue.get(&quantized_expiration).cloned().unwrap();
+    assert!(entry.fee_deduction.is_zero());
 
     // Now set the circulating supply to a non-zero value. Snapping should change the daily fee.
     let new_circulating_supply = TokenAmount::from_whole(500_000);
@@ -159,7 +194,7 @@ fn update_fee() {
 
     let cfg = ProveReplicaUpdatesConfig::default();
     let (result, claims, notifications) =
-        h.prove_replica_updates2_batch(&rt, &sector_updates, true, true, cfg).unwrap();
+        h.prove_replica_updates3_batch(&rt, &sector_updates, true, true, cfg).unwrap();
     assert_update_result(&vec![ExitCode::OK; sectors.len()], &result);
 
     // Explicitly verify claims match what we expect.
@@ -224,49 +259,49 @@ fn update_fee() {
         notifications
     );
 
-    // When checking sector daily_fee, for a reference we'll calculate the fee for a fully verified sector and
-    // divide as required
+    // When checking sector daily_fee, for a reference we'll calculate the fee for a fully verified
+    // sector and divide as required
     let full_verified_fee = daily_proof_fee(
         &rt.policy,
         &new_circulating_supply,
         &BigInt::from(h.sector_size as u64 * 10),
     );
 
-    // Sector 0: Even though there's no "deal", the data weight is set.
-    verify_weights(&rt, &h, snos[0], piece_size, 0);
-    assert_eq!(
-        full_verified_fee.div_floor(10),
-        h.get_sector(&rt, snos[0]).daily_fee,
-        "daily fee for sector {} matches expected fee",
-        snos[0]
-    );
+    let sectors_after = snos.iter().map(|sno| h.get_sector(&rt, *sno)).collect::<Vec<_>>();
+    for i in 0..sectors.len() {
+        // Sectors 1 and 3 are full of verified data, 0 and 2 are not
+        let has_verified = i % 2 == 1;
 
-    // Sector 1: With an allocation, the verified weight is set instead.
-    verify_weights(&rt, &h, snos[1], 0, piece_size);
-    assert_eq!(
-        full_verified_fee,
-        h.get_sector(&rt, snos[1]).daily_fee,
-        "daily fee for sector {} matches expected fee",
-        snos[1]
-    );
+        verify_weights(
+            &rt,
+            &h,
+            snos[i],
+            if has_verified { 0 } else { piece_size },
+            if has_verified { piece_size } else { 0 },
+        );
 
-    // Sector 2: Deal weight is set.
-    verify_weights(&rt, &h, snos[2], piece_size, 0);
-    assert_eq!(
-        full_verified_fee.div_floor(10),
-        h.get_sector(&rt, snos[2]).daily_fee,
-        "daily fee for sector {} matches expected fee",
-        snos[2]
-    );
+        // Check daily fees - for unverified sectors, the full verified fee is divided by 10
+        let expected_fee = full_verified_fee.div_floor(if has_verified { 1 } else { 10 });
+        assert_eq!(
+            expected_fee, sectors_after[i].daily_fee,
+            "daily fees differ for sector {}",
+            sectors[i].sector_number
+        );
+    }
 
-    // Sector 3: Deal doesn't make a difference to verified weight only set.
-    verify_weights(&rt, &h, snos[3], 0, piece_size);
-    assert_eq!(
-        full_verified_fee,
-        h.get_sector(&rt, snos[3]).daily_fee,
-        "daily fee for sector {} matches expected fee",
-        snos[3]
-    );
+    let total_fees = sectors_after.iter().map(|s| s.daily_fee.clone()).sum::<TokenAmount>();
+
+    let (deadline_index, partition_index) = st.find_sector(rt.store(), snos[0]).unwrap();
+    // check the deadline and partition state is correct for the replaced sector's fee
+    let (deadline, partition) = h.get_deadline_and_partition(&rt, deadline_index, partition_index);
+
+    // deadline has the total fees for all sectors
+    assert_eq!(total_fees, deadline.daily_fee);
+
+    // partition expiration queue has the total fees for all sectors as a deduction
+    let p_queue = h.collect_partition_expirations(&rt, &partition);
+    let entry = p_queue.get(&quantized_expiration).cloned().unwrap();
+    assert_eq!(total_fees, entry.fee_deduction);
 
     h.check_state(&rt);
 }
@@ -295,7 +330,7 @@ fn multiple_pieces_in_sector() {
 
     let cfg = ProveReplicaUpdatesConfig::default();
     let (result, claims, notifications) =
-        h.prove_replica_updates2_batch(&rt, &sector_updates, true, true, cfg).unwrap();
+        h.prove_replica_updates3_batch(&rt, &sector_updates, true, true, cfg).unwrap();
     assert_update_result(&[ExitCode::OK, ExitCode::OK], &result);
 
     // Explicitly verify claims match what we expect.
@@ -408,7 +443,7 @@ fn multiple_notifs_for_piece() {
 
     let cfg = ProveReplicaUpdatesConfig::default();
     let (result, _, notifications) =
-        h.prove_replica_updates2_batch(&rt, &sector_updates, true, true, cfg).unwrap();
+        h.prove_replica_updates3_batch(&rt, &sector_updates, true, true, cfg).unwrap();
     assert_update_result(&[ExitCode::OK, ExitCode::OK], &result);
 
     // Explicitly verify notifications match what we expect.
@@ -480,7 +515,7 @@ fn cant_update_nonempty_sector() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "cannot update sector with non-zero data",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, true, true, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, true, true, cfg),
     );
     h.check_state(&rt);
 }
@@ -502,7 +537,7 @@ fn invalid_update_dropped() {
 
     let cfg = ProveReplicaUpdatesConfig { validation_failure: vec![0], ..Default::default() };
     let (result, claims, notifications) =
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg).unwrap();
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, false, cfg).unwrap();
     assert_update_result(&[ExitCode::USR_ILLEGAL_ARGUMENT, ExitCode::OK], &result);
 
     // Sector 0: no change.
@@ -530,7 +565,7 @@ fn invalid_proof_dropped() {
 
     let cfg = ProveReplicaUpdatesConfig { proof_failure: vec![0], ..Default::default() };
     let (result, _, _) =
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg).unwrap();
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, false, cfg).unwrap();
     assert_update_result(&[ExitCode::USR_ILLEGAL_ARGUMENT, ExitCode::OK], &result);
 
     verify_weights(&rt, &h, snos[0], 0, 0);
@@ -552,7 +587,7 @@ fn invalid_claim_dropped() {
 
     let cfg = ProveReplicaUpdatesConfig { claim_failure: vec![0], ..Default::default() };
     let (result, _, _) =
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg).unwrap();
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, false, cfg).unwrap();
     assert_update_result(&[ExitCode::USR_ILLEGAL_ARGUMENT, ExitCode::OK], &result);
 
     verify_weights(&rt, &h, snos[0], 0, 0);
@@ -578,7 +613,7 @@ fn aborted_notification_dropped() {
         ..Default::default()
     };
     let (result, _, _) =
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg).unwrap();
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, false, cfg).unwrap();
     // All sectors succeed anyway.
     assert_update_result(&vec![ExitCode::OK; sectors.len()], &result);
 
@@ -604,7 +639,7 @@ fn rejected_notification_dropped() {
 
     let cfg = ProveReplicaUpdatesConfig { notification_rejected: true, ..Default::default() };
     let (result, _, _) =
-        h.prove_replica_updates2_batch(&rt, &sector_updates, false, false, cfg).unwrap();
+        h.prove_replica_updates3_batch(&rt, &sector_updates, false, false, cfg).unwrap();
     // All sectors succeed anyway.
     assert_update_result(&vec![ExitCode::OK; sectors.len()], &result);
 
@@ -628,7 +663,7 @@ fn update_to_empty() {
 
     let cfg = ProveReplicaUpdatesConfig::default();
     let (result, _, _) =
-        h.prove_replica_updates2_batch(&rt, &sector_updates, true, true, cfg).unwrap();
+        h.prove_replica_updates3_batch(&rt, &sector_updates, true, true, cfg).unwrap();
     assert_update_result(&vec![ExitCode::OK; sectors.len()], &result);
     verify_weights(&rt, &h, snos[0], 0, 0);
 
@@ -638,7 +673,7 @@ fn update_to_empty() {
 
     let cfg = ProveReplicaUpdatesConfig::default();
     let (result, _, _) =
-        h.prove_replica_updates2_batch(&rt, &sector_updates, true, true, cfg).unwrap();
+        h.prove_replica_updates3_batch(&rt, &sector_updates, true, true, cfg).unwrap();
     assert_update_result(&vec![ExitCode::OK; sectors.len()], &result);
 
     // But not again now it's non-empty.
@@ -646,7 +681,7 @@ fn update_to_empty() {
     expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "cannot update sector with non-zero data",
-        h.prove_replica_updates2_batch(&rt, &sector_updates, true, true, cfg),
+        h.prove_replica_updates3_batch(&rt, &sector_updates, true, true, cfg),
     );
 
     h.check_state(&rt);

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -1427,11 +1427,11 @@ impl ActorHarness {
         Ok((result, sector_allocation_claims, expected_sector_notifications))
     }
 
-    // Invokes prove_replica_updates2 with a batch of sector updates, and
+    // Invokes prove_replica_updates3 with a batch of sector updates, and
     // sets and checks mock expectations for the expected interactions.
     // Returns the result of the invocation along with the expected sector claims and notifications
     // (which match the actual, if mock verification succeeded).
-    pub fn prove_replica_updates2_batch(
+    pub fn prove_replica_updates3_batch(
         &self,
         rt: &MockRuntime,
         sector_updates: &[SectorUpdateManifest],
@@ -1654,6 +1654,7 @@ impl ActorHarness {
         dlinfo
     }
 
+    // TODO: remove this, duplicate of get_deadline_info
     pub fn deadline(&self, rt: &MockRuntime) -> DeadlineInfo {
         let state = self.get_state(rt);
         state.recorded_deadline_info(&rt.policy, *rt.epoch.borrow())

--- a/integration_tests/src/tests/prove_commit3_test.rs
+++ b/integration_tests/src/tests/prove_commit3_test.rs
@@ -12,9 +12,9 @@ use num_traits::Zero;
 
 use fil_actor_market::Method as MarketMethod;
 use fil_actor_miner::{
-    max_prove_commit_duration, CompactCommD, DataActivationNotification, PieceActivationManifest,
-    PieceChange, ProveCommitSectors3Params, SectorActivationManifest, SectorChanges,
-    SectorContentChangedParams, SectorOnChainInfoFlags,
+    daily_proof_fee, max_prove_commit_duration, qa_power_for_weight, CompactCommD,
+    DataActivationNotification, PieceActivationManifest, PieceChange, ProveCommitSectors3Params,
+    SectorActivationManifest, SectorChanges, SectorContentChangedParams, SectorOnChainInfoFlags,
 };
 use fil_actor_miner::{Method as MinerMethod, VerifiedAllocationKey};
 use fil_actor_verifreg::{
@@ -202,6 +202,8 @@ pub fn prove_commit_sectors2_test(v: &dyn VM) {
 
     let activation_epoch = v.epoch() + policy.pre_commit_challenge_delay + 1;
     advance_by_deadline_to_epoch(v, &maddr, activation_epoch);
+
+    let circulating_supply_at_commit = v.circulating_supply();
 
     // Prove-commit
     let proofs = vec![RawBytes::new(vec![1, 2, 3, 4]); manifests.len()];
@@ -391,16 +393,30 @@ pub fn prove_commit_sectors2_test(v: &dyn VM) {
     }
     let full_sector_weight =
         BigInt::from(full_piece_size.0 * (sector_expiry - activation_epoch) as u64);
+    let full_sector_power =
+        qa_power_for_weight(sector_size, sector_expiry - activation_epoch, &full_sector_weight);
+    let full_sector_daily_fee =
+        daily_proof_fee(&policy, &circulating_supply_at_commit, &full_sector_power);
+
     assert_eq!(BigInt::zero(), sectors[0].deal_weight);
     assert_eq!(BigInt::zero(), sectors[0].verified_deal_weight);
+    assert_eq!(full_sector_daily_fee.div_floor(10), sectors[0].daily_fee);
+
     assert_eq!(full_sector_weight, sectors[1].deal_weight);
     assert_eq!(BigInt::zero(), sectors[1].verified_deal_weight);
+    assert_eq!(full_sector_daily_fee.div_floor(10), sectors[1].daily_fee);
+
     assert_eq!(BigInt::zero(), sectors[2].deal_weight);
     assert_eq!(full_sector_weight, sectors[2].verified_deal_weight);
+    assert_eq!(full_sector_daily_fee, sectors[2].daily_fee);
+
     assert_eq!(full_sector_weight, sectors[3].deal_weight);
     assert_eq!(BigInt::zero(), sectors[3].verified_deal_weight);
+    assert_eq!(full_sector_daily_fee.div_floor(10), sectors[3].daily_fee);
+
     assert_eq!(BigInt::zero(), sectors[4].deal_weight);
     assert_eq!(full_sector_weight / 2, sectors[4].verified_deal_weight);
+    assert_eq!((full_sector_daily_fee * 11).div_floor(20), sectors[4].daily_fee);
 
     // Brief checks on state consistency between actors.
     let claims = verifreg_list_claims(v, miner_id);

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -24,7 +24,7 @@ itertools = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 multihash-codetable = { workspace = true }
-num = { workspace = true  }
+num = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 paste = { workspace = true }

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -385,7 +385,7 @@ pub mod policy_constants {
     // Fraction of circulating supply per byte of quality adjusted power that will
     // be used to calculate the daily fee for new sectors.
     // The target multiplier is 2.1536e-25, which is ≈ 7.4e-15 / 32 GiB as specified
-    // by FIP-0100. We implement this as // 21536e10^29.
+    // by FIP-0100. We implement this as 21536e10^29.
     pub const DAILY_FEE_CIRCULATING_SUPPLY_QAP_MULTIPLIER_NUM: u64 = 21536;
     pub const DAILY_FEE_CIRCULATING_SUPPLY_QAP_MULTIPLIER_DENOM: u128 =
         100_000_000_000_000_000_000_000_000_000;

--- a/test_vm/src/lib.rs
+++ b/test_vm/src/lib.rs
@@ -306,7 +306,7 @@ impl VM for TestVM {
             originator_stable_addr: *from,
             originator_call_seq: call_seq,
             new_actor_addr_count: RefCell::new(0),
-            circ_supply: TokenAmount::from_whole(1_000_000_000),
+            circ_supply: self.circulating_supply.borrow().clone(),
         };
         let msg = InternalMessage {
             from: from_id.id().unwrap(),


### PR DESCRIPTION
7.4e-15 per 32GiB QAP -> 2.1536e-25 per byte QAP

Closes: https://github.com/filecoin-project/builtin-actors/issues/1637

~_(Draft while I add tests that properly cover this—existing tests that care about fees are all 32GiB QAP)_~