### PR TITLE
chore: bump-version to 18.0.0-rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "fil_actors_runtime",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_datacap"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "cid",
  "fil_actors_runtime",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_eam"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "cid",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_ethaccount"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_evm"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "alloy-core",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "cid",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "cid",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "cid",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "cid",
@@ -938,11 +938,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_placeholder"
-version = "17.0.0"
+version = "18.0.0-rc1"
 
 [[package]]
 name = "fil_actor_power"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "cid",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "cid",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "cid",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_evm_shared"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "cid",
  "clap",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_state"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "bimap",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "test_vm"
-version = "17.0.0"
+version = "18.0.0-rc1"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "17.0.0"
+version = "18.0.0-rc1"
 license = "MIT OR Apache-2.0"
 edition = "2024"
 repository = "https://github.com/filecoin-project/builtin-actors"


### PR DESCRIPTION
Bumping the version in prep for the code-freeze and testing in Butterfly. Once confirmed to be working properly in Butterfly, will bump to a stable release with the RC