### PR TITLE
chore: update to rust 1.86.0

### DIFF
--- a/actors/datacap/src/lib.rs
+++ b/actors/datacap/src/lib.rs
@@ -412,7 +412,7 @@ struct SyscallProvider<'a, RT> {
     rt: &'a RT,
 }
 
-impl<'a, RT> Syscalls for &SyscallProvider<'a, RT>
+impl<RT> Syscalls for &SyscallProvider<'_, RT>
 where
     RT: Runtime,
 {

--- a/actors/evm/shared/src/uints.rs
+++ b/actors/evm/shared/src/uints.rs
@@ -1,6 +1,6 @@
 // to silence construct_uint! clippy warnings
 // see https://github.com/paritytech/parity-common/issues/660
-#![allow(clippy::ptr_offset_with_cast, clippy::assign_op_pattern)]
+#![allow(clippy::ptr_offset_with_cast, clippy::assign_op_pattern, clippy::manual_div_ceil)]
 
 #[doc(inline)]
 pub use uint::byteorder;
@@ -198,7 +198,7 @@ impl<'de> Deserialize<'de> for U256 {
         D: serde::Deserializer<'de>,
     {
         struct Visitor;
-        impl<'de> serde::de::Visitor<'de> for Visitor {
+        impl serde::de::Visitor<'_> for Visitor {
             type Value = U256;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/actors/evm/src/interpreter/memory.rs
+++ b/actors/evm/src/interpreter/memory.rs
@@ -53,7 +53,7 @@ impl Memory {
         // Reserve any new pages.
         let cap = self.0.capacity();
         if new_size > cap {
-            let required_pages = (new_size + PAGE_SIZE - 1) / PAGE_SIZE;
+            let required_pages = new_size.div_ceil(PAGE_SIZE);
             self.reserve_pages(required_pages);
         }
 

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -150,7 +150,7 @@ impl<'r, RT: Runtime> System<'r, RT> {
             return Err(actor_error!(forbidden, "can only resurrect a dead contract"));
         }
 
-        return Ok(Self::new(rt, read_only));
+        Ok(Self::new(rt, read_only))
     }
 
     /// Create the contract. This will return a new empty contract if, and only if, the contract
@@ -164,7 +164,7 @@ impl<'r, RT: Runtime> System<'r, RT> {
         if state_root != EMPTY_ARR_CID {
             return Err(actor_error!(illegal_state, "can't create over an existing actor"));
         }
-        return Ok(Self::new(rt, read_only));
+        Ok(Self::new(rt, read_only))
     }
 
     /// Load the actor from state.

--- a/actors/evm/src/lib.rs
+++ b/actors/evm/src/lib.rs
@@ -84,7 +84,7 @@ pub(crate) fn current_tombstone(rt: &impl Runtime) -> Tombstone {
 /// Specifically, this lets us mark the contract as "self-destructed" but keep it alive until the
 /// current top-level message finishes executing.
 pub(crate) fn is_dead(rt: &impl Runtime, state: &State) -> bool {
-    state.tombstone.map_or(false, |t| t != current_tombstone(rt))
+    state.tombstone.is_some_and(|t| t != current_tombstone(rt))
 }
 
 fn load_bytecode(bs: &impl Blockstore, cid: &Cid) -> Result<Option<Bytecode>, ActorError> {

--- a/integration_tests/src/tests/batch_onboarding_deals_test.rs
+++ b/integration_tests/src/tests/batch_onboarding_deals_test.rs
@@ -210,7 +210,7 @@ fn publish_deals(
     let ret = batcher.publish_ok(worker);
     let good_inputs = bf_all(ret.valid_deals);
     assert_eq!((0..count as u64).collect::<Vec<u64>>(), good_inputs);
-    return ret.ids.into_iter().zip(batcher.proposals().iter().cloned()).collect();
+    ret.ids.into_iter().zip(batcher.proposals().iter().cloned()).collect()
 }
 
 // This method doesn't check any trace expectations.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.86.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]

--- a/test_vm/src/messaging.rs
+++ b/test_vm/src/messaging.rs
@@ -303,7 +303,7 @@ impl<'invocation> InvocationCtx<'invocation> {
     }
 }
 
-impl<'invocation> Runtime for InvocationCtx<'invocation> {
+impl Runtime for InvocationCtx<'_> {
     type Blockstore = Rc<MemoryBlockstore>;
 
     fn create_actor(

--- a/vm_api/src/util/blockstore.rs
+++ b/vm_api/src/util/blockstore.rs
@@ -5,7 +5,7 @@ use fvm_ipld_blockstore::Blockstore;
 /// accept a generic BS: Blockstore parameter rather than a dyn Blockstore
 pub struct DynBlockstore<'bs>(&'bs dyn Blockstore);
 
-impl<'bs> Blockstore for DynBlockstore<'bs> {
+impl Blockstore for DynBlockstore<'_> {
     fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
         self.0.get(k)
     }


### PR DESCRIPTION
In theory, this enables the WASM multiple return values proposal. But my testing with the FVM indicates that everything "just works".

We've explicitly disabled this our compiler settings but... I haven't observed those options making a difference.

My plan is to merge this because everything does appear to be working correctly and we're not making any progress by sitting around holding our breaths.

fixes #1650