### PR TITLE
opt(make): unify the testing tools used in both development and CI (#1681)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ toolchain:
 	rustup show active-toolchain || rustup toolchain install
 .PHONY: toolchain
 
+install-nextest:
+	@command -v cargo-nextest >/dev/null 2>&1 || cargo install cargo-nextest --locked
+.PHONY: install-nextest
+
 # Run cargo fmt
 rustfmt: toolchain
 	cargo fmt --all --check
@@ -22,8 +26,8 @@ check: toolchain
 	cargo clippy --all -- -D warnings
 
 # Run cargo test
-test: toolchain
-	cargo test --workspace
+test: toolchain install-nextest
+	cargo nextest run test --workspace
 
 docker-builder:
 	$(DOCKER) buildx build $(DOCKER_PLATFORM) . -t $(DOCKER_IMAGE_NAME); \


### PR DESCRIPTION
close #1681 

Use `cargo-nextest` for `make test` as well, to unify the testing tools across development and CI.
If `cargo-nextest` is not installed, it will be installed automatically.