### PR TITLE
fip-0100: store only live QAP in deadline

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -2427,7 +2427,7 @@ impl Actor {
                     }
                 }
 
-                deadline.live_power += &deadline_power_delta;
+                deadline.live_qa_power += &deadline_power_delta.qa;
                 deadline.daily_fee += &deadline_daily_fee_delta;
 
                 power_delta += &deadline_power_delta;
@@ -4235,7 +4235,7 @@ where
                 new_sectors.push(new_sector_info);
             } // End loop over declarations in one deadline.
 
-            deadline.live_power += &deadline_power_delta;
+            deadline.live_qa_power += &deadline_power_delta.qa;
             deadline.daily_fee += &deadline_daily_fee_delta;
 
             power_delta += &deadline_power_delta;
@@ -4574,7 +4574,7 @@ fn handle_proving_deadline(
             let day_reward = expected_reward_for_power(
                 reward_smoothed,
                 quality_adj_power_smoothed,
-                &result.live_power.qa,
+                &result.live_qa_power,
                 fil_actors_runtime::EPOCHS_IN_DAY,
             );
             let daily_fee = daily_proof_fee_payable(policy, &result.daily_fee, &day_reward);

--- a/actors/miner/src/state.rs
+++ b/actors/miner/src/state.rs
@@ -15,7 +15,7 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::{ChainEpoch, EPOCH_UNDEFINED};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, SectorSize};
+use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, SectorSize, StoragePower};
 use fvm_shared::{ActorID, HAMT_BIT_WIDTH};
 use itertools::Itertools;
 use multihash_codetable::Code;
@@ -1088,7 +1088,7 @@ impl State {
                 detected_faulty_power: PowerPair::zero(),
                 total_faulty_power: PowerPair::zero(),
                 daily_fee: TokenAmount::zero(),
-                live_power: PowerPair::zero(),
+                live_qa_power: StoragePower::zero(),
             });
         }
 
@@ -1111,7 +1111,7 @@ impl State {
                 detected_faulty_power: PowerPair::zero(),
                 total_faulty_power: deadline.faulty_power,
                 daily_fee: TokenAmount::zero(),
-                live_power: PowerPair::zero(),
+                live_qa_power: StoragePower::zero(),
             });
         }
 
@@ -1156,7 +1156,7 @@ impl State {
             detected_faulty_power,
             total_faulty_power,
             daily_fee: deadline.daily_fee,
-            live_power: deadline.live_power,
+            live_qa_power: deadline.live_qa_power,
         })
     }
 
@@ -1197,8 +1197,8 @@ pub struct AdvanceDeadlineResult {
     pub total_faulty_power: PowerPair,
     /// Fee payable for the sectors in the deadline being advanced
     pub daily_fee: TokenAmount,
-    /// Total power for the deadline, including active, faulty, and unproven
-    pub live_power: PowerPair,
+    /// Total QAP for the deadline, including active, faulty, and unproven
+    pub live_qa_power: StoragePower,
 }
 
 /// Static information about miner

--- a/actors/miner/src/testing.rs
+++ b/actors/miner/src/testing.rs
@@ -984,10 +984,10 @@ pub fn check_deadline_state_invariants<BS: Blockstore>(
     );
 
     acc.require(
-        deadline.live_power == all_live_power,
+        deadline.live_qa_power == all_live_power.qa,
         format!(
             "deadline live power {:?} != partitions total {all_live_power:?}",
-            deadline.live_power
+            deadline.live_qa_power,
         ),
     );
 

--- a/actors/miner/tests/types_test.rs
+++ b/actors/miner/tests/types_test.rs
@@ -255,8 +255,8 @@ mod serialization {
     fn deadline() {
         let test_cases = vec![(
             Deadline { ..Default::default() },
-            // [baeaaaaa,baeaaaaa,[],[],0,0,[[],[]],baeaaaaa,baeaaaaa,baeaaaaa,baeaaaaa,[[],[]],[]]
-            &hex!("8dd82a450001000000d82a45000100000040400000824040d82a450001000000d82a450001000000d82a450001000000d82a45000100000082404040")[..],
+            // [baeaaaaa,baeaaaaa,[],[],0,0,[[],[]],baeaaaaa,baeaaaaa,baeaaaaa,baeaaaaa,[],[]]
+            &hex!("8dd82a450001000000d82a45000100000040400000824040d82a450001000000d82a450001000000d82a450001000000d82a4500010000004040")[..],
         ),
         (
             Deadline{
@@ -275,11 +275,11 @@ mod serialization {
                 sectors_snapshot: Cid::from_str("bagboea4seaaqg").unwrap(),
                 partitions_snapshot: Cid::from_str("bagboea4seaaqi").unwrap(),
                 optimistic_post_submissions_snapshot: Cid::from_str("bagboea4seaaqk").unwrap(),
-                live_power: PowerPair::new(BigInt::from(6), BigInt::from(7)),
+                live_qa_power: BigInt::from(6),
                 daily_fee: TokenAmount::from_whole(8),
             },
-            // [bagboea4seaaqa,bagboea4seaaqc,[DA],[GA],2,3,[[AAQ],[AAU]],bagboea4seaaqe,bagboea4seaaqg,bagboea4seaaqi,bagboea4seaaqk,[[AAY],[AAc]],[AG8FtZ07IAAA]]
-            &hex!("8dd82a49000182e20392200100d82a49000182e20392200101410c4118020382420004420005d82a49000182e20392200102d82a49000182e20392200103d82a49000182e20392200104d82a49000182e203922001058242000642000749006f05b59d3b200000"),
+            // [bagboea4seaaqa,bagboea4seaaqc,[DA],[GA],2,3,[[AAQ],[AAU]],bagboea4seaaqe,bagboea4seaaqg,bagboea4seaaqi,bagboea4seaaqk,[AAY],[AG8FtZ07IAAA]]
+            &hex!("8dd82a49000182e20392200100d82a49000182e20392200101410c4118020382420004420005d82a49000182e20392200102d82a49000182e20392200103d82a49000182e20392200104d82a49000182e2039220010542000649006f05b59d3b200000"),            
         ),
         ];
 


### PR DESCRIPTION
Saves 2 bytes in the simplest case of zero power