### PR TITLE
feat(evm): save a syscall for most precompile calls

### DIFF
--- a/actors/evm/src/interpreter/precompiles/evm.rs
+++ b/actors/evm/src/interpreter/precompiles/evm.rs
@@ -307,7 +307,7 @@ mod tests {
 
     impl Default for PrecompileContext {
         fn default() -> Self {
-            Self { call_type: CallKind::Call, gas_limit: u64::MAX, value: U256::ZERO }
+            Self { call_type: CallKind::Call, gas: U256::MAX, value: U256::ZERO }
         }
     }
 

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -181,7 +181,7 @@ pub(super) fn call_actor_shared<RT: Runtime>(
             method,
             params,
             TokenAmount::from(&value),
-            Some(ctx.gas_limit),
+            Some(system.call_gas_limit(ctx.gas)),
             flags,
         )?
     };

--- a/actors/evm/src/interpreter/precompiles/mod.rs
+++ b/actors/evm/src/interpreter/precompiles/mod.rs
@@ -168,7 +168,7 @@ impl From<GroupError> for PrecompileError {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct PrecompileContext {
     pub call_type: CallKind,
-    pub gas_limit: u64,
+    pub gas: U256,
     pub value: U256,
 }
 

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -534,6 +534,14 @@ impl<'r, RT: Runtime> System<'r, RT> {
         self.saved_state_root = None;
         self.tombstone = Some(crate::current_tombstone(self.rt));
     }
+
+    /// Return the gas limit for a call given the requested gas limit, ensuring that it's no more than
+    /// 63/64 of the remaining gas.
+    pub fn call_gas_limit(&self, gas: U256) -> u64 {
+        let gas_rsvp = (63 * self.rt.gas_available()) / 64;
+        let gas = gas.to_u64_saturating();
+        std::cmp::min(gas, gas_rsvp)
+    }
 }
 
 /// Returns the current transient data lifespan based on the execution environment.

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -517,6 +517,7 @@ fn test_callactor_inner(method_num: MethodNum, exit_code: ExitCode, valid_call_i
 
     if valid_call_input {
         // We only get to the send_generalized if the call params were valid
+        rt.expect_gas_available(10_000_000_000);
         rt.expect_send(
             target,
             method_num,
@@ -552,7 +553,6 @@ fn test_callactor_inner(method_num: MethodNum, exit_code: ExitCode, valid_call_i
         expected_exit_code: expected_exit,
         precompile_address: util::NativePrecompile::CallActor.eth_address(),
         output_size: 32,
-        gas_avaliable: 10_000_000_000u64,
         expected_return: expected_out,
         call_op: util::PrecompileCallOpcode::DelegateCall,
         input: contract_params,
@@ -591,12 +591,12 @@ fn call_actor_weird_offset() {
         expected_exit_code: util::PrecompileExit::Success,
         precompile_address: util::NativePrecompile::CallActor.eth_address(),
         output_size: 32,
-        gas_avaliable: 10_000_000_000u64,
         expected_return: vec![],
         call_op: util::PrecompileCallOpcode::DelegateCall,
         input,
     };
 
+    rt.expect_gas_available(10_000_000_000);
     rt.expect_send(
         addr,
         0,
@@ -640,7 +640,6 @@ fn call_actor_overlapping() {
     let mut test = util::PrecompileTest {
         precompile_address: util::NativePrecompile::CallActor.eth_address(),
         output_size: 32,
-        gas_avaliable: 10_000_000_000u64,
         call_op: util::PrecompileCallOpcode::DelegateCall,
         // overwritten in tests
         expected_return: vec![],
@@ -648,6 +647,7 @@ fn call_actor_overlapping() {
         input: call_params.clone().into(),
     };
 
+    rt.expect_gas_available(10_000_000_000);
     rt.expect_send(
         addr,
         0,
@@ -683,7 +683,6 @@ fn call_actor_id_with_full_address() {
     let mut test = util::PrecompileTest {
         precompile_address: util::NativePrecompile::CallActorId.eth_address(),
         output_size: 32,
-        gas_avaliable: 10_000_000_000u64,
         call_op: util::PrecompileCallOpcode::DelegateCall,
         // overwritten in tests
         expected_return: vec![],
@@ -691,6 +690,7 @@ fn call_actor_id_with_full_address() {
         input: call_params.clone().into(),
     };
 
+    rt.expect_gas_available(10_000_000_000);
     rt.expect_send(
         Address::new_id(actual_id_addr),
         0,
@@ -722,7 +722,6 @@ fn call_actor_syscall_error() {
     let mut test = util::PrecompileTest {
         precompile_address: util::NativePrecompile::CallActor.eth_address(),
         output_size: 32,
-        gas_avaliable: 10_000_000_000u64,
         call_op: util::PrecompileCallOpcode::DelegateCall,
         // overwritten in tests
         expected_return: vec![],
@@ -737,6 +736,7 @@ fn call_actor_syscall_error() {
         ..Default::default()
     };
 
+    rt.expect_gas_available(10_000_000_000);
     rt.expect_send(
         addr,
         0,
@@ -767,7 +767,6 @@ mod call_actor_invalid {
         let mut test = util::PrecompileTest {
             precompile_address: util::NativePrecompile::CallActor.eth_address(),
             output_size: 32,
-            gas_avaliable: 10_000_000_000u64,
             call_op: util::PrecompileCallOpcode::DelegateCall,
             // overwritten in tests
             expected_return: vec![],

--- a/actors/evm/tests/precompile.rs
+++ b/actors/evm/tests/precompile.rs
@@ -50,7 +50,6 @@ fn test_precompile_hash() {
     // invoke contract
     let contract_params = vec![0u8; 32];
 
-    rt.expect_gas_available(10_000_000_000u64);
     let result = util::invoke_contract(&rt, &contract_params);
     let expected =
         hex_literal::hex!("ace8597929092c14bd028ede7b07727875788c7e130278b5afed41940d965aba");
@@ -137,7 +136,6 @@ fn test_native_lookup_delegated_address() {
             precompile_address: NativePrecompile::LookupDelegatedAddress.eth_address(),
             output_size: 32,
             expected_exit_code: PrecompileExit::Success,
-            gas_avaliable: 10_000_000_000,
             call_op: util::PrecompileCallOpcode::Call(0),
             expected_return: expected,
             input: id_to_vec(&id),
@@ -185,7 +183,6 @@ fn test_resolve_delegated() {
     rt.add_id_address(bls, bls_target);
 
     fn test_resolve(rt: &MockRuntime, addr: FILAddress, expected: Vec<u8>) {
-        rt.expect_gas_available(10_000_000_000u64);
         let input = addr.to_bytes();
         let result = util::invoke_contract(rt, &input);
         rt.verify();
@@ -202,14 +199,12 @@ fn test_resolve_delegated() {
     test_resolve(&rt, unbound_del, vec![]);
 
     // invalid first param fails
-    rt.expect_gas_available(10_000_000_000u64);
     let result = util::invoke_contract(&rt, &[0xff; 1]);
     rt.verify();
     assert_eq!(&[0u8], result.as_slice());
     rt.reset();
 
     // invalid second param fails
-    rt.expect_gas_available(10_000_000_000u64);
     let input = {
         // first word is len
         let mut v = U256::from(5).to_bytes().to_vec();
@@ -237,7 +232,6 @@ fn test_precompile_randomness() {
             precompile_address: NativePrecompile::GetRandomness.eth_address(),
             output_size: 32,
             expected_exit_code: PrecompileExit::Success,
-            gas_avaliable: 10_000_000_000,
             call_op: util::PrecompileCallOpcode::StaticCall,
             input: rand_epoch_u256.to_bytes().to_vec(),
             expected_return: result.to_vec(),
@@ -251,7 +245,6 @@ fn test_precompile_randomness() {
             precompile_address: NativePrecompile::GetRandomness.eth_address(),
             output_size: 32,
             expected_exit_code: PrecompileExit::Reverted, // Precompile reverts due to syscall failure
-            gas_avaliable: 10_000_000_000,
             call_op: util::PrecompileCallOpcode::StaticCall,
             input: rand_epoch_u256.to_bytes().to_vec(),
             expected_return: vec![],
@@ -275,7 +268,6 @@ fn test_precompile_transfer() {
             precompile_address: addr,
             output_size: 32,
             expected_exit_code: PrecompileExit::Success,
-            gas_avaliable: 10_000_000_000,
             call_op: util::PrecompileCallOpcode::Call(1),
             input: vec![0xff; 32],
             expected_return: vec![],
@@ -308,7 +300,6 @@ fn test_precompile_transfer_nothing() {
             precompile_address: addr,
             output_size: 32,
             expected_exit_code: PrecompileExit::Success,
-            gas_avaliable: 10_000_000_000,
             call_op: util::PrecompileCallOpcode::Call(0),
             input: vec![0xff; 32],
             expected_return: vec![],
@@ -324,14 +315,12 @@ fn test_precompile_failure() {
     let rt = util::construct_and_verify(bytecode);
 
     // invalid input fails
-    rt.expect_gas_available(10_000_000_000u64);
     let result = util::invoke_contract(&rt, &[0xff; 32]);
     rt.verify();
     assert_eq!(&[0u8], result.as_slice());
     rt.reset();
 
     // not found succeeds with empty
-    rt.expect_gas_available(10_000_000_000u64);
     let input = FILAddress::new_delegated(111, b"foo").unwrap().to_bytes();
     let result = util::invoke_contract(&rt, &input);
     rt.verify();

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -187,7 +187,6 @@ pub struct PrecompileTest {
     pub expected_exit_code: PrecompileExit,
     pub precompile_address: EthAddress,
     pub output_size: u32,
-    pub gas_avaliable: u64,
     pub call_op: PrecompileCallOpcode,
     pub input: Vec<u8>,
     pub expected_return: Vec<u8>,
@@ -202,7 +201,6 @@ impl Debug for PrecompileTest {
             .field("output_size", &self.output_size)
             .field("input", &hex::encode(&self.input))
             .field("expected_output", &hex::encode(&self.expected_return))
-            .field("gas_avaliable", &self.gas_avaliable)
             .finish()
     }
 }
@@ -210,7 +208,6 @@ impl Debug for PrecompileTest {
 impl PrecompileTest {
     #[allow(dead_code)]
     pub fn run_test(&self, rt: &MockRuntime) {
-        rt.expect_gas_available(self.gas_avaliable);
         log::trace!("{:#?}", &self);
         // first byte is precompile number, second is output buffer size, rest is input to precompile
         let result = invoke_contract(


### PR DESCRIPTION
Previously, we'd query the remaining gas for every precompile call. Now, we only query the remaining gas when actually making a real call (i.e., only in the "native call" precompile.

Unfortunately, we make a syscall to query gas because we don't yet have a way to directly access this information from wasm. Ideally we'd implement https://github.com/filecoin-project/FIPs/discussions/845 and avoid this issue entirely, but that's a much larger project.

This should save ~14k gas per pre-compile call, which isn't nothing.