### PR TITLE
feat(evm): add EIP-7939 CLZ opcode (0x1e)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2075,15 +2075,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5befb5191be3584a4edaf63435e8ff92ffff622e711ca7e77f8f8f365a9df8"
+checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
 dependencies = [
  "proptest",
  "rand 0.8.5",
  "rand 0.9.0",
  "ruint-macro",
- "serde_core",
+ "serde",
  "valuable",
  "zeroize",
 ]

--- a/actors/evm/src/interpreter/execution.rs
+++ b/actors/evm/src/interpreter/execution.rs
@@ -293,11 +293,6 @@ pub fn execute(
 mod tests {
     use crate::evm_unit_test;
 
-    #[test]
-    fn test_clz_opcode_value() {
-        assert_eq!(super::opcodes::CLZ, 0x1e);
-    }
-
     macro_rules! check_underflow_err {
         ($($ins:ident,)*) => {
             $(do_check_underflow_err!($ins);)*
@@ -361,6 +356,7 @@ mod tests {
             SHL,
             SHR,
             SAR,
+            CLZ,
             DUP1,
             DUP2,
             DUP3,
@@ -421,7 +417,6 @@ mod tests {
             CODECOPY,
             CREATE,
             CREATE2,
-            CLZ,
             RETURN,
             REVERT,
             SELFDESTRUCT,

--- a/actors/evm/src/interpreter/instructions/bitwise.rs
+++ b/actors/evm/src/interpreter/instructions/bitwise.rs
@@ -43,6 +43,8 @@ pub fn sar(shift: U256, mut value: U256) -> U256 {
     }
 }
 
+/// Implements EIP-7939 `CLZ`, returning the number of leading zero bits in a 256-bit word.
+/// `CLZ(0)` returns 256.
 #[inline]
 pub fn clz(value: U256) -> U256 {
     U256::from(value.leading_zeros())
@@ -57,21 +59,15 @@ mod tests {
     use fil_actors_runtime::test_utils::MockRuntime;
     use fvm_shared::econ::TokenAmount;
 
-    #[test]
-    fn test_clz_eip7939_vectors_unit() {
-        // Directly matches the EIP-7939 test cases.
-        assert_eq!(clz(U256::ZERO), U256::from(256));
-        assert_eq!(clz(U256::ONE << 255), U256::ZERO);
-        assert_eq!(clz(U256::MAX), U256::ZERO);
-        assert_eq!(clz(U256::ONE << 254), U256::ONE);
-        assert_eq!(clz((U256::ONE << 255) - U256::ONE), U256::ONE);
-        assert_eq!(clz(U256::ONE), U256::from(255));
+    mod test_vectors {
+        include!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/test_vectors.rs"));
     }
 
     #[test]
-    fn test_clz_misc_unit() {
-        // 2 is 10 binary, so 256 - 2 = 254
-        assert_eq!(clz(U256::from(2)), U256::from(254));
+    fn test_clz_eip7939_vectors_unit() {
+        for (input, expected) in test_vectors::clz_eip7939_test_vectors() {
+            assert_eq!(clz(input), expected);
+        }
     }
 
     fn clz_via_evm(value: U256) -> U256 {
@@ -109,14 +105,10 @@ mod tests {
     }
 
     #[test]
-    fn test_clz_eip7939_vectors() {
-        // From EIP-7939 test cases.
-        assert_eq!(clz_via_evm(U256::ZERO), U256::from(256));
-        assert_eq!(clz_via_evm(U256::ONE << 255), U256::ZERO);
-        assert_eq!(clz_via_evm(U256::MAX), U256::ZERO);
-        assert_eq!(clz_via_evm(U256::ONE << 254), U256::ONE);
-        assert_eq!(clz_via_evm((U256::ONE << 255) - U256::ONE), U256::ONE);
-        assert_eq!(clz_via_evm(U256::ONE), U256::from(255));
+    fn test_clz_eip7939_vectors_via_evm() {
+        for (input, expected) in test_vectors::clz_eip7939_test_vectors() {
+            assert_eq!(clz_via_evm(input), expected);
+        }
     }
 
     #[test]

--- a/actors/evm/tests/eip7939_clz.rs
+++ b/actors/evm/tests/eip7939_clz.rs
@@ -1,43 +1,28 @@
 use fil_actor_evm::interpreter::opcodes;
 use fil_actors_evm_shared::uints::U256;
 
+mod test_vectors;
 mod util;
 
 fn initcode_for_runtime(runtime: &[u8]) -> Vec<u8> {
-    let len: u16 = runtime.len().try_into().expect("runtime too large");
-
-    // initcode:
-    // PUSH2 len
-    // PUSH2 offset
-    // PUSH1 0x00
-    // CODECOPY
-    // PUSH2 len
-    // PUSH1 0x00
-    // RETURN
-    // <runtime bytes>
-    let init_len: u16 = 15;
-    let offset = init_len;
-
-    let [len_hi, len_lo] = len.to_be_bytes();
-    let [off_hi, off_lo] = offset.to_be_bytes();
-
-    let mut code = vec![
-        opcodes::PUSH2,
-        len_hi,
-        len_lo,
-        opcodes::PUSH2,
-        off_hi,
-        off_lo,
+    // Universal runtime constructor:
+    // https://github.com/wjmelements/evm/pull/87
+    const CONSTRUCTOR: [u8; 11] = [
         opcodes::PUSH1,
-        0x00,
+        0x0b,
+        opcodes::CODESIZE,
+        opcodes::SUB,
+        opcodes::DUP1,
+        opcodes::PUSH1,
+        0x0b,
+        opcodes::RETURNDATASIZE,
         opcodes::CODECOPY,
-        opcodes::PUSH2,
-        len_hi,
-        len_lo,
-        opcodes::PUSH1,
-        0x00,
+        opcodes::RETURNDATASIZE,
         opcodes::RETURN,
     ];
+
+    let mut code = Vec::with_capacity(CONSTRUCTOR.len() + runtime.len());
+    code.extend_from_slice(&CONSTRUCTOR);
     code.extend_from_slice(runtime);
     code
 }
@@ -45,17 +30,13 @@ fn initcode_for_runtime(runtime: &[u8]) -> Vec<u8> {
 fn clz_runtime() -> Vec<u8> {
     // Reads a 32-byte word from calldata[0..32], computes CLZ, and returns the 32-byte result.
     vec![
-        opcodes::PUSH1,
-        0x00,
+        opcodes::PUSH0,
         opcodes::CALLDATALOAD,
         opcodes::CLZ,
-        opcodes::PUSH1,
-        0x00,
+        opcodes::PUSH0,
         opcodes::MSTORE,
-        opcodes::PUSH1,
-        0x20,
-        opcodes::PUSH1,
-        0x00,
+        opcodes::MSIZE,
+        opcodes::PUSH0,
         opcodes::RETURN,
     ]
 }
@@ -71,16 +52,7 @@ fn eip7939_clz_vectors_end_to_end() {
     let initcode = initcode_for_runtime(&clz_runtime());
     let rt = util::construct_and_verify(initcode);
 
-    let vectors = [
-        (U256::ZERO, U256::from(256)),
-        (U256::ONE << 255, U256::ZERO),
-        (U256::MAX, U256::ZERO),
-        (U256::ONE << 254, U256::ONE),
-        ((U256::ONE << 255) - U256::ONE, U256::ONE),
-        (U256::ONE, U256::from(255)),
-    ];
-
-    for (input, expected) in vectors {
+    for (input, expected) in test_vectors::clz_eip7939_test_vectors() {
         let ret = util::invoke_contract(&rt, &u256_be_bytes(input));
         assert_eq!(ret.len(), 32);
         assert_eq!(ret.as_slice(), &u256_be_bytes(expected));

--- a/actors/evm/tests/test_vectors.rs
+++ b/actors/evm/tests/test_vectors.rs
@@ -1,0 +1,14 @@
+use fil_actors_evm_shared::uints::U256;
+
+/// EIP-7939 `CLZ` test vectors from https://eips.ethereum.org/EIPS/eip-7939
+#[allow(dead_code)]
+pub fn clz_eip7939_test_vectors() -> [(U256, U256); 6] {
+    [
+        (U256::ZERO, U256::from(256)),
+        (U256::ONE << 255, U256::ZERO),
+        (U256::MAX, U256::ZERO),
+        (U256::ONE << 254, U256::ONE),
+        ((U256::ONE << 255) - U256::ONE, U256::ONE),
+        (U256::ONE, U256::from(255)),
+    ]
+}


### PR DESCRIPTION
## Summary

Implements Ethereum EIP-7939 (Count Leading Zeros) for the FEVM EVM interpreter by adding the `CLZ` opcode at byte `0x1e`.

## Changes

- Adds `CLZ` (`0x1e`) to the opcode table and instruction dispatch.
- Implements `CLZ` semantics over 256-bit words (`CLZ(0) = 256`).
- Adds tests covering the EIP-7939 test vectors:
  - unit + bytecode-level tests in the interpreter
  - end-to-end actor test executing `CLZ` in a deployed EVM actor

## Notes

- Full workspace `cargo test` may require a wasm32-capable clang; on macOS this can be run with `CC=/opt/homebrew/opt/llvm/bin/clang cargo test`.

## Related

- FIP discussion: https://github.com/filecoin-project/FIPs/discussions/1229
- FIP PR: https://github.com/filecoin-project/FIPs/pull/1230
