### PR TITLE
chore: update remaining deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,13 +349,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "07e9666f4a9a948d4f1dff0c08a4512b0f7c86414b23960104c243c10d79f4c3"
 dependencies = [
- "quote",
- "syn 2.0.100",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
 
 [[package]]
 name = "darling"
@@ -497,6 +503,21 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dtor"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222ef136a1c687d4aa0395c175f2c4586e379924c352fd02f7870cf7de783c23"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "dunce"
@@ -765,7 +786,7 @@ dependencies = [
  "serde",
  "serde_json",
  "substrate-bn",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -806,7 +827,7 @@ dependencies = [
  "fvm_shared",
  "integer-encoding",
  "ipld-core",
- "itertools 0.13.0",
+ "itertools",
  "lazy_static",
  "log",
  "multihash-codetable",
@@ -837,7 +858,7 @@ dependencies = [
  "fvm_ipld_hamt",
  "fvm_shared",
  "hex-literal",
- "itertools 0.13.0",
+ "itertools",
  "lazy_static",
  "log",
  "multihash",
@@ -1035,7 +1056,7 @@ dependencies = [
  "regex",
  "serde",
  "test-case",
- "thiserror 1.0.69",
+ "thiserror",
  "vm_api",
 ]
 
@@ -1061,7 +1082,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "integer-encoding",
- "itertools 0.13.0",
+ "itertools",
  "k256",
  "lazy_static",
  "log",
@@ -1076,7 +1097,7 @@ dependencies = [
  "serde",
  "serde_repr",
  "sha2",
- "thiserror 1.0.69",
+ "thiserror",
  "unsigned-varint",
  "vm_api",
 ]
@@ -1165,7 +1186,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_sdk",
  "fvm_shared",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1176,7 +1197,7 @@ checksum = "af72029ed0fafb01fda2d7f631b55f6916ad06e310a7b4241b933796b34d510c"
 dependencies = [
  "fvm_sdk",
  "fvm_shared",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1210,7 +1231,7 @@ dependencies = [
  "multihash-codetable",
  "num-traits",
  "serde",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1229,7 +1250,7 @@ dependencies = [
  "multihash-codetable",
  "num-traits",
  "serde",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1242,11 +1263,11 @@ dependencies = [
  "cid",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "itertools 0.14.0",
+ "itertools",
  "multihash-codetable",
  "once_cell",
  "serde",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1257,7 +1278,7 @@ checksum = "de140b940443d5d783824563f15b5fe6d1559e7b103a7b55082da93655585350"
 dependencies = [
  "fvm_ipld_encoding",
  "serde",
- "thiserror 2.0.12",
+ "thiserror",
  "unsigned-varint",
 ]
 
@@ -1284,7 +1305,7 @@ dependencies = [
  "multihash-codetable",
  "multihash-derive",
  "serde",
- "thiserror 2.0.12",
+ "thiserror",
  "unsigned-varint",
 ]
 
@@ -1302,7 +1323,7 @@ dependencies = [
  "serde_ipld_dagcbor",
  "serde_repr",
  "serde_tuple",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1322,7 +1343,7 @@ dependencies = [
  "once_cell",
  "serde",
  "sha2",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1339,7 +1360,7 @@ dependencies = [
  "multihash-codetable",
  "once_cell",
  "serde",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1354,7 +1375,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num-traits",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1375,7 +1396,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "thiserror 2.0.12",
+ "thiserror",
  "unsigned-varint",
 ]
 
@@ -1453,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "hex-literal"
-version = "0.4.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hmac"
@@ -1525,15 +1546,6 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1784,7 +1796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror",
  "ucd-trie",
 ]
 
@@ -2009,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
 dependencies = [
  "bytes",
  "rustc-hex",
@@ -2377,31 +2389,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "thiserror-impl",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ fil_actors_runtime = { workspace = true }
 num-traits = { workspace = true }
 
 [dependencies]
-clap = { version = "4.3.0", features = [
+clap = { version = "4.5.36", features = [
      "derive",
      "std",
      "help",
@@ -74,30 +74,30 @@ testing-fake-proofs = []
 
 [workspace.dependencies]
 # Common
-serde = { version = "1.0.136", features = ["derive"] }
-anyhow = "1.0.65"
-bitflags = "2.4.0"
+serde = { version = "1.0.219", features = ["derive"] }
+anyhow = "1.0.98"
+bitflags = "2.9.0"
 num = { version = "0.4", features = ["serde"] }
 num-derive = "0.4.2"
-num-traits = "0.2.14"
-lazy_static = "1.4.0"
-log = { version = "0.4.14", features = ["std"] }
-byteorder = "1.4.3"
-itertools = "0.13.0"
-indexmap = { version = "2.7.0" }
+num-traits = "0.2.19"
+lazy_static = "1.5.0"
+log = { version = "0.4.27", features = ["std"] }
+byteorder = "1.5.0"
+itertools = "0.14.0"
+indexmap = { version = "2.9.0" }
 derive_builder = "0.20.2"
-once_cell = "1.17.0"
+once_cell = "1.21.3"
 rand = { version = "0.8.5", default-features = false }
 hex = "0.4.3"
-hex-literal = "0.4.1"
+hex-literal = "1.0.0"
 serde_json = "1.0"
 regex = "1"
 test-case = "3.3.1"
-bimap = "0.6.2"
-castaway = "0.2.2"
-thiserror = "1.0.30"
+bimap = "0.6.3"
+castaway = "0.2.3"
+thiserror = "2.0.12"
 pretty_env_logger = "0.5.0"
-serde_repr = "0.1.8"
+serde_repr = "0.1.20"
 unsigned-varint = "0.8.0"
 rand_chacha = "0.3.1"
 
@@ -110,7 +110,7 @@ sha2 = "0.10"
 alloy-core = { version = "1.0.0", default-features = false, features = ["sol-types"] }
 uint = { version = "0.10.0", default-features = false }
 etk-asm = "^0.3.0"
-rlp = { version = "0.5.1", default-features = false }
+rlp = { version = "0.6.1", default-features = false }
 substrate-bn = { version = "0.6.0", default-features = false }
 
 # IPLD/Encoding
@@ -118,10 +118,10 @@ cid = { version = "0.11.1", default-features = false, features = [
      "serde",
      "std",
 ] }
-multihash = { version = "0.19.1", default-features = false }
+multihash = { version = "0.19.3", default-features = false }
 multihash-codetable = { version = "0.1.4", default-features = false }
 multihash-derive = { version = "0.9.1", default-features = false }
-ipld-core = { version = "0.4.1", features = ["serde"] }
+ipld-core = { version = "0.4.2", features = ["serde"] }
 integer-encoding = { version = "4.0.2", default-features = false }
 
 # actor-utils

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -59,7 +59,7 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 k256 = { workspace = true, features = ["ecdsa"] }
 export_macro = { path = "./macro" }
-ctor = "0.2.5"
+ctor = "0.4.1"
 multihash-codetable = { workspace = true }
 
 [dev-dependencies]

--- a/integration_tests/macro/Cargo.toml
+++ b/integration_tests/macro/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 proc-macro = true
 
 [dependencies]
-syn = "2.0.38"
-quote = "1.0.33"
-proc-macro2 = "1.0.69"
+syn = "2.0.100"
+quote = "1.0.40"
+proc-macro2 = "1.0.94"


### PR DESCRIPTION
Mostly patch/minor versions, but this has a few major updates:

- hex-literal (very safe)
- thiserror (probably safe)
- rlp (msrv bump)
- ctor (test only)