### PR TITLE
ci: do not trigger releaser on tag pushes

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -2,6 +2,7 @@ name: Releaser
 
 on:
   push:
+    branches: ["**"]
     paths: ["Cargo.toml"]
   workflow_dispatch:
 


### PR DESCRIPTION
We should not be triggering the releaser workflow on tag pushes. In a more common scenario where the default GITHUB_TOKEN is used by the releaser, this is not an issue because the tag push events created by the default GITHUB_TOKEN are not allowed to trigger further workflow runs. However, we use a custom PAT here, so we should disable running the releaser on tag pushes explicitly.