### PR TITLE
chore(coverage): allow code coverage to run of pull request

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,8 @@
 name: Coverage
 
-on: workflow_dispatch
+on:
+  pull_request:
+    branches: [ master ]
 
 env:
   RUSTFLAGS: -Dwarnings
@@ -49,3 +51,6 @@ jobs:
       uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
       with:
         files: lcov.info
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false
+        verbose: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,8 +1,10 @@
 name: Coverage
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
 
 env:
   RUSTFLAGS: -Dwarnings

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+- (?s:.*/tests/.*)\Z

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,4 @@
 ignore:
 - (?s:.*/tests/.*)\Z
+comment:
+  require_base: false


### PR DESCRIPTION
This PR adds:
- Runs `coverage` on every PR
- Adds `codecov.yml` for customising the test coverage generation