### PR TITLE
chore(ci): update install-action to address nextest errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Installing the toolchain
       run: make toolchain
     - name: Install cargo-nextest
-      uses: taiki-e/install-action@9903ab6feadaec33945de535fe9d181b91802a55 # v2.50.0
+      uses: taiki-e/install-action@c07504cae06f832dc8de08911c9a9c5cddb0d2d3 # v2.56.13
       with:
         tool: cargo-nextest
     - name: Running tests


### PR DESCRIPTION
There have been a couple of critical updates to install-action since the last pinned version which should fix the CI issues with nextest.