### PR TITLE
chore: fix advisory issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -442,7 +442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.106",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2075,15 +2075,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.14.0"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
+checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
 dependencies = [
  "proptest",
  "rand 0.8.5",
  "rand 0.9.0",
  "ruint-macro",
- "serde",
+ "serde_core",
  "valuable",
  "zeroize",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,6 @@
 [advisories]
 ignore = [
    { id = "RUSTSEC-2024-0436", reason = "paste@1.0.15 excluded pending removal from alloy-core and syn-solidity; see https://github.com/alloy-rs/core/issues/897" },
-   { id = "RUSTSEC-2025-0014", reason = "humantime@2.1.0 is excluded pending an update of pretty_env_logger to use env_logger@0.11 which removes it" },
 ]
 
 [licenses]


### PR DESCRIPTION
See issues in https://github.com/filecoin-project/builtin-actors/actions/runs/21986823338/job/63523064727?pr=1710

```
error[vulnerability]: Integer overflow in `BytesMut::reserve`
   ┌─ /github/workspace/Cargo.lock:21:1
   │
21 │ bytes 1.10.1 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
   │
   ├ ID: RUSTSEC-2026-0007
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0007
   ├ In the unique reclaim path of `BytesMut::reserve`, the condition
     ```rs
     if v_capacity >= new_cap + offset
     ```
     uses an unchecked addition. When `new_cap + offset` overflows `usize` in release builds, this condition may incorrectly pass, causing `self.cap` to be set to a value that exceeds the actual allocated capacity. Subsequent APIs such as `spare_capacity_mut()` then trust this corrupted `cap` value and may create out-of-bounds slices, leading to UB.
     
     This behavior is observable in release builds (integer overflow wraps), whereas debug builds panic due to overflow checks.
     
     ## PoC
     
     ```rs
     use bytes::*;
     
     fn main() {
         let mut a = BytesMut::from(&b"hello world"[..]);
         let mut b = a.split_off(5);
     
         // Ensure b becomes the unique owner of the backing storage
         drop(a);
     
         // Trigger overflow in new_cap + offset inside reserve
         b.reserve(usize::MAX - 6);
     
         // This call relies on the corrupted cap and may cause UB & HBO
         b.put_u8(b'h');
     }
     ```
     
     # Workarounds
     
     Users of `BytesMut::reserve` are only affected if integer overflow checks are configured to wrap. When integer overflow is configured to panic, this issue does not apply.
   ├ Announcement: https://github.com/advisories/GHSA-434x-w66g-qw3r
   ├ Solution: Upgrade to >=1.11.1 (try `cargo update -p bytes`)
   ├ bytes v1.10.1
     ├── alloy-primitives v1.0.0
     │   ├── alloy-core v1.0.0
     │   │   └── (dev) fil_actor_evm v17.0.0
     │   │       ├── (dev) fil_actor_eam v17.0.0
     │   │       │   └── fil_builtin_actors_bundle v17.0.0
     │   │       └── fil_builtin_actors_bundle v17.0.0 (*)
     │   └── alloy-sol-types v1.0.0
     │       └── alloy-core v1.0.0 (*)
     └── rlp v0.6.1
         └── fil_actor_eam v17.0.0 (*)

error[vulnerability]: Unsoundness of safe `reciprocal_mg10`
    ┌─ /github/workspace/Cargo.lock:166:1
    │
166 │ ruint 1.14.0 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
    │
    ├ ID: RUSTSEC-2025-0137
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0137
    ├ The function `reciprocal_mg10` is marked as safe but can trigger undefined behavior (out-of-bounds access) because it relies on `debug_assert!` for safety checks instead of `assert!`.
      
      When compiled in release mode, the `debug_assert!` is optimized out, potentially allowing invalid inputs to cause memory corruption.
    ├ Announcement: https://github.com/recmo/uint/issues/550
    ├ Solution: Upgrade to >=1.17.1 (try `cargo update -p ruint`)
    ├ ruint v1.14.0
      └── alloy-primitives v1.0.0
          ├── alloy-core v1.0.0
          │   └── (dev) fil_actor_evm v17.0.0
          │       ├── (dev) fil_actor_eam v17.0.0
          │       │   └── fil_builtin_actors_bundle v17.0.0
          │       └── fil_builtin_actors_bundle v17.0.0 (*)
          └── alloy-sol-types v1.0.0
              └── alloy-core v1.0.0 (*)

warning[advisory-not-detected]: advisory was not encountered
  ┌─ ./deny.toml:4:12
  │
4 │    { id = "RUSTSEC-2025-0014", reason = "humantime@2.1.0 is excluded pending an update of pretty_env_logger to use env_logger@0.11 which removes it" },
```