### PR TITLE
docs: add CONTRIBUTING.md guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,6 @@
 
 Welcome to the Filecoin built-in actors repository! This codebase serves as the canonical implementation of on-chain actors that power the Filecoin network and is a common good across all Filecoin client implementations.
 
-## Table of Contents
-
-- [Getting Started](#getting-started)
-- [Development Setup](#development-setup)
-- [Making Contributions](#making-contributions)
-- [Testing](#testing)
-- [Code Style and Standards](#code-style-and-standards)
-- [Pull Request Guidelines](#pull-request-guidelines)
-- [Issue Guidelines](#issue-guidelines)
-- [Release Process](#release-process)
-- [Getting Help](#getting-help)
-
 ## Getting Started
 
 ### Prerequisites
@@ -69,12 +57,14 @@ builtin-actors/
 
 ### Types of Contributions
 
-1. **FIP Implementation**: Implementing Filecoin Improvement Proposals
+1. **FIP Implementation**: Implementing Filecoin Improvement Proposals - many contributions involve implementing protocol improvements
 2. **Bug Fixes**: Addressing issues in actor logic or runtime
-3. **Performance Optimizations**: Improving gas efficiency and execution speed
-4. **Code Cleanup**: Removing deprecated code, improving maintainability
+3. **Performance Optimizations**: Improving gas efficiency and execution speed - reducing gas costs is a key focus area
+4. **Code Cleanup**: Removing deprecated code, improving maintainability - including actor method deprecation as per FIPs
 5. **Testing**: Adding integration tests, scenario tests, or improving test coverage
 6. **Documentation**: Improving code documentation and examples
+7. **EVM Integration**: Enhancing Ethereum compatibility features
+8. **Code Modernization**: Updating to latest Rust features and best practices
 
 ### Contribution Workflow
 
@@ -84,14 +74,6 @@ builtin-actors/
 4. **Implement changes**: Follow the coding standards and test your changes
 5. **Test thoroughly**: Run the full test suite and ensure all checks pass
 6. **Submit a pull request**: Follow the PR guidelines below
-
-### Common Contribution Areas
-
-- **FIP Implementation**: Many contributions involve implementing protocol improvements
-- **Actor Method Deprecation**: Removing deprecated methods as per FIPs
-- **Performance Optimization**: Reducing gas costs and improving execution efficiency
-- **EVM Integration**: Enhancing Ethereum compatibility features
-- **Code Modernization**: Updating to latest Rust features and best practices
 
 ## Testing
 
@@ -154,15 +136,7 @@ make bundle
 
 ### PR Title Format
 
-Use descriptive prefixes:
-- `feat:` - New features
-- `fix:` - Bug fixes  
-- `chore:` - Maintenance tasks
-- `test:` - Testing improvements
-- `opt:` - Performance optimizations
-- `build:` - Build system changes
-
-Include FIP numbers when applicable: `FIP-0XXX: Description`
+Follow [Conventional Commits](https://www.conventionalcommits.org/) format. If your PR is related to a FIP (Filecoin Improvement Proposal), include the FIP number in the title: `FIP-0XXX: Description`
 
 ### PR Description
 
@@ -179,71 +153,26 @@ Include FIP numbers when applicable: `FIP-0XXX: Description`
 - Large changes may require additional review from domain experts
 - Draft PRs are encouraged for work-in-progress to get early feedback
 
-## Issue Guidelines
+### Who merges PRs and when are they merged?
 
-### Reporting Bugs
+#### Maintainer Approval Process
 
-Include:
-- Clear reproduction steps
-- Expected vs actual behavior
-- Environment details (Rust version, network, etc.)
-- Relevant error messages or logs
+When maintainers give approval on a PR, they are conveying "this is ready to merge whenever" unless they leave comments indicating otherwise. Maintainers may also approve PRs that have minor cleanup items that would be nice to address but aren't blocking - authors should address these if at all possible.
 
-### Feature Requests
+**Important**: Maintainers generally won't merge PRs for you. This allows authors to:
+- Complete any final touchups they may be working on
+- Sequence the merge with other related changes
+- Maintain control over the timing of their contributions
 
-- Check if a FIP exists for the feature
-- Describe the use case and motivation
-- Consider backwards compatibility implications
-- Provide implementation suggestions if possible
+#### FIP-Related PRs
 
-### Labels
+For PRs implementing FIPs:
 
-- `good first issue`: Suitable for new contributors
-- `help wanted`: Community contributions welcome
-- `cleanup`: Code maintenance and cleanup
-- `enhancement`: New features or improvements
-- `bug`: Issues with existing functionality
-- `testing`: Test-related improvements
+- **Standard Process**: We generally wait to merge FIP implementation PRs until the FIP has moved to "Accepted" status.  This includes waiting for FIPs in "Last Call" to move out of "Last Call".
+- **Exception for Low-Risk Changes**: If a FIP is uncontroversial and represents pure code cleanup with low risk of needing to revert, we may merge to master before the FIP reaches "Accepted"
+
+This approach minimizes the risk of having to revert changes if FIP requirements change during the review process.
 
 ## Release Process
 
-Releases follow a structured process detailed in [RELEASE.md](RELEASE.md):
-
-1. Version updates are made via PR to `Cargo.toml`
-2. Automated workflows handle bundle building and asset uploads
-3. Git tags are created when releases are published
-4. Multiple network bundles are built for each release
-
-## Getting Help
-
-### Resources
-
-- **Documentation**: Check the [README](README.md) and inline code documentation
-- **Examples**: See the `examples/` directory for usage patterns
-- **Integration Tests**: Review `integration_tests/` for complex scenarios
-- **FIPs**: Filecoin Improvement Proposals at [github.com/filecoin-project/FIPs](https://github.com/filecoin-project/FIPs)
-
-### Communication
-
-- **GitHub Issues**: For bug reports and feature requests
-- **GitHub Discussions**: For general questions and community discussion
-- **Filecoin Slack**: Join the [Filecoin Slack](https://filecoin.io/slack) for real-time discussion
-
-### Finding Contribution Opportunities
-
-- Browse issues labeled `good first issue` for beginner-friendly tasks
-- Check `help wanted` issues for community contribution opportunities
-- Look for `cleanup` labeled issues for code maintenance tasks
-- Review open FIPs that need implementation
-
-## Code of Conduct
-
-This project follows the Filecoin community standards. Be respectful, inclusive, and constructive in all interactions.
-
-## License
-
-This project is dual-licensed under [MIT](LICENSE-MIT) and [Apache 2.0](LICENSE-APACHE) licenses. By contributing, you agree to license your contributions under the same terms.
-
----
-
-Thank you for contributing to the Filecoin built-in actors! Your contributions help secure and improve the Filecoin network for everyone.
+Releases follow a structured process detailed in [RELEASE.md](RELEASE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,7 @@ make bundle
 - Follow existing patterns for state management and CBOR encoding - specifically the Filecoin chain *strictly* uses tuple encoding and some types (such as `BigInt`) have custom encodings that must be explicitly declared
 - Ensure gas-efficient implementations - while hard to measure, knowing that gas is measured at the WASM instruction level, efficient code paths tend toward cheaper gas
 - Use appropriate error codes and messages
+- Include an appropriate amount of logging for future debugging
 
 ### Security Considerations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ builtin-actors/
 
 ### Types of Contributions
 
-1. **FIP Implementation**: Implementing Filecoin Improvement Proposals - many contributions involve implementing protocol improvements
+1. **FIP Implementation**: Implementing Filecoin Improvement Proposals - many contributions involve implementing protocol improvements or other backward-incompatible changes
 2. **Bug Fixes**: Addressing issues in actor logic or runtime
 3. **Performance Optimizations**: Improving gas efficiency and execution speed - reducing gas costs is a key focus area
 4. **Code Cleanup**: Removing deprecated code, improving maintainability - including actor method deprecation as per FIPs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,8 @@ make bundle
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/) format. If your PR is related to a FIP (Filecoin Improvement Proposal), include the FIP number in the title: `FIP-0XXX: Description`
 
+This project uses a GitHub build queue and your branch will be squashed down to a single commit with the name of your pull request. Ensure your PR title is of the appropriate format, or it may be changed for you before merging.
+
 ### PR Description
 
 1. **Clear summary** of what the PR accomplishes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ make bundle
 
 ### Security Considerations
 
-- All actor methods must validate caller permissions
+- All actor methods must validate caller permissions - e.g. see `rt.validate_immediate_caller_is()` calls in existing actors
 - Input parameters must be thoroughly validated
 - State mutations must be atomic and consistent
 - Avoid patterns that could lead to reentrancy issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ builtin-actors/
 5. **Testing**: Adding integration tests, scenario tests, or improving test coverage
 6. **Documentation**: Improving code documentation and examples
 7. **EVM Integration**: Enhancing Ethereum compatibility features
-8. **Code Modernization**: Updating to latest Rust features and best practices
+8. **Code Modernization**: Updating to latest Rust features and best practices, or updating / replacing dependencies
 
 ### Contribution Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ make bundle
 
 - All actor methods must validate caller permissions - e.g. see `rt.validate_immediate_caller_is()` calls in existing actors
 - Input parameters must be thoroughly validated
-- State mutations must be atomic and consistent
+- State mutations must be atomic and consistent - note the use of `rt.transaction()` in existing actors to mutate state
 - Avoid patterns that could lead to reentrancy issues
 
 ## Pull Request Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ make bundle
 
 - Implement the `Actor` trait for new actors
 - Use the shared runtime utilities from the `runtime` crate
-- Follow existing patterns for state management and CBOR encoding
+- Follow existing patterns for state management and CBOR encoding - specifically the Filecoin chain *strictly* uses tuple encoding and some types (such as `BigInt`) have custom encodings that must be explicitly declared
 - Ensure gas-efficient implementations
 - Use appropriate error codes and messages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ make bundle
 - All actor methods must validate caller permissions - e.g. see `rt.validate_immediate_caller_is()` calls in existing actors
 - Input parameters must be thoroughly validated
 - State mutations must be atomic and consistent - note the use of `rt.transaction()` in existing actors to mutate state
-- Avoid patterns that could lead to reentrancy issues
+- Take extreme care when interacting with smart contracts, either via exported methods or message sends to actors other than those defined here - be mindful of gas exhaustion, reentrancy issues and other potential vectors for malicious or unintended behavior
 
 ## Pull Request Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ make bundle
 
 - Use Rust 2024 edition features
 - Follow the project's `rustfmt.toml` configuration
-- Address all Clippy warnings (`cargo clippy --all -- -D warnings`)
+- Address all Clippy warnings (`cargo clippy --all -- -D warnings` - available as `make check`)
 - Use explicit error handling with `ActorError` types
 - Prefer `cargo-nextest` for test execution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,249 @@
+# Contributing to Filecoin Built-in Actors
+
+Welcome to the Filecoin built-in actors repository! This codebase serves as the canonical implementation of on-chain actors that power the Filecoin network and is a common good across all Filecoin client implementations.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Development Setup](#development-setup)
+- [Making Contributions](#making-contributions)
+- [Testing](#testing)
+- [Code Style and Standards](#code-style-and-standards)
+- [Pull Request Guidelines](#pull-request-guidelines)
+- [Issue Guidelines](#issue-guidelines)
+- [Release Process](#release-process)
+- [Getting Help](#getting-help)
+
+## Getting Started
+
+### Prerequisites
+
+- **Rust**: This project uses Rust 2024 edition. Install via [rustup](https://rustup.rs/)
+- **Make**: Required for build automation
+- **Docker**: Required for reproducible builds
+- **Git**: For version control
+- **GitHub CLI (gh)**: Recommended for managing issues and PRs
+
+### Repository Structure
+
+```
+builtin-actors/
+├── actors/           # Individual actor implementations
+│   ├── account/      # Account actor
+│   ├── cron/         # Cron actor
+│   ├── miner/        # Storage miner actor
+│   ├── market/       # Storage market actor
+│   ├── evm/          # Ethereum Virtual Machine actor
+│   └── ...           # Other actors
+├── runtime/          # Shared actor runtime utilities
+├── test_vm/          # Test virtual machine
+├── integration_tests/ # Cross-actor integration tests
+└── state/            # State management utilities
+```
+
+## Development Setup
+
+1. **Clone the repository:**
+   ```bash
+   git clone https://github.com/filecoin-project/builtin-actors.git
+   cd builtin-actors
+   ```
+
+2. **Install the toolchain:**
+   ```bash
+   make toolchain
+   ```
+
+3. **Install testing dependencies:**
+   ```bash
+   make install-nextest
+   ```
+
+4. **Verify your setup:**
+   ```bash
+   make check
+   make test
+   ```
+
+## Making Contributions
+
+### Types of Contributions
+
+1. **FIP Implementation**: Implementing Filecoin Improvement Proposals
+2. **Bug Fixes**: Addressing issues in actor logic or runtime
+3. **Performance Optimizations**: Improving gas efficiency and execution speed
+4. **Code Cleanup**: Removing deprecated code, improving maintainability
+5. **Testing**: Adding integration tests, scenario tests, or improving test coverage
+6. **Documentation**: Improving code documentation and examples
+
+### Contribution Workflow
+
+1. **Check existing issues**: Look for relevant issues, especially those labeled `good first issue` or `help wanted`
+2. **Create an issue**: For new features or significant changes, create an issue first to discuss the approach
+3. **Fork and branch**: Create a feature branch from `master`
+4. **Implement changes**: Follow the coding standards and test your changes
+5. **Test thoroughly**: Run the full test suite and ensure all checks pass
+6. **Submit a pull request**: Follow the PR guidelines below
+
+### Common Contribution Areas
+
+- **FIP Implementation**: Many contributions involve implementing protocol improvements
+- **Actor Method Deprecation**: Removing deprecated methods as per FIPs
+- **Performance Optimization**: Reducing gas costs and improving execution efficiency
+- **EVM Integration**: Enhancing Ethereum compatibility features
+- **Code Modernization**: Updating to latest Rust features and best practices
+
+## Testing
+
+### Running Tests
+
+```bash
+# Run all tests
+make test
+
+# Run formatting check
+make rustfmt
+
+# Run linting
+make check
+
+# Build bundles for testing
+make bundle
+```
+
+### Test Requirements
+
+- All new code must include appropriate unit tests
+- Integration tests should be added for cross-actor functionality
+- Performance-sensitive changes should include benchmarks
+- Test scenarios should cover edge cases and error conditions
+
+### Test Categories
+
+1. **Unit Tests**: Located in each actor's `tests/` directory
+2. **Integration Tests**: Located in `integration_tests/src/tests/`
+3. **Scenario Tests**: Complex multi-actor workflows
+4. **EVM Tests**: Ethereum compatibility testing in `actors/evm/tests/`
+
+## Code Style and Standards
+
+### Rust Guidelines
+
+- Use Rust 2024 edition features
+- Follow the project's `rustfmt.toml` configuration
+- Address all Clippy warnings (`cargo clippy --all -- -D warnings`)
+- Use explicit error handling with `ActorError` types
+- Prefer `cargo-nextest` for test execution
+
+### Actor Development
+
+- Implement the `Actor` trait for new actors
+- Use the shared runtime utilities from the `runtime` crate
+- Follow existing patterns for state management and CBOR encoding
+- Ensure gas-efficient implementations
+- Use appropriate error codes and messages
+
+### Security Considerations
+
+- All actor methods must validate caller permissions
+- Input parameters must be thoroughly validated
+- State mutations must be atomic and consistent
+- Avoid patterns that could lead to reentrancy issues
+
+## Pull Request Guidelines
+
+### PR Title Format
+
+Use descriptive prefixes:
+- `feat:` - New features
+- `fix:` - Bug fixes  
+- `chore:` - Maintenance tasks
+- `test:` - Testing improvements
+- `opt:` - Performance optimizations
+- `build:` - Build system changes
+
+Include FIP numbers when applicable: `FIP-0XXX: Description`
+
+### PR Description
+
+1. **Clear summary** of what the PR accomplishes
+2. **Context** explaining why the change is needed
+3. **Testing** information describing how the change was validated
+4. **Related issues** using `Closes #XXX` or `Relates to #XXX`
+5. **Breaking changes** clearly documented if any
+
+### Review Process
+
+- All PRs require review from core maintainers
+- Automated checks must pass (formatting, linting, tests, builds)
+- Large changes may require additional review from domain experts
+- Draft PRs are encouraged for work-in-progress to get early feedback
+
+## Issue Guidelines
+
+### Reporting Bugs
+
+Include:
+- Clear reproduction steps
+- Expected vs actual behavior
+- Environment details (Rust version, network, etc.)
+- Relevant error messages or logs
+
+### Feature Requests
+
+- Check if a FIP exists for the feature
+- Describe the use case and motivation
+- Consider backwards compatibility implications
+- Provide implementation suggestions if possible
+
+### Labels
+
+- `good first issue`: Suitable for new contributors
+- `help wanted`: Community contributions welcome
+- `cleanup`: Code maintenance and cleanup
+- `enhancement`: New features or improvements
+- `bug`: Issues with existing functionality
+- `testing`: Test-related improvements
+
+## Release Process
+
+Releases follow a structured process detailed in [RELEASE.md](RELEASE.md):
+
+1. Version updates are made via PR to `Cargo.toml`
+2. Automated workflows handle bundle building and asset uploads
+3. Git tags are created when releases are published
+4. Multiple network bundles are built for each release
+
+## Getting Help
+
+### Resources
+
+- **Documentation**: Check the [README](README.md) and inline code documentation
+- **Examples**: See the `examples/` directory for usage patterns
+- **Integration Tests**: Review `integration_tests/` for complex scenarios
+- **FIPs**: Filecoin Improvement Proposals at [github.com/filecoin-project/FIPs](https://github.com/filecoin-project/FIPs)
+
+### Communication
+
+- **GitHub Issues**: For bug reports and feature requests
+- **GitHub Discussions**: For general questions and community discussion
+- **Filecoin Slack**: Join the [Filecoin Slack](https://filecoin.io/slack) for real-time discussion
+
+### Finding Contribution Opportunities
+
+- Browse issues labeled `good first issue` for beginner-friendly tasks
+- Check `help wanted` issues for community contribution opportunities
+- Look for `cleanup` labeled issues for code maintenance tasks
+- Review open FIPs that need implementation
+
+## Code of Conduct
+
+This project follows the Filecoin community standards. Be respectful, inclusive, and constructive in all interactions.
+
+## License
+
+This project is dual-licensed under [MIT](LICENSE-MIT) and [Apache 2.0](LICENSE-APACHE) licenses. By contributing, you agree to license your contributions under the same terms.
+
+---
+
+Thank you for contributing to the Filecoin built-in actors! Your contributions help secure and improve the Filecoin network for everyone.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,6 @@ Welcome to the Filecoin built-in actors repository! This codebase serves as the 
 - **Make**: Required for build automation
 - **Docker**: Required for reproducible builds
 - **Git**: For version control
-- **GitHub CLI (gh)**: Recommended for managing issues and PRs
 
 ### Repository Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ make bundle
 - Implement the `Actor` trait for new actors
 - Use the shared runtime utilities from the `runtime` crate
 - Follow existing patterns for state management and CBOR encoding - specifically the Filecoin chain *strictly* uses tuple encoding and some types (such as `BigInt`) have custom encodings that must be explicitly declared
-- Ensure gas-efficient implementations
+- Ensure gas-efficient implementations - while hard to measure, knowing that gas is measured at the WASM instruction level, efficient code paths tend toward cheaper gas
 - Use appropriate error codes and messages
 
 ### Security Considerations

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ Precompiled actor bundles are provided as [release binaries][releases] in this r
 [`fil_builtin_actors_bundle`](https://crates.io/crates/fil_builtin_actors_bundle) crate on
 [crates.io](https://crates.io) will not be updated.
 
-## [Releasing](RELEASE.md)
+## Releasing
+
+See [RELEASE.md](RELEASE.md) for the release process.
 
 ## Instructions for client implementations
 
@@ -166,6 +168,10 @@ and fulfils two roles:
 This codebase was originally forked from the actors v6 implementation of the
 [Forest client](https://github.com/ChainSafe/forest/), and was adapted to the
 FVM environment.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to this project.
 
 ## Community
 


### PR DESCRIPTION
## Summary

- Add comprehensive CONTRIBUTING.md guide with development setup, contribution workflow, testing guidelines, and PR/merge process
- Update README.md to link to CONTRIBUTING.md and improve release section formatting

## Changes

- **CONTRIBUTING.md**: New comprehensive contribution guide covering:
  - Development setup and prerequisites
  - Types of contributions and workflow
  - Testing requirements and categories
  - Code style and security standards
  - PR guidelines with conventional commits format
  - Clear process for when PRs are merged, including FIP-related policies
- **README.md**: Add contributing section and update release section formatting

🤖 Generated with [Claude Code](https://claude.ai/code)