### PR TITLE
ci: upload release again before the release is published

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -11,7 +11,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -22,33 +22,6 @@ jobs:
   upload-release-assets:
     needs: [release-check]
     if: fromJSON(needs.release-check.outputs.json)['Cargo.toml']
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CARGO_INCREMENTAL: 0
-      CACHE_SKIP_SAVE: ${{ matrix.push == '' || matrix.push == 'false' }}
-      RUSTFLAGS: -Dwarnings
-    strategy:
-      matrix:
-        network: [ 'mainnet', 'caterpillarnet', 'butterflynet', 'calibrationnet', 'devnet', 'testing', 'testing-fake-proofs' ]
-    steps:
-    - name: Checking out
-      uses: actions/checkout@v4
-    - name: Setting up cache
-      uses: pl-strflt/rust-sccache-action@v1
-      env:
-        SCCACHE_CACHE_SIZE: 2G
-        SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
-        CACHE_SKIP_SAVE: true
-    - name: Writing bundle
-      env:
-        BUILD_FIL_NETWORK: ${{ matrix.network }}
-      run: |
-        make bundle-repro
-    - name: Upload release assets to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_RELEASE_URL: ${{ github.api_url }}/repos/${{ github.repository }}/releases/${{ fromJSON(needs.release-check.outputs.json)['Cargo.toml'].id }}
-        BUILD_FIL_NETWORK: ${{ matrix.network }}
-      run: |
-        ./scripts/upload-release-assets.sh
+    uses: ./.github/workflows/upload-release-assets.yml
+    with:
+      tag_name: ${{ fromJSON(needs.release-check.outputs.json)['Cargo.toml'].id }}

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -19,9 +19,3 @@ jobs:
     uses: ipdxco/unified-github-workflows/.github/workflows/release-check.yml@v1.0
     with:
       sources: '["Cargo.toml"]'
-  upload-release-assets:
-    needs: [release-check]
-    if: fromJSON(needs.release-check.outputs.json)['Cargo.toml']
-    uses: ./.github/workflows/upload-release-assets.yml
-    with:
-      tag_name: ${{ fromJSON(needs.release-check.outputs.json)['Cargo.toml'].id }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -25,7 +25,7 @@ jobs:
     if: fromJSON(needs.draft.outputs.json)['Cargo.toml']
     uses: ./.github/workflows/upload-release-assets.yml
     with:
-      tag_name: ${{ fromJSON(needs.draft.outputs.json)['Cargo.toml'].id }}
+      release_id: ${{ fromJSON(needs.draft.outputs.json)['Cargo.toml'].id }}
   # If a draft release was created/update, publish the release
   releaser:
     needs: [draft, upload-release-assets]

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -28,7 +28,7 @@ jobs:
       tag_name: ${{ fromJSON(needs.draft.outputs.json)['Cargo.toml'].id }}
   # If a draft release was created/update, publish the release
   releaser:
-    needs: [draft]
+    needs: [draft, upload-release-assets]
     if: fromJSON(needs.draft.outputs.json)['Cargo.toml']
     uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1.0
     with:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -9,13 +9,30 @@ permissions:
   contents: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:
-  releaser:
+  # Create/update a draft release if this is a release creating push event
+  draft:
     uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1.0
     with:
       sources: '["Cargo.toml"]'
+      draft: true
+  # If a draft release was created/updated, build and upload release assets
+  upload-release-assets:
+    needs: [draft]
+    if: fromJSON(needs.draft.outputs.json)['Cargo.toml']
+    uses: ./.github/workflows/upload-release-assets.yml
+    with:
+      tag_name: ${{ fromJSON(needs.draft.outputs.json)['Cargo.toml'].id }}
+  # If a draft release was created/update, publish the release
+  releaser:
+    needs: [draft]
+    if: fromJSON(needs.draft.outputs.json)['Cargo.toml']
+    uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1.0
+    with:
+      sources: '["Cargo.toml"]'
+      draft: false
     secrets:
       UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -23,10 +23,6 @@ on:
 permissions:
   contents: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
-  cancel-in-progress: true
-
 jobs:
   upload-release-assets:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -1,0 +1,66 @@
+name: Upload Release Assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'The name of the tag to upload assets for'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag_name || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upload-release-assets:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CARGO_INCREMENTAL: 0
+      CACHE_SKIP_SAVE: true
+      RUSTFLAGS: -Dwarnings
+    strategy:
+      matrix:
+        network: [ 'mainnet', 'caterpillarnet', 'butterflynet', 'calibrationnet', 'devnet', 'testing', 'testing-fake-proofs' ]
+    steps:
+    - id: tag
+      env:
+        TAG_NAME: ${{ inputs.tag_name }}
+      run: |
+        if [[ "$TAG_NAME" != '' ]]; then
+          echo "name=$TAG_NAME" | tee -a "$GITHUB_OUTPUT"
+        else
+          echo "name=${GITHUB_REF#refs/tags/}" | tee -a "$GITHUB_OUTPUT"
+        fi
+    - name: Checking out the release
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ format('refs/tags/{0}', steps.tag.outputs.name) }}
+    - name: Setting up cache
+      uses: pl-strflt/rust-sccache-action@v1
+      env:
+        SCCACHE_CACHE_SIZE: 2G
+        SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
+        CACHE_SKIP_SAVE: true
+    - name: Writing bundle
+      env:
+        BUILD_FIL_NETWORK: ${{ matrix.network }}
+      run: |
+        make bundle-repro
+    - name: Upload release assets to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_RELEASE_URL: ${{ github.api_url }}/repos/${{ github.repository }}/releases/${{ steps.tag.outputs.name }}
+        BUILD_FIL_NETWORK: ${{ matrix.network }}
+      run: |
+        git checkout $GITHUB_REF -- scripts/upload-release-assets.sh
+        ./scripts/upload-release-assets.sh

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -3,21 +3,28 @@ name: Upload Release Assets
 on:
   workflow_dispatch:
     inputs:
