### PR TITLE
feat: allow readonly delegatecalls to the call actor precompiles

### DIFF
--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -242,40 +242,41 @@ pub(super) fn get_randomness<RT: Runtime>(
 #[cfg(test)]
 mod tests {
     use super::call_actor_shared;
-    use crate::interpreter::precompiles::{PrecompileContext, PrecompileError};
+    use crate::interpreter::precompiles::PrecompileContext;
     use crate::interpreter::{CallKind, System};
     use fil_actors_evm_shared::uints::U256;
     use fil_actors_runtime::test_utils::MockRuntime;
+    use fvm_shared::sys::SendFlags;
+    use fvm_shared::{METHOD_SEND, address::Address, econ::TokenAmount, error::ExitCode};
 
-    // Regression test for the bug fixed by PR #1739:
-    // delegatecall into the CallActorId precompile from within a readonly (staticcall) context
-    // must be rejected with CallForbidden rather than proceeding to make cross-actor calls.
-    //
-    // Before the fix: reaches send_raw (consuming the gas_available expectation), then fails in
-    // flush() with ActorError::forbidden, and returns PrecompileError::VMError — not CallForbidden.
-    // After the fix: returns PrecompileError::CallForbidden immediately on the readonly check.
     #[test]
-    fn call_actor_id_precompile_rejects_readonly_delegatecall() {
+    fn call_actor_id_precompile_allows_readonly_delegatecall() {
         let rt = MockRuntime::default();
         rt.in_call.replace(true);
-        // gas_available() is called when evaluating send_raw's gas argument before the fix;
-        // after the fix the early return happens before that evaluation.
+        rt.set_read_only(true);
         rt.expect_gas_available(10_000_000_000);
-        // readonly=true simulates being inside an outer staticcall context.
+        // Empty input → method=METHOD_SEND (0), no params, addr_id=0 (f00).
+        // The mock adds READ_ONLY to the effective flags, matching this expectation.
+        let gas_limit = (63 * 10_000_000_000_u64) / 64;
+        rt.expect_send(
+            Address::new_id(0),
+            METHOD_SEND,
+            None,
+            TokenAmount::from_atto(0),
+            Some(gas_limit),
+            SendFlags::READ_ONLY,
+            None,
+            ExitCode::OK,
+            None,
+        );
         let mut system = System::new(&rt, true);
         let ctx = PrecompileContext {
-            call_type: CallKind::DelegateCall, // passes the existing call_type guard
+            call_type: CallKind::DelegateCall,
             gas: U256::MAX,
             value: U256::ZERO,
         };
-        // Empty input → method=METHOD_SEND (0), no params, addr_id=0.
         let result = call_actor_shared(&mut system, &[], ctx, true);
-        assert!(
-            matches!(result, Err(PrecompileError::CallForbidden)),
-            "expected CallForbidden for delegatecall in readonly context, got: {:?}",
-            result
-        );
-        // Clear any unconsumed expectations left over when the fix eliminates the gas_available call.
-        rt.reset();
+        assert!(result.is_ok(), "readonly delegatecall must be allowed, got: {:?}", result);
+        rt.verify();
     }
 }

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -138,11 +138,7 @@ pub(super) fn call_actor_shared<RT: Runtime>(
     let value: U256 = input_params.read_value()?;
 
     let flags: u64 = input_params.read_value()?;
-    let mut flags = SendFlags::from_bits(flags).ok_or(PrecompileError::InvalidInput)?;
-
-    if system.readonly {
-        flags |= SendFlags::READ_ONLY;
-    }
+    let flags = SendFlags::from_bits(flags).ok_or(PrecompileError::InvalidInput)?;
 
     let codec: u64 = input_params.read_value()?;
 

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -238,3 +238,44 @@ pub(super) fn get_randomness<RT: Runtime>(
     let randomness = system.rt.get_beacon_randomness(randomness_epoch);
     randomness.map(|r| r.to_vec()).map_err(|_| PrecompileError::InvalidInput)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::call_actor_shared;
+    use crate::interpreter::precompiles::{PrecompileContext, PrecompileError};
+    use crate::interpreter::{CallKind, System};
+    use fil_actors_evm_shared::uints::U256;
+    use fil_actors_runtime::test_utils::MockRuntime;
+
+    // Regression test for the bug fixed by PR #1739:
+    // delegatecall into the CallActorId precompile from within a readonly (staticcall) context
+    // must be rejected with CallForbidden rather than proceeding to make cross-actor calls.
+    //
+    // Before the fix: reaches send_raw (consuming the gas_available expectation), then fails in
+    // flush() with ActorError::forbidden, and returns PrecompileError::VMError — not CallForbidden.
+    // After the fix: returns PrecompileError::CallForbidden immediately on the readonly check.
+    #[test]
+    fn call_actor_id_precompile_rejects_readonly_delegatecall() {
+        let rt = MockRuntime::default();
+        rt.in_call.replace(true);
+        // gas_available() is called when evaluating send_raw's gas argument before the fix;
+        // after the fix the early return happens before that evaluation.
+        rt.expect_gas_available(10_000_000_000);
+        // readonly=true simulates being inside an outer staticcall context.
+        let mut system = System::new(&rt, true);
+        let ctx = PrecompileContext {
+            call_type: CallKind::DelegateCall, // passes the existing call_type guard
+            gas: U256::MAX,
+            value: U256::ZERO,
+        };
+        // Empty input → method=METHOD_SEND (0), no params, addr_id=0.
+        let result = call_actor_shared(&mut system, &[], ctx, true);
+        assert!(
+            matches!(result, Err(PrecompileError::CallForbidden)),
+            "expected CallForbidden for delegatecall in readonly context, got: {:?}",
+            result
+        );
+        // Clear any unconsumed expectations left over when the fix eliminates the gas_available call.
+        rt.reset();
+    }
+}

--- a/actors/evm/src/interpreter/precompiles/fvm.rs
+++ b/actors/evm/src/interpreter/precompiles/fvm.rs
@@ -138,7 +138,11 @@ pub(super) fn call_actor_shared<RT: Runtime>(
     let value: U256 = input_params.read_value()?;
 
     let flags: u64 = input_params.read_value()?;
-    let flags = SendFlags::from_bits(flags).ok_or(PrecompileError::InvalidInput)?;
+    let mut flags = SendFlags::from_bits(flags).ok_or(PrecompileError::InvalidInput)?;
+
+    if system.readonly {
+        flags |= SendFlags::READ_ONLY;
+    }
 
     let codec: u64 = input_params.read_value()?;
 

--- a/actors/evm/src/interpreter/system.rs
+++ b/actors/evm/src/interpreter/system.rs
@@ -291,10 +291,6 @@ impl<'r, RT: Runtime> System<'r, RT> {
             return Ok(());
         }
 
-        if self.readonly {
-            return Err(ActorError::forbidden("contract invocation is read only".to_string()));
-        }
-
         let EvmBytecode { cid, evm_hash } = match self.bytecode {
             Some(cid) => cid,
             // set empty bytecode hashes

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -747,8 +747,10 @@ fn call_actor_id_delegatecall_in_readonly_context_propagates_read_only() {
     let rt = util::construct_and_verify(contract);
     let actual_id_addr = 1234u64;
 
-    let mut call_params = CallActorParams::default();
-    call_params.addr_offset = U256::from(actual_id_addr);
+    let call_params = CallActorParams {
+        addr_offset: U256::from(actual_id_addr),
+        ..Default::default()
+    };
 
     let mut test = util::PrecompileTest {
         precompile_address: util::NativePrecompile::CallActorId.eth_address(),

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -747,10 +747,8 @@ fn call_actor_id_delegatecall_in_readonly_context_propagates_read_only() {
     let rt = util::construct_and_verify(contract);
     let actual_id_addr = 1234u64;
 
-    let call_params = CallActorParams {
-        addr_offset: U256::from(actual_id_addr),
-        ..Default::default()
-    };
+    let call_params =
+        CallActorParams { addr_offset: U256::from(actual_id_addr), ..Default::default() };
 
     let mut test = util::PrecompileTest {
         precompile_address: util::NativePrecompile::CallActorId.eth_address(),

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -708,6 +708,37 @@ fn call_actor_id_with_full_address() {
 }
 
 #[test]
+fn call_actor_id_inside_staticcall() {
+    let contract = {
+        let (init, body) = util::PrecompileTest::test_runner_assembly();
+        asm::new_contract("call_actor-precompile-test", &init, &body).unwrap()
+    };
+    let rt = util::construct_and_verify(contract);
+    let addr = Address::new_delegated(1234, b"foobarboxy").unwrap();
+    let actual_id_addr = 1234;
+
+    let mut call_params = CallActorParams::default();
+    // garbage bytes
+    call_params.set_addr(CallActorParams::EMPTY_PARAM_ADDR_OFFSET, addr.to_bytes());
+    // id address
+    call_params.addr_offset = U256::from(actual_id_addr);
+
+    let mut test = util::PrecompileTest {
+        precompile_address: util::NativePrecompile::CallActorId.eth_address(),
+        output_size: 32,
+        call_op: util::PrecompileCallOpcode::StaticCall,
+        expected_return: vec![],
+        expected_exit_code: util::PrecompileExit::Reverted,
+        input: call_params.clone().into(),
+    };
+
+    // staticcall into the CallActorId precompile must be rejected (call_type != DelegateCall).
+    // No send should occur.
+    test.input = call_params.into();
+    test.run_test_expecting(&rt, vec![], util::PrecompileExit::Reverted);
+}
+
+#[test]
 fn call_actor_syscall_error() {
     let contract = {
         let (init, body) = util::PrecompileTest::test_runner_assembly();

--- a/actors/evm/tests/call.rs
+++ b/actors/evm/tests/call.rs
@@ -739,6 +739,53 @@ fn call_actor_id_inside_staticcall() {
 }
 
 #[test]
+fn call_actor_id_delegatecall_in_readonly_context_propagates_read_only() {
+    let contract = {
+        let (init, body) = util::PrecompileTest::test_runner_assembly();
+        asm::new_contract("call_actor-precompile-test", &init, &body).unwrap()
+    };
+    let rt = util::construct_and_verify(contract);
+    let actual_id_addr = 1234u64;
+
+    let mut call_params = CallActorParams::default();
+    call_params.addr_offset = U256::from(actual_id_addr);
+
+    let mut test = util::PrecompileTest {
+        precompile_address: util::NativePrecompile::CallActorId.eth_address(),
+        output_size: 32,
+        call_op: util::PrecompileCallOpcode::DelegateCall,
+        expected_return: vec![],
+        expected_exit_code: util::PrecompileExit::Success,
+        input: call_params.into(),
+    };
+
+    // Simulate the EVM actor being invoked in a readonly (staticcall) context.
+    rt.set_read_only(true);
+    rt.expect_gas_available(10_000_000_000);
+    // The mock propagates READ_ONLY to sub-calls, mirroring FVM kernel behavior.
+    // The target actor rejects the mutation attempt with USR_FORBIDDEN.
+    rt.expect_send(
+        Address::new_id(actual_id_addr),
+        0,
+        None,
+        TokenAmount::zero(),
+        Some(0),
+        SendFlags::READ_ONLY,
+        None,
+        ExitCode::USR_FORBIDDEN,
+        None,
+    );
+
+    let expected = CallActorReturn {
+        send_exit_code: U256::from(ExitCode::USR_FORBIDDEN.value()),
+        ..Default::default()
+    };
+    // The precompile itself succeeds (returns 1); the target actor's rejection is
+    // surfaced in the ABI-encoded send_exit_code, not as a precompile-level revert.
+    test.run_test_expecting(&rt, expected, util::PrecompileExit::Success);
+}
+
+#[test]
 fn call_actor_syscall_error() {
     let contract = {
         let (init, body) = util::PrecompileTest::test_runner_assembly();

--- a/actors/evm/tests/util.rs
+++ b/actors/evm/tests/util.rs
@@ -388,7 +388,7 @@ p_staticcall:
     # gas
     push1 0x00
 
-    delegatecall
+    staticcall
 
     # return
 

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -164,6 +164,7 @@ pub struct MockRuntime {
 
     // VM Impl
     pub in_call: RefCell<bool>,
+    pub read_only: RefCell<bool>,
     pub store: Rc<MemoryBlockstore>,
     pub in_transaction: RefCell<bool>,
 
@@ -349,6 +350,7 @@ impl MockRuntime {
             state: Default::default(),
             balance: Default::default(),
             in_call: Default::default(),
+            read_only: Default::default(),
             store: Rc::new(Default::default()),
             in_transaction: Default::default(),
             expectations: Default::default(),
@@ -578,6 +580,10 @@ impl MockRuntime {
     /// Clears all mock expectations.
     pub fn reset(&self) {
         self.expectations.borrow_mut().reset();
+    }
+
+    pub fn set_read_only(&self, read_only: bool) {
+        self.read_only.replace(read_only);
     }
 
     ///// Mock expectations /////
@@ -1168,6 +1174,7 @@ impl Runtime for MockRuntime {
         send_flags: SendFlags,
     ) -> Result<Response, SendError> {
         self.require_in_call();
+        let send_flags = if self.read_only() { send_flags | SendFlags::READ_ONLY } else { send_flags };
         if *self.in_transaction.borrow() {
             return Ok(Response { exit_code: ExitCode::USR_ASSERTION_FAILED, return_data: None });
         }
@@ -1342,7 +1349,7 @@ impl Runtime for MockRuntime {
     }
 
     fn read_only(&self) -> bool {
-        false
+        *self.read_only.borrow()
     }
 }
 

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -1174,7 +1174,8 @@ impl Runtime for MockRuntime {
         send_flags: SendFlags,
     ) -> Result<Response, SendError> {
         self.require_in_call();
-        let send_flags = if self.read_only() { send_flags | SendFlags::READ_ONLY } else { send_flags };
+        let send_flags =
+            if self.read_only() { send_flags | SendFlags::READ_ONLY } else { send_flags };
         if *self.in_transaction.borrow() {
             return Ok(Response { exit_code: ExitCode::USR_ASSERTION_FAILED, return_data: None });
         }


### PR DESCRIPTION

Reviewer @rvagg
### Changes
#### Allow readonly delegatecall
Currently we require call actor (by address or by id) to use `delegatecall`.
But if the delegatecaller context is readonly (it or one of its parents is a `staticcall`), that fails.
The reason seems to be that we do `flush`, so that reentrancy works (since it will reload).
However, we skip flush if there's nothing to flush, and I think that's the case in this situation.
So I think we can allow this case.