### PR TITLE
fix(deps): resolve `ruint` cargo-deny advisory failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "proptest",
  "rand 0.8.6",
@@ -2511,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "static_assertions"

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,6 @@
 [advisories]
 ignore = [
    { id = "RUSTSEC-2024-0436", reason = "paste@1.0.15 excluded pending removal from alloy-core and syn-solidity; see https://github.com/alloy-rs/core/issues/897" },
-   { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained; transitive dependency via alloy-core." },
 ]
 
 [licenses]


### PR DESCRIPTION
Closes https://github.com/filecoin-project/builtin-actors/issues/1770

## Summary
- Bump `ruint` 1.17.2 → 1.20.0, fixing RUSTSEC-2026-0220 (incorrect overflow flags / truncated shift amounts in `Uint` shift ops)
- Bump `spin` 0.9.8 → 0.9.9, resolving a yanked-crate warning
- Remove the now-stale `RUSTSEC-2026-0173` ignore entry in `deny.toml` (no crate in the tree matches it anymore, so cargo-deny warns it's unused)

Fixes the `cargo-deny` CI job failure: https://github.com/filecoin-project/builtin-actors/actions/runs/30580932424/job/91000685017

## Test plan
- [x] `cargo deny --all-features check` passes locally (advisories/bans/licenses/sources all ok)
- [x] `cargo check -p fil_actor_evm --all-features` builds cleanly with the updated `ruint`/`spin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SABE9Y8uJZpDrx8UB339NN