### PR TITLE
Remove reentrant approval -- checks effects interactions

### DIFF
--- a/integration_tests/src/tests/multisig_test.rs
+++ b/integration_tests/src/tests/multisig_test.rs
@@ -1,8 +1,9 @@
 use export_macro::vm_test;
 use fil_actor_init::ExecReturn;
 use fil_actor_multisig::{
-    Method as MsigMethod, PENDING_TXN_CONFIG, PendingTxnMap, ApproveReturn, ProposeParams, RemoveSignerParams, AddSignerParams,
-    State as MsigState, SwapSignerParams, Transaction, TxnID, TxnIDParams, compute_proposal_hash,
+    AddSignerParams, ApproveReturn, Method as MsigMethod, PENDING_TXN_CONFIG, PendingTxnMap,
+    ProposeParams, RemoveSignerParams, State as MsigState, SwapSignerParams, Transaction, TxnID,
+    TxnIDParams, compute_proposal_hash,
 };
 use fil_actors_runtime::cbor::serialize;
 use fil_actors_runtime::runtime::Policy;
@@ -208,10 +209,7 @@ pub fn recursive_approve_fails_test(v: &dyn VM) {
 
     // Add multisig as signer
     // Add msig_addr itself as signer using the AddSigner method
-    let add_signer_params = AddSignerParams {
-        signer: msig_addr,
-        increase: true,
-    };
+    let add_signer_params = AddSignerParams { signer: msig_addr, increase: true };
     println!("add signer coming");
     // Propose to add msig_addr as a signer (only msig can call AddSigner directly, so we must propose)
     let propose_add_signer_params = ProposeParams {
@@ -231,14 +229,7 @@ pub fn recursive_approve_fails_test(v: &dyn VM) {
 
     println!("add signer worked");
     // Fund the multisig
-    apply_ok(
-        v,
-        &alice,
-        &msig_addr,
-        &TokenAmount::from_whole(100),
-        METHOD_SEND,
-        None::<RawBytes>,
-    );
+    apply_ok(v, &alice, &msig_addr, &TokenAmount::from_whole(100), METHOD_SEND, None::<RawBytes>);
 
     // Create a transaction that tries to approve itself
     let approve_params = TxnIDParams {
@@ -280,18 +271,15 @@ pub fn recursive_approve_fails_test(v: &dyn VM) {
     );
 
     // Bob approves the transaction, which should execute the call to approve itself
-    let approve_txn_params = TxnIDParams {
-        id: TxnID(1),
-        proposal_hash: vec![],
-    };
+    let approve_txn_params = TxnIDParams { id: TxnID(1), proposal_hash: vec![] };
 
     // When Bob approves, the transaction should execute successfully, but the inner call
-    // to approve itself should fail with USR_NOT_FOUND since we have now implemented 
-    // checks effects interactions correctly and remove the pending txn id before making the 
+    // to approve itself should fail with USR_NOT_FOUND since we have now implemented
+    // checks effects interactions correctly and remove the pending txn id before making the
     // execution inner call
     println!("approve coming");
 
-    let result : ApproveReturn = apply_ok(
+    let result: ApproveReturn = apply_ok(
         v,
         &bob,
         &msig_addr,

--- a/integration_tests/src/tests/multisig_test.rs
+++ b/integration_tests/src/tests/multisig_test.rs
@@ -205,12 +205,11 @@ pub fn recursive_approve_fails_test(v: &dyn VM) {
 
     // Create a 1-of-2 multisig
     let msig_addr = create_msig(v, &[alice, bob], 1);
-    println!("msig_addr: {:?}", msig_addr);
 
     // Add multisig as signer
     // Add msig_addr itself as signer using the AddSigner method
     let add_signer_params = AddSignerParams { signer: msig_addr, increase: true };
-    println!("add signer coming");
+
     // Propose to add msig_addr as a signer (only msig can call AddSigner directly, so we must propose)
     let propose_add_signer_params = ProposeParams {
         to: msig_addr,
@@ -227,7 +226,6 @@ pub fn recursive_approve_fails_test(v: &dyn VM) {
         Some(propose_add_signer_params),
     );
 
-    println!("add signer worked");
     // Fund the multisig
     apply_ok(v, &alice, &msig_addr, &TokenAmount::from_whole(100), METHOD_SEND, None::<RawBytes>);
 
@@ -277,7 +275,6 @@ pub fn recursive_approve_fails_test(v: &dyn VM) {
     // to approve itself should fail with USR_NOT_FOUND since we have now implemented
     // checks effects interactions correctly and remove the pending txn id before making the
     // execution inner call
-    println!("approve coming");
 
     let result: ApproveReturn = apply_ok(
         v,
@@ -289,7 +286,6 @@ pub fn recursive_approve_fails_test(v: &dyn VM) {
     )
     .deserialize()
     .expect("failed to deserialize ApproveReturn");
-    println!("approve worked");
 
     // But the return should indicate that the inner transaction failed with USR_NOT_FOUND
     assert!(result.applied, "Transaction should have been applied");

--- a/test_vm/tests/suite/multisig_test.rs
+++ b/test_vm/tests/suite/multisig_test.rs
@@ -1,5 +1,6 @@
 use fil_actors_integration_tests::tests::{
     proposal_hash_test, swap_self_1_of_2_test, swap_self_2_of_3_test, test_delete_self_inner_test,
+    recursive_approve_fails_test,
 };
 use fil_actors_runtime::test_blockstores::MemoryBlockstore;
 use test_vm::TestVM;
@@ -36,4 +37,11 @@ fn swap_self_2_of_3() {
     let store = MemoryBlockstore::new();
     let v = TestVM::new_with_singletons(store);
     swap_self_2_of_3_test(&v);
+}
+
+#[test]
+fn recursive_approve_fails() {
+    let store = MemoryBlockstore::new();
+    let v = TestVM::new_with_singletons(store);
+    recursive_approve_fails_test(&v);
 }

--- a/test_vm/tests/suite/multisig_test.rs
+++ b/test_vm/tests/suite/multisig_test.rs
@@ -1,6 +1,6 @@
 use fil_actors_integration_tests::tests::{
-    proposal_hash_test, swap_self_1_of_2_test, swap_self_2_of_3_test, test_delete_self_inner_test,
-    recursive_approve_fails_test,
+    proposal_hash_test, recursive_approve_fails_test, swap_self_1_of_2_test, swap_self_2_of_3_test,
+    test_delete_self_inner_test,
 };
 use fil_actors_runtime::test_blockstores::MemoryBlockstore;
 use test_vm::TestVM;


### PR DESCRIPTION
For the past 5 years we've put up with the builtin multisig having re-entrant approvals.  We haven't revisitied this since the launch of fvm but when composed with a smart contract the unexpected nature of this behavior could be used as a primitive in an attack relying on trust or social engineering.  Let's close up this security hole now.

The new test produces stack overflow on test_vm when applied to master without the fix since it is not as clever as ref fvm.  With the fix the test passes demonstrating that the issue is gone for good.