### PR TITLE
chore: fix deny checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,7 @@ dependencies = [
  "num-bigint",
  "pest",
  "pest_derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha3 0.10.8",
  "snafu",
 ]
@@ -2079,7 +2079,7 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "unarray",
@@ -2102,9 +2102,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2268,7 +2268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
 dependencies = [
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand 0.9.4",
  "ruint-macro",
  "serde_core",
@@ -2543,7 +2543,7 @@ dependencies = [
  "byteorder",
  "crunchy",
  "lazy_static",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,7 @@
 [advisories]
 ignore = [
    { id = "RUSTSEC-2024-0436", reason = "paste@1.0.15 excluded pending removal from alloy-core and syn-solidity; see https://github.com/alloy-rs/core/issues/897" },
+   { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained; transitive dependency via alloy-core." },
 ]
 
 [licenses]


### PR DESCRIPTION
Fixes recent `cargo deny check` warnings.

- updated `rand`
- added `proc-macro-error2` to ignores for now, nothing we can do; it's a transitive dependency via `alloy-core`, see https://github.com/alloy-rs/core/issues/1120

```
❯ cargo deny check advisories
error[unmaintained]: proc-macro-error2 is unmaintained
    ┌─ /home/rumcajs/prj/builtin-actors/Cargo.lock:169:1
    │
169 │ proc-macro-error2 2.0.1 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
    │
    ├ ID: RUSTSEC-2026-0173
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0173
    ├ The author of `proc-macro-error2` has [confirmed](https://github.com/GnomedDev/proc-macro-error-2/issues/17#issuecomment-4643215473) that the crate is no longer maintained and recommends that users migrate away from it.

      `proc-macro-error2` was originally created as a maintained fork of [`proc-macro-error`](https://crates.io/crates/proc-macro-error) (see [RUSTSEC-2024-0370](https://rustsec.org/advisories/RUSTSEC-2024-0370)). Both the original crate and this fork are now unmaintained.

      ## Possible Alternative(s)

      - [manyhow](https://crates.io/crates/manyhow)
      - [proc-macro2-diagnostics](https://github.com/SergioBenitez/proc-macro2-diagnostics)
    ├ Announcement: https://github.com/GnomedDev/proc-macro-error-2/issues/17
    ├ Solution: No safe upgrade is available!
    ├ proc-macro-error2 v2.0.1
      ├── alloy-sol-macro v1.6.0
      │   └── alloy-sol-types v1.6.0
      │       └── alloy-core v1.6.0
      │           └── (dev) fil_actor_evm v18.0.0
      │               ├── (dev) fil_actor_eam v18.0.0
      │               │   └── fil_builtin_actors_bundle v18.0.0
      │               └── fil_builtin_actors_bundle v18.0.0 (*)
      └── alloy-sol-macro-expander v1.6.0
          └── alloy-sol-macro v1.6.0 (*)

error[unsound]: Rand is unsound with a custom logger using `rand::rng()`
    ┌─ /home/rumcajs/prj/builtin-actors/Cargo.lock:173:1
    │
173 │ rand 0.8.5 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory detected
    │
    ├ ID: RUSTSEC-2026-0097
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0097
    ├ It has been reported (by @lopopolo) that the `rand` library is [unsound](https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#soundness-of-code--of-a-library) (i.e. that safe code using the public API can cause Undefined Behaviour) when all the following conditions are met:

      - The `log` and `thread_rng` features are enabled
      - A [custom logger](https://docs.rs/log/latest/log/#implementing-a-logger) is defined
      - The custom logger accesses `rand::rng()` (previously `rand::thread_rng()`) and calls any `TryRng` (previously `RngCore`) methods on `ThreadRng`
      - The `ThreadRng` (attempts to) reseed while called from the custom logger (this happens every 64 kB of generated data)
      - Trace-level logging is enabled or warn-level logging is enabled and the random source (the `getrandom` crate) is unable to provide a new seed

      `TryRng` (previously `RngCore`) methods for `ThreadRng` use `unsafe` code to cast `*mut BlockRng<ReseedingCore>` to `&mut BlockRng<ReseedingCore>`. When all the above conditions are met this results in an aliased mutable reference, violating the Stacked Borrows rules. Miri is able to detect this violation in sample code. Since construction of [aliased mutable references is Undefined Behaviour](https://doc.rust-lang.org/stable/nomicon/references.html), the behaviour of optimized builds is hard to predict.
    ├ Announcement: https://github.com/rust-random/rand/pull/1763
    ├ Solution: Upgrade to >=0.10.1 OR <0.10.0, >=0.9.3 OR <0.9.0, >=0.8.6 (try `cargo update -p rand`)
    ├ rand v0.8.5
      ├── etk-asm v0.3.0
      │   └── (dev) fil_actor_evm v18.0.0
      │       ├── (dev) fil_actor_eam v18.0.0
      │       │   └── fil_builtin_actors_bundle v18.0.0
      │       └── fil_builtin_actors_bundle v18.0.0 (*)
      └── substrate-bn v0.6.0
          └── fil_actor_evm v18.0.0 (*)
```