### PR TITLE
chore: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,16 @@ updates:
     directory: "/"
     open-pull-requests-limit: 1
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+    groups:
+      patch-versions:
+        update-types:
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     schedule:
       interval: "monthly"


### PR DESCRIPTION
Configured basic dependabot for the repo. Do we want to limit the dependencies scanned like in https://github.com/filecoin-project/ref-fvm/blob/f3629afcc9e339a89c4f2440edb77b09b11588c7/.github/dependabot.yml#L8-L35? Not sure. I think we should allow all updates.