### PR TITLE
chore(docs): add minor clarifying docs on FIP-0100 power & fee use

### DIFF
--- a/actors/miner/src/deadline_state.rs
+++ b/actors/miner/src/deadline_state.rs
@@ -166,6 +166,8 @@ pub struct Deadline {
 
     /// Memoized sum of all non-terminated power in partitions, including active, faulty, and
     /// unproven. Used to cap the daily fee as a proportion of expected block reward.
+    /// This field should not be used as an accurate measure of a miner's power as it includes
+    /// faulty and unproven power.
     pub live_power: PowerPair,
 
     /// Memoized sum of daily fee payable to the network for the active sectors

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -4497,9 +4497,11 @@ fn handle_proving_deadline(
 
         if result.daily_fee.is_positive() {
             // Apply daily fee for sectors in this deadline, applied through the penalty/fee_debt
-            // mechanism.
-            // The daily fee payable is capped at a fraction of estimated daily block reward for the
-            // sectors being charged.
+            // mechanism. The daily fee payable is capped at a fraction of estimated daily block
+            // reward for the sectors being charged.
+            // Note that the daily_fee and live_power values here do not include sectors that have
+            // just been removed from the deadline via advance_dealine (above), but they do include
+            // sectors that have been added within the current proving period.
             let day_reward = expected_reward_for_power(
                 reward_smoothed,
                 quality_adj_power_smoothed,


### PR DESCRIPTION
~Ongoing discussion: if the fee is a proof fee, that is you're paying per window post, then should you pay for every deadline you're posting _including_ the last one.~

~Currently we pop expired sectors and deduct the fees from those before we figure out how much to pay.~

/cc @irenegia