-      tag_name:
-        description: 'The name of the tag to upload assets for'
+      release_id:
+        description: 'The id of the release to upload the assets for'
         required: true
+        type: string
+      release_ref:
+        description: 'The ref to build the release assets from'
+        required: false
         type: string
   workflow_call:
     inputs:
-      tag_name:
+      release_id:
         required: true
+        type: string
+      release_ref:
+        required: false
         type: string
 
 permissions:
   contents: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.tag_name || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -32,19 +39,10 @@ jobs:
       matrix:
         network: [ 'mainnet', 'caterpillarnet', 'butterflynet', 'calibrationnet', 'devnet', 'testing', 'testing-fake-proofs' ]
     steps:
-    - id: tag
-      env:
-        TAG_NAME: ${{ inputs.tag_name }}
-      run: |
-        if [[ "$TAG_NAME" != '' ]]; then
-          echo "name=$TAG_NAME" | tee -a "$GITHUB_OUTPUT"
-        else
-          echo "name=${GITHUB_REF#refs/tags/}" | tee -a "$GITHUB_OUTPUT"
-        fi
-    - name: Checking out the release
+    - name: Checking out builtin-actors
       uses: actions/checkout@v4
       with:
-        ref: ${{ format('refs/tags/{0}', steps.tag.outputs.name) }}
+        ref: ${{ inputs.release_ref || github.ref }}
     - name: Setting up cache
       uses: pl-strflt/rust-sccache-action@v1
       env:
@@ -59,7 +57,7 @@ jobs:
     - name: Upload release assets to GitHub Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_RELEASE_URL: ${{ github.api_url }}/repos/${{ github.repository }}/releases/${{ steps.tag.outputs.name }}
+        GITHUB_RELEASE_URL: ${{ github.api_url }}/repos/${{ github.repository }}/releases/${{ inputs.release_id }}
         BUILD_FIL_NETWORK: ${{ matrix.network }}
       run: |
         git checkout $GITHUB_REF -- scripts/upload-release-assets.sh

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -32,6 +32,7 @@ jobs:
       CACHE_SKIP_SAVE: true
       RUSTFLAGS: -Dwarnings
     strategy:
