### PR TITLE
fip-0100: proposed adjustments from feedback round

### DIFF
--- a/actors/miner/src/expiration_queue.rs
+++ b/actors/miner/src/expiration_queue.rs
@@ -45,6 +45,11 @@ pub struct ExpirationSet {
     pub faulty_power: PowerPair,
     /// Adjustment to the daily fee recorded for the deadline associated with this expiration set
     /// to account for expiring sectors.
+    ///
+    /// This field is not included in the serialised form of the struct prior to the activation of
+    /// FIP-0100, and is added as the 6th element of the array after that point only for new objects
+    /// or objects that are updated after that point. For old objects, the value of this field will
+    /// always be zero.
     #[serde(default)]
     pub fee_deduction: TokenAmount,
 }

--- a/actors/miner/src/policy.rs
+++ b/actors/miner/src/policy.rs
@@ -12,6 +12,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::commcid::{FIL_COMMITMENT_SEALED, POSEIDON_BLS12_381_A1_FC1};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof, SectorSize, StoragePower};
+use fvm_shared::version::NetworkVersion;
 use lazy_static::lazy_static;
 
 use super::types::SectorOnChainInfo;
@@ -202,6 +203,11 @@ pub fn reward_for_disputed_window_post(
     // This is currently just the base. In the future, the fee may scale based on the disputed power.
     BASE_REWARD_FOR_DISPUTED_WINDOW_POST.clone()
 }
+
+// Network version at which the FIP-0100 grace period for application of the fee to legacy sector
+// extensions ends. After we reach this network version, the fee will be applied to all sector
+// extensions which currently have a zero fee value.
+pub const FIP_0100_GRACE_PERIOD_END_VERSION: NetworkVersion = NetworkVersion::new(26);
 
 // Calculate the daily fee for a sector's quality-adjusted power based on the current circulating
 // supply.

--- a/actors/miner/tests/daily_fees_test.rs
+++ b/actors/miner/tests/daily_fees_test.rs
@@ -31,9 +31,9 @@ const PERIOD_OFFSET: ChainEpoch = 100;
 fn fee_paid_at_deadline() {
     let (mut h, rt) = setup();
     // set circulating supply to a value that will yield a predictable fee using the original
-    // 7.4e-15 * CS for 32GiB QAP metric: 5155580000000 for a CS of 696.7M FIL
+    // 5.56e-15 * CS for 32GiB QAP metric: 3873652000000 for a CS of 696.7M FIL
     let reference_cs = TokenAmount::from_whole(696_700_000);
-    let reference_fee = TokenAmount::from_atto(5_155_580_000_000_u64);
+    let reference_fee = TokenAmount::from_atto(3_873_652_000_000_u64);
     rt.set_circulating_supply(reference_cs);
 
     let one_sector = h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, vec![], true);
