### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,13 +247,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cid"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
+checksum = "cbb4913a732503de004e94ce7a4e7119ffc55d1727cc9979ac3b52f511e6578c"
 dependencies = [
- "core2",
  "multibase",
  "multihash",
+ "no_std_io2",
  "serde",
  "serde_bytes",
  "unsigned-varint",
@@ -295,7 +304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "hex",
  "proptest",
  "serde",
@@ -308,25 +317,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -357,6 +372,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -451,7 +475,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -513,10 +537,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -553,7 +588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -585,7 +620,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -639,7 +674,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "rand 0.8.5",
- "sha3",
+ "sha3 0.10.8",
  "snafu",
 ]
 
@@ -694,9 +729,8 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_bundler"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45a69ccfe5935bb364169a6ff14a6d25d40a6d64b4c250693bf6cee699e0d79"
+version = "8.1.0"
+source = "git+https://github.com/hanabi1224/builtin-actors-bundler.git?branch=hm%2Fno-core2#88ae74bbd6778d46eaa29ddc7e5d17385f774bdf"
 dependencies = [
  "anyhow",
  "cid",
@@ -1121,7 +1155,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_repr",
- "sha2",
+ "sha2 0.11.0",
  "thiserror",
  "unsigned-varint",
  "vm_api",
@@ -1202,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "frc42_dispatch"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4701d2d5e6a8ed95ee124d607e8ef51bd8bda11f3bf3f472a5e14d552ed696e6"
+checksum = "5adda887b823f91643af62fbe2b44e8e08aecdc55167463996f30ccf4891d9c4"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
@@ -1216,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "frc42_hasher"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af72029ed0fafb01fda2d7f631b55f6916ad06e310a7b4241b933796b34d510c"
+checksum = "c23f342605b9ee11ae783e259b553e305807787be5ec7ead9ef086f6a17b4bfc"
 dependencies = [
  "fvm_sdk",
  "fvm_shared",
@@ -1227,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "frc42_macros"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0211504c112b71bcc2f1e9f25b8bc84b3bff043ff5a0ac3b960d273cb22c7bf"
+checksum = "f4a55499fbd3b12d5bbbecd18fbc59bc8774734c59e508776d0506a94c0e8178"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
@@ -1240,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "frc46_token"
-version = "14.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891f9917156c52c5c1c3f95e083e3e21370b8044164ebf7894f74c02fa5c4a18"
+checksum = "6d916a9e49951ff90d124cbb4e61306bb4012ef6dbda39628684e1cfecd2ed5b"
 dependencies = [
  "cid",
  "frc42_dispatch",
@@ -1303,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_actor_utils"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a9591b569cbafcc4685381067e702dedf56824db4f8b64d697a1bb9205530c"
+checksum = "e02939b3f50b030941710c3609fa8296d88cfde3793a973184fdafacc0262f0b"
 dependencies = [
  "anyhow",
  "cid",
@@ -1322,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_amt"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437a2791237a87bbb91f3c827b5c2e05789b8ba22467a8bce1be831e74612d00"
+checksum = "fe03301f8a37c660dc94ba6c912e885664eec151bfb6bbe9dd3f09c18fdf6e5b"
 dependencies = [
  "anyhow",
  "cid",
@@ -1351,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_blockstore"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b8b31e022f71b73440054f7e5171231a1ebc745adf075014d5aa8ea78ea283"
+checksum = "abf4ac541f791ccb38b3d7926045a16636dafda045e768fed58c96f35bead1ae"
 dependencies = [
  "anyhow",
  "cid",
@@ -1362,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_car"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f49d53950e37e2b310a6527135f4b9b09c2fb8c25f1846622131f9db965be0"
+checksum = "36ca69774997f300516f7795e092464c56765c7f5ab63d51061682cbef64772b"
 dependencies = [
  "cid",
  "fvm_ipld_blockstore",
@@ -1378,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_encoding"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fd0c7d16be0076920acd5bf13e705a80dfe6540d4722b19745daa9ea93722a"
+checksum = "60b78ddd909cfbcb210242e9b19804fbe17aae3866b6be3adcc1ed123484f928"
 dependencies = [
  "anyhow",
  "cid",
@@ -1395,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_hamt"
-version = "0.10.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92fa6ad9ebdb821f7d3183666a94b6fabd6640d5c83ce1cd850865746d2e4db"
+checksum = "e9f488edd2c502303fd956f2830abc24444a28567f8e212237851e35e13d3779"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1409,15 +1443,15 @@ dependencies = [
  "multihash-codetable",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.11.0",
  "thiserror",
 ]
 
 [[package]]
 name = "fvm_ipld_kamt"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a7ef4cf7dab3bf09a2c988f7fc88fa0a532be2ca96136470942426ec5f99f0"
+checksum = "808c3f259184b5e0c5eca5d081dac06c65ac28f7a50b2b93b81ac28dd693978c"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1432,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "4.7.5"
+version = "4.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e532109bf5bc699cfbe1b7e3bf694bed381c28f8a9243a1549254d43866e1588"
+checksum = "29dc0e6fe5cfac6cb6166b02b1a92eb8107afde1acd0bf2663c630da2434892a"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",
@@ -1447,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.7.5"
+version = "4.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d3a23bf6d2a96ca280745afea1a79c5b701d5ac07814ec50ea34380762d47a"
+checksum = "1616995131e985185980751c8852d9ad4877a42cf1d4b9b203406f98cba6b47b"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1575,7 +1609,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1583,6 +1617,15 @@ name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "ident_case"
@@ -1663,7 +1706,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1672,7 +1715,17 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1732,39 +1785,39 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
 dependencies = [
- "core2",
+ "no_std_io2",
  "serde",
  "unsigned-varint",
 ]
 
 [[package]]
 name = "multihash-codetable"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67996849749d25f1da9f238e8ace2ece8f9d6bdf3f9750aaf2ae7de3a5cad8ea"
+checksum = "facfe64780489b29aae20d32d0245219f4a8167f91193f7061589f5dae9ba307"
 dependencies = [
  "blake2b_simd",
- "core2",
- "digest",
+ "digest 0.11.2",
  "multihash-derive",
+ "no_std_io2",
  "ripemd",
- "sha2",
- "sha3",
+ "sha2 0.11.0",
+ "sha3 0.11.0",
 ]
 
 [[package]]
 name = "multihash-derive"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1b7edab35d920890b88643a765fc9bd295cf0201f4154dda231bef9b8404eb"
+checksum = "0576e09c49157d1910e522e595d2b32749b029dd0bc10ff6967d588490c30348"
 dependencies = [
- "core2",
  "multihash",
  "multihash-derive-impl",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -1778,6 +1831,15 @@ dependencies = [
  "quote",
  "syn 2.0.106",
  "synstructure",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1893,7 +1955,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1944,7 +2006,7 @@ checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2165,11 +2227,11 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
 dependencies = [
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2319,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "serde_ipld_dagcbor"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99600723cf53fb000a66175555098db7e75217c415bdd9a16a65d52a19dcc4fc"
+checksum = "46182f4f08349a02b45c998ba3215d3f9de826246ba02bb9dddfe9a2a2100778"
 dependencies = [
  "cbor4ii",
  "ipld-core",
@@ -2355,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "serde_tuple"
-version = "0.5.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f025b91216f15a2a32aa39669329a475733590a015835d1783549a56d09427"
+checksum = "6af196b9c06f0aa5555ab980c01a2527b0f67517da8d68b1731b9d4764846a6f"
 dependencies = [
  "serde",
  "serde_tuple_macros",
@@ -2365,13 +2427,13 @@ dependencies = [
 
 [[package]]
 name = "serde_tuple_macros"
-version = "0.5.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4076151d1a2b688e25aaf236997933c66e18b870d0369f8b248b8ab2be630d7e"
+checksum = "ec3a1e7d2eadec84deabd46ae061bf480a91a6bce74d25dad375bd656f2e19d8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2381,8 +2443,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2391,8 +2464,18 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
- "keccak",
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -2407,7 +2490,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,13 +247,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cid"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb4913a732503de004e94ce7a4e7119ffc55d1727cc9979ac3b52f511e6578c"
+checksum = "21a304f95f84d169a6f31c4d0a30d784643aaa0bbc9c1e449a2c23e963ec4971"
 dependencies = [
  "multibase",
  "multihash",
- "no_std_io2",
  "serde",
  "serde_bytes",
  "unsigned-varint",
@@ -730,7 +729,8 @@ dependencies = [
 [[package]]
 name = "fil_actor_bundler"
 version = "8.1.0"
-source = "git+https://github.com/hanabi1224/builtin-actors-bundler.git?branch=hm%2Fno-core2#88ae74bbd6778d46eaa29ddc7e5d17385f774bdf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee74a23eeee16b761e3afd12f31f57fc04853efd3190bfc3b09121902620eff"
 dependencies = [
  "anyhow",
  "cid",
@@ -1785,25 +1785,23 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "no_std_io2",
  "serde",
  "unsigned-varint",
 ]
 
 [[package]]
 name = "multihash-codetable"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "facfe64780489b29aae20d32d0245219f4a8167f91193f7061589f5dae9ba307"
+checksum = "60384411b100398c5b2fdca476eed82e9898d09f2c60d1b1b66c5080ebe06118"
 dependencies = [
  "blake2b_simd",
  "digest 0.11.2",
  "multihash-derive",
- "no_std_io2",
  "ripemd",
  "sha2 0.11.0",
  "sha3 0.11.0",
@@ -1811,35 +1809,25 @@ dependencies = [
 
 [[package]]
 name = "multihash-derive"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0576e09c49157d1910e522e595d2b32749b029dd0bc10ff6967d588490c30348"
+checksum = "4723acdce756db211a53f01b3419dbdf63cb48cef5df86260f55309364735fbf"
 dependencies = [
  "multihash",
  "multihash-derive-impl",
- "no_std_io2",
 ]
 
 [[package]]
 name = "multihash-derive-impl"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3dc7141bd06405929948754f0628d247f5ca1865be745099205e5086da957cb"
+checksum = "f932556f78452e5604cef711349d337ec081a9aa3c96e67b3127c8f5df05d550"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
  "synstructure",
-]
-
-[[package]]
-name = "no_std_io2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
-dependencies = [
- "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,7 @@ fil_actor_system = { workspace = true, features = ["fil-actor"] }
 fil_actor_verifreg = { workspace = true, features = ["fil-actor"] }
 
 [build-dependencies]
-# Pending merge and release of https://github.com/filecoin-project/builtin-actors-bundler/pull/29
-fil_actor_bundler = { version = "8.1.0", git = "https://github.com/hanabi1224/builtin-actors-bundler.git", branch = "hm/no-core2" }
+fil_actor_bundler = "8.1.0"
 cid = { workspace = true }
 fil_actors_runtime = { workspace = true }
 num-traits = { workspace = true }
@@ -115,13 +114,13 @@ rlp = { version = "0.6.1", default-features = false }
 substrate-bn = { version = "0.6.0", default-features = false }
 
 # IPLD/Encoding
-cid = { version = "0.11.1", default-features = false, features = [
+cid = { version = "0.11.3", default-features = false, features = [
      "serde",
      "std",
 ] }
-multihash = { version = "0.19.3", default-features = false }
-multihash-codetable = { version = "0.2", default-features = false }
-multihash-derive = { version = "0.9.1", default-features = false }
+multihash = { version = "0.19.5", default-features = false }
+multihash-codetable = { version = "0.2.2", default-features = false }
+multihash-derive = { version = "0.9.3", default-features = false }
 ipld-core = { version = "0.4.3", features = ["serde"] }
 integer-encoding = { version = "4.1.0", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,8 @@ fil_actor_system = { workspace = true, features = ["fil-actor"] }
 fil_actor_verifreg = { workspace = true, features = ["fil-actor"] }
 
 [build-dependencies]
-fil_actor_bundler = "8.0.0"
+# Pending merge and release of https://github.com/filecoin-project/builtin-actors-bundler/pull/29
+fil_actor_bundler = { version = "8.1.0", git = "https://github.com/hanabi1224/builtin-actors-bundler.git", branch = "hm/no-core2" }
 cid = { workspace = true }
 fil_actors_runtime = { workspace = true }
 num-traits = { workspace = true }
@@ -104,7 +105,7 @@ rand_chacha = "0.9.0"
 # Crypto
 k256 = { version = "0.13.4", default-features = false }
 blake2b_simd = "1.0"
-sha2 = "0.10"
+sha2 = "0.11"
 
 # EVM
 alloy-core = { version = "1.0.0", default-features = false, features = ["sol-types"] }
@@ -119,24 +120,24 @@ cid = { version = "0.11.1", default-features = false, features = [
      "std",
 ] }
 multihash = { version = "0.19.3", default-features = false }
-multihash-codetable = { version = "0.1.4", default-features = false }
+multihash-codetable = { version = "0.2", default-features = false }
 multihash-derive = { version = "0.9.1", default-features = false }
 ipld-core = { version = "0.4.3", features = ["serde"] }
 integer-encoding = { version = "4.1.0", default-features = false }
 
 # actor-utils
-fvm_actor_utils = "14.0.0"
-frc42_dispatch = "10.0.0"
-frc46_token = "14.1.0"
+fvm_actor_utils = "15"
+frc42_dispatch = "11"
+frc46_token = "15"
 
 # FVM
-fvm_sdk = "~4.7"
-fvm_shared = "~4.7"
+fvm_sdk = "~4.8"
+fvm_shared = "~4.8"
 fvm_ipld_encoding = "0.5.3"
 fvm_ipld_blockstore = "0.3.1"
-fvm_ipld_hamt = "0.10.4"
-fvm_ipld_kamt = "0.4.5"
-fvm_ipld_amt = "0.7.5"
+fvm_ipld_hamt = "0.10.6"
+fvm_ipld_kamt = "0.4.6"
+fvm_ipld_amt = "0.7.7"
 fvm_ipld_bitfield = "0.7.2"
 
 # workspace


### PR DESCRIPTION
With this, we could eliminate `core2` in `ref-fvm`.

Depends on: https://github.com/filecoin-project/builtin-actors-bundler/pull/29