+      fail-fast: false
       matrix:
         network: [ 'mainnet', 'caterpillarnet', 'butterflynet', 'calibrationnet', 'devnet', 'testing', 'testing-fake-proofs' ]
     steps:

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -28,9 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CARGO_INCREMENTAL: 0
-      CACHE_SKIP_SAVE: true
-      RUSTFLAGS: -Dwarnings
     strategy:
       fail-fast: false
       matrix:
@@ -40,12 +37,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.release_ref || github.ref }}
-    - name: Setting up cache
-      uses: pl-strflt/rust-sccache-action@v1
-      env:
-        SCCACHE_CACHE_SIZE: 2G
-        SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
-        CACHE_SKIP_SAVE: true
     - name: Writing bundle
       env:
         BUILD_FIL_NETWORK: ${{ matrix.network }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,21 +9,18 @@ This document describes the process for releasing a new version of the `builtin-
 2. On pull request creation, a [Release Checker](.github/workflows/release-check.yml) workflow will run. It will perform the following actions:
     1. Extract the version from the top-level `Cargo.toml` file.
     2. Check if a git tag for the version already exists. Continue only if it does not.
-    3. Create a draft GitHub release with the version as the tag.  (A git tag with this version string will be created when the release is published.)
+    3. Create a draft GitHub release with the version as the tag. (A git tag with this version string will be created when the release is published.)
     4. Comment on the pull request with a link to the draft release.
-    5. Build `builtin-actors.car`s for various networks.
-    6. Generate checksums for the built `builtin-actors.car`s.
-    7. Upload the built `builtin-actors.car`s and checksums as assets to the draft release (replace any existing assets with the same name).
-3. On pull request merge, a [Releaser](.github/workflows/release.yml) workflow will run. It will perform the following actions:
+3. On pull request merge, a [Releaser](.github/workflows/releaser.yml) workflow will run. It will perform the following actions:
     1. Extract the version from the top-level `Cargo.toml` file.
     2. Check if a git tag for the version already exists. Continue only if it does not.
-    3. Check if a draft GitHub release with the version as the tag exists.
-    4. If the draft release exists, publish it. Otherwise, create and publish a new release with the version as the git tag.  Publishing the release creates the git tag.
+    3. Check if a draft GitHub release with the version as the tag exists. Otherwise, create it.
+    4. Trigger the [Upload Release Assets](.github/workflows/upload-release-assets.yml) workflow to:
+        1. Build `builtin-actors.car`s for various networks.
+        2. Generate checksums for the built `builtin-actors.car`s.
+        3. Upload the built `builtin-actors.car`s and checksums as assets to the draft release.
+    5. Publish the draft release. Publishing the release creates the git tag.
 
 ## Known Limitations
 
-1. If one pushes an update to the `workspace.package.version` in the top-level `Cargo.toml` file without creating a pull request, the Release Checker workflow will not run. Hence, the release assets will not be automatically built and uploaded.
-
-## Possible Improvements
-
-1. Add a check to the [Releaser](.github/workflows/release.yml) workflow to ensure that the created/published release contains the expected assets. If it does not, create them and run the [upload-release-assets.sh](scripts/upload-release-assets.sh) script to upload the missing assets.
+1. Unless triggered manually, release assets will only be built after merging the release PR.


### PR DESCRIPTION
Resolves https://github.com/filecoin-project/builtin-actors/issues/1656

In this PR I extracted the release upload action to a separate workflow that can be triggered either manually or from other workflows. After this PR is merged, the release flow will be as follows:
1. I create a release PR.
2. CI creates a draft release.
3. ~~Release assets are uploaded to the draft release.~~
4. I merge the release PR.
5. CI ensures the draft release exists.
6. CI uploads release assets to the draft release.
7. CI publishes the draft release.

If this sounds reasonable to you, I'm going to proceed with the tests of this flow in a fork of this repository.