@@ -43,8 +43,8 @@ fn fee_paid_at_deadline() {
         // sanity check that we get within a reasonable distance from the reference amount using our
         // per-byte multiplier (we expect to round under the reference amount)
         let fee_ref_diff = reference_fee.atto() - daily_fee.atto();
-        // should be within 1/5 of a nanoFIL of the reference amount
-        let fee_ref_diff_tolerance = TokenAmount::from_nano(1).div_floor(5);
+        // should be within 1/100th of a nanoFIL of the reference amount
+        let fee_ref_diff_tolerance = TokenAmount::from_nano(1).div_floor(100);
         assert!(
             fee_ref_diff.is_positive() && fee_ref_diff.abs() <= *fee_ref_diff_tolerance.atto(),
             "daily_fee: {} !≈ reference amount ({})",

--- a/actors/miner/tests/policy_test.rs
+++ b/actors/miner/tests/policy_test.rs
@@ -299,17 +299,17 @@ fn original_quality_for_weight(
 #[test]
 fn daily_proof_fee_calc() {
     let policy = Policy::default();
-    // Given a CS of 680M FIL, 32GiB QAP, a fee multiplier of 7.4e-15 per 32GiB QAP, the daily proof
-    // fee should be 5032 nanoFIL.
-    //   680M * 7.4e-15 = 0.000005032 FIL
-    //   0.000005032 * 1e9 = 5032 nanoFIL
-    //   0.000005032 * 1e18 = 5032000000000 attoFIL
-    // As a per-byte multiplier we use 2.1536e-25, a close approximation of 7.4e-15 / 32GiB.
-    //   680M * 32GiB * 2.1536e-25 = 0.000005031805013354 FIL
-    //   0.000005031805013354 * 1e18 = 5031805013354 attoFIL
+    // Given a CS of 680M FIL, 32GiB QAP, a fee multiplier of 5.56e-15 per 32GiB QAP, the daily proof
+    // fee should be 3780 nanoFIL.
+    //   680M * 5.56e-15 = 0.000003780800 FIL
+    //   0.0000037808 * 1e9 = 3780 nanoFIL
+    //   0.0000037808 * 1e18 = 3780800000000 attoFIL
+    // As a per-byte multiplier we use 1.61817e-25, a close approximation of 5.56e-15 / 32GiB.
+    //   680M * 32GiB * 1.61817e-25 = 0.000003780793052776 FIL
+    //   0.000003780793052776 * 1e18 = 3780793052776 attoFIL
     let circulating_supply = TokenAmount::from_whole(680_000_000);
 
-    let ref_32gib_fee = 5031805013354_u64;
+    let ref_32gib_fee = 3780793052776_u64;
     [
         (32_u64, ref_32gib_fee),
         (64, ref_32gib_fee * 2),
@@ -322,8 +322,9 @@ fn daily_proof_fee_calc() {
         let power = BigInt::from(*size) << 30; // 32GiB raw QAP
         let fee = daily_proof_fee(&policy, &circulating_supply, &power);
         assert!(
-            (fee.atto() - BigInt::from(*expected_fee)).abs() <= BigInt::from(1),
-            "fee: {}, expected_fee: {}",
+            (fee.atto() - BigInt::from(*expected_fee)).abs() <= BigInt::from(10),
+            "size: {}, fee: {}, expected_fee: {} (±10)",
+            size,
             fee.atto(),
             expected_fee
         );

--- a/integration_tests/src/tests/prove_commit3_test.rs
+++ b/integration_tests/src/tests/prove_commit3_test.rs
@@ -8,7 +8,7 @@ use fvm_shared::deal::DealID;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::{PaddedPieceSize, PieceInfo};
 use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
-use num_traits::Zero;
+use num_traits::{Signed, Zero};
 
 use fil_actor_market::Method as MarketMethod;
 use fil_actor_miner::{
@@ -415,7 +415,13 @@ pub fn prove_commit_sectors2_test(v: &dyn VM) {
 
     assert_eq!(BigInt::zero(), sectors[4].deal_weight);
     assert_eq!(full_sector_weight / 2, sectors[4].verified_deal_weight);
-    assert_eq!((full_sector_daily_fee * 11).div_floor(20), sectors[4].daily_fee);
+    assert!(
+        ((&full_sector_daily_fee * 11).div_floor(20) - &sectors[4].daily_fee).atto().abs()
+            <= BigInt::from(1),
+        "expected: {}, got: {}",
+        (full_sector_daily_fee * 11).div_floor(20),
+        sectors[4].daily_fee
+    );
 
     // Brief checks on state consistency between actors.
     let claims = verifreg_list_claims(v, miner_id);

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -363,10 +363,12 @@ pub mod policy_constants {
     /// This is a conservative value that is chosen via simulations of all known attacks.
     pub const CHAIN_FINALITY: ChainEpoch = 900;
 
-    // Fraction of circulating supply per byte of quality adjusted power that will
-    // be used to calculate the daily fee for new sectors.
-    // The target multiplier is 1.61817e-25, which is ≈ 5.56e-15 / 32GiB as specified
-    // by FIP-0100. We implement this as 161817e-30.
+    // Fraction of circulating supply per byte of quality adjusted power that will be used to calculate
+    // the daily fee for new sectors.
+    // The target multiplier is:
+    //   5.56e-15 / 32GiB = 5.56e-15 / (32 * 2^30) = 5.56e-15 / 34,359,738,368 ≈ 1.61817e-25
+    // (i.e. slightly rounded for simplicity and a more direct multiplication).
+    // We implement this as 161817e-30.
     pub const DAILY_FEE_CIRCULATING_SUPPLY_QAP_MULTIPLIER_NUM: u64 = 161817;
     pub const DAILY_FEE_CIRCULATING_SUPPLY_QAP_MULTIPLIER_DENOM: u128 =
         1_000_000_000_000_000_000_000_000_000_000; // 10^30

--- a/runtime/src/runtime/policy.rs
+++ b/runtime/src/runtime/policy.rs
@@ -365,11 +365,11 @@ pub mod policy_constants {
 
     // Fraction of circulating supply per byte of quality adjusted power that will
     // be used to calculate the daily fee for new sectors.
-    // The target multiplier is 2.1536e-25, which is ≈ 7.4e-15 / 32 GiB as specified
-    // by FIP-0100. We implement this as 21536e10^29.
-    pub const DAILY_FEE_CIRCULATING_SUPPLY_QAP_MULTIPLIER_NUM: u64 = 21536;
+    // The target multiplier is 1.61817e-25, which is ≈ 5.56e-15 / 32GiB as specified
+    // by FIP-0100. We implement this as 161817e-30.
+    pub const DAILY_FEE_CIRCULATING_SUPPLY_QAP_MULTIPLIER_NUM: u64 = 161817;
     pub const DAILY_FEE_CIRCULATING_SUPPLY_QAP_MULTIPLIER_DENOM: u128 =
-        100_000_000_000_000_000_000_000_000_000;
+        1_000_000_000_000_000_000_000_000_000_000; // 10^30
 
     // 50% of estimated daily block rewards
     pub const DAILY_FEE_BLOCK_REWARD_CAP_DENOM: i64 = 2;

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -157,7 +157,7 @@ pub struct MockRuntime {
             &[u8; SECP_SIG_LEN],
         ) -> Result<[u8; SECP_PUB_LEN], ()>,
     >,
-    pub network_version: NetworkVersion,
+    pub network_version: RefCell<NetworkVersion>,
 
     // Actor State
     pub state: RefCell<Option<Cid>>,
@@ -346,7 +346,7 @@ impl MockRuntime {
             value_received: Default::default(),
             hash_func: Box::new(hash),
             recover_secp_pubkey_fn: Box::new(recover_secp_public_key),
-            network_version: NetworkVersion::V0,
+            network_version: RefCell::new(NetworkVersion::V0),
             state: Default::default(),
             balance: Default::default(),
             in_call: Default::default(),
@@ -730,6 +730,10 @@ impl MockRuntime {
         self.circulating_supply.replace(circ_supply);
     }
 
+    pub fn set_network_version(&self, nv: NetworkVersion) {
+        self.network_version.replace(nv);
+    }
+
     #[allow(dead_code)]
     pub fn set_epoch(&self, epoch: ChainEpoch) -> ChainEpoch {
         self.epoch.replace(epoch);
@@ -853,7 +857,7 @@ impl Runtime for MockRuntime {
     type Blockstore = Rc<MemoryBlockstore>;
 
     fn network_version(&self) -> NetworkVersion {
-        self.network_version
+        *self.network_version.borrow()
     }
 
     fn message(&self) -> &dyn MessageInfo {


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/FIPs/discussions/1105#discussioncomment-12471015

* Reduce daily_fee to 5.56e-15 / 32GiB, we use a per-byte rounded multiplier of 1.61817e-25, which is a bit more precise than the previous per-byte rounded multiplier, we use `161817 / 1_000_000_000_000_000_000_000_000_000_000` (161817e-30).
* Add grace period for extensions of legacy sectors using a network-version mechanism. As long as the network version is less than 26 then we don't put a `daily_fee` on sectors that don't have one during extensions.