### PR TITLE
feat: add `UpgradeSectorQuality` to update the existing sectors to 10x QAP

### DIFF
--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -2180,9 +2180,10 @@ impl Actor {
     /// May only be called by the miner's owner, worker, or a control address. Each
     /// declaration addresses active sectors in one partition; a declaration without a
     /// new expiration upgrades its sectors in place, leaving their expirations, power
-    /// base epochs and weights untouched. A sector already at full power is not
-    /// eligible and is skipped rather than extended or re-pledged, so repeating a call, or
-    /// naming the sector again in a later declaration of the same call, changes nothing.
+    /// base epochs and weights untouched. A sector already at full power is not upgraded
+    /// and its pledge is not raised: with a new expiration it is extended exactly as
+    /// `ExtendSectorExpiration2` would, without one it is skipped, so repeating a call
+    /// locks nothing.
     ///
     /// # Errors
     /// Aborts with `USR_INSUFFICIENT_FUNDS` unless the available balance covers the
@@ -2242,22 +2243,33 @@ impl Actor {
                             key
                         ));
                     }
-                    // Already at full power, whether by flag or by its weights: not
-                    // eligible, and skipped rather than failed so that a repeated call
-                    // locks and moves nothing.
-                    if qa_power_for_sector(info.sector_size, sector) >= full_qa_power {
-                        return Ok(None);
+                    // Already at full power, by flag or by weights, there is nothing to
+                    // upgrade or re-pledge: the sector is only extended if asked, else
+                    // skipped rather than failed.
+                    let at_full_power =
+                        qa_power_for_sector(info.sector_size, sector) >= full_qa_power;
+                    match (at_full_power, decl.new_expiration) {
+                        (true, None) => Ok(None),
+                        (true, Some(new_expiration)) => extend_sector_committment(
+                            policy,
+                            curr_epoch,
+                            &pledge_inputs.circulating_supply,
+                            new_expiration,
+                            sector,
+                            info.sector_size,
+                        )
+                        .map(Some),
+                        (false, _) => upgrade_sector_to_full_power(
+                            policy,
+                            curr_epoch,
+                            decl.new_expiration,
+                            sector,
+                            info.sector_size,
+                            &pledge_inputs.circulating_supply,
+                            &full_power_pledge,
+                        )
+                        .map(Some),
                     }
-                    upgrade_sector_to_full_power(
-                        policy,
-                        curr_epoch,
-                        decl.new_expiration,
-                        sector,
-                        info.sector_size,
-                        &pledge_inputs.circulating_supply,
-                        &full_power_pledge,
-                    )
-                    .map(Some)
                 },
             )?;
 
@@ -2285,14 +2297,15 @@ impl Actor {
                 .map_err(|e| actor_error!(illegal_state, "failed to add initial pledge: {}", e))?;
 
             let fee_to_burn = repay_debts_or_abort(rt, state)?;
-
-            state.check_balance_invariants(&current_balance).map_err(balance_invariants_broken)?;
             Ok((power_delta, pledge_delta, fee_to_burn))
         })?;
 
         burn_funds(rt, fee_to_burn)?;
         request_update_power(rt, power_delta)?;
         notify_pledge_changed(rt, &pledge_delta)?;
+
+        let state: State = rt.state()?;
+        state.check_balance_invariants(&rt.current_balance()).map_err(balance_invariants_broken)?;
         Ok(())
     }
 
@@ -3772,8 +3785,8 @@ fn validate_upgrade_quality_extensions(
 
 /// Builds the record for one sector upgraded to full quality-adjusted power
 /// (FIP-0118) by `UpgradeSectorQuality`, optionally extending it. Expects a sector
-/// below full power (the caller skips any other), so the pledge, set to the larger of
-/// the recorded pledge and `full_power_pledge`, is raised at most once.
+/// below full power (the caller only extends or skips any other), so the pledge, set
+/// to the larger of the recorded pledge and `full_power_pledge`, is raised at most once.
 ///
 /// Without a new expiration the record keeps its expiration, power base epoch and
 /// weights, so the sector stays exactly where it is already scheduled; only the

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -2186,7 +2186,7 @@ impl Actor {
     /// whole batch's pledge increase and any outstanding fee debt, which is repaid in
     /// the same call. Any invalid declaration or non-active sector fails the whole
     /// message; no partial upgrade is applied.
-    fn upgradeSectorQuality(
+    fn upgrade_sector_quality(
         rt: &impl Runtime,
         params: UpgradeSectorQualityParams,
     ) -> Result<(), ActorError> {
@@ -2218,25 +2218,38 @@ impl Actor {
             let full_power_pledge = pledge_inputs.initial_pledge_for_power(&full_qa_power);
             let policy = rt.policy();
 
-            let ve: Vec<ValidatedExpirationExtension> =  params.extensions.into_iter().map(|e| e.into()).collect();
+            let ve: Vec<ValidatedExpirationExtension> =
+                params.extensions.into_iter().map(|e| e.into()).collect();
             let (power_delta, pledge_delta) = replace_sector_records(
-               policy,
-               rt.store(),
-               state,
-               info.sector_size,
-               &ve,
-               |_partition, ve, sector_info| {
-                   upgrade_sector_to_full_power(
-                       policy,
-                       curr_epoch,
-                       ve.new_expiration,
-                       sector_info,
-                       info.sector_size,
-                       &pledge_inputs.circulating_supply,
-                       &full_qa_power,
-                       &full_power_pledge,
-                   )
-               }
+                policy,
+                rt.store(),
+                state,
+                info.sector_size,
+                &ve,
+                |partition, decl, sector| {
+                    // Only active sectors may upgrade; a faulty, unproven, terminated
+                    // or foreign sector fails the whole message.
+                    if !partition.active_sectors().get(sector.sector_number) {
+                        let key =
+                            PartitionKey { deadline: decl.deadline, partition: decl.partition };
+                        return Err(actor_error!(
+                            illegal_argument,
+                            "can only upgrade active sectors: sector {} is not active in {:?}",
+                            sector.sector_number,
+                            key
+                        ));
+                    }
+                    upgrade_sector_to_full_power(
+                        policy,
+                        curr_epoch,
+                        decl.new_expiration,
+                        sector,
+                        info.sector_size,
+                        &pledge_inputs.circulating_supply,
+                        &full_qa_power,
+                        &full_power_pledge,
+                    )
+                },
             )?;
 
             // Lock the pledge top-up, checking funds before adding it so a shortfall
@@ -3393,22 +3406,11 @@ impl From<ExpirationExtension2> for ValidatedExpirationExtension {
 impl From<UpgradeSectorQuality> for ValidatedExpirationExtension {
     fn from(uq: UpgradeSectorQuality) -> Self {
         // Destructure all fields at once
-        let UpgradeSectorQuality {
-            deadline,
-            partition,
-            sectors,
-            new_expiration,
-        } = uq;
+        let UpgradeSectorQuality { deadline, partition, sectors, new_expiration } = uq;
 
-        Self {
-            deadline,
-            partition,
-            sectors,
-            new_expiration,
-        }
+        Self { deadline, partition, sectors, new_expiration }
     }
 }
-
 
 /// Rewrites the sectors named by each declaration, moving each partition's expiration queue
 /// and its deadline's power and fee books to match, and returns the aggregate power and
@@ -5744,7 +5746,7 @@ impl ActorCode for Actor {
         ProveCommitSectors3 => prove_commit_sectors3,
         ProveReplicaUpdates3 => prove_replica_updates3,
         ProveCommitSectorsNI => prove_commit_sectors_ni,
-        UpgradeSectorQuality => upgradeSectorQuality,
+        UpgradeSectorQuality => upgrade_sector_quality,
         MaxTerminationFeeExported => max_termination_fee,
         InitialPledgeExported => initial_pledge,
         GenerateSectorLocationExported => generate_sector_location,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -2157,8 +2157,9 @@ impl Actor {
                         new_expiration,
                         sector,
                         info.sector_size,
-                    ),
-                    None => Ok(sector.clone()),
+                    )
+                    .map(Some),
+                    None => Ok(Some(sector.clone())),
                 },
             )
         })?;
@@ -2179,7 +2180,9 @@ impl Actor {
     /// May only be called by the miner's owner, worker, or a control address. Each
     /// declaration addresses active sectors in one partition; a declaration without a
     /// new expiration upgrades its sectors in place, leaving their expirations, power
-    /// base epochs and weights untouched.
+    /// base epochs and weights untouched. A sector already at full power is not
+    /// eligible and is skipped rather than extended or re-pledged, so repeating a call
+    /// changes nothing.
     ///
     /// # Errors
     /// Aborts with `USR_INSUFFICIENT_FUNDS` unless the available balance covers the
@@ -2190,7 +2193,15 @@ impl Actor {
         rt: &impl Runtime,
         params: UpgradeSectorQualityParams,
     ) -> Result<(), ActorError> {
+        let state: State = rt.state()?;
+        let info = get_miner_info(rt.store(), &state)?;
+        rt.validate_immediate_caller_is(
+            info.control_addresses.iter().chain(&[info.worker, info.owner]),
+        )?;
         validate_upgrade_quality_extensions(rt, &params.extensions)?;
+
+        let policy = rt.policy();
+        let curr_epoch = rt.curr_epoch();
 
         // Pledge inputs come from other actors and must be fetched before the
         // transaction, where sends are blocked.
@@ -2201,31 +2212,24 @@ impl Actor {
             network_baseline: rew.this_epoch_baseline_power,
             circulating_supply: rt.total_fil_circ_supply(),
             epoch_reward: rew.this_epoch_reward_smoothed,
-            epochs_since_ramp_start: rt.curr_epoch() - pow.ramp_start_epoch,
+            epochs_since_ramp_start: curr_epoch - pow.ramp_start_epoch,
             ramp_duration_epochs: pow.ramp_duration_epochs,
         };
-        let curr_epoch = rt.curr_epoch();
+
+        // The upgraded power and its pledge depend only on the sector size, so they
+        // are the same for every sector in the batch.
+        let full_qa_power = qa_power_max(info.sector_size);
+        let full_power_pledge = pledge_inputs.initial_pledge_for_power(&full_qa_power);
 
         let (power_delta, pledge_delta, fee_to_burn) = rt.transaction(|state: &mut State, rt| {
-            let info = get_miner_info(rt.store(), state)?;
-            rt.validate_immediate_caller_is(
-                info.control_addresses.iter().chain(&[info.worker, info.owner]),
-            )?;
-
-            // The upgraded power and its pledge depend only on the sector size, so
-            // they are the same for every sector in the batch.
-            let full_qa_power = qa_power_max(info.sector_size);
-            let full_power_pledge = pledge_inputs.initial_pledge_for_power(&full_qa_power);
-            let policy = rt.policy();
-
-            let ve: Vec<ValidatedExpirationExtension> =
+            let declarations: Vec<ValidatedExpirationExtension> =
                 params.extensions.into_iter().map(|e| e.into()).collect();
             let (power_delta, pledge_delta) = replace_sector_records(
                 policy,
                 rt.store(),
                 state,
                 info.sector_size,
-                &ve,
+                &declarations,
                 |partition, decl, sector| {
                     // Only active sectors may upgrade; a faulty, unproven, terminated
                     // or foreign sector fails the whole message.
@@ -2239,6 +2243,12 @@ impl Actor {
                             key
                         ));
                     }
+                    // Already at full power, whether by flag or by its weights: not
+                    // eligible, and skipped rather than failed so that a repeated call
+                    // locks and moves nothing.
+                    if qa_power_for_sector(info.sector_size, sector) >= full_qa_power {
+                        return Ok(None);
+                    }
                     upgrade_sector_to_full_power(
                         policy,
                         curr_epoch,
@@ -2246,9 +2256,9 @@ impl Actor {
                         sector,
                         info.sector_size,
                         &pledge_inputs.circulating_supply,
-                        &full_qa_power,
                         &full_power_pledge,
                     )
+                    .map(Some)
                 },
             )?;
 
@@ -3416,12 +3426,14 @@ impl From<UpgradeSectorQuality> for ValidatedExpirationExtension {
 /// and its deadline's power and fee books to match, and returns the aggregate power and
 /// pledge deltas.
 ///
-/// `rewrite` produces each sector's replacement record. It receives the partition holding the
-/// sector, so a caller can reject sectors its operation does not accept. Declarations apply in
-/// order and later ones read back earlier ones, so a sector named twice is rewritten twice.
+/// `rewrite` produces each sector's replacement record, or `None` to leave the sector exactly
+/// as it is. It receives the partition holding the sector, so a caller can reject sectors its
+/// operation does not accept. Declarations apply in order and later ones read back earlier
+/// ones, so a sector named twice is rewritten twice.
 ///
 /// A declaration with a new expiration re-registers its partition in the deadline's expiration
-/// queue. Without one the sectors stay where they are already scheduled.
+/// queue, unless it rewrote no sector. Without one the sectors stay where they are already
+/// scheduled.
 fn replace_sector_records<BS: Blockstore>(
     policy: &Policy,
     store: &BS,
@@ -3432,7 +3444,7 @@ fn replace_sector_records<BS: Blockstore>(
         &Partition,
         &ValidatedExpirationExtension,
         &SectorOnChainInfo,
-    ) -> Result<SectorOnChainInfo, ActorError>,
+    ) -> Result<Option<SectorOnChainInfo>, ActorError>,
 ) -> Result<(PowerPair, TokenAmount), ActorError> {
     let mut deadlines =
         state.load_deadlines(store).map_err(|e| e.wrap("failed to load deadlines"))?;
@@ -3491,13 +3503,19 @@ fn replace_sector_records<BS: Blockstore>(
                 .cloned()
                 .ok_or_else(|| actor_error!(not_found, "no such partition {:?}", key))?;
 
-            let old_sectors = sectors
-                .load_sectors(&decl.sectors)
-                .map_err(|e| e.wrap("failed to load sectors"))?;
-            let new_sectors: Vec<SectorOnChainInfo> = old_sectors
-                .iter()
-                .map(|sector| rewrite(&partition, decl, sector))
-                .collect::<Result<_, _>>()?;
+            let mut old_sectors = Vec::new();
+            let mut new_sectors = Vec::new();
+            for sector in
+                sectors.load_sectors(&decl.sectors).map_err(|e| e.wrap("failed to load sectors"))?
+            {
+                if let Some(new_sector) = rewrite(&partition, decl, &sector)? {
+                    old_sectors.push(sector);
+                    new_sectors.push(new_sector);
+                }
+            }
+            if new_sectors.is_empty() {
+                continue;
+            }
 
             // Overwrite sector infos.
             sectors.store(new_sectors.clone()).map_err(|e| {
@@ -3696,10 +3714,10 @@ fn extend_sector_weights(
     Ok(new_sector)
 }
 
-/// Validates `UpgradeSectorQuality` declarations before any state changes:
-/// deadline indices in range, no empty sector selections, requested expirations
-/// inside the allowed window, and the batch under the addressed-partitions and
-/// addressed-sectors limits.
+/// Validates `UpgradeSectorQuality` declarations before any state changes: at
+/// least one declaration, deadline indices in range, no empty sector selections,
+/// and requested expirations inside the allowed window. There is no batch cap:
+/// gas bounds the batch, as it does for `ExtendSectorExpiration2`.
 fn validate_upgrade_quality_extensions(
     rt: &impl Runtime,
     extensions: &[UpgradeSectorQuality],
@@ -3707,10 +3725,9 @@ fn validate_upgrade_quality_extensions(
     let policy = rt.policy();
     let curr_epoch = rt.curr_epoch();
 
-    // Used only to validate the bitfields and count the batch. Declarations for
-    // the same partition must stay separate for execution, because each carries
-    // its own new expiration and this map would merge them.
-    let mut batch = DeadlineSectorMap::new();
+    if extensions.is_empty() {
+        return Err(actor_error!(illegal_argument, "no extension declarations"));
+    }
 
     for decl in extensions {
         // Checked first: the deadline index guards vector indexing later.
@@ -3754,21 +3771,7 @@ fn validate_upgrade_quality_extensions(
                 ));
             }
         }
-
-        batch.add(policy, decl.deadline, decl.partition, decl.sectors.clone()).map_err(|e| {
-            actor_error!(
-                illegal_argument,
-                "failed to process deadline {}, partition {}: {}",
-                decl.deadline,
-                decl.partition,
-                e
-            )
-        })?;
     }
-
-    batch.check(policy.addressed_partitions_max, policy.addressed_sectors_max).map_err(|e| {
-        actor_error!(illegal_argument, "cannot process requested parameters: {}", e)
-    })?;
 
     Ok(())
 }
@@ -3778,12 +3781,12 @@ fn validate_upgrade_quality_extensions(
 ///
 /// Without a new expiration the record keeps its expiration, power base epoch and
 /// weights, so the sector stays exactly where it is already scheduled; only the
-/// flags, pledge and daily fee change.
+/// flags, pledge and daily fee change. The deprecated day-reward and storage-pledge
+/// estimates are cleared either way, as extension and replica update do.
 ///
 /// # Errors
 /// Rejects sectors that have already expired, and expirations that would shorten
 /// the sector's life or fall outside the allowed window.
-#[allow(clippy::too_many_arguments)]
 fn upgrade_sector_to_full_power(
     policy: &Policy,
     curr_epoch: ChainEpoch,
@@ -3791,7 +3794,6 @@ fn upgrade_sector_to_full_power(
     sector: &SectorOnChainInfo,
     sector_size: SectorSize,
     circulating_supply: &TokenAmount,
-    full_qa_power: &StoragePower,
     full_power_pledge: &TokenAmount,
 ) -> Result<SectorOnChainInfo, ActorError> {
     // An upgrade-only sector keeps its own expiration but must pass the same
@@ -3809,19 +3811,25 @@ fn upgrade_sector_to_full_power(
     // maximum for FULL_QA_POWER sectors. Same pair as replica updates set.
     new_sector.flags |=
         SectorOnChainInfoFlags::SIMPLE_QA_POWER | SectorOnChainInfoFlags::FULL_QA_POWER;
+    let full_qa_power = qa_power_max(sector_size);
+
+    // Deprecated estimates, read nowhere; cleared whenever a sector is touched.
+    new_sector.expected_day_reward = None;
+    new_sector.expected_storage_pledge = None;
+    new_sector.replaced_day_reward = None;
 
     // Pledge for the upgraded power, never lowered below what is already held.
     new_sector.initial_pledge = max(new_sector.initial_pledge, full_power_pledge.clone());
 
     if new_sector.daily_fee.is_zero() {
         // Sector predates FIP-0100 fees; attach the fee at the upgraded rate.
-        new_sector.daily_fee = daily_proof_fee(policy, circulating_supply, full_qa_power);
+        new_sector.daily_fee = daily_proof_fee(policy, circulating_supply, &full_qa_power);
     } else {
         // Scale the fee by the power change, reading the old power from the
         // pre-upgrade record (the new one is already flagged and reports maximum).
         let old_qa_power = qa_power_for_sector(sector_size, sector);
         new_sector.daily_fee =
-            daily_proof_fee_adjust(&new_sector.daily_fee, &old_qa_power, full_qa_power);
+            daily_proof_fee_adjust(&new_sector.daily_fee, &old_qa_power, &full_qa_power);
     }
 
     Ok(new_sector)

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -2181,8 +2181,8 @@ impl Actor {
     /// declaration addresses active sectors in one partition; a declaration without a
     /// new expiration upgrades its sectors in place, leaving their expirations, power
     /// base epochs and weights untouched. A sector already at full power is not
-    /// eligible and is skipped rather than extended or re-pledged, so repeating a call
-    /// changes nothing.
+    /// eligible and is skipped rather than extended or re-pledged, so repeating a call, or
+    /// naming the sector again in a later declaration of the same call, changes nothing.
     ///
     /// # Errors
     /// Aborts with `USR_INSUFFICIENT_FUNDS` unless the available balance covers the
@@ -2198,10 +2198,9 @@ impl Actor {
         rt.validate_immediate_caller_is(
             info.control_addresses.iter().chain(&[info.worker, info.owner]),
         )?;
-        validate_upgrade_quality_extensions(rt, &params.extensions)?;
-
         let policy = rt.policy();
         let curr_epoch = rt.curr_epoch();
+        validate_upgrade_quality_extensions(policy, curr_epoch, &params.extensions)?;
 
         // Pledge inputs come from other actors and must be fetched before the
         // transaction, where sends are blocked.
@@ -2233,7 +2232,7 @@ impl Actor {
                 |partition, decl, sector| {
                     // Only active sectors may upgrade; a faulty, unproven, terminated
                     // or foreign sector fails the whole message.
-                    if !partition.active_sectors().get(sector.sector_number) {
+                    if !partition.is_active(sector.sector_number) {
                         let key =
                             PartitionKey { deadline: decl.deadline, partition: decl.partition };
                         return Err(actor_error!(
@@ -2292,7 +2291,6 @@ impl Actor {
         })?;
 
         burn_funds(rt, fee_to_burn)?;
-        // Unlike plain extension, the upgrade routinely adds power and pledge.
         request_update_power(rt, power_delta)?;
         notify_pledge_changed(rt, &pledge_delta)?;
         Ok(())
@@ -3415,9 +3413,7 @@ impl From<ExpirationExtension2> for ValidatedExpirationExtension {
 
 impl From<UpgradeSectorQuality> for ValidatedExpirationExtension {
     fn from(uq: UpgradeSectorQuality) -> Self {
-        // Destructure all fields at once
         let UpgradeSectorQuality { deadline, partition, sectors, new_expiration } = uq;
-
         Self { deadline, partition, sectors, new_expiration }
     }
 }
@@ -3428,8 +3424,9 @@ impl From<UpgradeSectorQuality> for ValidatedExpirationExtension {
 ///
 /// `rewrite` produces each sector's replacement record, or `None` to leave the sector exactly
 /// as it is. It receives the partition holding the sector, so a caller can reject sectors its
-/// operation does not accept. Declarations apply in order and later ones read back earlier
-/// ones, so a sector named twice is rewritten twice.
+/// operation does not accept. Declarations are not merged but applied in order, each seeing the
+/// records the previous ones produced, so a sector named twice is offered to `rewrite` twice
+/// (and rewritten again only if `rewrite` says so).
 ///
 /// A declaration with a new expiration re-registers its partition in the deadline's expiration
 /// queue, unless it rewrote no sector. Without one the sectors stay where they are already
@@ -3517,14 +3514,6 @@ fn replace_sector_records<BS: Blockstore>(
                 continue;
             }
 
-            // Overwrite sector infos.
-            sectors.store(new_sectors.clone()).map_err(|e| {
-                e.downcast_default(
-                    ExitCode::USR_ILLEGAL_STATE,
-                    format!("failed to update sectors {:?}", decl.sectors),
-                )
-            })?;
-
             // Remove old sectors from partition and assign new sectors.
             let (partition_power_delta, partition_pledge_delta, partition_daily_fee_delta) =
                 partition
@@ -3535,6 +3524,14 @@ fn replace_sector_records<BS: Blockstore>(
                             format!("failed to replace sector expirations at {:?}", key),
                         )
                     })?;
+
+            // Overwrite sector infos.
+            sectors.store(new_sectors).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::USR_ILLEGAL_STATE,
+                    format!("failed to update sectors {:?}", decl.sectors),
+                )
+            })?;
 
             deadline_power_delta += &partition_power_delta;
             deadline_pledge_delta += &partition_pledge_delta;
@@ -3719,18 +3716,16 @@ fn extend_sector_weights(
 /// and requested expirations inside the allowed window. There is no batch cap:
 /// gas bounds the batch, as it does for `ExtendSectorExpiration2`.
 fn validate_upgrade_quality_extensions(
-    rt: &impl Runtime,
+    policy: &Policy,
+    curr_epoch: ChainEpoch,
     extensions: &[UpgradeSectorQuality],
 ) -> Result<(), ActorError> {
-    let policy = rt.policy();
-    let curr_epoch = rt.curr_epoch();
-
     if extensions.is_empty() {
         return Err(actor_error!(illegal_argument, "no extension declarations"));
     }
 
     for decl in extensions {
-        // Checked first: the deadline index guards vector indexing later.
+        // Must precede replace_sector_records, which indexes by deadline.
         if decl.deadline >= policy.wpost_period_deadlines {
             return Err(actor_error!(
                 illegal_argument,
@@ -3749,9 +3744,8 @@ fn validate_upgrade_quality_extensions(
             ));
         }
 
-        // A requested extension must land after the current epoch and inside the
-        // maximum extension window. Checks against each sector's own expiration,
-        // activation and lifetime run per sector later.
+        // Bounds that need no sector are rejected here, before the network queries;
+        // each sector's own expiration, activation and lifetime are checked later.
         if let Some(new_expiration) = decl.new_expiration {
             if new_expiration <= curr_epoch {
                 return Err(actor_error!(
@@ -3777,7 +3771,9 @@ fn validate_upgrade_quality_extensions(
 }
 
 /// Builds the record for one sector upgraded to full quality-adjusted power
-/// (FIP-0118) by `UpgradeSectorQuality`, optionally extending it.
+/// (FIP-0118) by `UpgradeSectorQuality`, optionally extending it. Expects a sector
+/// below full power (the caller skips any other), so the pledge, set to the larger of
+/// the recorded pledge and `full_power_pledge`, is raised at most once.
 ///
 /// Without a new expiration the record keeps its expiration, power base epoch and
 /// weights, so the sector stays exactly where it is already scheduled; only the
@@ -3803,30 +3799,27 @@ fn upgrade_sector_to_full_power(
 
     let mut new_sector = match new_expiration {
         None => sector.clone(),
-        // Same weight and power-base-epoch math as ExtendSectorExpiration2.
         Some(new_expiration) => extend_sector_weights(new_expiration, curr_epoch, sector)?,
     };
 
     // The flags are the entire power change: qa_power_for_sector returns the
-    // maximum for FULL_QA_POWER sectors. Same pair as replica updates set.
+    // maximum for FULL_QA_POWER sectors.
     new_sector.flags |=
         SectorOnChainInfoFlags::SIMPLE_QA_POWER | SectorOnChainInfoFlags::FULL_QA_POWER;
     let full_qa_power = qa_power_max(sector_size);
 
-    // Deprecated estimates, read nowhere; cleared whenever a sector is touched.
+    // extend_sector_weights already clears these; the upgrade-only branch needs it too.
     new_sector.expected_day_reward = None;
     new_sector.expected_storage_pledge = None;
     new_sector.replaced_day_reward = None;
 
-    // Pledge for the upgraded power, never lowered below what is already held.
     new_sector.initial_pledge = max(new_sector.initial_pledge, full_power_pledge.clone());
 
     if new_sector.daily_fee.is_zero() {
         // Sector predates FIP-0100 fees; attach the fee at the upgraded rate.
         new_sector.daily_fee = daily_proof_fee(policy, circulating_supply, &full_qa_power);
     } else {
-        // Scale the fee by the power change, reading the old power from the
-        // pre-upgrade record (the new one is already flagged and reports maximum).
+        // The old power must come from the pre-upgrade record; new_sector is flagged.
         let old_qa_power = qa_power_for_sector(sector_size, sector);
         new_sector.daily_fee =
             daily_proof_fee_adjust(&new_sector.daily_fee, &old_qa_power, &full_qa_power);

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -140,6 +140,7 @@ pub enum Method {
     ProveCommitSectors3 = 34,
     ProveReplicaUpdates3 = 35,
     ProveCommitSectorsNI = 36,
+    UpgradeSectorQuality = 37,
     // Method numbers derived from FRC-0042 standards
     ChangeWorkerAddressExported = frc42_dispatch::method_hash!("ChangeWorkerAddress"),
     ChangePeerIDExported = frc42_dispatch::method_hash!("ChangePeerID"),
@@ -2172,6 +2173,108 @@ impl Actor {
         Ok(())
     }
 
+    /// Upgrades sectors to full quality-adjusted power (FIP-0118), optionally also
+    /// extending their expiration, and locks the pledge top-up the new power requires.
+    ///
+    /// May only be called by the miner's owner, worker, or a control address. Each
+    /// declaration addresses active sectors in one partition; a declaration without a
+    /// new expiration upgrades its sectors in place, leaving their expirations, power
+    /// base epochs and weights untouched.
+    ///
+    /// # Errors
+    /// Aborts with `USR_INSUFFICIENT_FUNDS` unless the available balance covers the
+    /// whole batch's pledge increase and any outstanding fee debt, which is repaid in
+    /// the same call. Any invalid declaration or non-active sector fails the whole
+    /// message; no partial upgrade is applied.
+    fn upgradeSectorQuality(
+        rt: &impl Runtime,
+        params: UpgradeSectorQualityParams,
+    ) -> Result<(), ActorError> {
+        validate_upgrade_quality_extensions(rt, &params.extensions)?;
+
+        // Pledge inputs come from other actors and must be fetched before the
+        // transaction, where sends are blocked.
+        let rew = request_current_epoch_block_reward(rt)?;
+        let pow = request_current_total_power(rt)?;
+        let pledge_inputs = NetworkPledgeInputs {
+            network_qap: pow.quality_adj_power_smoothed,
+            network_baseline: rew.this_epoch_baseline_power,
+            circulating_supply: rt.total_fil_circ_supply(),
+            epoch_reward: rew.this_epoch_reward_smoothed,
+            epochs_since_ramp_start: rt.curr_epoch() - pow.ramp_start_epoch,
+            ramp_duration_epochs: pow.ramp_duration_epochs,
+        };
+        let curr_epoch = rt.curr_epoch();
+
+        let (power_delta, pledge_delta, fee_to_burn) = rt.transaction(|state: &mut State, rt| {
+            let info = get_miner_info(rt.store(), state)?;
+            rt.validate_immediate_caller_is(
+                info.control_addresses.iter().chain(&[info.worker, info.owner]),
+            )?;
+
+            // The upgraded power and its pledge depend only on the sector size, so
+            // they are the same for every sector in the batch.
+            let full_qa_power = qa_power_max(info.sector_size);
+            let full_power_pledge = pledge_inputs.initial_pledge_for_power(&full_qa_power);
+            let policy = rt.policy();
+
+            let ve: Vec<ValidatedExpirationExtension> =  params.extensions.into_iter().map(|e| e.into()).collect();
+            let (power_delta, pledge_delta) = replace_sector_records(
+               policy,
+               rt.store(),
+               state,
+               info.sector_size,
+               &ve,
+               |_partition, ve, sector_info| {
+                   upgrade_sector_to_full_power(
+                       policy,
+                       curr_epoch,
+                       ve.new_expiration,
+                       sector_info,
+                       info.sector_size,
+                       &pledge_inputs.circulating_supply,
+                       &full_qa_power,
+                       &full_power_pledge,
+                   )
+               }
+            )?;
+
+            // Lock the pledge top-up, checking funds before adding it so a shortfall
+            // reports the true available balance. Fee debt must be repaid in full in
+            // the same call.
+            let current_balance = rt.current_balance();
+            if pledge_delta.is_positive() {
+                let available_balance =
+                    state.get_available_balance(&current_balance).map_err(|e| {
+                        actor_error!(illegal_state, "failed to calculate available balance: {}", e)
+                    })?;
+                if available_balance < pledge_delta {
+                    return Err(actor_error!(
+                        insufficient_funds,
+                        "insufficient funds for aggregate initial pledge requirement {}, available: {}",
+                        pledge_delta,
+                        available_balance
+                    ));
+                }
+            }
+
+            state
+                .add_initial_pledge(&pledge_delta)
+                .map_err(|e| actor_error!(illegal_state, "failed to add initial pledge: {}", e))?;
+
+            let fee_to_burn = repay_debts_or_abort(rt, state)?;
+
+            state.check_balance_invariants(&current_balance).map_err(balance_invariants_broken)?;
+            Ok((power_delta, pledge_delta, fee_to_burn))
+        })?;
+
+        burn_funds(rt, fee_to_burn)?;
+        // Unlike plain extension, the upgrade routinely adds power and pledge.
+        request_update_power(rt, power_delta)?;
+        notify_pledge_changed(rt, &pledge_delta)?;
+        Ok(())
+    }
+
     /// Marks some sectors as terminated at the present epoch, earlier than their
     /// scheduled termination, and adds these sectors to the early termination queue.
     /// This method then processes up to AddressedSectorsMax sectors and
@@ -3287,6 +3390,26 @@ impl From<ExpirationExtension2> for ValidatedExpirationExtension {
     }
 }
 
+impl From<UpgradeSectorQuality> for ValidatedExpirationExtension {
+    fn from(uq: UpgradeSectorQuality) -> Self {
+        // Destructure all fields at once
+        let UpgradeSectorQuality {
+            deadline,
+            partition,
+            sectors,
+            new_expiration,
+        } = uq;
+
+        Self {
+            deadline,
+            partition,
+            sectors,
+            new_expiration,
+        }
+    }
+}
+
+
 /// Rewrites the sectors named by each declaration, moving each partition's expiration queue
 /// and its deadline's power and fee books to match, and returns the aggregate power and
 /// pledge deltas.
@@ -3567,6 +3690,137 @@ fn extend_sector_weights(
     new_sector.expected_day_reward = None;
     new_sector.expected_storage_pledge = None;
     new_sector.replaced_day_reward = None;
+
+    Ok(new_sector)
+}
+
+/// Validates `UpgradeSectorQuality` declarations before any state changes:
+/// deadline indices in range, no empty sector selections, requested expirations
+/// inside the allowed window, and the batch under the addressed-partitions and
+/// addressed-sectors limits.
+fn validate_upgrade_quality_extensions(
+    rt: &impl Runtime,
+    extensions: &[UpgradeSectorQuality],
+) -> Result<(), ActorError> {
+    let policy = rt.policy();
+    let curr_epoch = rt.curr_epoch();
+
+    // Used only to validate the bitfields and count the batch. Declarations for
+    // the same partition must stay separate for execution, because each carries
+    // its own new expiration and this map would merge them.
+    let mut batch = DeadlineSectorMap::new();
+
+    for decl in extensions {
+        // Checked first: the deadline index guards vector indexing later.
+        if decl.deadline >= policy.wpost_period_deadlines {
+            return Err(actor_error!(
+                illegal_argument,
+                "deadline {} not in range 0..{}",
+                decl.deadline,
+                policy.wpost_period_deadlines
+            ));
+        }
+
+        if decl.sectors.is_empty() {
+            return Err(actor_error!(
+                illegal_argument,
+                "no sectors selected in deadline {} partition {}",
+                decl.deadline,
+                decl.partition
+            ));
+        }
+
+        // A requested extension must land after the current epoch and inside the
+        // maximum extension window. Checks against each sector's own expiration,
+        // activation and lifetime run per sector later.
+        if let Some(new_expiration) = decl.new_expiration {
+            if new_expiration <= curr_epoch {
+                return Err(actor_error!(
+                    illegal_argument,
+                    "new expiration {} must be after current epoch {}",
+                    new_expiration,
+                    curr_epoch
+                ));
+            }
+            if new_expiration > curr_epoch + policy.max_sector_expiration_extension {
+                return Err(actor_error!(
+                    illegal_argument,
+                    "new expiration {} cannot be more than {} past current epoch {}",
+                    new_expiration,
+                    policy.max_sector_expiration_extension,
+                    curr_epoch
+                ));
+            }
+        }
+
+        batch.add(policy, decl.deadline, decl.partition, decl.sectors.clone()).map_err(|e| {
+            actor_error!(
+                illegal_argument,
+                "failed to process deadline {}, partition {}: {}",
+                decl.deadline,
+                decl.partition,
+                e
+            )
+        })?;
+    }
+
+    batch.check(policy.addressed_partitions_max, policy.addressed_sectors_max).map_err(|e| {
+        actor_error!(illegal_argument, "cannot process requested parameters: {}", e)
+    })?;
+
+    Ok(())
+}
+
+/// Builds the record for one sector upgraded to full quality-adjusted power
+/// (FIP-0118) by `UpgradeSectorQuality`, optionally extending it.
+///
+/// Without a new expiration the record keeps its expiration, power base epoch and
+/// weights, so the sector stays exactly where it is already scheduled; only the
+/// flags, pledge and daily fee change.
+///
+/// # Errors
+/// Rejects sectors that have already expired, and expirations that would shorten
+/// the sector's life or fall outside the allowed window.
+#[allow(clippy::too_many_arguments)]
+fn upgrade_sector_to_full_power(
+    policy: &Policy,
+    curr_epoch: ChainEpoch,
+    new_expiration: Option<ChainEpoch>,
+    sector: &SectorOnChainInfo,
+    sector_size: SectorSize,
+    circulating_supply: &TokenAmount,
+    full_qa_power: &StoragePower,
+    full_power_pledge: &TokenAmount,
+) -> Result<SectorOnChainInfo, ActorError> {
+    // An upgrade-only sector keeps its own expiration but must pass the same
+    // validation, so expired-but-not-yet-removed sectors are rejected here too.
+    let effective_expiration = new_expiration.unwrap_or(sector.expiration);
+    validate_extended_expiration(policy, curr_epoch, effective_expiration, sector)?;
+
+    let mut new_sector = match new_expiration {
+        None => sector.clone(),
+        // Same weight and power-base-epoch math as ExtendSectorExpiration2.
+        Some(new_expiration) => extend_sector_weights(new_expiration, curr_epoch, sector)?,
+    };
+
+    // The flags are the entire power change: qa_power_for_sector returns the
+    // maximum for FULL_QA_POWER sectors. Same pair as replica updates set.
+    new_sector.flags |=
+        SectorOnChainInfoFlags::SIMPLE_QA_POWER | SectorOnChainInfoFlags::FULL_QA_POWER;
+
+    // Pledge for the upgraded power, never lowered below what is already held.
+    new_sector.initial_pledge = max(new_sector.initial_pledge, full_power_pledge.clone());
+
+    if new_sector.daily_fee.is_zero() {
+        // Sector predates FIP-0100 fees; attach the fee at the upgraded rate.
+        new_sector.daily_fee = daily_proof_fee(policy, circulating_supply, full_qa_power);
+    } else {
+        // Scale the fee by the power change, reading the old power from the
+        // pre-upgrade record (the new one is already flagged and reports maximum).
+        let old_qa_power = qa_power_for_sector(sector_size, sector);
+        new_sector.daily_fee =
+            daily_proof_fee_adjust(&new_sector.daily_fee, &old_qa_power, full_qa_power);
+    }
 
     Ok(new_sector)
 }
@@ -5490,6 +5744,7 @@ impl ActorCode for Actor {
         ProveCommitSectors3 => prove_commit_sectors3,
         ProveReplicaUpdates3 => prove_replica_updates3,
         ProveCommitSectorsNI => prove_commit_sectors_ni,
+        UpgradeSectorQuality => upgradeSectorQuality,
         MaxTerminationFeeExported => max_termination_fee,
         InitialPledgeExported => initial_pledge,
         GenerateSectorLocationExported => generate_sector_location,

--- a/actors/miner/src/lib.rs
+++ b/actors/miner/src/lib.rs
@@ -2149,7 +2149,7 @@ impl Actor {
                 state,
                 info.sector_size,
                 &inner.extensions,
-                |_partition, decl, sector| match decl.new_expiration {
+                |decl, sector| match decl.new_expiration {
                     Some(new_expiration) => extend_sector_committment(
                         policy,
                         curr_epoch,
@@ -2230,19 +2230,7 @@ impl Actor {
                 state,
                 info.sector_size,
                 &declarations,
-                |partition, decl, sector| {
-                    // Only active sectors may upgrade; a faulty, unproven, terminated
-                    // or foreign sector fails the whole message.
-                    if !partition.is_active(sector.sector_number) {
-                        let key =
-                            PartitionKey { deadline: decl.deadline, partition: decl.partition };
-                        return Err(actor_error!(
-                            illegal_argument,
-                            "can only upgrade active sectors: sector {} is not active in {:?}",
-                            sector.sector_number,
-                            key
-                        ));
-                    }
+                |decl, sector| {
                     // Already at full power, by flag or by weights, there is nothing to
                     // upgrade or re-pledge: the sector is only extended if asked, else
                     // skipped rather than failed.
@@ -3436,8 +3424,8 @@ impl From<UpgradeSectorQuality> for ValidatedExpirationExtension {
 /// pledge deltas.
 ///
 /// `rewrite` produces each sector's replacement record, or `None` to leave the sector exactly
-/// as it is. It receives the partition holding the sector, so a caller can reject sectors its
-/// operation does not accept. Declarations are not merged but applied in order, each seeing the
+/// as it is. Every named sector must be active, else the call fails with
+/// `USR_ILLEGAL_ARGUMENT`. Declarations are not merged but applied in order, each seeing the
 /// records the previous ones produced, so a sector named twice is offered to `rewrite` twice
 /// (and rewritten again only if `rewrite` says so).
 ///
@@ -3451,7 +3439,6 @@ fn replace_sector_records<BS: Blockstore>(
     sector_size: SectorSize,
     declarations: &[ValidatedExpirationExtension],
     rewrite: impl Fn(
-        &Partition,
         &ValidatedExpirationExtension,
         &SectorOnChainInfo,
     ) -> Result<Option<SectorOnChainInfo>, ActorError>,
@@ -3518,7 +3505,16 @@ fn replace_sector_records<BS: Blockstore>(
             for sector in
                 sectors.load_sectors(&decl.sectors).map_err(|e| e.wrap("failed to load sectors"))?
             {
-                if let Some(new_sector) = rewrite(&partition, decl, &sector)? {
+                // Reject a faulty, unproven, terminated or foreign sector.
+                if !partition.is_active(sector.sector_number) {
+                    return Err(actor_error!(
+                        illegal_argument,
+                        "sector {} is not active in {:?}",
+                        sector.sector_number,
+                        key
+                    ));
+                }
+                if let Some(new_sector) = rewrite(decl, &sector)? {
                     old_sectors.push(sector);
                     new_sectors.push(new_sector);
                 }

--- a/actors/miner/src/partition_state.rs
+++ b/actors/miner/src/partition_state.rs
@@ -15,6 +15,7 @@ use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
+use fvm_shared::sector::SectorNumber;
 use fvm_shared::sector::{SectorSize, StoragePower};
 use num_traits::{Signed, Zero};
 
@@ -100,6 +101,14 @@ impl Partition {
     pub fn active_sectors(&self) -> BitField {
         let non_faulty = &self.live_sectors() - &self.faults;
         &non_faulty - &self.unproven
+    }
+
+    /// Whether one sector is active (see `active_sectors`), without building the set.
+    pub fn is_active(&self, sector_number: SectorNumber) -> bool {
+        self.sectors.get(sector_number)
+            && !self.terminated.get(sector_number)
+            && !self.faults.get(sector_number)
+            && !self.unproven.get(sector_number)
     }
 
     /// Active power is power of non-faulty sectors.

--- a/actors/miner/src/types.rs
+++ b/actors/miner/src/types.rs
@@ -257,6 +257,23 @@ pub struct ExpirationExtension2 {
     pub new_expiration: ChainEpoch,
 }
 
+#[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct UpgradeSectorQualityParams {
+    pub extensions: Vec<UpgradeSectorQuality>,
+}
+
+#[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct UpgradeSectorQuality {
+    pub deadline: u64,
+    pub partition: u64,
+    /// Sectors to upgrade to full quality-adjusted power (FIP-0118).
+    pub sectors: BitField,
+    /// Unset means upgrade only: every selected sector keeps its own expiration.
+    /// Otherwise the absolute epoch to extend all selected sectors to; it must be
+    /// after the current epoch and at or beyond each sector's current expiration.
+    pub new_expiration: Option<ChainEpoch>,
+}
+
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct TerminateSectorsParams {
     pub terminations: Vec<TerminationDeclaration>,

--- a/actors/miner/tests/extend_sector_expiration_test.rs
+++ b/actors/miner/tests/extend_sector_expiration_test.rs
@@ -1,6 +1,6 @@
 use fil_actor_miner::{
     Actor, ExpirationExtension2, ExtendSectorExpiration2Params, Method, PoStPartition, SectorClaim,
-    SectorOnChainInfo, State, daily_proof_fee, power_for_sector,
+    SectorOnChainInfo, State, daily_proof_fee, pledge_penalty_for_termination, power_for_sector,
     seal_proof_sector_maximum_lifetime,
 };
 use fil_actors_runtime::{
@@ -58,6 +58,7 @@ fn commit_sector(h: &mut ActorHarness, rt: &MockRuntime) -> SectorOnChainInfo {
 fn rejects_negative_extensions() {
     let (mut h, rt) = setup();
     let sector = commit_sector(&mut h, &rt);
+    h.advance_and_submit_posts(&rt, std::slice::from_ref(&sector));
 
     // attempt to shorten epoch
     let new_expiration = sector.expiration - rt.policy().wpost_proving_period;
@@ -130,6 +131,7 @@ fn rejects_out_of_range_deadline() {
 fn rejects_extension_too_far_in_future() {
     let (mut h, rt) = setup();
     let sector = commit_sector(&mut h, &rt);
+    h.advance_and_submit_posts(&rt, std::slice::from_ref(&sector));
 
     // extend by even proving period after max
     rt.set_epoch(sector.expiration);
@@ -211,6 +213,77 @@ fn rejects_extension_past_max_for_seal_proof() {
     let res = h.extend_sectors2(&rt, params);
     expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "total sector lifetime", res);
     h.check_state(&rt);
+}
+
+fn expect_not_active(h: &ActorHarness, rt: &MockRuntime, params: ExtendSectorExpiration2Params) {
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        "is not active in",
+        h.extend_sectors2(rt, params),
+    );
+    rt.reset();
+}
+
+/// Only active sectors can be extended: an unproven, foreign, faulty or terminated sector aborts
+/// the call as the caller's error, before the expiration queue is touched.
+#[test]
+fn rejects_sectors_that_are_not_active() {
+    let (mut h, rt) = setup();
+    h.construct_and_verify(&rt);
+    // Three sectors: two share a partition, the third lands in another.
+    let sectors =
+        h.commit_and_prove_sectors(&rt, 3, DEFAULT_SECTOR_EXPIRATION as u64, Vec::new(), true);
+    let location = |sector: &SectorOnChainInfo| {
+        rt.get_state::<State>().find_sector(rt.store(), sector.sector_number).unwrap()
+    };
+    let (deadline, partition) = location(&sectors[0]);
+    assert_eq!((deadline, partition), location(&sectors[1]));
+    let (other_deadline, other_partition) = location(&sectors[2]);
+    assert_ne!((deadline, partition), (other_deadline, other_partition));
+    let new_expiration = sectors[0].expiration + 42 * EPOCHS_IN_DAY;
+    let declare = |deadline, partition, sector: &SectorOnChainInfo| ExtendSectorExpiration2Params {
+        extensions: vec![ExpirationExtension2 {
+            deadline,
+            partition,
+            sectors: make_bitfield(&[sector.sector_number]),
+            sectors_with_claims: vec![],
+            new_expiration,
+        }],
+    };
+
+    // Committed but not yet proven in a WindowPoSt.
+    expect_not_active(&h, &rt, declare(deadline, partition, &sectors[0]));
+    h.advance_and_submit_posts(&rt, &sectors);
+
+    // Held by a partition other than the declared one.
+    expect_not_active(&h, &rt, declare(deadline, partition, &sectors[2]));
+
+    // Faulty.
+    h.declare_faults(&rt, std::slice::from_ref(&sectors[0]));
+    expect_not_active(&h, &rt, declare(deadline, partition, &sectors[0]));
+
+    // Terminated, its record still in place until cleanup. Locked rewards make the fee
+    // unlockable, as in the terminate tests.
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
+    let fault_fee = h.continued_fault_penalty(std::slice::from_ref(&sectors[1]));
+    let termination_fee = pledge_penalty_for_termination(
+        &sectors[1].initial_pledge,
+        *rt.epoch.borrow() - sectors[1].activation,
+        &fault_fee,
+    );
+    h.terminate_sectors(&rt, &make_bitfield(&[sectors[1].sector_number]), termination_fee);
+    expect_not_active(&h, &rt, declare(deadline, partition, &sectors[1]));
+
+    // The sector rejected as foreign extends normally under its own partition.
+    h.extend_sectors2(&rt, declare(other_deadline, other_partition, &sectors[2])).unwrap();
+    check_for_expiration(
+        &mut h,
+        &rt,
+        new_expiration,
+        sectors[2].sector_number,
+        other_deadline,
+        other_partition,
+    );
 }
 
 #[test]

--- a/actors/miner/tests/upgrade_sector_quality_test.rs
+++ b/actors/miner/tests/upgrade_sector_quality_test.rs
@@ -1,11 +1,13 @@
 use fil_actor_miner::{
-    Actor, ExpirationExtension2, ExtendSectorExpiration2Params, Method, PowerPair,
+    Actor, ExpirationExtension2, ExtendSectorExpiration2Params, Method, PoStPartition, PowerPair,
     SectorOnChainInfo, SectorOnChainInfoFlags, State, UpgradeSectorQuality,
-    UpgradeSectorQualityParams, daily_proof_fee, daily_proof_fee_adjust, qa_power_for_sector,
-    qa_power_max,
+    UpgradeSectorQualityParams, daily_proof_fee, daily_proof_fee_adjust,
+    pledge_penalty_for_continued_fault, pledge_penalty_for_termination, power_for_sectors,
+    qa_power_for_sector, qa_power_max,
 };
 use fil_actors_runtime::{
     EPOCHS_IN_DAY,
+    reward::FilterEstimate,
     runtime::{Runtime, RuntimePolicy},
     test_utils::{ACCOUNT_ACTOR_CODE_ID, MockRuntime, expect_abort, expect_abort_contains_message},
 };
@@ -16,10 +18,12 @@ use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
 
 use num_traits::Zero;
+use std::cmp::max;
 use std::collections::BTreeMap;
+use std::ops::Neg;
 
 mod util;
 use util::*;
@@ -63,6 +67,20 @@ fn make_legacy(
     numbers.iter().map(|&n| h.get_sector(rt, n)).collect()
 }
 
+/// Commits and proves `count` sectors, leaving their as-committed (full-power) records for
+/// tests that fabricate their own legacy shape.
+fn commit_proven_sectors(
+    h: &mut ActorHarness,
+    rt: &MockRuntime,
+    count: usize,
+) -> Vec<SectorOnChainInfo> {
+    h.construct_and_verify(rt);
+    let sectors =
+        h.commit_and_prove_sectors(rt, count, DEFAULT_SECTOR_EXPIRATION as u64, Vec::new(), true);
+    h.advance_and_submit_posts(rt, &sectors);
+    sectors
+}
+
 /// Commits and proves `count` sectors, then rewrites them as legacy sectors of the given shape.
 fn commit_legacy_sectors(
     h: &mut ActorHarness,
@@ -71,10 +89,7 @@ fn commit_legacy_sectors(
     flags: SectorOnChainInfoFlags,
     verified_space: u64,
 ) -> Vec<SectorOnChainInfo> {
-    h.construct_and_verify(rt);
-    let sectors =
-        h.commit_and_prove_sectors(rt, count, DEFAULT_SECTOR_EXPIRATION as u64, Vec::new(), true);
-    h.advance_and_submit_posts(rt, &sectors);
+    let sectors = commit_proven_sectors(h, rt, count);
     make_legacy(h, rt, &sectors, flags, verified_space)
 }
 
@@ -102,6 +117,22 @@ fn group_by_partition(
     by_partition
 }
 
+/// One upgrade-only declaration per (deadline, partition) home of the sectors.
+fn upgrade_only_declarations(
+    rt: &MockRuntime,
+    sectors: &[SectorOnChainInfo],
+) -> Vec<UpgradeSectorQuality> {
+    group_by_partition(rt, sectors)
+        .into_iter()
+        .map(|((deadline, partition), sectors)| UpgradeSectorQuality {
+            deadline,
+            partition,
+            sectors: make_bitfield(&sectors),
+            new_expiration: None,
+        })
+        .collect()
+}
+
 fn upgrade_params(
     rt: &MockRuntime,
     sector_number: SectorNumber,
@@ -118,7 +149,8 @@ fn upgrade_params(
     }
 }
 
-/// Power and pledge deltas expected from upgrading these sectors to full power.
+/// Power and pledge deltas expected from upgrading these sectors to full power: power rises to
+/// the maximum, pledge to `max(old, 10x requirement)`.
 fn expected_upgrade_deltas(
     h: &ActorHarness,
     rt: &MockRuntime,
@@ -129,7 +161,7 @@ fn expected_upgrade_deltas(
     let mut pledge_delta = TokenAmount::zero();
     for sector in sectors {
         qa_delta += qa_power_max(h.sector_size) - qa_power_for_sector(h.sector_size, sector);
-        pledge_delta += &pledge_10x - &sector.initial_pledge;
+        pledge_delta += max(&pledge_10x, &sector.initial_pledge) - &sector.initial_pledge;
     }
     (PowerPair::new(BigInt::zero(), qa_delta), pledge_delta)
 }
@@ -161,7 +193,7 @@ fn assert_full_power_record(
     );
     assert_eq!(qa_power_max(h.sector_size), qa_power_for_sector(h.sector_size, upgraded));
     let pledge_10x = h.initial_pledge_for_power(rt, &qa_power_max(h.sector_size));
-    assert_eq!(pledge_10x, upgraded.initial_pledge);
+    assert_eq!(max(&pledge_10x, &legacy.initial_pledge), &upgraded.initial_pledge);
     assert_eq!(upgraded_fee(h, rt, legacy), upgraded.daily_fee);
 }
 
@@ -246,7 +278,7 @@ fn upgrade_with_extension_in_one_declaration() {
 }
 
 #[test]
-fn second_upgrade_is_a_no_op() {
+fn repeated_upgrade_is_a_no_op() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
 
@@ -259,9 +291,57 @@ fn second_upgrade_is_a_no_op() {
         pledge_delta,
     )
     .unwrap();
-    let state_root_after_first = *rt.state.borrow();
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    let state_root = *rt.state.borrow();
 
-    // The same call again moves no power, pledge or fee, and leaves state byte-identical.
+    // A sector at full power is skipped: neither an in-place repeat nor one asking for an
+    // extension moves power, pledge, fee or expiration, and state stays byte-identical.
+    for new_expiration in [None, Some(upgraded.expiration + 42 * EPOCHS_IN_DAY)] {
+        h.upgrade_sector_quality(
+            &rt,
+            upgrade_params(&rt, upgraded.sector_number, new_expiration),
+            PowerPair::zero(),
+            TokenAmount::zero(),
+        )
+        .unwrap();
+        assert_eq!(state_root, *rt.state.borrow());
+    }
+    h.check_state(&rt);
+}
+
+#[test]
+fn repeated_upgrade_locks_nothing_when_pledge_requirement_rises() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+
+    // Depress the pledge requirement below the sector's recorded pledge for the first
+    // upgrade: zero supply removes the supply share, and a small reward keeps the base term
+    // under the per-byte pledge cap.
+    let normal_supply = rt.total_fil_circ_supply();
+    let normal_reward = h.epoch_reward_smooth.clone();
+    rt.set_circulating_supply(TokenAmount::zero());
+    h.epoch_reward_smooth =
+        FilterEstimate::new(TokenAmount::from_nano(10_000_000).atto().clone(), BigInt::zero());
+
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    assert!(pledge_delta.is_zero());
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+    let after_first = h.get_sector(&rt, legacy.sector_number);
+
+    // Conditions recover, so the full-power requirement now exceeds what the sector holds.
+    // Already at full power, a repeat must lock nothing.
+    rt.set_circulating_supply(normal_supply);
+    h.epoch_reward_smooth = normal_reward;
+    let raised_requirement = h.initial_pledge_for_power(&rt, &qa_power_max(h.sector_size));
+    assert!(raised_requirement > after_first.initial_pledge);
+
     h.upgrade_sector_quality(
         &rt,
         upgrade_params(&rt, legacy.sector_number, None),
@@ -269,7 +349,7 @@ fn second_upgrade_is_a_no_op() {
         TokenAmount::zero(),
     )
     .unwrap();
-    assert_eq!(state_root_after_first, *rt.state.borrow());
+    assert_eq!(after_first, h.get_sector(&rt, legacy.sector_number));
     h.check_state(&rt);
 }
 
@@ -302,6 +382,47 @@ fn upgrades_partially_verified_pre_fip0045_sector() {
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
     assert_eq!(legacy.verified_deal_weight, upgraded.verified_deal_weight);
     assert_eq!(legacy.power_base_epoch, upgraded.power_base_epoch);
+    h.check_state(&rt);
+}
+
+#[test]
+fn upgrades_sector_with_unverified_data_keeping_weights() {
+    let (mut h, rt) = setup();
+    let sector = commit_proven_sectors(&mut h, &rt, 1).remove(0);
+
+    // A legacy sector half-full of unverified deal data. Deal weight has no power effect, so
+    // it counts 1x before the upgrade, like a CC sector.
+    let raw_power = StoragePower::from(h.sector_size as u64);
+    let pledge_1x = h.initial_pledge_for_power(&rt, &raw_power);
+    let fee_1x = daily_proof_fee(rt.policy(), &rt.total_fil_circ_supply(), &raw_power);
+    let half_space = BigInt::from(h.sector_size as u64 / 2);
+    h.rewrite_sectors(&rt, &[sector.sector_number], |s| {
+        s.flags = SectorOnChainInfoFlags::SIMPLE_QA_POWER;
+        s.deal_weight = &half_space * (s.expiration - s.power_base_epoch);
+        s.initial_pledge = pledge_1x.clone();
+        s.daily_fee = fee_1x.clone();
+    });
+    let legacy = h.get_sector(&rt, sector.sector_number);
+    assert_eq!(raw_power, qa_power_for_sector(h.sector_size, &legacy));
+    h.check_state(&rt);
+
+    // The upgrade is the same full 9x jump as for a CC sector, and the deal weight survives
+    // untouched.
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    assert_eq!(BigInt::from(h.sector_size as u64 * 9), power_delta.qa);
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    assert_full_power_record(&h, &rt, &legacy, &upgraded);
+    assert_eq!(legacy.deal_weight, upgraded.deal_weight);
+    assert!(upgraded.verified_deal_weight.is_zero());
     h.check_state(&rt);
 }
 
@@ -341,19 +462,17 @@ fn extension_restates_verified_weight_and_grants_full_power() {
 }
 
 #[test]
-fn fully_verified_sector_moves_no_power_or_pledge() {
+fn already_full_power_by_weights_is_skipped() {
     let (mut h, rt) = setup();
-    // Already 10x through its weights, so there is nothing to raise. Whether such a sector is
-    // flagged or skipped is not pinned here; either way it must move no power, pledge or fee.
+    // Already 10x through its weights alone, so there is nothing to raise: the sector is not
+    // eligible and is skipped — not even flagged — leaving state byte-identical.
     let full = h.sector_size as u64;
     let legacy =
         commit_legacy_sectors(&mut h, &rt, 1, SectorOnChainInfoFlags::SIMPLE_QA_POWER, full)
             .remove(0);
     assert_eq!(qa_power_max(h.sector_size), qa_power_for_sector(h.sector_size, &legacy));
-    let pledge_10x = h.initial_pledge_for_power(&rt, &qa_power_max(h.sector_size));
-    assert_eq!(pledge_10x, legacy.initial_pledge);
+    let state_root = *rt.state.borrow();
 
-    let state_before: State = rt.get_state();
     h.upgrade_sector_quality(
         &rt,
         upgrade_params(&rt, legacy.sector_number, None),
@@ -362,20 +481,105 @@ fn fully_verified_sector_moves_no_power_or_pledge() {
     )
     .unwrap();
 
-    let after = h.get_sector(&rt, legacy.sector_number);
-    assert_eq!(legacy.initial_pledge, after.initial_pledge);
-    assert_eq!(legacy.daily_fee, after.daily_fee);
-    assert_eq!(state_before.initial_pledge, rt.get_state::<State>().initial_pledge);
+    assert_eq!(legacy, h.get_sector(&rt, legacy.sector_number));
+    assert_eq!(state_root, *rt.state.borrow());
+    h.check_state(&rt);
+}
+
+#[test]
+fn keeps_higher_existing_pledge_without_topping_up() {
+    let (mut h, rt) = setup();
+    let sector = commit_proven_sectors(&mut h, &rt, 1).remove(0);
+
+    // The sector already holds more pledge than today's 10x requirement (e.g. it onboarded
+    // when pledge ran higher). The rule is max(old, new): nothing extra to lock, and the
+    // pledge is never lowered.
+    let raw_power = StoragePower::from(h.sector_size as u64);
+    let pledge_10x = h.initial_pledge_for_power(&rt, &qa_power_max(h.sector_size));
+    let high_pledge = &pledge_10x * 2;
+    let fee_1x = daily_proof_fee(rt.policy(), &rt.total_fil_circ_supply(), &raw_power);
+    h.rewrite_sectors(&rt, &[sector.sector_number], |s| {
+        s.flags = SectorOnChainInfoFlags::SIMPLE_QA_POWER;
+        s.initial_pledge = high_pledge.clone();
+        s.daily_fee = fee_1x.clone();
+    });
+    let legacy = h.get_sector(&rt, sector.sector_number);
+    h.check_state(&rt);
+
+    let state_before: State = rt.get_state();
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    assert!(pledge_delta.is_zero());
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+
+    // Power and fee still move to the 10x level; the pledge stays put.
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    assert_full_power_record(&h, &rt, &legacy, &upgraded);
+    assert_eq!(high_pledge, upgraded.initial_pledge);
+    let state_after: State = rt.get_state();
+    assert_eq!(state_before.initial_pledge, state_after.initial_pledge);
+    h.check_state(&rt);
+}
+
+#[test]
+fn clears_deprecated_reward_estimates_on_upgrade() {
+    let (mut h, rt) = setup();
+    let sectors = commit_legacy_sectors(&mut h, &rt, 2, SectorOnChainInfoFlags::SIMPLE_QA_POWER, 0);
+    let numbers = [sectors[0].sector_number, sectors[1].sector_number];
+    let (deadline, partition) = sector_location(&rt, numbers[0]);
+    assert_eq!((deadline, partition), sector_location(&rt, numbers[1]));
+
+    // Real pre-FIP-0100 records still carry the deprecated estimates.
+    h.rewrite_sectors(&rt, &numbers, |s| {
+        s.expected_day_reward = Some(TokenAmount::from_whole(1));
+        s.expected_storage_pledge = Some(TokenAmount::from_whole(2));
+        s.replaced_day_reward = Some(TokenAmount::from_whole(3));
+    });
+    let legacy: Vec<_> = numbers.iter().map(|&n| h.get_sector(&rt, n)).collect();
+
+    // One sector upgrades in place, the other also extends: both paths clear the estimates.
+    let extensions = vec![
+        UpgradeSectorQuality {
+            deadline,
+            partition,
+            sectors: make_bitfield(&[numbers[0]]),
+            new_expiration: None,
+        },
+        UpgradeSectorQuality {
+            deadline,
+            partition,
+            sectors: make_bitfield(&[numbers[1]]),
+            new_expiration: Some(legacy[1].expiration + 42 * EPOCHS_IN_DAY),
+        },
+    ];
+    let (power_delta, pledge_delta) = expected_upgrade_deltas(&h, &rt, &legacy);
+    h.upgrade_sector_quality(
+        &rt,
+        UpgradeSectorQualityParams { extensions },
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+
+    for &number in &numbers {
+        let upgraded = h.get_sector(&rt, number);
+        assert_eq!(None, upgraded.expected_day_reward);
+        assert_eq!(None, upgraded.expected_storage_pledge);
+        assert_eq!(None, upgraded.replaced_day_reward);
+    }
     h.check_state(&rt);
 }
 
 #[test]
 fn one_declaration_upgrades_sectors_with_different_expirations() {
     let (mut h, rt) = setup();
-    h.construct_and_verify(&rt);
-    let sectors =
-        h.commit_and_prove_sectors(&rt, 2, DEFAULT_SECTOR_EXPIRATION as u64, Vec::new(), true);
-    h.advance_and_submit_posts(&rt, &sectors);
+    let sectors = commit_proven_sectors(&mut h, &rt, 2);
     let (deadline, partition) = sector_location(&rt, sectors[0].sector_number);
     assert_eq!((deadline, partition), sector_location(&rt, sectors[1].sector_number));
 
@@ -418,26 +622,97 @@ fn one_declaration_upgrades_sectors_with_different_expirations() {
 }
 
 #[test]
-fn upgrades_across_deadlines_with_mixed_declarations() {
+fn extension_skips_sectors_already_at_full_power() {
     let (mut h, rt) = setup();
-    let legacy = commit_legacy_sectors(&mut h, &rt, 3, SectorOnChainInfoFlags::SIMPLE_QA_POWER, 0);
-    let by_partition = group_by_partition(&rt, &legacy);
-    assert!(by_partition.len() >= 2, "test needs sectors in more than one partition");
+    let sectors = commit_proven_sectors(&mut h, &rt, 2);
+    let (deadline, partition) = sector_location(&rt, sectors[0].sector_number);
+    assert_eq!((deadline, partition), sector_location(&rt, sectors[1].sector_number));
 
-    // The first partition upgrades in place; every other one also extends.
-    let new_expiration = legacy[0].expiration + 42 * EPOCHS_IN_DAY;
-    let in_place = by_partition.values().next().unwrap().clone();
-    let extensions: Vec<_> = by_partition
-        .iter()
-        .map(|(&(deadline, partition), sectors)| UpgradeSectorQuality {
+    // One sector is made legacy; its partition-mate keeps its as-committed full power.
+    let legacy =
+        make_legacy(&h, &rt, &sectors[..1], SectorOnChainInfoFlags::SIMPLE_QA_POWER, 0).remove(0);
+    let full = h.get_sector(&rt, sectors[1].sector_number);
+    assert!(full.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
+
+    // One declaration extends both. Only the legacy sector is upgraded and extended; the
+    // full-power one is not eligible, so it keeps its expiration (ExtendSectorExpiration2
+    // is the way to extend it).
+    let new_expiration = legacy.expiration + 42 * EPOCHS_IN_DAY;
+    let params = UpgradeSectorQualityParams {
+        extensions: vec![UpgradeSectorQuality {
             deadline,
             partition,
-            sectors: make_bitfield(sectors),
-            new_expiration: if *sectors == in_place { None } else { Some(new_expiration) },
-        })
-        .collect();
+            sectors: make_bitfield(&[legacy.sector_number, full.sector_number]),
+            new_expiration: Some(new_expiration),
+        }],
+    };
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(&rt, params, power_delta, pledge_delta).unwrap();
 
-    let (power_delta, pledge_delta) = expected_upgrade_deltas(&h, &rt, &legacy);
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    assert_full_power_record(&h, &rt, &legacy, &upgraded);
+    assert_eq!(new_expiration, upgraded.expiration);
+    assert_eq!(full, h.get_sector(&rt, full.sector_number));
+    h.check_state(&rt);
+}
+
+#[test]
+fn mixed_batch_upgrades_extends_and_requeues_across_epochs() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_sectors(&mut h, &rt, 4, SectorOnChainInfoFlags::SIMPLE_QA_POWER, 0);
+
+    // The batch needs one partition holding at least two sectors and one other partition.
+    let by_partition = group_by_partition(&rt, &legacy);
+    let (&(deadline, partition), pair) = by_partition
+        .iter()
+        .find(|(_, sectors)| sectors.len() >= 2)
+        .expect("need a partition with two sectors");
+    let (&(other_deadline, other_partition), other) = by_partition
+        .iter()
+        .find(|&(&key, _)| key != (deadline, partition))
+        .expect("need a second partition");
+    let by_number: BTreeMap<u64, &SectorOnChainInfo> =
+        legacy.iter().map(|s| (s.sector_number, s)).collect();
+
+    // Two different epochs inside one partition, the first epoch declared twice (the repeat
+    // finds its sector already at full power and skips it), an in-place upgrade in the other
+    // partition, and that partition's second sector left out of the batch entirely.
+    let base = max(by_number[&pair[0]].expiration, by_number[&pair[1]].expiration);
+    let epoch_one = base + 30 * EPOCHS_IN_DAY;
+    let epoch_two = base + 60 * EPOCHS_IN_DAY;
+    let extensions = vec![
+        UpgradeSectorQuality {
+            deadline,
+            partition,
+            sectors: make_bitfield(&[pair[0]]),
+            new_expiration: Some(epoch_one),
+        },
+        UpgradeSectorQuality {
+            deadline,
+            partition,
+            sectors: make_bitfield(&[pair[1]]),
+            new_expiration: Some(epoch_two),
+        },
+        UpgradeSectorQuality {
+            deadline,
+            partition,
+            sectors: make_bitfield(&[pair[0]]),
+            new_expiration: Some(epoch_one),
+        },
+        UpgradeSectorQuality {
+            deadline: other_deadline,
+            partition: other_partition,
+            sectors: make_bitfield(&[other[0]]),
+            new_expiration: None,
+        },
+    ];
+
+    let (power_delta, pledge_delta) = expected_upgrade_deltas(
+        &h,
+        &rt,
+        &[by_number[&pair[0]].clone(), by_number[&pair[1]].clone(), by_number[&other[0]].clone()],
+    );
     h.upgrade_sector_quality(
         &rt,
         UpgradeSectorQualityParams { extensions },
@@ -446,15 +721,22 @@ fn upgrades_across_deadlines_with_mixed_declarations() {
     )
     .unwrap();
 
-    for sector in &legacy {
-        let upgraded = h.get_sector(&rt, sector.sector_number);
-        assert_full_power_record(&h, &rt, sector, &upgraded);
-        let expected_expiration = if in_place.contains(&sector.sector_number) {
-            sector.expiration
-        } else {
-            new_expiration
-        };
-        assert_eq!(expected_expiration, upgraded.expiration);
+    // Every declared sector is upgraded; the extended ones landed on their own epochs, the
+    // in-place one kept its schedule, and the undeclared one is untouched. check_state then
+    // rebuilds each partition's expiration sets from the records (power, pledge, fee, epoch)
+    // and requires every set's epoch to be registered in the deadline's queue: the requeue
+    // bookkeeping for both new epochs.
+    let first = h.get_sector(&rt, pair[0]);
+    let second = h.get_sector(&rt, pair[1]);
+    let in_place = h.get_sector(&rt, other[0]);
+    assert_full_power_record(&h, &rt, by_number[&pair[0]], &first);
+    assert_full_power_record(&h, &rt, by_number[&pair[1]], &second);
+    assert_full_power_record(&h, &rt, by_number[&other[0]], &in_place);
+    assert_eq!(epoch_one, first.expiration);
+    assert_eq!(epoch_two, second.expiration);
+    assert_eq!(by_number[&other[0]].expiration, in_place.expiration);
+    for &bystander in &other[1..] {
+        assert_eq!(*by_number[&bystander], h.get_sector(&rt, bystander));
     }
     h.check_state(&rt);
 }
@@ -486,7 +768,7 @@ fn duplicate_sector_across_declarations_upgrades_once() {
 }
 
 #[test]
-fn next_proving_period_charges_the_upgraded_fee() {
+fn deadline_cron_charges_the_upgraded_fee() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
 
@@ -502,9 +784,175 @@ fn next_proving_period_charges_the_upgraded_fee() {
     let upgraded = h.get_sector(&rt, legacy.sector_number);
     assert!(upgraded.daily_fee > legacy.daily_fee);
 
-    // The harness derives the fee burn it expects from the record, so the deadline's fee books
-    // must agree with it for the next period's PoSt and cron to pass.
+    // The deadline's fee book now carries the upgraded fee. Driving the next proving period
+    // (PoSt at the sector's deadline, cron at every deadline) makes the actor charge that book
+    // at the sector's deadline cron; the harness expects the burn to f099, and any vesting-funds
+    // draw that pays it, computed from the record, to the atto.
+    let (deadline_index, _) = sector_location(&rt, legacy.sector_number);
+    assert_eq!(upgraded.daily_fee, h.get_deadline(&rt, deadline_index).daily_fee);
     h.advance_and_submit_posts(&rt, std::slice::from_ref(&upgraded));
+    h.check_state(&rt);
+}
+
+#[test]
+fn deadline_cron_releases_upgraded_power_and_pledge_at_expiration() {
+    // Bespoke setup with a one-period minimum lifetime, so the sector's whole life fits in a
+    // few proving periods of cron driving.
+    let mut h = ActorHarness::new(100);
+    h.set_proof_type(RegisteredSealProof::StackedDRG512MiBV1);
+    let mut rt = h.new_runtime();
+    rt.policy.min_sector_expiration = rt.policy.wpost_proving_period;
+    rt.balance.replace(BIG_BALANCE.clone());
+    rt.set_epoch(1);
+
+    h.construct_and_verify(&rt);
+    let sector = h.commit_and_prove_sectors(&rt, 1, 3, Vec::new(), true).remove(0);
+    h.advance_and_submit_posts(&rt, std::slice::from_ref(&sector));
+    let legacy = make_legacy(
+        &h,
+        &rt,
+        std::slice::from_ref(&sector),
+        SectorOnChainInfoFlags::SIMPLE_QA_POWER,
+        0,
+    )
+    .remove(0);
+
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    let (deadline_index, partition_index) = sector_location(&rt, upgraded.sector_number);
+
+    // Keep the sector proven until the period holding its expiration.
+    while *rt.epoch.borrow() + rt.policy.wpost_proving_period < upgraded.expiration {
+        h.advance_and_submit_posts(&rt, std::slice::from_ref(&upgraded));
+    }
+
+    // Prove the final window, then let its deadline cron pop the expiration: it must release
+    // exactly the upgraded power and the topped-up pledge.
+    let final_window = h.advance_to_deadline(&rt, deadline_index);
+    h.submit_window_post(
+        &rt,
+        &final_window,
+        vec![PoStPartition { index: partition_index, skipped: BitField::new() }],
+        vec![upgraded.clone()],
+        PoStConfig::with_expected_power_delta(&PowerPair::zero()),
+    );
+    let power_10x = power_for_sectors(h.sector_size, std::slice::from_ref(&upgraded));
+    assert_eq!(qa_power_max(h.sector_size), power_10x.qa);
+    h.advance_deadline(
+        &rt,
+        CronConfig {
+            no_enrollment: true,
+            power_delta: Some(power_10x.neg()),
+            pledge_delta: upgraded.initial_pledge.clone().neg(),
+            ..CronConfig::empty()
+        },
+    );
+
+    // The sector is out of the proving set (its record lingers until cleanup) and the miner
+    // holds no pledge any more.
+    let (_, partition) = h.get_deadline_and_partition(&rt, deadline_index, partition_index);
+    assert!(partition.terminated.get(upgraded.sector_number));
+    assert!(partition.live_power.is_zero());
+    let state: State = rt.get_state();
+    assert!(state.initial_pledge.is_zero());
+    h.check_state(&rt);
+}
+
+#[test]
+fn terminates_upgraded_sector_at_upgraded_pledge_and_power() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+
+    // Locked rewards ensure the fee is unlockable, as in the terminate tests.
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
+
+    // The termination fee's fault-fee floor runs on the upgraded (10x) power, and the released
+    // pledge is the topped-up one.
+    let sector_power = qa_power_for_sector(h.sector_size, &upgraded);
+    assert_eq!(qa_power_max(h.sector_size), sector_power);
+    let fault_fee = pledge_penalty_for_continued_fault(
+        &h.epoch_reward_smooth,
+        &h.epoch_qa_power_smooth,
+        &sector_power,
+    );
+    let expected_fee = pledge_penalty_for_termination(
+        &upgraded.initial_pledge,
+        *rt.epoch.borrow() - upgraded.activation,
+        &fault_fee,
+    );
+    let (power_removed, pledge_removed) =
+        h.terminate_sectors(&rt, &make_bitfield(&[upgraded.sector_number]), expected_fee.clone());
+    assert_eq!(
+        power_for_sectors(h.sector_size, std::slice::from_ref(&upgraded)).neg(),
+        power_removed
+    );
+    assert_eq!(-(expected_fee + &upgraded.initial_pledge), pledge_removed);
+
+    let state: State = rt.get_state();
+    assert!(state.initial_pledge.is_zero());
+    h.check_state(&rt);
+}
+
+#[test]
+fn extend2_after_upgrade_keeps_full_power_and_pledge() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+
+    // A later plain extension keeps the 10x contract: flag, pledge and fee ride along; only
+    // the expiration and power base move.
+    let (deadline, partition) = sector_location(&rt, upgraded.sector_number);
+    let new_expiration = upgraded.expiration + 42 * EPOCHS_IN_DAY;
+    h.extend_sectors2(
+        &rt,
+        ExtendSectorExpiration2Params {
+            extensions: vec![ExpirationExtension2 {
+                deadline,
+                partition,
+                sectors: make_bitfield(&[upgraded.sector_number]),
+                sectors_with_claims: vec![],
+                new_expiration,
+            }],
+        },
+    )
+    .unwrap();
+
+    let extended = h.get_sector(&rt, upgraded.sector_number);
+    assert_eq!(new_expiration, extended.expiration);
+    assert_eq!(*rt.epoch.borrow(), extended.power_base_epoch);
+    assert_eq!(upgraded.flags, extended.flags);
+    assert_eq!(upgraded.initial_pledge, extended.initial_pledge);
+    assert_eq!(upgraded.daily_fee, extended.daily_fee);
+    assert_eq!(qa_power_max(h.sector_size), qa_power_for_sector(h.sector_size, &extended));
     h.check_state(&rt);
 }
 
@@ -530,6 +978,77 @@ fn withdraw_after_upgrade_leaves_the_new_pledge_locked() {
     h.withdraw_funds(&rt, h.owner, &rt.get_balance(), &free, &TokenAmount::zero()).unwrap();
     let pledge_10x = h.initial_pledge_for_power(&rt, &qa_power_max(h.sector_size));
     assert_eq!(pledge_10x, rt.get_state::<State>().initial_pledge);
+    h.check_state(&rt);
+}
+
+#[test]
+fn attaches_full_rate_fee_to_pre_fip0100_sector() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    h.rewrite_sectors(&rt, &[legacy.sector_number], |sector| {
+        sector.daily_fee = TokenAmount::zero()
+    });
+    let legacy = h.get_sector(&rt, legacy.sector_number);
+
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+
+    let expected_fee =
+        daily_proof_fee(rt.policy(), &rt.total_fil_circ_supply(), &qa_power_max(h.sector_size));
+    assert!(expected_fee.is_positive());
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    assert_eq!(expected_fee, upgraded.daily_fee);
+    assert_full_power_record(&h, &rt, &legacy, &upgraded);
+    h.check_state(&rt);
+}
+
+#[test]
+fn extend_sector_expiration2_does_not_upgrade() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    let (deadline, partition) = sector_location(&rt, legacy.sector_number);
+
+    let new_expiration = legacy.expiration + 42 * EPOCHS_IN_DAY;
+    let params = ExtendSectorExpiration2Params {
+        extensions: vec![ExpirationExtension2 {
+            deadline,
+            partition,
+            sectors: make_bitfield(&[legacy.sector_number]),
+            sectors_with_claims: vec![],
+            new_expiration,
+        }],
+    };
+    h.extend_sectors2(&rt, params).unwrap();
+
+    // The plain extension contract holds: no flag, no pledge or fee change.
+    let extended = h.get_sector(&rt, legacy.sector_number);
+    assert!(!extended.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
+    assert_eq!(new_expiration, extended.expiration);
+    assert_eq!(legacy.initial_pledge, extended.initial_pledge);
+    assert_eq!(legacy.daily_fee, extended.daily_fee);
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_empty_declaration_list() {
+    let (h, rt) = setup();
+    h.construct_and_verify(&rt);
+
+    let res = h.upgrade_sector_quality(
+        &rt,
+        UpgradeSectorQualityParams { extensions: vec![] },
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    );
+    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "no extension declarations", res);
+    rt.reset();
     h.check_state(&rt);
 }
 
@@ -672,14 +1191,21 @@ fn rejects_unknown_deadline_partition_and_sector() {
 }
 
 #[test]
-fn rejects_faulty_sector() {
+fn faulty_declaration_aborts_the_whole_batch() {
     let (mut h, rt) = setup();
-    let legacy = commit_legacy_cc_sector(&mut h, &rt);
-    h.declare_faults(&rt, std::slice::from_ref(&legacy));
+    let legacy = commit_legacy_sectors(&mut h, &rt, 3, SectorOnChainInfoFlags::SIMPLE_QA_POWER, 0);
+    let faulty = legacy[2].clone();
+    h.declare_faults(&rt, std::slice::from_ref(&faulty));
+
+    // Good declarations first, the faulty sector's declaration last: the good partitions are
+    // processed before the abort, and must still roll back.
+    let mut declarations = upgrade_only_declarations(&rt, &legacy);
+    declarations.sort_by_key(|d| d.sectors.get(faulty.sector_number));
+    assert!(declarations.len() >= 2, "need the faulty sector in its own declaration");
 
     let res = h.upgrade_sector_quality(
         &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
+        UpgradeSectorQualityParams { extensions: declarations },
         PowerPair::zero(),
         TokenAmount::zero(),
     );
@@ -689,6 +1215,13 @@ fn rejects_faulty_sector() {
         res,
     );
     rt.reset();
+
+    // No sector was upgraded, including the ones in the good declarations.
+    for sector in &legacy {
+        let after = h.get_sector(&rt, sector.sector_number);
+        assert!(!after.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
+        assert_eq!(sector.initial_pledge, after.initial_pledge);
+    }
     h.check_state(&rt);
 }
 
@@ -741,6 +1274,15 @@ fn rejects_sector_from_another_partition() {
         res,
     );
     rt.reset();
+
+    // The same sector upgrades under its own partition, so the rejection was about the
+    // declared location, not the sector's state.
+    let elsewhere_record = legacy.iter().find(|s| s.sector_number == elsewhere).unwrap();
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(elsewhere_record));
+    h.upgrade_sector_quality(&rt, upgrade_params(&rt, elsewhere, None), power_delta, pledge_delta)
+        .unwrap();
+    assert_full_power_record(&h, &rt, elsewhere_record, &h.get_sector(&rt, elsewhere));
     h.check_state(&rt);
 }
 
@@ -882,112 +1424,55 @@ fn repays_fee_debt_and_locks_pledge() {
 }
 
 #[test]
-fn attaches_full_rate_fee_to_pre_fip0100_sector() {
-    let (mut h, rt) = setup();
-    let legacy = commit_legacy_cc_sector(&mut h, &rt);
-    h.rewrite_sectors(&rt, &[legacy.sector_number], |sector| {
-        sector.daily_fee = TokenAmount::zero()
-    });
-    let legacy = h.get_sector(&rt, legacy.sector_number);
-
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-
-    let expected_fee =
-        daily_proof_fee(rt.policy(), &rt.total_fil_circ_supply(), &qa_power_max(h.sector_size));
-    assert!(expected_fee.is_positive());
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
-    assert_eq!(expected_fee, upgraded.daily_fee);
-    assert_full_power_record(&h, &rt, &legacy, &upgraded);
-    h.check_state(&rt);
-}
-
-#[test]
-fn extend_sector_expiration2_does_not_upgrade() {
-    let (mut h, rt) = setup();
-    let legacy = commit_legacy_cc_sector(&mut h, &rt);
-    let (deadline, partition) = sector_location(&rt, legacy.sector_number);
-
-    let new_expiration = legacy.expiration + 42 * EPOCHS_IN_DAY;
-    let params = ExtendSectorExpiration2Params {
-        extensions: vec![ExpirationExtension2 {
-            deadline,
-            partition,
-            sectors: make_bitfield(&[legacy.sector_number]),
-            sectors_with_claims: vec![],
-            new_expiration,
-        }],
-    };
-    h.extend_sectors2(&rt, params).unwrap();
-
-    // The plain extension contract holds: no flag, no pledge or fee change.
-    let extended = h.get_sector(&rt, legacy.sector_number);
-    assert!(!extended.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
-    assert_eq!(new_expiration, extended.expiration);
-    assert_eq!(legacy.initial_pledge, extended.initial_pledge);
-    assert_eq!(legacy.daily_fee, extended.daily_fee);
-    h.check_state(&rt);
-}
-
-#[test]
-fn rejects_batches_beyond_addressing_limits() {
-    let (h, rt) = setup();
-    h.construct_and_verify(&rt);
-
-    // One partition too many.
-    let extensions: Vec<_> = (0..=rt.policy().addressed_partitions_max)
-        .map(|i| UpgradeSectorQuality {
-            deadline: 0,
-            partition: i,
-            sectors: make_bitfield(&[i]),
-            new_expiration: None,
-        })
-        .collect();
-    let res = h.upgrade_sector_quality(
-        &rt,
-        UpgradeSectorQualityParams { extensions },
-        PowerPair::zero(),
-        TokenAmount::zero(),
-    );
-    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "too many partitions", res);
-    rt.reset();
-
-    // One sector too many.
-    let params = UpgradeSectorQualityParams {
-        extensions: vec![UpgradeSectorQuality {
-            deadline: 0,
-            partition: 0,
-            sectors: BitField::try_from_bits(0..=rt.policy().addressed_sectors_max).unwrap(),
-            new_expiration: None,
-        }],
-    };
-    let res = h.upgrade_sector_quality(&rt, params, PowerPair::zero(), TokenAmount::zero());
-    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "too many sectors", res);
-    rt.reset();
-}
-
-#[test]
 fn rejects_unauthorized_caller() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
     let params = upgrade_params(&rt, legacy.sector_number, None);
 
+    // The caller is checked before anything else, so no network queries are made.
     rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(1234));
     rt.expect_validate_caller_addr(h.caller_addrs());
-    // Pledge inputs are fetched before the transaction validates the caller.
-    h.expect_query_network_info(&rt);
-
     let res = rt.call::<Actor>(
         Method::UpgradeSectorQuality as u64,
         IpldBlock::serialize_cbor(&params).unwrap(),
     );
     expect_abort(ExitCode::USR_FORBIDDEN, res);
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_terminated_sector() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+
+    // Locked rewards ensure the termination fee is unlockable, as in the terminate tests.
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
+    let sector_power = qa_power_for_sector(h.sector_size, &legacy);
+    let fault_fee = pledge_penalty_for_continued_fault(
+        &h.epoch_reward_smooth,
+        &h.epoch_qa_power_smooth,
+        &sector_power,
+    );
+    let termination_fee = pledge_penalty_for_termination(
+        &legacy.initial_pledge,
+        *rt.epoch.borrow() - legacy.activation,
+        &fault_fee,
+    );
+    h.terminate_sectors(&rt, &make_bitfield(&[legacy.sector_number]), termination_fee);
+
+    // A terminated sector stays in its partition's books until its record is cleaned up, but
+    // it is no longer active.
+    let res = h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    );
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        "can only upgrade active sectors",
+        res,
+    );
+    rt.reset();
     h.check_state(&rt);
 }

--- a/actors/miner/tests/upgrade_sector_quality_test.rs
+++ b/actors/miner/tests/upgrade_sector_quality_test.rs
@@ -2,8 +2,7 @@ use fil_actor_miner::{
     Actor, ExpirationExtension2, ExtendSectorExpiration2Params, Method, PoStPartition, PowerPair,
     SectorOnChainInfo, SectorOnChainInfoFlags, State, UpgradeSectorQuality,
     UpgradeSectorQualityParams, daily_proof_fee, daily_proof_fee_adjust,
-    pledge_penalty_for_continued_fault, pledge_penalty_for_termination, power_for_sectors,
-    qa_power_for_sector, qa_power_max,
+    pledge_penalty_for_termination, power_for_sectors, qa_power_for_sector, qa_power_max,
 };
 use fil_actors_runtime::{
     EPOCHS_IN_DAY,
@@ -18,7 +17,7 @@ use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
 
 use num_traits::Zero;
 use std::cmp::max;
@@ -28,19 +27,12 @@ use std::ops::Neg;
 mod util;
 use util::*;
 
-// an expiration ~10 days greater than effective min expiration taking into account 30 days max between pre and prove commit
-const DEFAULT_SECTOR_EXPIRATION: ChainEpoch = 220;
-
 fn setup() -> (ActorHarness, MockRuntime) {
-    let period_offset = 100;
-    let precommit_epoch = 1;
-
-    let mut h = ActorHarness::new(period_offset);
+    let mut h = ActorHarness::new(100);
     h.set_proof_type(RegisteredSealProof::StackedDRG512MiBV1);
     let rt = h.new_runtime();
     rt.balance.replace(BIG_BALANCE.clone());
-    rt.set_epoch(precommit_epoch);
-
+    rt.set_epoch(1);
     (h, rt)
 }
 
@@ -76,7 +68,7 @@ fn commit_proven_sectors(
 ) -> Vec<SectorOnChainInfo> {
     h.construct_and_verify(rt);
     let sectors =
-        h.commit_and_prove_sectors(rt, count, DEFAULT_SECTOR_EXPIRATION as u64, Vec::new(), true);
+        h.commit_and_prove_sectors(rt, count, DEFAULT_SECTOR_EXPIRATION, Vec::new(), true);
     h.advance_and_submit_posts(rt, &sectors);
     sectors
 }
@@ -117,6 +109,15 @@ fn group_by_partition(
     by_partition
 }
 
+fn declaration(
+    deadline: u64,
+    partition: u64,
+    sectors: &[SectorNumber],
+    new_expiration: Option<ChainEpoch>,
+) -> UpgradeSectorQuality {
+    UpgradeSectorQuality { deadline, partition, sectors: make_bitfield(sectors), new_expiration }
+}
+
 /// One upgrade-only declaration per (deadline, partition) home of the sectors.
 fn upgrade_only_declarations(
     rt: &MockRuntime,
@@ -124,12 +125,7 @@ fn upgrade_only_declarations(
 ) -> Vec<UpgradeSectorQuality> {
     group_by_partition(rt, sectors)
         .into_iter()
-        .map(|((deadline, partition), sectors)| UpgradeSectorQuality {
-            deadline,
-            partition,
-            sectors: make_bitfield(&sectors),
-            new_expiration: None,
-        })
+        .map(|((deadline, partition), sectors)| declaration(deadline, partition, &sectors, None))
         .collect()
 }
 
@@ -140,17 +136,12 @@ fn upgrade_params(
 ) -> UpgradeSectorQualityParams {
     let (deadline, partition) = sector_location(rt, sector_number);
     UpgradeSectorQualityParams {
-        extensions: vec![UpgradeSectorQuality {
-            deadline,
-            partition,
-            sectors: make_bitfield(&[sector_number]),
-            new_expiration,
-        }],
+        extensions: vec![declaration(deadline, partition, &[sector_number], new_expiration)],
     }
 }
 
 /// Power and pledge deltas expected from upgrading these sectors to full power: power rises to
-/// the maximum, pledge to `max(old, 10x requirement)`.
+/// the maximum, pledge to max(old, 10x requirement) — never down.
 fn expected_upgrade_deltas(
     h: &ActorHarness,
     rt: &MockRuntime,
@@ -197,12 +188,54 @@ fn assert_full_power_record(
     assert_eq!(upgraded_fee(h, rt, legacy), upgraded.daily_fee);
 }
 
+/// Upgrades one sector, expecting exactly the power and pledge deltas its record implies, and
+/// returns the new record.
+fn upgrade_one(
+    h: &ActorHarness,
+    rt: &MockRuntime,
+    legacy: &SectorOnChainInfo,
+    new_expiration: Option<ChainEpoch>,
+) -> SectorOnChainInfo {
+    let (power_delta, pledge_delta) = expected_upgrade_deltas(h, rt, std::slice::from_ref(legacy));
+    h.upgrade_sector_quality(
+        rt,
+        upgrade_params(rt, legacy.sector_number, new_expiration),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+    h.get_sector(rt, legacy.sector_number)
+}
+
+/// Calls `UpgradeSectorQuality` expecting it to abort with `code` and `message`.
+fn expect_upgrade_abort(
+    h: &ActorHarness,
+    rt: &MockRuntime,
+    params: UpgradeSectorQualityParams,
+    code: ExitCode,
+    message: &str,
+) {
+    let res = h.upgrade_sector_quality(rt, params, PowerPair::zero(), TokenAmount::zero());
+    expect_abort_contains_message(code, message, res);
+    rt.reset();
+}
+
+/// The fee `TerminateSectors` charges for `sector` now: the pledge-and-age formula, floored by
+/// the continued-fault fee at the sector's current power.
+fn termination_fee(h: &ActorHarness, rt: &MockRuntime, sector: &SectorOnChainInfo) -> TokenAmount {
+    let fault_fee = h.continued_fault_penalty(std::slice::from_ref(sector));
+    pledge_penalty_for_termination(
+        &sector.initial_pledge,
+        *rt.epoch.borrow() - sector.activation,
+        &fault_fee,
+    )
+}
+
 #[test]
 fn upgrade_only_upgrades_in_place() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
     let (deadline_index, _) = sector_location(&rt, legacy.sector_number);
-
     let state_before: State = rt.get_state();
     let deadline_before = h.get_deadline(&rt, deadline_index);
 
@@ -211,17 +244,9 @@ fn upgrade_only_upgrades_in_place() {
         expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
     assert_eq!(BigInt::from(h.sector_size as u64 * 9), power_delta.qa);
     assert!(pledge_delta.is_positive());
-
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta.clone(),
-    )
-    .unwrap();
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
 
     // Only the flags, pledge and fee changed on the record.
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
     assert_eq!(legacy.expiration, upgraded.expiration);
     assert_eq!(legacy.power_base_epoch, upgraded.power_base_epoch);
@@ -244,36 +269,14 @@ fn upgrade_only_upgrades_in_place() {
 fn upgrade_with_extension_in_one_declaration() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
-    let (deadline_index, partition_index) = sector_location(&rt, legacy.sector_number);
     let new_expiration = legacy.expiration + 42 * EPOCHS_IN_DAY;
 
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, Some(new_expiration)),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    let upgraded = upgrade_one(&h, &rt, &legacy, Some(new_expiration));
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
     assert_eq!(new_expiration, upgraded.expiration);
     assert_eq!(*rt.epoch.borrow(), upgraded.power_base_epoch);
-
-    // The partition's expiration queue holds the sector at the new expiration and nowhere
-    // earlier.
-    let state: State = rt.get_state();
-    let quant = state.quant_spec_for_deadline(rt.policy(), deadline_index);
-    let (_, mut partition) = h.get_deadline_and_partition(&rt, deadline_index, partition_index);
-    assert!(
-        partition.pop_expired_sectors(rt.store(), new_expiration - 1, quant).unwrap().is_empty()
-    );
-    let expiring = partition
-        .pop_expired_sectors(rt.store(), quant.quantize_up(new_expiration), quant)
-        .unwrap();
-    assert!(expiring.on_time_sectors.get(upgraded.sector_number));
+    // check_state requires the partition and deadline queues to hold the sector at its new
+    // expiration.
     h.check_state(&rt);
 }
 
@@ -281,29 +284,13 @@ fn upgrade_with_extension_in_one_declaration() {
 fn repeated_upgrade_is_a_no_op() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
-
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
     let state_root = *rt.state.borrow();
 
     // A sector at full power is skipped: neither an in-place repeat nor one asking for an
     // extension moves power, pledge, fee or expiration, and state stays byte-identical.
     for new_expiration in [None, Some(upgraded.expiration + 42 * EPOCHS_IN_DAY)] {
-        h.upgrade_sector_quality(
-            &rt,
-            upgrade_params(&rt, upgraded.sector_number, new_expiration),
-            PowerPair::zero(),
-            TokenAmount::zero(),
-        )
-        .unwrap();
+        upgrade_one(&h, &rt, &upgraded, new_expiration);
         assert_eq!(state_root, *rt.state.borrow());
     }
     h.check_state(&rt);
@@ -322,18 +309,8 @@ fn repeated_upgrade_locks_nothing_when_pledge_requirement_rises() {
     rt.set_circulating_supply(TokenAmount::zero());
     h.epoch_reward_smooth =
         FilterEstimate::new(TokenAmount::from_nano(10_000_000).atto().clone(), BigInt::zero());
-
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    assert!(pledge_delta.is_zero());
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-    let after_first = h.get_sector(&rt, legacy.sector_number);
+    let after_first = upgrade_one(&h, &rt, &legacy, None);
+    assert_eq!(legacy.initial_pledge, after_first.initial_pledge);
 
     // Conditions recover, so the full-power requirement now exceeds what the sector holds.
     // Already at full power, a repeat must lock nothing.
@@ -341,7 +318,6 @@ fn repeated_upgrade_locks_nothing_when_pledge_requirement_rises() {
     h.epoch_reward_smooth = normal_reward;
     let raised_requirement = h.initial_pledge_for_power(&rt, &qa_power_max(h.sector_size));
     assert!(raised_requirement > after_first.initial_pledge);
-
     h.upgrade_sector_quality(
         &rt,
         upgrade_params(&rt, legacy.sector_number, None),
@@ -366,19 +342,9 @@ fn upgrades_partially_verified_pre_fip0045_sector() {
         "half verified is 5.5x"
     );
 
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-
     // Full power, with pledge and fee scaled up from 5.5x; the weights stay as they were, now
     // masked by the flag.
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
     assert_eq!(legacy.verified_deal_weight, upgraded.verified_deal_weight);
     assert_eq!(legacy.power_base_epoch, upgraded.power_base_epoch);
@@ -388,38 +354,18 @@ fn upgrades_partially_verified_pre_fip0045_sector() {
 #[test]
 fn upgrades_sector_with_unverified_data_keeping_weights() {
     let (mut h, rt) = setup();
-    let sector = commit_proven_sectors(&mut h, &rt, 1).remove(0);
-
-    // A legacy sector half-full of unverified deal data. Deal weight has no power effect, so
-    // it counts 1x before the upgrade, like a CC sector.
-    let raw_power = StoragePower::from(h.sector_size as u64);
-    let pledge_1x = h.initial_pledge_for_power(&rt, &raw_power);
-    let fee_1x = daily_proof_fee(rt.policy(), &rt.total_fil_circ_supply(), &raw_power);
+    // A legacy sector half-full of unverified deal data: deal weight has no power effect, so
+    // it is a 1x sector that happens to carry a deal weight.
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
     let half_space = BigInt::from(h.sector_size as u64 / 2);
-    h.rewrite_sectors(&rt, &[sector.sector_number], |s| {
-        s.flags = SectorOnChainInfoFlags::SIMPLE_QA_POWER;
-        s.deal_weight = &half_space * (s.expiration - s.power_base_epoch);
-        s.initial_pledge = pledge_1x.clone();
-        s.daily_fee = fee_1x.clone();
+    h.rewrite_sectors(&rt, &[legacy.sector_number], |s| {
+        s.deal_weight = &half_space * (s.expiration - s.power_base_epoch)
     });
-    let legacy = h.get_sector(&rt, sector.sector_number);
-    assert_eq!(raw_power, qa_power_for_sector(h.sector_size, &legacy));
-    h.check_state(&rt);
+    let legacy = h.get_sector(&rt, legacy.sector_number);
+    assert_eq!(BigInt::from(h.sector_size as u64), qa_power_for_sector(h.sector_size, &legacy));
 
-    // The upgrade is the same full 9x jump as for a CC sector, and the deal weight survives
-    // untouched.
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    assert_eq!(BigInt::from(h.sector_size as u64 * 9), power_delta.qa);
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    // The same full 9x jump as for a CC sector, and the deal weight survives untouched.
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
     assert_eq!(legacy.deal_weight, upgraded.deal_weight);
     assert!(upgraded.verified_deal_weight.is_zero());
@@ -436,19 +382,9 @@ fn extension_restates_verified_weight_and_grants_full_power() {
     let curr_epoch = *rt.epoch.borrow();
     let new_expiration = legacy.expiration + 42 * EPOCHS_IN_DAY;
 
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, Some(new_expiration)),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-
     // Same weight math as ExtendSectorExpiration2: the verified space is restated over the new
     // duration. Power comes from the flag, so the restated weight is not what raised it.
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    let upgraded = upgrade_one(&h, &rt, &legacy, Some(new_expiration));
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
     assert_eq!(new_expiration, upgraded.expiration);
     assert_eq!(curr_epoch, upgraded.power_base_epoch);
@@ -473,15 +409,7 @@ fn already_full_power_by_weights_is_skipped() {
     assert_eq!(qa_power_max(h.sector_size), qa_power_for_sector(h.sector_size, &legacy));
     let state_root = *rt.state.borrow();
 
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        PowerPair::zero(),
-        TokenAmount::zero(),
-    )
-    .unwrap();
-
-    assert_eq!(legacy, h.get_sector(&rt, legacy.sector_number));
+    assert_eq!(legacy, upgrade_one(&h, &rt, &legacy, None));
     assert_eq!(state_root, *rt.state.borrow());
     h.check_state(&rt);
 }
@@ -489,41 +417,20 @@ fn already_full_power_by_weights_is_skipped() {
 #[test]
 fn keeps_higher_existing_pledge_without_topping_up() {
     let (mut h, rt) = setup();
-    let sector = commit_proven_sectors(&mut h, &rt, 1).remove(0);
-
-    // The sector already holds more pledge than today's 10x requirement (e.g. it onboarded
-    // when pledge ran higher). The rule is max(old, new): nothing extra to lock, and the
-    // pledge is never lowered.
-    let raw_power = StoragePower::from(h.sector_size as u64);
+    // The sector holds twice today's 10x requirement (it onboarded when pledge ran higher).
+    // The rule is max(old, new): nothing extra to lock, and the pledge is never lowered.
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
     let pledge_10x = h.initial_pledge_for_power(&rt, &qa_power_max(h.sector_size));
     let high_pledge = &pledge_10x * 2;
-    let fee_1x = daily_proof_fee(rt.policy(), &rt.total_fil_circ_supply(), &raw_power);
-    h.rewrite_sectors(&rt, &[sector.sector_number], |s| {
-        s.flags = SectorOnChainInfoFlags::SIMPLE_QA_POWER;
-        s.initial_pledge = high_pledge.clone();
-        s.daily_fee = fee_1x.clone();
-    });
-    let legacy = h.get_sector(&rt, sector.sector_number);
-    h.check_state(&rt);
-
+    h.rewrite_sectors(&rt, &[legacy.sector_number], |s| s.initial_pledge = high_pledge.clone());
+    let legacy = h.get_sector(&rt, legacy.sector_number);
     let state_before: State = rt.get_state();
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    assert!(pledge_delta.is_zero());
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
 
     // Power and fee still move to the 10x level; the pledge stays put.
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
     assert_eq!(high_pledge, upgraded.initial_pledge);
-    let state_after: State = rt.get_state();
-    assert_eq!(state_before.initial_pledge, state_after.initial_pledge);
+    assert_eq!(state_before.initial_pledge, rt.get_state::<State>().initial_pledge);
     h.check_state(&rt);
 }
 
@@ -545,18 +452,13 @@ fn clears_deprecated_reward_estimates_on_upgrade() {
 
     // One sector upgrades in place, the other also extends: both paths clear the estimates.
     let extensions = vec![
-        UpgradeSectorQuality {
+        declaration(deadline, partition, &[numbers[0]], None),
+        declaration(
             deadline,
             partition,
-            sectors: make_bitfield(&[numbers[0]]),
-            new_expiration: None,
-        },
-        UpgradeSectorQuality {
-            deadline,
-            partition,
-            sectors: make_bitfield(&[numbers[1]]),
-            new_expiration: Some(legacy[1].expiration + 42 * EPOCHS_IN_DAY),
-        },
+            &[numbers[1]],
+            Some(legacy[1].expiration + 42 * EPOCHS_IN_DAY),
+        ),
     ];
     let (power_delta, pledge_delta) = expected_upgrade_deltas(&h, &rt, &legacy);
     h.upgrade_sector_quality(
@@ -602,16 +504,17 @@ fn one_declaration_upgrades_sectors_with_different_expirations() {
     assert_ne!(legacy[0].expiration, legacy[1].expiration);
 
     // One upgrade-only declaration covers both expirations at once.
-    let params = UpgradeSectorQualityParams {
-        extensions: vec![UpgradeSectorQuality {
-            deadline,
-            partition,
-            sectors: make_bitfield(&[legacy[0].sector_number, legacy[1].sector_number]),
-            new_expiration: None,
-        }],
-    };
+    let numbers = [legacy[0].sector_number, legacy[1].sector_number];
     let (power_delta, pledge_delta) = expected_upgrade_deltas(&h, &rt, &legacy);
-    h.upgrade_sector_quality(&rt, params, power_delta, pledge_delta).unwrap();
+    h.upgrade_sector_quality(
+        &rt,
+        UpgradeSectorQualityParams {
+            extensions: vec![declaration(deadline, partition, &numbers, None)],
+        },
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
 
     for sector in &legacy {
         let upgraded = h.get_sector(&rt, sector.sector_number);
@@ -635,20 +538,21 @@ fn extension_skips_sectors_already_at_full_power() {
     assert!(full.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
 
     // One declaration extends both. Only the legacy sector is upgraded and extended; the
-    // full-power one is not eligible, so it keeps its expiration (ExtendSectorExpiration2
-    // is the way to extend it).
+    // full-power one is not eligible and keeps its expiration (ExtendSectorExpiration2 is the
+    // way to extend it).
     let new_expiration = legacy.expiration + 42 * EPOCHS_IN_DAY;
-    let params = UpgradeSectorQualityParams {
-        extensions: vec![UpgradeSectorQuality {
-            deadline,
-            partition,
-            sectors: make_bitfield(&[legacy.sector_number, full.sector_number]),
-            new_expiration: Some(new_expiration),
-        }],
-    };
+    let both = [legacy.sector_number, full.sector_number];
     let (power_delta, pledge_delta) =
         expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(&rt, params, power_delta, pledge_delta).unwrap();
+    h.upgrade_sector_quality(
+        &rt,
+        UpgradeSectorQualityParams {
+            extensions: vec![declaration(deadline, partition, &both, Some(new_expiration))],
+        },
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
 
     let upgraded = h.get_sector(&rt, legacy.sector_number);
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
@@ -662,7 +566,7 @@ fn mixed_batch_upgrades_extends_and_requeues_across_epochs() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_sectors(&mut h, &rt, 4, SectorOnChainInfoFlags::SIMPLE_QA_POWER, 0);
 
-    // The batch needs one partition holding at least two sectors and one other partition.
+    // One partition holding two sectors, and one other partition.
     let by_partition = group_by_partition(&rt, &legacy);
     let (&(deadline, partition), pair) = by_partition
         .iter()
@@ -675,44 +579,19 @@ fn mixed_batch_upgrades_extends_and_requeues_across_epochs() {
     let by_number: BTreeMap<u64, &SectorOnChainInfo> =
         legacy.iter().map(|s| (s.sector_number, s)).collect();
 
-    // Two different epochs inside one partition, the first epoch declared twice (the repeat
-    // finds its sector already at full power and skips it), an in-place upgrade in the other
-    // partition, and that partition's second sector left out of the batch entirely.
+    // Two different epochs inside one partition, an in-place upgrade in the other partition,
+    // and that partition's second sector left out of the batch entirely.
     let base = max(by_number[&pair[0]].expiration, by_number[&pair[1]].expiration);
     let epoch_one = base + 30 * EPOCHS_IN_DAY;
     let epoch_two = base + 60 * EPOCHS_IN_DAY;
     let extensions = vec![
-        UpgradeSectorQuality {
-            deadline,
-            partition,
-            sectors: make_bitfield(&[pair[0]]),
-            new_expiration: Some(epoch_one),
-        },
-        UpgradeSectorQuality {
-            deadline,
-            partition,
-            sectors: make_bitfield(&[pair[1]]),
-            new_expiration: Some(epoch_two),
-        },
-        UpgradeSectorQuality {
-            deadline,
-            partition,
-            sectors: make_bitfield(&[pair[0]]),
-            new_expiration: Some(epoch_one),
-        },
-        UpgradeSectorQuality {
-            deadline: other_deadline,
-            partition: other_partition,
-            sectors: make_bitfield(&[other[0]]),
-            new_expiration: None,
-        },
+        declaration(deadline, partition, &[pair[0]], Some(epoch_one)),
+        declaration(deadline, partition, &[pair[1]], Some(epoch_two)),
+        declaration(other_deadline, other_partition, &[other[0]], None),
     ];
-
-    let (power_delta, pledge_delta) = expected_upgrade_deltas(
-        &h,
-        &rt,
-        &[by_number[&pair[0]].clone(), by_number[&pair[1]].clone(), by_number[&other[0]].clone()],
-    );
+    let declared =
+        [by_number[&pair[0]].clone(), by_number[&pair[1]].clone(), by_number[&other[0]].clone()];
+    let (power_delta, pledge_delta) = expected_upgrade_deltas(&h, &rt, &declared);
     h.upgrade_sector_quality(
         &rt,
         UpgradeSectorQualityParams { extensions },
@@ -721,11 +600,9 @@ fn mixed_batch_upgrades_extends_and_requeues_across_epochs() {
     )
     .unwrap();
 
-    // Every declared sector is upgraded; the extended ones landed on their own epochs, the
-    // in-place one kept its schedule, and the undeclared one is untouched. check_state then
-    // rebuilds each partition's expiration sets from the records (power, pledge, fee, epoch)
-    // and requires every set's epoch to be registered in the deadline's queue: the requeue
-    // bookkeeping for both new epochs.
+    // The extended sectors landed on their own epochs, the in-place one kept its schedule and
+    // the undeclared one is untouched; check_state verifies the queues and books against the
+    // records.
     let first = h.get_sector(&rt, pair[0]);
     let second = h.get_sector(&rt, pair[1]);
     let in_place = h.get_sector(&rt, other[0]);
@@ -742,28 +619,33 @@ fn mixed_batch_upgrades_extends_and_requeues_across_epochs() {
 }
 
 #[test]
-fn duplicate_sector_across_declarations_upgrades_once() {
+fn later_declaration_for_an_upgraded_sector_is_skipped() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
     let (deadline, partition) = sector_location(&rt, legacy.sector_number);
 
-    let decl = UpgradeSectorQuality {
-        deadline,
-        partition,
-        sectors: make_bitfield(&[legacy.sector_number]),
-        new_expiration: None,
-    };
-    let params = UpgradeSectorQualityParams { extensions: vec![decl.clone(), decl] };
-
-    // Exactly one power bump and one pledge raise despite two declarations.
-    let state_before: State = rt.get_state();
+    // Declarations apply in order: the first upgrades and extends the sector, the second finds
+    // it already at full power and leaves it alone, so the first expiration stands and the
+    // sector is charged once.
+    let first = legacy.expiration + 30 * EPOCHS_IN_DAY;
+    let second = legacy.expiration + 60 * EPOCHS_IN_DAY;
+    let extensions = vec![
+        declaration(deadline, partition, &[legacy.sector_number], Some(first)),
+        declaration(deadline, partition, &[legacy.sector_number], Some(second)),
+    ];
     let (power_delta, pledge_delta) =
         expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(&rt, params, power_delta, pledge_delta.clone()).unwrap();
+    h.upgrade_sector_quality(
+        &rt,
+        UpgradeSectorQualityParams { extensions },
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
 
-    let state_after: State = rt.get_state();
-    assert_eq!(pledge_delta, &state_after.initial_pledge - &state_before.initial_pledge);
-    assert_full_power_record(&h, &rt, &legacy, &h.get_sector(&rt, legacy.sector_number));
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    assert_full_power_record(&h, &rt, &legacy, &upgraded);
+    assert_eq!(first, upgraded.expiration);
     h.check_state(&rt);
 }
 
@@ -771,23 +653,11 @@ fn duplicate_sector_across_declarations_upgrades_once() {
 fn deadline_cron_charges_the_upgraded_fee() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
-
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
     assert!(upgraded.daily_fee > legacy.daily_fee);
 
-    // The deadline's fee book now carries the upgraded fee. Driving the next proving period
-    // (PoSt at the sector's deadline, cron at every deadline) makes the actor charge that book
-    // at the sector's deadline cron; the harness expects the burn to f099, and any vesting-funds
-    // draw that pays it, computed from the record, to the atto.
+    // The deadline's fee book carries the upgraded fee, and the next period's cron charges
+    // that book: the harness expects the burn it derives from the record, to the atto.
     let (deadline_index, _) = sector_location(&rt, legacy.sector_number);
     assert_eq!(upgraded.daily_fee, h.get_deadline(&rt, deadline_index).daily_fee);
     h.advance_and_submit_posts(&rt, std::slice::from_ref(&upgraded));
@@ -796,15 +666,9 @@ fn deadline_cron_charges_the_upgraded_fee() {
 
 #[test]
 fn deadline_cron_releases_upgraded_power_and_pledge_at_expiration() {
-    // Bespoke setup with a one-period minimum lifetime, so the sector's whole life fits in a
-    // few proving periods of cron driving.
-    let mut h = ActorHarness::new(100);
-    h.set_proof_type(RegisteredSealProof::StackedDRG512MiBV1);
-    let mut rt = h.new_runtime();
+    // A one-period minimum lifetime keeps the sector's whole life to a few proving periods.
+    let (mut h, mut rt) = setup();
     rt.policy.min_sector_expiration = rt.policy.wpost_proving_period;
-    rt.balance.replace(BIG_BALANCE.clone());
-    rt.set_epoch(1);
-
     h.construct_and_verify(&rt);
     let sector = h.commit_and_prove_sectors(&rt, 1, 3, Vec::new(), true).remove(0);
     h.advance_and_submit_posts(&rt, std::slice::from_ref(&sector));
@@ -816,17 +680,7 @@ fn deadline_cron_releases_upgraded_power_and_pledge_at_expiration() {
         0,
     )
     .remove(0);
-
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
     let (deadline_index, partition_index) = sector_location(&rt, upgraded.sector_number);
 
     // Keep the sector proven until the period holding its expiration.
@@ -861,8 +715,7 @@ fn deadline_cron_releases_upgraded_power_and_pledge_at_expiration() {
     let (_, partition) = h.get_deadline_and_partition(&rt, deadline_index, partition_index);
     assert!(partition.terminated.get(upgraded.sector_number));
     assert!(partition.live_power.is_zero());
-    let state: State = rt.get_state();
-    assert!(state.initial_pledge.is_zero());
+    assert!(rt.get_state::<State>().initial_pledge.is_zero());
     h.check_state(&rt);
 }
 
@@ -870,35 +723,14 @@ fn deadline_cron_releases_upgraded_power_and_pledge_at_expiration() {
 fn terminates_upgraded_sector_at_upgraded_pledge_and_power() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
-
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
-
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
     // Locked rewards ensure the fee is unlockable, as in the terminate tests.
     h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
 
     // The termination fee's fault-fee floor runs on the upgraded (10x) power, and the released
     // pledge is the topped-up one.
-    let sector_power = qa_power_for_sector(h.sector_size, &upgraded);
-    assert_eq!(qa_power_max(h.sector_size), sector_power);
-    let fault_fee = pledge_penalty_for_continued_fault(
-        &h.epoch_reward_smooth,
-        &h.epoch_qa_power_smooth,
-        &sector_power,
-    );
-    let expected_fee = pledge_penalty_for_termination(
-        &upgraded.initial_pledge,
-        *rt.epoch.borrow() - upgraded.activation,
-        &fault_fee,
-    );
+    assert_eq!(qa_power_max(h.sector_size), qa_power_for_sector(h.sector_size, &upgraded));
+    let expected_fee = termination_fee(&h, &rt, &upgraded);
     let (power_removed, pledge_removed) =
         h.terminate_sectors(&rt, &make_bitfield(&[upgraded.sector_number]), expected_fee.clone());
     assert_eq!(
@@ -906,9 +738,7 @@ fn terminates_upgraded_sector_at_upgraded_pledge_and_power() {
         power_removed
     );
     assert_eq!(-(expected_fee + &upgraded.initial_pledge), pledge_removed);
-
-    let state: State = rt.get_state();
-    assert!(state.initial_pledge.is_zero());
+    assert!(rt.get_state::<State>().initial_pledge.is_zero());
     h.check_state(&rt);
 }
 
@@ -916,17 +746,7 @@ fn terminates_upgraded_sector_at_upgraded_pledge_and_power() {
 fn extend2_after_upgrade_keeps_full_power_and_pledge() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
-
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
 
     // A later plain extension keeps the 10x contract: flag, pledge and fee ride along; only
     // the expiration and power base move.
@@ -960,16 +780,7 @@ fn extend2_after_upgrade_keeps_full_power_and_pledge() {
 fn withdraw_after_upgrade_leaves_the_new_pledge_locked() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
-
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
+    upgrade_one(&h, &rt, &legacy, None);
 
     // Everything above the pledge and vesting funds can leave; the top-up cannot.
     let state: State = rt.get_state();
@@ -985,25 +796,13 @@ fn withdraw_after_upgrade_leaves_the_new_pledge_locked() {
 fn attaches_full_rate_fee_to_pre_fip0100_sector() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
-    h.rewrite_sectors(&rt, &[legacy.sector_number], |sector| {
-        sector.daily_fee = TokenAmount::zero()
-    });
+    h.rewrite_sectors(&rt, &[legacy.sector_number], |s| s.daily_fee = TokenAmount::zero());
     let legacy = h.get_sector(&rt, legacy.sector_number);
 
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
     let expected_fee =
         daily_proof_fee(rt.policy(), &rt.total_fil_circ_supply(), &qa_power_max(h.sector_size));
     assert!(expected_fee.is_positive());
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
     assert_eq!(expected_fee, upgraded.daily_fee);
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
     h.check_state(&rt);
@@ -1040,15 +839,13 @@ fn extend_sector_expiration2_does_not_upgrade() {
 fn rejects_empty_declaration_list() {
     let (h, rt) = setup();
     h.construct_and_verify(&rt);
-
-    let res = h.upgrade_sector_quality(
+    expect_upgrade_abort(
+        &h,
         &rt,
         UpgradeSectorQualityParams { extensions: vec![] },
-        PowerPair::zero(),
-        TokenAmount::zero(),
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        "no extension declarations",
     );
-    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "no extension declarations", res);
-    rt.reset();
     h.check_state(&rt);
 }
 
@@ -1056,89 +853,52 @@ fn rejects_empty_declaration_list() {
 fn rejects_empty_sector_selection() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
-    let (deadline_index, partition) = sector_location(&rt, legacy.sector_number);
-    let deadline_before = h.get_deadline(&rt, deadline_index);
+    let (deadline, partition) = sector_location(&rt, legacy.sector_number);
 
-    // Even a huge requested expiration must fail cleanly without touching state.
+    // The empty-selection check fires before the expiration checks.
     for new_expiration in [None, Some(i64::MAX)] {
-        let params = UpgradeSectorQualityParams {
-            extensions: vec![UpgradeSectorQuality {
-                deadline: deadline_index,
-                partition,
-                sectors: BitField::new(),
-                new_expiration,
-            }],
-        };
-        let res = h.upgrade_sector_quality(&rt, params, PowerPair::zero(), TokenAmount::zero());
-        expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "no sectors selected", res);
-        rt.reset();
+        expect_upgrade_abort(
+            &h,
+            &rt,
+            UpgradeSectorQualityParams {
+                extensions: vec![declaration(deadline, partition, &[], new_expiration)],
+            },
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            "no sectors selected",
+        );
     }
-
-    let deadline_after = h.get_deadline(&rt, deadline_index);
-    assert_eq!(deadline_before.expirations_epochs, deadline_after.expirations_epochs);
     h.check_state(&rt);
 }
 
 #[test]
-fn rejects_expiration_at_or_before_current_epoch() {
+fn rejects_out_of_range_expirations() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
     let curr_epoch = *rt.epoch.borrow();
 
-    for bad_expiration in [0, -1, curr_epoch] {
-        let res = h.upgrade_sector_quality(
+    // The first four are rejected before the network queries; reducing is a per-sector check.
+    let cases = [
+        (0, "must be after current epoch".to_string()),
+        (-1, "must be after current epoch".to_string()),
+        (curr_epoch, "must be after current epoch".to_string()),
+        (
+            curr_epoch + rt.policy().max_sector_expiration_extension + 1,
+            "cannot be more than".to_string(),
+        ),
+        (
+            legacy.expiration - 1,
+            format!("cannot reduce sector {} expiration", legacy.sector_number),
+        ),
+    ];
+    for (new_expiration, message) in cases {
+        expect_upgrade_abort(
+            &h,
             &rt,
-            upgrade_params(&rt, legacy.sector_number, Some(bad_expiration)),
-            PowerPair::zero(),
-            TokenAmount::zero(),
-        );
-        expect_abort_contains_message(
+            upgrade_params(&rt, legacy.sector_number, Some(new_expiration)),
             ExitCode::USR_ILLEGAL_ARGUMENT,
-            "must be after current epoch",
-            res,
+            &message,
         );
-        rt.reset();
     }
-
-    let after = h.get_sector(&rt, legacy.sector_number);
-    assert!(!after.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
-    h.check_state(&rt);
-}
-
-#[test]
-fn rejects_expiration_beyond_max_extension() {
-    let (mut h, rt) = setup();
-    let legacy = commit_legacy_cc_sector(&mut h, &rt);
-    let too_far = *rt.epoch.borrow() + rt.policy().max_sector_expiration_extension + 1;
-
-    let res = h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, Some(too_far)),
-        PowerPair::zero(),
-        TokenAmount::zero(),
-    );
-    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "cannot be more than", res);
-    rt.reset();
-    h.check_state(&rt);
-}
-
-#[test]
-fn rejects_reducing_expiration() {
-    let (mut h, rt) = setup();
-    let legacy = commit_legacy_cc_sector(&mut h, &rt);
-
-    let res = h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, Some(legacy.expiration - 1)),
-        PowerPair::zero(),
-        TokenAmount::zero(),
-    );
-    expect_abort_contains_message(
-        ExitCode::USR_ILLEGAL_ARGUMENT,
-        &format!("cannot reduce sector {} expiration", legacy.sector_number),
-        res,
-    );
-    rt.reset();
     h.check_state(&rt);
 }
 
@@ -1172,21 +932,16 @@ fn rejects_unknown_deadline_partition_and_sector() {
         ),
     ];
     for (deadline, partition, sector_number, code, message) in cases {
-        let params = UpgradeSectorQualityParams {
-            extensions: vec![UpgradeSectorQuality {
-                deadline,
-                partition,
-                sectors: make_bitfield(&[sector_number]),
-                new_expiration: None,
-            }],
-        };
-        let res = h.upgrade_sector_quality(&rt, params, PowerPair::zero(), TokenAmount::zero());
-        expect_abort_contains_message(code, message, res);
-        rt.reset();
+        expect_upgrade_abort(
+            &h,
+            &rt,
+            UpgradeSectorQualityParams {
+                extensions: vec![declaration(deadline, partition, &[sector_number], None)],
+            },
+            code,
+            message,
+        );
     }
-
-    let after = h.get_sector(&rt, legacy.sector_number);
-    assert!(!after.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
     h.check_state(&rt);
 }
 
@@ -1197,31 +952,18 @@ fn faulty_declaration_aborts_the_whole_batch() {
     let faulty = legacy[2].clone();
     h.declare_faults(&rt, std::slice::from_ref(&faulty));
 
-    // Good declarations first, the faulty sector's declaration last: the good partitions are
-    // processed before the abort, and must still roll back.
+    // Good declarations first, the faulty sector's last: a faulty sector anywhere in the batch
+    // fails the whole message.
     let mut declarations = upgrade_only_declarations(&rt, &legacy);
     declarations.sort_by_key(|d| d.sectors.get(faulty.sector_number));
     assert!(declarations.len() >= 2, "need the faulty sector in its own declaration");
-
-    let res = h.upgrade_sector_quality(
+    expect_upgrade_abort(
+        &h,
         &rt,
         UpgradeSectorQualityParams { extensions: declarations },
-        PowerPair::zero(),
-        TokenAmount::zero(),
-    );
-    expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "can only upgrade active sectors",
-        res,
     );
-    rt.reset();
-
-    // No sector was upgraded, including the ones in the good declarations.
-    for sector in &legacy {
-        let after = h.get_sector(&rt, sector.sector_number);
-        assert!(!after.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
-        assert_eq!(sector.initial_pledge, after.initial_pledge);
-    }
     h.check_state(&rt);
 }
 
@@ -1230,22 +972,15 @@ fn rejects_unproven_sector() {
     let (mut h, rt) = setup();
     h.construct_and_verify(&rt);
     // Committed but not yet proven in a WindowPoSt, so not yet active.
-    let sector = h
-        .commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, Vec::new(), true)
-        .remove(0);
-
-    let res = h.upgrade_sector_quality(
+    let sector =
+        h.commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION, Vec::new(), true).remove(0);
+    expect_upgrade_abort(
+        &h,
         &rt,
         upgrade_params(&rt, sector.sector_number, None),
-        PowerPair::zero(),
-        TokenAmount::zero(),
-    );
-    expect_abort_contains_message(
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "can only upgrade active sectors",
-        res,
     );
-    rt.reset();
     h.check_state(&rt);
 }
 
@@ -1259,30 +994,45 @@ fn rejects_sector_from_another_partition() {
     // A sector that exists, declared under a partition that does not hold it.
     let (&(deadline, partition), _) = by_partition.iter().next().unwrap();
     let elsewhere = by_partition.values().nth(1).unwrap()[0];
-    let params = UpgradeSectorQualityParams {
-        extensions: vec![UpgradeSectorQuality {
-            deadline,
-            partition,
-            sectors: make_bitfield(&[elsewhere]),
-            new_expiration: None,
-        }],
-    };
-    let res = h.upgrade_sector_quality(&rt, params, PowerPair::zero(), TokenAmount::zero());
-    expect_abort_contains_message(
+    expect_upgrade_abort(
+        &h,
+        &rt,
+        UpgradeSectorQualityParams {
+            extensions: vec![declaration(deadline, partition, &[elsewhere], None)],
+        },
         ExitCode::USR_ILLEGAL_ARGUMENT,
         "can only upgrade active sectors",
-        res,
     );
-    rt.reset();
 
     // The same sector upgrades under its own partition, so the rejection was about the
     // declared location, not the sector's state.
     let elsewhere_record = legacy.iter().find(|s| s.sector_number == elsewhere).unwrap();
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(elsewhere_record));
-    h.upgrade_sector_quality(&rt, upgrade_params(&rt, elsewhere, None), power_delta, pledge_delta)
-        .unwrap();
-    assert_full_power_record(&h, &rt, elsewhere_record, &h.get_sector(&rt, elsewhere));
+    let upgraded = upgrade_one(&h, &rt, elsewhere_record, None);
+    assert_full_power_record(&h, &rt, elsewhere_record, &upgraded);
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_terminated_sector() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    // Locked rewards ensure the termination fee is unlockable, as in the terminate tests.
+    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
+    h.terminate_sectors(
+        &rt,
+        &make_bitfield(&[legacy.sector_number]),
+        termination_fee(&h, &rt, &legacy),
+    );
+
+    // A terminated sector stays in its partition's books until its record is cleaned up, but
+    // it is no longer active.
+    expect_upgrade_abort(
+        &h,
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        "can only upgrade active sectors",
+    );
     h.check_state(&rt);
 }
 
@@ -1293,131 +1043,65 @@ fn rejects_expired_sector_awaiting_cron() {
 
     // Past its expiration but not yet removed by the deadline cron: no longer upgradable.
     rt.set_epoch(legacy.expiration + 1);
-    let res = h.upgrade_sector_quality(
+    expect_upgrade_abort(
+        &h,
         &rt,
         upgrade_params(&rt, legacy.sector_number, None),
-        PowerPair::zero(),
-        TokenAmount::zero(),
-    );
-    expect_abort_contains_message(
         ExitCode::USR_FORBIDDEN,
         "cannot extend expiration for expired sector",
-        res,
     );
-    rt.reset();
 
     // At its expiration epoch it is still live and upgrades normally.
     rt.set_epoch(legacy.expiration);
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-    assert_full_power_record(&h, &rt, &legacy, &h.get_sector(&rt, legacy.sector_number));
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
+    assert_full_power_record(&h, &rt, &legacy, &upgraded);
     h.check_state(&rt);
 }
 
 #[test]
-fn insufficient_balance_aborts_whole_message() {
-    let (mut h, rt) = setup();
-    let legacy = commit_legacy_cc_sector(&mut h, &rt);
-    let (_, pledge_delta) = expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+fn insufficient_available_balance_aborts_whole_message() {
+    // Available balance is the unlocked balance less fee debt: one atto short of the top-up,
+    // with or without debt, is rejected before anything is locked.
+    for debt in [TokenAmount::zero(), TokenAmount::from_whole(5)] {
+        let (mut h, rt) = setup();
+        let legacy = commit_legacy_cc_sector(&mut h, &rt);
+        let (_, pledge_delta) = expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+        let mut state: State = rt.get_state();
+        state.fee_debt = debt.clone();
+        rt.replace_state(&state);
+        rt.balance.replace(
+            &state.initial_pledge
+                + &state.locked_funds
+                + &state.pre_commit_deposits
+                + &pledge_delta
+                + &debt
+                - TokenAmount::from_atto(1),
+        );
 
-    // One atto short of the required top-up.
-    let state: State = rt.get_state();
-    rt.balance.replace(
-        &state.initial_pledge + &state.locked_funds + &state.pre_commit_deposits + &pledge_delta
-            - TokenAmount::from_atto(1),
-    );
-
-    let res = h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        PowerPair::zero(),
-        TokenAmount::zero(),
-    );
-    expect_abort_contains_message(
-        ExitCode::USR_INSUFFICIENT_FUNDS,
-        "insufficient funds for aggregate initial pledge requirement",
-        res,
-    );
-    rt.reset();
-
-    // Nothing changed.
-    let after = h.get_sector(&rt, legacy.sector_number);
-    assert!(!after.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
-    assert_eq!(legacy.initial_pledge, after.initial_pledge);
-
-    rt.balance.replace(BIG_BALANCE.clone());
-    h.check_state(&rt);
-}
-
-#[test]
-fn fee_debt_counts_against_available_balance() {
-    let (mut h, rt) = setup();
-    let legacy = commit_legacy_cc_sector(&mut h, &rt);
-    let (_, pledge_delta) = expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-
-    // Unlocked balance covers the top-up but not the fee debt as well, so the
-    // debt-aware check must reject the upgrade.
-    let debt = TokenAmount::from_whole(5);
-    let mut state: State = rt.get_state();
-    state.fee_debt = debt.clone();
-    rt.balance.replace(
-        &state.initial_pledge
-            + &state.locked_funds
-            + &state.pre_commit_deposits
-            + &pledge_delta
-            + &debt
-            - TokenAmount::from_atto(1),
-    );
-    rt.replace_state(&state);
-
-    let res = h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        PowerPair::zero(),
-        TokenAmount::zero(),
-    );
-    expect_abort_contains_message(
-        ExitCode::USR_INSUFFICIENT_FUNDS,
-        "insufficient funds for aggregate initial pledge requirement",
-        res,
-    );
-    rt.reset();
-
-    rt.balance.replace(BIG_BALANCE.clone());
-    h.check_state(&rt);
+        expect_upgrade_abort(
+            &h,
+            &rt,
+            upgrade_params(&rt, legacy.sector_number, None),
+            ExitCode::USR_INSUFFICIENT_FUNDS,
+            "insufficient funds for aggregate initial pledge requirement",
+        );
+        rt.balance.replace(BIG_BALANCE.clone());
+        h.check_state(&rt);
+    }
 }
 
 #[test]
 fn repays_fee_debt_and_locks_pledge() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
-
-    let debt = TokenAmount::from_whole(5);
     let mut state: State = rt.get_state();
-    state.fee_debt = debt.clone();
+    state.fee_debt = TokenAmount::from_whole(5);
     rt.replace_state(&state);
 
     // The harness expects the fee-debt burn along with the upgrade effects.
-    let (power_delta, pledge_delta) =
-        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
     let state: State = rt.get_state();
     assert!(state.fee_debt.is_zero());
-    let upgraded = h.get_sector(&rt, legacy.sector_number);
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
     assert_eq!(upgraded.initial_pledge, state.initial_pledge);
     h.check_state(&rt);
@@ -1437,42 +1121,5 @@ fn rejects_unauthorized_caller() {
         IpldBlock::serialize_cbor(&params).unwrap(),
     );
     expect_abort(ExitCode::USR_FORBIDDEN, res);
-    h.check_state(&rt);
-}
-
-#[test]
-fn rejects_terminated_sector() {
-    let (mut h, rt) = setup();
-    let legacy = commit_legacy_cc_sector(&mut h, &rt);
-
-    // Locked rewards ensure the termination fee is unlockable, as in the terminate tests.
-    h.apply_rewards(&rt, BIG_REWARDS.clone(), TokenAmount::zero());
-    let sector_power = qa_power_for_sector(h.sector_size, &legacy);
-    let fault_fee = pledge_penalty_for_continued_fault(
-        &h.epoch_reward_smooth,
-        &h.epoch_qa_power_smooth,
-        &sector_power,
-    );
-    let termination_fee = pledge_penalty_for_termination(
-        &legacy.initial_pledge,
-        *rt.epoch.borrow() - legacy.activation,
-        &fault_fee,
-    );
-    h.terminate_sectors(&rt, &make_bitfield(&[legacy.sector_number]), termination_fee);
-
-    // A terminated sector stays in its partition's books until its record is cleaned up, but
-    // it is no longer active.
-    let res = h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        PowerPair::zero(),
-        TokenAmount::zero(),
-    );
-    expect_abort_contains_message(
-        ExitCode::USR_ILLEGAL_ARGUMENT,
-        "can only upgrade active sectors",
-        res,
-    );
-    rt.reset();
     h.check_state(&rt);
 }

--- a/actors/miner/tests/upgrade_sector_quality_test.rs
+++ b/actors/miner/tests/upgrade_sector_quality_test.rs
@@ -1054,7 +1054,7 @@ fn faulty_declaration_aborts_the_whole_batch() {
         &rt,
         UpgradeSectorQualityParams { extensions: declarations },
         ExitCode::USR_ILLEGAL_ARGUMENT,
-        "can only upgrade active sectors",
+        "is not active in",
     );
     h.check_state(&rt);
 }
@@ -1071,7 +1071,7 @@ fn rejects_unproven_sector() {
         &rt,
         upgrade_params(&rt, sector.sector_number, None),
         ExitCode::USR_ILLEGAL_ARGUMENT,
-        "can only upgrade active sectors",
+        "is not active in",
     );
     h.check_state(&rt);
 }
@@ -1093,7 +1093,7 @@ fn rejects_sector_from_another_partition() {
             extensions: vec![declaration(deadline, partition, &[elsewhere], None)],
         },
         ExitCode::USR_ILLEGAL_ARGUMENT,
-        "can only upgrade active sectors",
+        "is not active in",
     );
 
     // The same sector upgrades under its own partition, so the rejection was about the
@@ -1123,7 +1123,7 @@ fn rejects_terminated_sector() {
         &rt,
         upgrade_params(&rt, legacy.sector_number, None),
         ExitCode::USR_ILLEGAL_ARGUMENT,
-        "can only upgrade active sectors",
+        "is not active in",
     );
     h.check_state(&rt);
 }

--- a/actors/miner/tests/upgrade_sector_quality_test.rs
+++ b/actors/miner/tests/upgrade_sector_quality_test.rs
@@ -1,0 +1,993 @@
+use fil_actor_miner::{
+    Actor, ExpirationExtension2, ExtendSectorExpiration2Params, Method, PowerPair,
+    SectorOnChainInfo, SectorOnChainInfoFlags, State, UpgradeSectorQuality,
+    UpgradeSectorQualityParams, daily_proof_fee, daily_proof_fee_adjust, qa_power_for_sector,
+    qa_power_max,
+};
+use fil_actors_runtime::{
+    EPOCHS_IN_DAY,
+    runtime::{Runtime, RuntimePolicy},
+    test_utils::{ACCOUNT_ACTOR_CODE_ID, MockRuntime, expect_abort, expect_abort_contains_message},
+};
+use fvm_ipld_bitfield::BitField;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fvm_shared::address::Address;
+use fvm_shared::bigint::BigInt;
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber};
+
+use num_traits::Zero;
+use std::collections::BTreeMap;
+
+mod util;
+use util::*;
+
+// an expiration ~10 days greater than effective min expiration taking into account 30 days max between pre and prove commit
+const DEFAULT_SECTOR_EXPIRATION: ChainEpoch = 220;
+
+fn setup() -> (ActorHarness, MockRuntime) {
+    let period_offset = 100;
+    let precommit_epoch = 1;
+
+    let mut h = ActorHarness::new(period_offset);
+    h.set_proof_type(RegisteredSealProof::StackedDRG512MiBV1);
+    let rt = h.new_runtime();
+    rt.balance.replace(BIG_BALANCE.clone());
+    rt.set_epoch(precommit_epoch);
+
+    (h, rt)
+}
+
+/// Rewrites proven sectors as pre-FIP-0118 sectors: the given flags (never `FULL_QA_POWER`),
+/// `verified_space` bytes of verified data held for their whole life, and pledge and daily fee
+/// at the rate of the resulting quality-adjusted power. Returns the rewritten records.
+fn make_legacy(
+    h: &ActorHarness,
+    rt: &MockRuntime,
+    sectors: &[SectorOnChainInfo],
+    flags: SectorOnChainInfoFlags,
+    verified_space: u64,
+) -> Vec<SectorOnChainInfo> {
+    let numbers: Vec<_> = sectors.iter().map(|s| s.sector_number).collect();
+    h.rewrite_sectors(rt, &numbers, |sector| {
+        sector.flags = flags;
+        sector.verified_deal_weight =
+            BigInt::from(verified_space) * (sector.expiration - sector.power_base_epoch);
+        let qa_power = qa_power_for_sector(h.sector_size, sector);
+        sector.initial_pledge = h.initial_pledge_for_power(rt, &qa_power);
+        sector.daily_fee = daily_proof_fee(rt.policy(), &rt.total_fil_circ_supply(), &qa_power);
+    });
+    h.check_state(rt);
+    numbers.iter().map(|&n| h.get_sector(rt, n)).collect()
+}
+
+/// Commits and proves `count` sectors, then rewrites them as legacy sectors of the given shape.
+fn commit_legacy_sectors(
+    h: &mut ActorHarness,
+    rt: &MockRuntime,
+    count: usize,
+    flags: SectorOnChainInfoFlags,
+    verified_space: u64,
+) -> Vec<SectorOnChainInfo> {
+    h.construct_and_verify(rt);
+    let sectors =
+        h.commit_and_prove_sectors(rt, count, DEFAULT_SECTOR_EXPIRATION as u64, Vec::new(), true);
+    h.advance_and_submit_posts(rt, &sectors);
+    make_legacy(h, rt, &sectors, flags, verified_space)
+}
+
+/// A CC sector at 1x, as committed before FIP-0118.
+fn commit_legacy_cc_sector(h: &mut ActorHarness, rt: &MockRuntime) -> SectorOnChainInfo {
+    commit_legacy_sectors(h, rt, 1, SectorOnChainInfoFlags::SIMPLE_QA_POWER, 0).remove(0)
+}
+
+fn sector_location(rt: &MockRuntime, sector_number: SectorNumber) -> (u64, u64) {
+    let state: State = rt.get_state();
+    state.find_sector(rt.store(), sector_number).unwrap()
+}
+
+fn group_by_partition(
+    rt: &MockRuntime,
+    sectors: &[SectorOnChainInfo],
+) -> BTreeMap<(u64, u64), Vec<SectorNumber>> {
+    let mut by_partition: BTreeMap<(u64, u64), Vec<SectorNumber>> = BTreeMap::new();
+    for sector in sectors {
+        by_partition
+            .entry(sector_location(rt, sector.sector_number))
+            .or_default()
+            .push(sector.sector_number);
+    }
+    by_partition
+}
+
+fn upgrade_params(
+    rt: &MockRuntime,
+    sector_number: SectorNumber,
+    new_expiration: Option<ChainEpoch>,
+) -> UpgradeSectorQualityParams {
+    let (deadline, partition) = sector_location(rt, sector_number);
+    UpgradeSectorQualityParams {
+        extensions: vec![UpgradeSectorQuality {
+            deadline,
+            partition,
+            sectors: make_bitfield(&[sector_number]),
+            new_expiration,
+        }],
+    }
+}
+
+/// Power and pledge deltas expected from upgrading these sectors to full power.
+fn expected_upgrade_deltas(
+    h: &ActorHarness,
+    rt: &MockRuntime,
+    sectors: &[SectorOnChainInfo],
+) -> (PowerPair, TokenAmount) {
+    let pledge_10x = h.initial_pledge_for_power(rt, &qa_power_max(h.sector_size));
+    let mut qa_delta = BigInt::zero();
+    let mut pledge_delta = TokenAmount::zero();
+    for sector in sectors {
+        qa_delta += qa_power_max(h.sector_size) - qa_power_for_sector(h.sector_size, sector);
+        pledge_delta += &pledge_10x - &sector.initial_pledge;
+    }
+    (PowerPair::new(BigInt::zero(), qa_delta), pledge_delta)
+}
+
+/// The daily fee a sector carries after its upgrade: attached at the full rate if it had none
+/// (pre-FIP-0100), otherwise scaled from its old power to full power.
+fn upgraded_fee(h: &ActorHarness, rt: &MockRuntime, sector: &SectorOnChainInfo) -> TokenAmount {
+    let full_power = qa_power_max(h.sector_size);
+    if sector.daily_fee.is_zero() {
+        daily_proof_fee(rt.policy(), &rt.total_fil_circ_supply(), &full_power)
+    } else {
+        let old_power = qa_power_for_sector(h.sector_size, sector);
+        daily_proof_fee_adjust(&sector.daily_fee, &old_power, &full_power)
+    }
+}
+
+/// Asserts `upgraded` carries full power's flags, pledge and daily fee, given the legacy record
+/// it replaced.
+fn assert_full_power_record(
+    h: &ActorHarness,
+    rt: &MockRuntime,
+    legacy: &SectorOnChainInfo,
+    upgraded: &SectorOnChainInfo,
+) {
+    assert!(
+        upgraded.flags.contains(
+            SectorOnChainInfoFlags::SIMPLE_QA_POWER | SectorOnChainInfoFlags::FULL_QA_POWER
+        )
+    );
+    assert_eq!(qa_power_max(h.sector_size), qa_power_for_sector(h.sector_size, upgraded));
+    let pledge_10x = h.initial_pledge_for_power(rt, &qa_power_max(h.sector_size));
+    assert_eq!(pledge_10x, upgraded.initial_pledge);
+    assert_eq!(upgraded_fee(h, rt, legacy), upgraded.daily_fee);
+}
+
+#[test]
+fn upgrade_only_upgrades_in_place() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    let (deadline_index, _) = sector_location(&rt, legacy.sector_number);
+
+    let state_before: State = rt.get_state();
+    let deadline_before = h.get_deadline(&rt, deadline_index);
+
+    // A 1x sector gains nine more units of QA power and the pledge top-up to match.
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    assert_eq!(BigInt::from(h.sector_size as u64 * 9), power_delta.qa);
+    assert!(pledge_delta.is_positive());
+
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta.clone(),
+    )
+    .unwrap();
+
+    // Only the flags, pledge and fee changed on the record.
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    assert_full_power_record(&h, &rt, &legacy, &upgraded);
+    assert_eq!(legacy.expiration, upgraded.expiration);
+    assert_eq!(legacy.power_base_epoch, upgraded.power_base_epoch);
+    assert_eq!(legacy.deal_weight, upgraded.deal_weight);
+    assert_eq!(legacy.verified_deal_weight, upgraded.verified_deal_weight);
+
+    // The miner's pledge total grew by the top-up and equals the record's pledge, so the
+    // sector's eventual expiry releases exactly what is locked.
+    let state_after: State = rt.get_state();
+    assert_eq!(pledge_delta, &state_after.initial_pledge - &state_before.initial_pledge);
+    assert_eq!(upgraded.initial_pledge, state_after.initial_pledge);
+
+    // No expiration moved, so the deadline's schedule was not rewritten.
+    let deadline_after = h.get_deadline(&rt, deadline_index);
+    assert_eq!(deadline_before.expirations_epochs, deadline_after.expirations_epochs);
+    h.check_state(&rt);
+}
+
+#[test]
+fn upgrade_with_extension_in_one_declaration() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    let (deadline_index, partition_index) = sector_location(&rt, legacy.sector_number);
+    let new_expiration = legacy.expiration + 42 * EPOCHS_IN_DAY;
+
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, Some(new_expiration)),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    assert_full_power_record(&h, &rt, &legacy, &upgraded);
+    assert_eq!(new_expiration, upgraded.expiration);
+    assert_eq!(*rt.epoch.borrow(), upgraded.power_base_epoch);
+
+    // The partition's expiration queue holds the sector at the new expiration and nowhere
+    // earlier.
+    let state: State = rt.get_state();
+    let quant = state.quant_spec_for_deadline(rt.policy(), deadline_index);
+    let (_, mut partition) = h.get_deadline_and_partition(&rt, deadline_index, partition_index);
+    assert!(
+        partition.pop_expired_sectors(rt.store(), new_expiration - 1, quant).unwrap().is_empty()
+    );
+    let expiring = partition
+        .pop_expired_sectors(rt.store(), quant.quantize_up(new_expiration), quant)
+        .unwrap();
+    assert!(expiring.on_time_sectors.get(upgraded.sector_number));
+    h.check_state(&rt);
+}
+
+#[test]
+fn second_upgrade_is_a_no_op() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+    let state_root_after_first = *rt.state.borrow();
+
+    // The same call again moves no power, pledge or fee, and leaves state byte-identical.
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    )
+    .unwrap();
+    assert_eq!(state_root_after_first, *rt.state.borrow());
+    h.check_state(&rt);
+}
+
+#[test]
+fn upgrades_partially_verified_pre_fip0045_sector() {
+    let (mut h, rt) = setup();
+    // Half the sector holds verified data, and it predates FIP-0045 so it carries no flag.
+    let half = h.sector_size as u64 / 2;
+    let legacy =
+        commit_legacy_sectors(&mut h, &rt, 1, SectorOnChainInfoFlags::empty(), half).remove(0);
+    assert_eq!(
+        BigInt::from(h.sector_size as u64 * 11 / 2),
+        qa_power_for_sector(h.sector_size, &legacy),
+        "half verified is 5.5x"
+    );
+
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+
+    // Full power, with pledge and fee scaled up from 5.5x; the weights stay as they were, now
+    // masked by the flag.
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    assert_full_power_record(&h, &rt, &legacy, &upgraded);
+    assert_eq!(legacy.verified_deal_weight, upgraded.verified_deal_weight);
+    assert_eq!(legacy.power_base_epoch, upgraded.power_base_epoch);
+    h.check_state(&rt);
+}
+
+#[test]
+fn extension_restates_verified_weight_and_grants_full_power() {
+    let (mut h, rt) = setup();
+    let half = h.sector_size as u64 / 2;
+    let legacy =
+        commit_legacy_sectors(&mut h, &rt, 1, SectorOnChainInfoFlags::SIMPLE_QA_POWER, half)
+            .remove(0);
+    let curr_epoch = *rt.epoch.borrow();
+    let new_expiration = legacy.expiration + 42 * EPOCHS_IN_DAY;
+
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, Some(new_expiration)),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+
+    // Same weight math as ExtendSectorExpiration2: the verified space is restated over the new
+    // duration. Power comes from the flag, so the restated weight is not what raised it.
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    assert_full_power_record(&h, &rt, &legacy, &upgraded);
+    assert_eq!(new_expiration, upgraded.expiration);
+    assert_eq!(curr_epoch, upgraded.power_base_epoch);
+    let old_duration = legacy.expiration - legacy.power_base_epoch;
+    let new_duration = new_expiration - curr_epoch;
+    assert_eq!(
+        (&legacy.verified_deal_weight / old_duration) * new_duration,
+        upgraded.verified_deal_weight
+    );
+    h.check_state(&rt);
+}
+
+#[test]
+fn fully_verified_sector_moves_no_power_or_pledge() {
+    let (mut h, rt) = setup();
+    // Already 10x through its weights, so there is nothing to raise. Whether such a sector is
+    // flagged or skipped is not pinned here; either way it must move no power, pledge or fee.
+    let full = h.sector_size as u64;
+    let legacy =
+        commit_legacy_sectors(&mut h, &rt, 1, SectorOnChainInfoFlags::SIMPLE_QA_POWER, full)
+            .remove(0);
+    assert_eq!(qa_power_max(h.sector_size), qa_power_for_sector(h.sector_size, &legacy));
+    let pledge_10x = h.initial_pledge_for_power(&rt, &qa_power_max(h.sector_size));
+    assert_eq!(pledge_10x, legacy.initial_pledge);
+
+    let state_before: State = rt.get_state();
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    )
+    .unwrap();
+
+    let after = h.get_sector(&rt, legacy.sector_number);
+    assert_eq!(legacy.initial_pledge, after.initial_pledge);
+    assert_eq!(legacy.daily_fee, after.daily_fee);
+    assert_eq!(state_before.initial_pledge, rt.get_state::<State>().initial_pledge);
+    h.check_state(&rt);
+}
+
+#[test]
+fn one_declaration_upgrades_sectors_with_different_expirations() {
+    let (mut h, rt) = setup();
+    h.construct_and_verify(&rt);
+    let sectors =
+        h.commit_and_prove_sectors(&rt, 2, DEFAULT_SECTOR_EXPIRATION as u64, Vec::new(), true);
+    h.advance_and_submit_posts(&rt, &sectors);
+    let (deadline, partition) = sector_location(&rt, sectors[0].sector_number);
+    assert_eq!((deadline, partition), sector_location(&rt, sectors[1].sector_number));
+
+    // Push one sector's expiration out so the partition holds two different ones.
+    h.extend_sectors2(
+        &rt,
+        ExtendSectorExpiration2Params {
+            extensions: vec![ExpirationExtension2 {
+                deadline,
+                partition,
+                sectors: make_bitfield(&[sectors[1].sector_number]),
+                sectors_with_claims: vec![],
+                new_expiration: sectors[1].expiration + 40 * EPOCHS_IN_DAY,
+            }],
+        },
+    )
+    .unwrap();
+    let sectors: Vec<_> = sectors.iter().map(|s| h.get_sector(&rt, s.sector_number)).collect();
+    let legacy = make_legacy(&h, &rt, &sectors, SectorOnChainInfoFlags::SIMPLE_QA_POWER, 0);
+    assert_ne!(legacy[0].expiration, legacy[1].expiration);
+
+    // One upgrade-only declaration covers both expirations at once.
+    let params = UpgradeSectorQualityParams {
+        extensions: vec![UpgradeSectorQuality {
+            deadline,
+            partition,
+            sectors: make_bitfield(&[legacy[0].sector_number, legacy[1].sector_number]),
+            new_expiration: None,
+        }],
+    };
+    let (power_delta, pledge_delta) = expected_upgrade_deltas(&h, &rt, &legacy);
+    h.upgrade_sector_quality(&rt, params, power_delta, pledge_delta).unwrap();
+
+    for sector in &legacy {
+        let upgraded = h.get_sector(&rt, sector.sector_number);
+        assert_full_power_record(&h, &rt, sector, &upgraded);
+        assert_eq!(sector.expiration, upgraded.expiration);
+    }
+    h.check_state(&rt);
+}
+
+#[test]
+fn upgrades_across_deadlines_with_mixed_declarations() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_sectors(&mut h, &rt, 3, SectorOnChainInfoFlags::SIMPLE_QA_POWER, 0);
+    let by_partition = group_by_partition(&rt, &legacy);
+    assert!(by_partition.len() >= 2, "test needs sectors in more than one partition");
+
+    // The first partition upgrades in place; every other one also extends.
+    let new_expiration = legacy[0].expiration + 42 * EPOCHS_IN_DAY;
+    let in_place = by_partition.values().next().unwrap().clone();
+    let extensions: Vec<_> = by_partition
+        .iter()
+        .map(|(&(deadline, partition), sectors)| UpgradeSectorQuality {
+            deadline,
+            partition,
+            sectors: make_bitfield(sectors),
+            new_expiration: if *sectors == in_place { None } else { Some(new_expiration) },
+        })
+        .collect();
+
+    let (power_delta, pledge_delta) = expected_upgrade_deltas(&h, &rt, &legacy);
+    h.upgrade_sector_quality(
+        &rt,
+        UpgradeSectorQualityParams { extensions },
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+
+    for sector in &legacy {
+        let upgraded = h.get_sector(&rt, sector.sector_number);
+        assert_full_power_record(&h, &rt, sector, &upgraded);
+        let expected_expiration = if in_place.contains(&sector.sector_number) {
+            sector.expiration
+        } else {
+            new_expiration
+        };
+        assert_eq!(expected_expiration, upgraded.expiration);
+    }
+    h.check_state(&rt);
+}
+
+#[test]
+fn duplicate_sector_across_declarations_upgrades_once() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    let (deadline, partition) = sector_location(&rt, legacy.sector_number);
+
+    let decl = UpgradeSectorQuality {
+        deadline,
+        partition,
+        sectors: make_bitfield(&[legacy.sector_number]),
+        new_expiration: None,
+    };
+    let params = UpgradeSectorQualityParams { extensions: vec![decl.clone(), decl] };
+
+    // Exactly one power bump and one pledge raise despite two declarations.
+    let state_before: State = rt.get_state();
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(&rt, params, power_delta, pledge_delta.clone()).unwrap();
+
+    let state_after: State = rt.get_state();
+    assert_eq!(pledge_delta, &state_after.initial_pledge - &state_before.initial_pledge);
+    assert_full_power_record(&h, &rt, &legacy, &h.get_sector(&rt, legacy.sector_number));
+    h.check_state(&rt);
+}
+
+#[test]
+fn next_proving_period_charges_the_upgraded_fee() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    assert!(upgraded.daily_fee > legacy.daily_fee);
+
+    // The harness derives the fee burn it expects from the record, so the deadline's fee books
+    // must agree with it for the next period's PoSt and cron to pass.
+    h.advance_and_submit_posts(&rt, std::slice::from_ref(&upgraded));
+    h.check_state(&rt);
+}
+
+#[test]
+fn withdraw_after_upgrade_leaves_the_new_pledge_locked() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+
+    // Everything above the pledge and vesting funds can leave; the top-up cannot.
+    let state: State = rt.get_state();
+    let free =
+        rt.get_balance() - &state.initial_pledge - &state.locked_funds - &state.pre_commit_deposits;
+    h.withdraw_funds(&rt, h.owner, &rt.get_balance(), &free, &TokenAmount::zero()).unwrap();
+    let pledge_10x = h.initial_pledge_for_power(&rt, &qa_power_max(h.sector_size));
+    assert_eq!(pledge_10x, rt.get_state::<State>().initial_pledge);
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_empty_sector_selection() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    let (deadline_index, partition) = sector_location(&rt, legacy.sector_number);
+    let deadline_before = h.get_deadline(&rt, deadline_index);
+
+    // Even a huge requested expiration must fail cleanly without touching state.
+    for new_expiration in [None, Some(i64::MAX)] {
+        let params = UpgradeSectorQualityParams {
+            extensions: vec![UpgradeSectorQuality {
+                deadline: deadline_index,
+                partition,
+                sectors: BitField::new(),
+                new_expiration,
+            }],
+        };
+        let res = h.upgrade_sector_quality(&rt, params, PowerPair::zero(), TokenAmount::zero());
+        expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "no sectors selected", res);
+        rt.reset();
+    }
+
+    let deadline_after = h.get_deadline(&rt, deadline_index);
+    assert_eq!(deadline_before.expirations_epochs, deadline_after.expirations_epochs);
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_expiration_at_or_before_current_epoch() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    let curr_epoch = *rt.epoch.borrow();
+
+    for bad_expiration in [0, -1, curr_epoch] {
+        let res = h.upgrade_sector_quality(
+            &rt,
+            upgrade_params(&rt, legacy.sector_number, Some(bad_expiration)),
+            PowerPair::zero(),
+            TokenAmount::zero(),
+        );
+        expect_abort_contains_message(
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            "must be after current epoch",
+            res,
+        );
+        rt.reset();
+    }
+
+    let after = h.get_sector(&rt, legacy.sector_number);
+    assert!(!after.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_expiration_beyond_max_extension() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    let too_far = *rt.epoch.borrow() + rt.policy().max_sector_expiration_extension + 1;
+
+    let res = h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, Some(too_far)),
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    );
+    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "cannot be more than", res);
+    rt.reset();
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_reducing_expiration() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+
+    let res = h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, Some(legacy.expiration - 1)),
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    );
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        &format!("cannot reduce sector {} expiration", legacy.sector_number),
+        res,
+    );
+    rt.reset();
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_unknown_deadline_partition_and_sector() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    let (deadline, partition) = sector_location(&rt, legacy.sector_number);
+
+    let cases = [
+        (
+            rt.policy().wpost_period_deadlines,
+            partition,
+            legacy.sector_number,
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            "not in range",
+        ),
+        (
+            deadline,
+            partition + 1,
+            legacy.sector_number,
+            ExitCode::USR_NOT_FOUND,
+            "no such partition",
+        ),
+        (
+            deadline,
+            partition,
+            legacy.sector_number + 1,
+            ExitCode::USR_NOT_FOUND,
+            "sector not found",
+        ),
+    ];
+    for (deadline, partition, sector_number, code, message) in cases {
+        let params = UpgradeSectorQualityParams {
+            extensions: vec![UpgradeSectorQuality {
+                deadline,
+                partition,
+                sectors: make_bitfield(&[sector_number]),
+                new_expiration: None,
+            }],
+        };
+        let res = h.upgrade_sector_quality(&rt, params, PowerPair::zero(), TokenAmount::zero());
+        expect_abort_contains_message(code, message, res);
+        rt.reset();
+    }
+
+    let after = h.get_sector(&rt, legacy.sector_number);
+    assert!(!after.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_faulty_sector() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    h.declare_faults(&rt, std::slice::from_ref(&legacy));
+
+    let res = h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    );
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        "can only upgrade active sectors",
+        res,
+    );
+    rt.reset();
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_unproven_sector() {
+    let (mut h, rt) = setup();
+    h.construct_and_verify(&rt);
+    // Committed but not yet proven in a WindowPoSt, so not yet active.
+    let sector = h
+        .commit_and_prove_sectors(&rt, 1, DEFAULT_SECTOR_EXPIRATION as u64, Vec::new(), true)
+        .remove(0);
+
+    let res = h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, sector.sector_number, None),
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    );
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        "can only upgrade active sectors",
+        res,
+    );
+    rt.reset();
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_sector_from_another_partition() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_sectors(&mut h, &rt, 3, SectorOnChainInfoFlags::SIMPLE_QA_POWER, 0);
+    let by_partition = group_by_partition(&rt, &legacy);
+    assert!(by_partition.len() >= 2, "test needs sectors in more than one partition");
+
+    // A sector that exists, declared under a partition that does not hold it.
+    let (&(deadline, partition), _) = by_partition.iter().next().unwrap();
+    let elsewhere = by_partition.values().nth(1).unwrap()[0];
+    let params = UpgradeSectorQualityParams {
+        extensions: vec![UpgradeSectorQuality {
+            deadline,
+            partition,
+            sectors: make_bitfield(&[elsewhere]),
+            new_expiration: None,
+        }],
+    };
+    let res = h.upgrade_sector_quality(&rt, params, PowerPair::zero(), TokenAmount::zero());
+    expect_abort_contains_message(
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        "can only upgrade active sectors",
+        res,
+    );
+    rt.reset();
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_expired_sector_awaiting_cron() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+
+    // Past its expiration but not yet removed by the deadline cron: no longer upgradable.
+    rt.set_epoch(legacy.expiration + 1);
+    let res = h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    );
+    expect_abort_contains_message(
+        ExitCode::USR_FORBIDDEN,
+        "cannot extend expiration for expired sector",
+        res,
+    );
+    rt.reset();
+
+    // At its expiration epoch it is still live and upgrades normally.
+    rt.set_epoch(legacy.expiration);
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+    assert_full_power_record(&h, &rt, &legacy, &h.get_sector(&rt, legacy.sector_number));
+    h.check_state(&rt);
+}
+
+#[test]
+fn insufficient_balance_aborts_whole_message() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    let (_, pledge_delta) = expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+
+    // One atto short of the required top-up.
+    let state: State = rt.get_state();
+    rt.balance.replace(
+        &state.initial_pledge + &state.locked_funds + &state.pre_commit_deposits + &pledge_delta
+            - TokenAmount::from_atto(1),
+    );
+
+    let res = h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    );
+    expect_abort_contains_message(
+        ExitCode::USR_INSUFFICIENT_FUNDS,
+        "insufficient funds for aggregate initial pledge requirement",
+        res,
+    );
+    rt.reset();
+
+    // Nothing changed.
+    let after = h.get_sector(&rt, legacy.sector_number);
+    assert!(!after.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
+    assert_eq!(legacy.initial_pledge, after.initial_pledge);
+
+    rt.balance.replace(BIG_BALANCE.clone());
+    h.check_state(&rt);
+}
+
+#[test]
+fn fee_debt_counts_against_available_balance() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    let (_, pledge_delta) = expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+
+    // Unlocked balance covers the top-up but not the fee debt as well, so the
+    // debt-aware check must reject the upgrade.
+    let debt = TokenAmount::from_whole(5);
+    let mut state: State = rt.get_state();
+    state.fee_debt = debt.clone();
+    rt.balance.replace(
+        &state.initial_pledge
+            + &state.locked_funds
+            + &state.pre_commit_deposits
+            + &pledge_delta
+            + &debt
+            - TokenAmount::from_atto(1),
+    );
+    rt.replace_state(&state);
+
+    let res = h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    );
+    expect_abort_contains_message(
+        ExitCode::USR_INSUFFICIENT_FUNDS,
+        "insufficient funds for aggregate initial pledge requirement",
+        res,
+    );
+    rt.reset();
+
+    rt.balance.replace(BIG_BALANCE.clone());
+    h.check_state(&rt);
+}
+
+#[test]
+fn repays_fee_debt_and_locks_pledge() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+
+    let debt = TokenAmount::from_whole(5);
+    let mut state: State = rt.get_state();
+    state.fee_debt = debt.clone();
+    rt.replace_state(&state);
+
+    // The harness expects the fee-debt burn along with the upgrade effects.
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+
+    let state: State = rt.get_state();
+    assert!(state.fee_debt.is_zero());
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    assert_full_power_record(&h, &rt, &legacy, &upgraded);
+    assert_eq!(upgraded.initial_pledge, state.initial_pledge);
+    h.check_state(&rt);
+}
+
+#[test]
+fn attaches_full_rate_fee_to_pre_fip0100_sector() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    h.rewrite_sectors(&rt, &[legacy.sector_number], |sector| {
+        sector.daily_fee = TokenAmount::zero()
+    });
+    let legacy = h.get_sector(&rt, legacy.sector_number);
+
+    let (power_delta, pledge_delta) =
+        expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
+    h.upgrade_sector_quality(
+        &rt,
+        upgrade_params(&rt, legacy.sector_number, None),
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+
+    let expected_fee =
+        daily_proof_fee(rt.policy(), &rt.total_fil_circ_supply(), &qa_power_max(h.sector_size));
+    assert!(expected_fee.is_positive());
+    let upgraded = h.get_sector(&rt, legacy.sector_number);
+    assert_eq!(expected_fee, upgraded.daily_fee);
+    assert_full_power_record(&h, &rt, &legacy, &upgraded);
+    h.check_state(&rt);
+}
+
+#[test]
+fn extend_sector_expiration2_does_not_upgrade() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    let (deadline, partition) = sector_location(&rt, legacy.sector_number);
+
+    let new_expiration = legacy.expiration + 42 * EPOCHS_IN_DAY;
+    let params = ExtendSectorExpiration2Params {
+        extensions: vec![ExpirationExtension2 {
+            deadline,
+            partition,
+            sectors: make_bitfield(&[legacy.sector_number]),
+            sectors_with_claims: vec![],
+            new_expiration,
+        }],
+    };
+    h.extend_sectors2(&rt, params).unwrap();
+
+    // The plain extension contract holds: no flag, no pledge or fee change.
+    let extended = h.get_sector(&rt, legacy.sector_number);
+    assert!(!extended.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
+    assert_eq!(new_expiration, extended.expiration);
+    assert_eq!(legacy.initial_pledge, extended.initial_pledge);
+    assert_eq!(legacy.daily_fee, extended.daily_fee);
+    h.check_state(&rt);
+}
+
+#[test]
+fn rejects_batches_beyond_addressing_limits() {
+    let (h, rt) = setup();
+    h.construct_and_verify(&rt);
+
+    // One partition too many.
+    let extensions: Vec<_> = (0..=rt.policy().addressed_partitions_max)
+        .map(|i| UpgradeSectorQuality {
+            deadline: 0,
+            partition: i,
+            sectors: make_bitfield(&[i]),
+            new_expiration: None,
+        })
+        .collect();
+    let res = h.upgrade_sector_quality(
+        &rt,
+        UpgradeSectorQualityParams { extensions },
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    );
+    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "too many partitions", res);
+    rt.reset();
+
+    // One sector too many.
+    let params = UpgradeSectorQualityParams {
+        extensions: vec![UpgradeSectorQuality {
+            deadline: 0,
+            partition: 0,
+            sectors: BitField::try_from_bits(0..=rt.policy().addressed_sectors_max).unwrap(),
+            new_expiration: None,
+        }],
+    };
+    let res = h.upgrade_sector_quality(&rt, params, PowerPair::zero(), TokenAmount::zero());
+    expect_abort_contains_message(ExitCode::USR_ILLEGAL_ARGUMENT, "too many sectors", res);
+    rt.reset();
+}
+
+#[test]
+fn rejects_unauthorized_caller() {
+    let (mut h, rt) = setup();
+    let legacy = commit_legacy_cc_sector(&mut h, &rt);
+    let params = upgrade_params(&rt, legacy.sector_number, None);
+
+    rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, Address::new_id(1234));
+    rt.expect_validate_caller_addr(h.caller_addrs());
+    // Pledge inputs are fetched before the transaction validates the caller.
+    h.expect_query_network_info(&rt);
+
+    let res = rt.call::<Actor>(
+        Method::UpgradeSectorQuality as u64,
+        IpldBlock::serialize_cbor(&params).unwrap(),
+    );
+    expect_abort(ExitCode::USR_FORBIDDEN, res);
+    h.check_state(&rt);
+}

--- a/actors/miner/tests/upgrade_sector_quality_test.rs
+++ b/actors/miner/tests/upgrade_sector_quality_test.rs
@@ -207,6 +207,24 @@ fn upgrade_one(
     h.get_sector(rt, legacy.sector_number)
 }
 
+/// Calls `UpgradeSectorQuality` on a sector already at full power, which may move its
+/// expiration but never its power or pledge, and returns its record.
+fn call_at_full_power(
+    h: &ActorHarness,
+    rt: &MockRuntime,
+    sector: &SectorOnChainInfo,
+    new_expiration: Option<ChainEpoch>,
+) -> SectorOnChainInfo {
+    h.upgrade_sector_quality(
+        rt,
+        upgrade_params(rt, sector.sector_number, new_expiration),
+        PowerPair::zero(),
+        TokenAmount::zero(),
+    )
+    .unwrap();
+    h.get_sector(rt, sector.sector_number)
+}
+
 /// Calls `UpgradeSectorQuality` expecting it to abort with `code` and `message`.
 fn expect_upgrade_abort(
     h: &ActorHarness,
@@ -287,12 +305,10 @@ fn repeated_upgrade_is_a_no_op() {
     let upgraded = upgrade_one(&h, &rt, &legacy, None);
     let state_root = *rt.state.borrow();
 
-    // A sector at full power is skipped: neither an in-place repeat nor one asking for an
-    // extension moves power, pledge, fee or expiration, and state stays byte-identical.
-    for new_expiration in [None, Some(upgraded.expiration + 42 * EPOCHS_IN_DAY)] {
-        upgrade_one(&h, &rt, &upgraded, new_expiration);
-        assert_eq!(state_root, *rt.state.borrow());
-    }
+    // A sector at full power has nothing to upgrade: an in-place repeat moves no power,
+    // pledge or fee, and state stays byte-identical.
+    assert_eq!(upgraded, call_at_full_power(&h, &rt, &upgraded, None));
+    assert_eq!(state_root, *rt.state.borrow());
     h.check_state(&rt);
 }
 
@@ -313,19 +329,21 @@ fn repeated_upgrade_locks_nothing_when_pledge_requirement_rises() {
     assert_eq!(legacy.initial_pledge, after_first.initial_pledge);
 
     // Conditions recover, so the full-power requirement now exceeds what the sector holds.
-    // Already at full power, a repeat must lock nothing.
+    // Already at full power, a repeat locks nothing: in place it changes nothing, with a
+    // new expiration it only extends.
     rt.set_circulating_supply(normal_supply);
     h.epoch_reward_smooth = normal_reward;
     let raised_requirement = h.initial_pledge_for_power(&rt, &qa_power_max(h.sector_size));
     assert!(raised_requirement > after_first.initial_pledge);
-    h.upgrade_sector_quality(
-        &rt,
-        upgrade_params(&rt, legacy.sector_number, None),
-        PowerPair::zero(),
-        TokenAmount::zero(),
-    )
-    .unwrap();
-    assert_eq!(after_first, h.get_sector(&rt, legacy.sector_number));
+    let new_expiration = after_first.expiration + 42 * EPOCHS_IN_DAY;
+    for repeat in [None, Some(new_expiration)] {
+        let sector = call_at_full_power(&h, &rt, &after_first, repeat);
+        assert_eq!(repeat.unwrap_or(after_first.expiration), sector.expiration);
+        assert_eq!(after_first.flags, sector.flags);
+        assert_eq!(after_first.initial_pledge, sector.initial_pledge);
+        assert_eq!(after_first.daily_fee, sector.daily_fee);
+    }
+    assert_eq!(after_first.initial_pledge, rt.get_state::<State>().initial_pledge);
     h.check_state(&rt);
 }
 
@@ -398,19 +416,30 @@ fn extension_restates_verified_weight_and_grants_full_power() {
 }
 
 #[test]
-fn already_full_power_by_weights_is_skipped() {
+fn already_full_power_by_weights_is_not_upgraded() {
     let (mut h, rt) = setup();
-    // Already 10x through its weights alone, so there is nothing to raise: the sector is not
-    // eligible and is skipped — not even flagged — leaving state byte-identical.
+    // Already 10x through its weights alone, so there is nothing to raise.
     let full = h.sector_size as u64;
     let legacy =
         commit_legacy_sectors(&mut h, &rt, 1, SectorOnChainInfoFlags::SIMPLE_QA_POWER, full)
             .remove(0);
     assert_eq!(qa_power_max(h.sector_size), qa_power_for_sector(h.sector_size, &legacy));
-    let state_root = *rt.state.borrow();
 
-    assert_eq!(legacy, upgrade_one(&h, &rt, &legacy, None));
+    // In place, the sector is skipped — not even flagged — leaving state byte-identical.
+    let state_root = *rt.state.borrow();
+    assert_eq!(legacy, call_at_full_power(&h, &rt, &legacy, None));
     assert_eq!(state_root, *rt.state.borrow());
+
+    // With a new expiration it is extended as ExtendSectorExpiration2 would: still
+    // unflagged, its verified weight restated so it stays at 10x, pledge and fee untouched.
+    let new_expiration = legacy.expiration + 42 * EPOCHS_IN_DAY;
+    let extended = call_at_full_power(&h, &rt, &legacy, Some(new_expiration));
+    assert_eq!(legacy.flags, extended.flags);
+    assert_eq!(new_expiration, extended.expiration);
+    assert_eq!(*rt.epoch.borrow(), extended.power_base_epoch);
+    assert_eq!(qa_power_max(h.sector_size), qa_power_for_sector(h.sector_size, &extended));
+    assert_eq!(legacy.initial_pledge, extended.initial_pledge);
+    assert_eq!(legacy.daily_fee, extended.daily_fee);
     h.check_state(&rt);
 }
 
@@ -525,7 +554,7 @@ fn one_declaration_upgrades_sectors_with_different_expirations() {
 }
 
 #[test]
-fn extension_skips_sectors_already_at_full_power() {
+fn extension_extends_but_does_not_upgrade_full_power_sectors() {
     let (mut h, rt) = setup();
     let sectors = commit_proven_sectors(&mut h, &rt, 2);
     let (deadline, partition) = sector_location(&rt, sectors[0].sector_number);
@@ -537,9 +566,9 @@ fn extension_skips_sectors_already_at_full_power() {
     let full = h.get_sector(&rt, sectors[1].sector_number);
     assert!(full.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
 
-    // One declaration extends both. Only the legacy sector is upgraded and extended; the
-    // full-power one is not eligible and keeps its expiration (ExtendSectorExpiration2 is the
-    // way to extend it).
+    // One declaration extends both. The legacy sector is upgraded and extended; the
+    // full-power one is only extended, as ExtendSectorExpiration2 would, so the batch locks
+    // just the legacy sector's top-up.
     let new_expiration = legacy.expiration + 42 * EPOCHS_IN_DAY;
     let both = [legacy.sector_number, full.sector_number];
     let (power_delta, pledge_delta) =
@@ -557,7 +586,12 @@ fn extension_skips_sectors_already_at_full_power() {
     let upgraded = h.get_sector(&rt, legacy.sector_number);
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
     assert_eq!(new_expiration, upgraded.expiration);
-    assert_eq!(full, h.get_sector(&rt, full.sector_number));
+    let extended = h.get_sector(&rt, full.sector_number);
+    assert_eq!(new_expiration, extended.expiration);
+    assert_eq!(*rt.epoch.borrow(), extended.power_base_epoch);
+    assert_eq!(full.flags, extended.flags);
+    assert_eq!(full.initial_pledge, extended.initial_pledge);
+    assert_eq!(full.daily_fee, extended.daily_fee);
     h.check_state(&rt);
 }
 
@@ -619,33 +653,37 @@ fn mixed_batch_upgrades_extends_and_requeues_across_epochs() {
 }
 
 #[test]
-fn later_declaration_for_an_upgraded_sector_is_skipped() {
+fn later_declaration_extends_an_upgraded_sector_again() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
     let (deadline, partition) = sector_location(&rt, legacy.sector_number);
-
-    // Declarations apply in order: the first upgrades and extends the sector, the second finds
-    // it already at full power and leaves it alone, so the first expiration stands and the
-    // sector is charged once.
     let first = legacy.expiration + 30 * EPOCHS_IN_DAY;
     let second = legacy.expiration + 60 * EPOCHS_IN_DAY;
-    let extensions = vec![
-        declaration(deadline, partition, &[legacy.sector_number], Some(first)),
-        declaration(deadline, partition, &[legacy.sector_number], Some(second)),
-    ];
+    let declare_twice = |expirations: [ChainEpoch; 2]| UpgradeSectorQualityParams {
+        extensions: expirations
+            .iter()
+            .map(|&e| declaration(deadline, partition, &[legacy.sector_number], Some(e)))
+            .collect(),
+    };
+
+    // Declarations apply in order: the first upgrades and extends the sector, the second
+    // finds it at full power and extends it again, which cannot shorten it...
+    expect_upgrade_abort(
+        &h,
+        &rt,
+        declare_twice([second, first]),
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        &format!("cannot reduce sector {} expiration", legacy.sector_number),
+    );
+
+    // ...so the last expiration stands, and the sector is charged its top-up once.
     let (power_delta, pledge_delta) =
         expected_upgrade_deltas(&h, &rt, std::slice::from_ref(&legacy));
-    h.upgrade_sector_quality(
-        &rt,
-        UpgradeSectorQualityParams { extensions },
-        power_delta,
-        pledge_delta,
-    )
-    .unwrap();
-
+    h.upgrade_sector_quality(&rt, declare_twice([first, second]), power_delta, pledge_delta)
+        .unwrap();
     let upgraded = h.get_sector(&rt, legacy.sector_number);
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
-    assert_eq!(first, upgraded.expiration);
+    assert_eq!(second, upgraded.expiration);
     h.check_state(&rt);
 }
 
@@ -777,6 +815,50 @@ fn extend2_after_upgrade_keeps_full_power_and_pledge() {
 }
 
 #[test]
+fn extension_of_full_power_sector_matches_extend_sector_expiration2() {
+    let (mut h, rt) = setup();
+    // Two identical half-verified legacy sectors, upgraded in place, so both carry a
+    // verified weight to restate.
+    let half = h.sector_size as u64 / 2;
+    let legacy =
+        commit_legacy_sectors(&mut h, &rt, 2, SectorOnChainInfoFlags::SIMPLE_QA_POWER, half);
+    let (power_delta, pledge_delta) = expected_upgrade_deltas(&h, &rt, &legacy);
+    h.upgrade_sector_quality(
+        &rt,
+        UpgradeSectorQualityParams { extensions: upgrade_only_declarations(&rt, &legacy) },
+        power_delta,
+        pledge_delta,
+    )
+    .unwrap();
+
+    // Extend one through UpgradeSectorQuality and the other through ExtendSectorExpiration2.
+    let new_expiration = legacy[0].expiration + 42 * EPOCHS_IN_DAY;
+    let upgraded = h.get_sector(&rt, legacy[0].sector_number);
+    let by_upgrade = call_at_full_power(&h, &rt, &upgraded, Some(new_expiration));
+    let (deadline, partition) = sector_location(&rt, legacy[1].sector_number);
+    h.extend_sectors2(
+        &rt,
+        ExtendSectorExpiration2Params {
+            extensions: vec![ExpirationExtension2 {
+                deadline,
+                partition,
+                sectors: make_bitfield(&[legacy[1].sector_number]),
+                sectors_with_claims: vec![],
+                new_expiration,
+            }],
+        },
+    )
+    .unwrap();
+
+    // The records agree in everything but the sector's identity.
+    let mut by_extend2 = h.get_sector(&rt, legacy[1].sector_number);
+    by_extend2.sector_number = by_upgrade.sector_number;
+    by_extend2.sealed_cid = by_upgrade.sealed_cid;
+    assert_eq!(by_extend2, by_upgrade);
+    h.check_state(&rt);
+}
+
+#[test]
 fn withdraw_after_upgrade_leaves_the_new_pledge_locked() {
     let (mut h, rt) = setup();
     let legacy = commit_legacy_cc_sector(&mut h, &rt);
@@ -899,6 +981,16 @@ fn rejects_out_of_range_expirations() {
             &message,
         );
     }
+
+    // The per-sector check also guards the extension of a sector already at full power.
+    let upgraded = upgrade_one(&h, &rt, &legacy, None);
+    expect_upgrade_abort(
+        &h,
+        &rt,
+        upgrade_params(&rt, upgraded.sector_number, Some(upgraded.expiration - 1)),
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        &format!("cannot reduce sector {} expiration", legacy.sector_number),
+    );
     h.check_state(&rt);
 }
 
@@ -1055,6 +1147,18 @@ fn rejects_expired_sector_awaiting_cron() {
     rt.set_epoch(legacy.expiration);
     let upgraded = upgrade_one(&h, &rt, &legacy, None);
     assert_full_power_record(&h, &rt, &legacy, &upgraded);
+
+    // Expired at full power, an extension is refused as ExtendSectorExpiration2 refuses it,
+    // while an in-place repeat has nothing to do and nothing to reject.
+    rt.set_epoch(legacy.expiration + 1);
+    expect_upgrade_abort(
+        &h,
+        &rt,
+        upgrade_params(&rt, upgraded.sector_number, Some(upgraded.expiration + EPOCHS_IN_DAY)),
+        ExitCode::USR_FORBIDDEN,
+        "cannot extend expiration for expired sector",
+    );
+    assert_eq!(upgraded, call_at_full_power(&h, &rt, &upgraded, None));
     h.check_state(&rt);
 }
 

--- a/actors/miner/tests/util.rs
+++ b/actors/miner/tests/util.rs
@@ -67,8 +67,9 @@ use fil_actor_miner::{
     SectorContentChangedParams, SectorContentChangedReturn, SectorOnChainInfo, SectorPreCommitInfo,
     SectorPreCommitOnChainInfo, SectorReturn, SectorStatusCode, SectorUpdateManifest, Sectors,
     State, SubmitWindowedPoStParams, TerminateSectorsParams, TerminationDeclaration,
-    ValidateSectorStatusParams, ValidateSectorStatusReturn, VerifiedAllocationKey, WindowedPoSt,
-    WithdrawBalanceParams, WithdrawBalanceReturn, consensus_fault_penalty, ext,
+    UpgradeSectorQualityParams, ValidateSectorStatusParams, ValidateSectorStatusReturn,
+    VerifiedAllocationKey, WindowedPoSt, WithdrawBalanceParams, WithdrawBalanceReturn,
+    consensus_fault_penalty, ext,
     ext::market::ON_MINER_SECTORS_TERMINATE_METHOD,
     ext::power::UPDATE_CLAIMED_POWER_METHOD,
     initial_pledge_for_power, locked_reward_from_reward, max_prove_commit_duration,
@@ -2587,6 +2588,86 @@ impl ActorHarness {
 
         rt.verify();
         Ok(ret)
+    }
+
+    /// Calls `UpgradeSectorQuality` as the worker, expecting the pledge-input
+    /// queries, a burn of any outstanding fee debt, and the given power and
+    /// pledge deltas (no sends for zero deltas).
+    pub fn upgrade_sector_quality(
+        &self,
+        rt: &MockRuntime,
+        params: UpgradeSectorQualityParams,
+        expected_power_delta: PowerPair,
+        expected_pledge_delta: TokenAmount,
+    ) -> Result<Option<IpldBlock>, ActorError> {
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, self.worker);
+        rt.expect_validate_caller_addr(self.caller_addrs());
+
+        self.expect_query_network_info(rt);
+        expect_burn(rt, self.get_state(rt).fee_debt);
+        expect_update_power(rt, expected_power_delta);
+        expect_update_pledge(rt, &expected_pledge_delta);
+
+        let ret = rt.call::<Actor>(
+            Method::UpgradeSectorQuality as u64,
+            IpldBlock::serialize_cbor(&params).unwrap(),
+        )?;
+
+        rt.verify();
+        Ok(ret)
+    }
+
+    /// Rewrites the given sectors' on-chain records with `edit`, moving the
+    /// partition expiration queue, deadline power and fee books, and the miner's
+    /// pledge total along with the change. Simulates cohorts no onboarding path
+    /// can produce anymore, e.g. pre-FIP-0118 sectors without `FULL_QA_POWER`.
+    pub fn rewrite_sectors(
+        &self,
+        rt: &MockRuntime,
+        sector_numbers: &[SectorNumber],
+        edit: impl Fn(&mut SectorOnChainInfo),
+    ) {
+        let mut state: State = rt.get_state();
+        let store = rt.store();
+
+        let mut sectors = Sectors::load(store, &state.sectors).unwrap();
+        let mut deadlines = state.load_deadlines(store).unwrap();
+
+        let mut pledge_delta = TokenAmount::zero();
+        for &sector_number in sector_numbers {
+            let (dl_idx, p_idx) = state.find_sector(store, sector_number).unwrap();
+            let mut deadline = deadlines.load_deadline(store, dl_idx).unwrap();
+            let mut partitions = deadline.partitions_amt(store).unwrap();
+            let mut partition = partitions.get(p_idx).unwrap().cloned().unwrap();
+
+            let old_sector = sectors.must_get(sector_number).unwrap();
+            let mut new_sector = old_sector.clone();
+            edit(&mut new_sector);
+
+            let quant = state.quant_spec_for_deadline(&rt.policy, dl_idx);
+            let (power_delta, partition_pledge_delta, fee_delta) = partition
+                .replace_sectors(
+                    store,
+                    std::slice::from_ref(&old_sector),
+                    std::slice::from_ref(&new_sector),
+                    self.sector_size,
+                    quant,
+                )
+                .unwrap();
+            deadline.live_power += &power_delta;
+            deadline.daily_fee += &fee_delta;
+            pledge_delta += partition_pledge_delta;
+
+            sectors.store(vec![new_sector]).unwrap();
+            partitions.set(p_idx, partition).unwrap();
+            deadline.partitions = partitions.flush().unwrap();
+            deadlines.update_deadline(&rt.policy, store, dl_idx, &deadline).unwrap();
+        }
+
+        state.sectors = sectors.amt.flush().unwrap();
+        state.save_deadlines(store, deadlines).unwrap();
+        state.add_initial_pledge(&pledge_delta).unwrap();
+        rt.replace_state(&state);
     }
 
     pub fn compact_partitions(

--- a/integration_tests/src/tests/fip0118_test.rs
+++ b/integration_tests/src/tests/fip0118_test.rs
@@ -499,7 +499,7 @@ fn set_sector_daily_fee(
     });
 }
 
-fn current_initial_pledge(v: &dyn VM, qa_power: &StoragePower) -> TokenAmount {
+pub fn current_initial_pledge(v: &dyn VM, qa_power: &StoragePower) -> TokenAmount {
     let power: PowerState = get_state(v, &STORAGE_POWER_ACTOR_ADDR).unwrap();
     let reward: RewardState = get_state(v, &REWARD_ACTOR_ADDR).unwrap();
     initial_pledge_for_power(

--- a/integration_tests/src/tests/mod.rs
+++ b/integration_tests/src/tests/mod.rs
@@ -50,3 +50,5 @@ mod replica_update3_test;
 pub use replica_update3_test::*;
 pub mod fip0118_test;
 pub use fip0118_test::*;
+pub mod upgrade_sector_quality_test;
+pub use upgrade_sector_quality_test::*;

--- a/integration_tests/src/tests/upgrade_sector_quality_test.rs
+++ b/integration_tests/src/tests/upgrade_sector_quality_test.rs
@@ -21,8 +21,8 @@ use crate::expects::Expect;
 use crate::tests::{create_sector, current_initial_pledge};
 use crate::util::{
     advance_by_deadline_to_index, advance_to_proving_deadline, assert_invariants, create_accounts,
-    create_miner, miner_extend_sector_expiration2, miner_power,
-    override_compute_unsealed_sector_cid, sector_info, submit_windowed_post,
+    create_miner, miner_power, override_compute_unsealed_sector_cid, sector_info,
+    submit_windowed_post,
 };
 
 /// Rewrites a freshly onboarded (10x) sector as a pre-FIP-0118 legacy CC sector:
@@ -99,8 +99,8 @@ fn make_legacy_cc_sector(v: &dyn VM, maddr: &Address, sector_number: SectorNumbe
 }
 
 /// FIP-0118: `UpgradeSectorQuality` upgrades a legacy CC sector to 10x QA power, locking the
-/// pledge top-up. The upgraded sector is then skipped by a repeat call, and a plain extension
-/// locks nothing more.
+/// pledge top-up. A repeat call upgrades nothing more: in place it is a no-op, with a new
+/// expiration it only extends.
 #[vm_test]
 pub fn upgrade_sector_quality_upgrades_legacy_sector_test(v: &dyn VM) {
     override_compute_unsealed_sector_cid(v);
@@ -188,57 +188,45 @@ pub fn upgrade_sector_quality_upgrades_legacy_sector_test(v: &dyn VM) {
     .matches(v.take_invocations().last().unwrap());
     assert_eq!(full_qa_power, miner_power(v, &maddr).qa);
 
-    // Already at full power, the sector is not eligible: a repeat call — even one asking for
-    // an extension — skips it, changing nothing and notifying nobody.
+    // Already at full power, the sector is not upgraded again: an in-place repeat changes
+    // nothing, and one asking for an extension only extends, locking nothing and notifying
+    // nobody.
     let new_expiration = v.epoch() + policy.max_sector_expiration_extension;
-    apply_ok(
-        v,
-        &worker,
-        &maddr,
-        &TokenAmount::zero(),
-        MinerMethod::UpgradeSectorQuality as u64,
-        Some(UpgradeSectorQualityParams {
-            extensions: vec![UpgradeSectorQuality {
-                deadline,
-                partition,
-                sectors,
-                new_expiration: Some(new_expiration),
-            }],
-        }),
-    );
-    assert_eq!(upgraded, sector_info(v, &maddr, sector_number));
-    ExpectInvocation {
-        from: worker_id,
-        to: maddr,
-        method: MinerMethod::UpgradeSectorQuality as u64,
-        subinvocs: Some(vec![
-            Expect::reward_this_epoch(miner_id),
-            Expect::power_current_total(miner_id),
-        ]),
-        events: Some(vec![]),
-        ..Default::default()
+    for repeat in [None, Some(new_expiration)] {
+        apply_ok(
+            v,
+            &worker,
+            &maddr,
+            &TokenAmount::zero(),
+            MinerMethod::UpgradeSectorQuality as u64,
+            Some(UpgradeSectorQualityParams {
+                extensions: vec![UpgradeSectorQuality {
+                    deadline,
+                    partition,
+                    sectors: sectors.clone(),
+                    new_expiration: repeat,
+                }],
+            }),
+        );
+        ExpectInvocation {
+            from: worker_id,
+            to: maddr,
+            method: MinerMethod::UpgradeSectorQuality as u64,
+            subinvocs: Some(vec![
+                Expect::reward_this_epoch(miner_id),
+                Expect::power_current_total(miner_id),
+            ]),
+            events: Some(vec![]),
+            ..Default::default()
+        }
+        .matches(v.take_invocations().last().unwrap());
+        let sector = sector_info(v, &maddr, sector_number);
+        assert_eq!(repeat.unwrap_or(upgraded.expiration), sector.expiration);
+        assert_eq!(upgraded.flags, sector.flags);
+        assert_eq!(upgraded.initial_pledge, sector.initial_pledge);
+        assert_eq!(upgraded.daily_fee, sector.daily_fee);
     }
-    .matches(v.take_invocations().last().unwrap());
-
-    // A plain extension moves the expiration and locks nothing more: flag, pledge and fee ride
-    // along, and no power or pledge notification is sent.
-    miner_extend_sector_expiration2(
-        v,
-        &worker,
-        &maddr,
-        deadline,
-        partition,
-        vec![sector_number],
-        vec![],
-        new_expiration,
-        PowerPair::zero(),
-    );
-    let extended = sector_info(v, &maddr, sector_number);
-    assert_eq!(new_expiration, extended.expiration);
-    assert_eq!(v.epoch(), extended.power_base_epoch);
-    assert_eq!(upgraded.flags, extended.flags);
-    assert_eq!(upgraded.initial_pledge, extended.initial_pledge);
-    assert_eq!(upgraded.daily_fee, extended.daily_fee);
+    assert_eq!(v.epoch(), sector_info(v, &maddr, sector_number).power_base_epoch);
 
     // The sector keeps proving at its upgraded power.
     let (deadline_info, partition_index) = advance_to_proving_deadline(v, &maddr, sector_number);

--- a/integration_tests/src/tests/upgrade_sector_quality_test.rs
+++ b/integration_tests/src/tests/upgrade_sector_quality_test.rs
@@ -1,14 +1,11 @@
 use export_macro::vm_test;
 use fil_actor_miner::{
-    ExpirationExtension2, ExtendSectorExpiration2Params, Method as MinerMethod, PowerPair,
-    SectorOnChainInfoFlags, Sectors, State as MinerState, UpgradeSectorQuality,
-    UpgradeSectorQualityParams, daily_proof_fee_adjust, initial_pledge_for_power,
-    max_prove_commit_duration, qa_power_max,
+    Method as MinerMethod, PowerPair, SectorOnChainInfoFlags, Sectors, State as MinerState,
+    UpgradeSectorQuality, UpgradeSectorQualityParams, daily_proof_fee_adjust, qa_power_max,
 };
 use fil_actor_power::{State as PowerState, consensus_miner_min_power, set_claim};
-use fil_actor_reward::State as RewardState;
+use fil_actors_runtime::STORAGE_POWER_ACTOR_ADDR;
 use fil_actors_runtime::runtime::Policy;
-use fil_actors_runtime::{EPOCHS_IN_DAY, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR};
 use fvm_ipld_bitfield::BitField;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
@@ -18,13 +15,13 @@ use num_traits::Zero;
 use std::cmp::max;
 use vm_api::VM;
 use vm_api::trace::ExpectInvocation;
-use vm_api::util::{DynBlockstore, apply_ok, get_state, mutate_state};
+use vm_api::util::{DynBlockstore, apply_ok, mutate_state};
 
 use crate::expects::Expect;
+use crate::tests::{create_sector, current_initial_pledge};
 use crate::util::{
-    PrecommitMetadata, advance_by_deadline_to_epoch, advance_by_deadline_to_index,
-    advance_to_proving_deadline, assert_invariants, create_accounts, create_miner, cron_tick,
-    miner_power, miner_precommit_one_sector_v2, miner_prove_sector,
+    advance_by_deadline_to_index, advance_to_proving_deadline, assert_invariants, create_accounts,
+    create_miner, miner_extend_sector_expiration2, miner_power,
     override_compute_unsealed_sector_cid, sector_info, submit_windowed_post,
 };
 
@@ -112,85 +109,46 @@ pub fn upgrade_sector_quality_upgrades_legacy_sector_test(v: &dyn VM) {
     let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
     let sector_size = seal_proof.sector_size().unwrap();
     let (owner, worker) = (addrs[0], addrs[0]);
-    let (maddr, miner_id) = {
-        let (maddr, _) = create_miner(
-            v,
-            &owner,
-            &worker,
-            seal_proof.registered_window_post_proof().unwrap(),
-            &TokenAmount::from_whole(8_000),
-        );
-        (maddr, maddr.id().unwrap())
-    };
+    let (maddr, _) = create_miner(
+        v,
+        &owner,
+        &worker,
+        seal_proof.registered_window_post_proof().unwrap(),
+        &TokenAmount::from_whole(8_000),
+    );
+    let miner_id = maddr.id().unwrap();
     let worker_id = worker.id().unwrap();
-
     v.set_epoch(200);
 
-    // Onboard one CC sector and prove it, activating its (10x) power.
+    // Onboard and prove one CC sector, activating its (10x) power, then rewrite it into the
+    // pre-FIP-0118 shape: 1x power, 1x pledge, 1x fee.
     let sector_number: SectorNumber = 100;
-    let expiration = v.epoch()
-        + policy.min_sector_expiration
-        + max_prove_commit_duration(&policy, seal_proof).unwrap()
-        + 1;
-    miner_precommit_one_sector_v2(
-        v,
-        &worker,
-        &maddr,
-        seal_proof,
-        sector_number,
-        PrecommitMetadata::default(),
-        true,
-        expiration,
-    );
-    let prove_time = v.epoch() + policy.pre_commit_challenge_delay + 1;
-    advance_by_deadline_to_epoch(v, &maddr, prove_time);
-    miner_prove_sector(v, &worker, &maddr, sector_number, vec![]);
-    cron_tick(v);
-
-    let (deadline_info, partition_index) = advance_to_proving_deadline(v, &maddr, sector_number);
-    let full_power =
-        PowerPair { raw: StoragePower::from(sector_size as u64), qa: qa_power_max(sector_size) };
-    submit_windowed_post(
-        v,
-        &worker,
-        &maddr,
-        deadline_info,
-        partition_index,
-        Some(full_power.clone()),
-    );
-    advance_by_deadline_to_index(
-        v,
-        &maddr,
-        (deadline_info.index + 1) % policy.wpost_period_deadlines,
-    );
-    assert_eq!(full_power.qa, miner_power(v, &maddr).qa);
-
-    // Fabricate the pre-FIP-0118 shape: 1x power, 1x pledge, 1x fee.
+    let (deadline, partition) = create_sector(v, worker, maddr, sector_number, seal_proof);
+    let raw_power = StoragePower::from(sector_size as u64);
+    let full_qa_power = qa_power_max(sector_size);
+    assert_eq!(full_qa_power, miner_power(v, &maddr).qa);
     make_legacy_cc_sector(v, &maddr, sector_number);
     let legacy = sector_info(v, &maddr, sector_number);
     assert!(!legacy.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
-    assert_eq!(full_power.raw, miner_power(v, &maddr).qa);
+    assert_eq!(raw_power, miner_power(v, &maddr).qa);
 
+    // Upgrade in place.
     let sectors = BitField::try_from_bits([sector_number]).unwrap();
-    let upgrade_params = UpgradeSectorQualityParams {
-        extensions: vec![UpgradeSectorQuality {
-            deadline: deadline_info.index,
-            partition: partition_index,
-            sectors: sectors.clone(),
-            new_expiration: None,
-        }],
-    };
-
     apply_ok(
         v,
         &worker,
         &maddr,
         &TokenAmount::zero(),
         MinerMethod::UpgradeSectorQuality as u64,
-        Some(upgrade_params),
+        Some(UpgradeSectorQualityParams {
+            extensions: vec![UpgradeSectorQuality {
+                deadline,
+                partition,
+                sectors: sectors.clone(),
+                new_expiration: None,
+            }],
+        }),
     );
-
-    // The record reflects the upgrade, in place.
     let upgraded = sector_info(v, &maddr, sector_number);
     assert!(
         upgraded.flags.contains(
@@ -200,27 +158,15 @@ pub fn upgrade_sector_quality_upgrades_legacy_sector_test(v: &dyn VM) {
     assert_eq!(legacy.expiration, upgraded.expiration);
     assert_eq!(legacy.power_base_epoch, upgraded.power_base_epoch);
     assert_eq!(
-        daily_proof_fee_adjust(
-            &legacy.daily_fee,
-            &StoragePower::from(sector_size as u64),
-            &qa_power_max(sector_size),
-        ),
+        daily_proof_fee_adjust(&legacy.daily_fee, &raw_power, &full_qa_power),
         upgraded.daily_fee
     );
-    let reward_state: RewardState = get_state(v, &REWARD_ACTOR_ADDR).unwrap();
-    let power_state: PowerState = get_state(v, &STORAGE_POWER_ACTOR_ADDR).unwrap();
-    let full_power_pledge = initial_pledge_for_power(
-        &qa_power_max(sector_size),
-        &reward_state.this_epoch_baseline_power,
-        &reward_state.this_epoch_reward_smoothed,
-        &power_state.this_epoch_qa_power_smoothed,
-        &v.circulating_supply(),
-        v.epoch() - power_state.ramp_start_epoch,
-        power_state.ramp_duration_epochs,
+    assert_eq!(
+        max(legacy.initial_pledge.clone(), current_initial_pledge(v, &full_qa_power)),
+        upgraded.initial_pledge
     );
-    assert_eq!(max(legacy.initial_pledge.clone(), full_power_pledge), upgraded.initial_pledge);
 
-    // The power actor was told about the QA lift and the pledge top-up.
+    // The power actor was told about the QA lift and the pledge top-up; no event is emitted.
     let pledge_delta = &upgraded.initial_pledge - &legacy.initial_pledge;
     assert!(pledge_delta.is_positive());
     ExpectInvocation {
@@ -232,7 +178,7 @@ pub fn upgrade_sector_quality_upgrades_legacy_sector_test(v: &dyn VM) {
             Expect::power_current_total(miner_id),
             Expect::power_update_claim(
                 miner_id,
-                PowerPair { raw: BigInt::zero(), qa: &full_power.qa - &full_power.raw },
+                PowerPair { raw: BigInt::zero(), qa: &full_qa_power - &raw_power },
             ),
             Expect::power_update_pledge(miner_id, Some(pledge_delta)),
         ]),
@@ -240,11 +186,11 @@ pub fn upgrade_sector_quality_upgrades_legacy_sector_test(v: &dyn VM) {
         ..Default::default()
     }
     .matches(v.take_invocations().last().unwrap());
-    assert_eq!(full_power.qa, miner_power(v, &maddr).qa);
+    assert_eq!(full_qa_power, miner_power(v, &maddr).qa);
 
     // Already at full power, the sector is not eligible: a repeat call — even one asking for
     // an extension — skips it, changing nothing and notifying nobody.
-    let new_expiration = upgraded.expiration + 42 * EPOCHS_IN_DAY;
+    let new_expiration = v.epoch() + policy.max_sector_expiration_extension;
     apply_ok(
         v,
         &worker,
@@ -253,9 +199,9 @@ pub fn upgrade_sector_quality_upgrades_legacy_sector_test(v: &dyn VM) {
         MinerMethod::UpgradeSectorQuality as u64,
         Some(UpgradeSectorQualityParams {
             extensions: vec![UpgradeSectorQuality {
-                deadline: deadline_info.index,
-                partition: partition_index,
-                sectors: sectors.clone(),
+                deadline,
+                partition,
+                sectors,
                 new_expiration: Some(new_expiration),
             }],
         }),
@@ -275,22 +221,17 @@ pub fn upgrade_sector_quality_upgrades_legacy_sector_test(v: &dyn VM) {
     .matches(v.take_invocations().last().unwrap());
 
     // A plain extension moves the expiration and locks nothing more: flag, pledge and fee ride
-    // along, and no power or pledge notification is sent at all.
-    apply_ok(
+    // along, and no power or pledge notification is sent.
+    miner_extend_sector_expiration2(
         v,
         &worker,
         &maddr,
-        &TokenAmount::zero(),
-        MinerMethod::ExtendSectorExpiration2 as u64,
-        Some(ExtendSectorExpiration2Params {
-            extensions: vec![ExpirationExtension2 {
-                deadline: deadline_info.index,
-                partition: partition_index,
-                sectors,
-                sectors_with_claims: vec![],
-                new_expiration,
-            }],
-        }),
+        deadline,
+        partition,
+        vec![sector_number],
+        vec![],
+        new_expiration,
+        PowerPair::zero(),
     );
     let extended = sector_info(v, &maddr, sector_number);
     assert_eq!(new_expiration, extended.expiration);
@@ -298,15 +239,6 @@ pub fn upgrade_sector_quality_upgrades_legacy_sector_test(v: &dyn VM) {
     assert_eq!(upgraded.flags, extended.flags);
     assert_eq!(upgraded.initial_pledge, extended.initial_pledge);
     assert_eq!(upgraded.daily_fee, extended.daily_fee);
-    ExpectInvocation {
-        from: worker_id,
-        to: maddr,
-        method: MinerMethod::ExtendSectorExpiration2 as u64,
-        subinvocs: Some(vec![]),
-        events: Some(vec![]),
-        ..Default::default()
-    }
-    .matches(v.take_invocations().last().unwrap());
 
     // The sector keeps proving at its upgraded power.
     let (deadline_info, partition_index) = advance_to_proving_deadline(v, &maddr, sector_number);
@@ -316,7 +248,7 @@ pub fn upgrade_sector_quality_upgrades_legacy_sector_test(v: &dyn VM) {
         &maddr,
         (deadline_info.index + 1) % policy.wpost_period_deadlines,
     );
-    assert_eq!(full_power.qa, miner_power(v, &maddr).qa);
+    assert_eq!(full_qa_power, miner_power(v, &maddr).qa);
 
     assert_invariants(v, &policy, None);
 }

--- a/integration_tests/src/tests/upgrade_sector_quality_test.rs
+++ b/integration_tests/src/tests/upgrade_sector_quality_test.rs
@@ -1,0 +1,322 @@
+use export_macro::vm_test;
+use fil_actor_miner::{
+    ExpirationExtension2, ExtendSectorExpiration2Params, Method as MinerMethod, PowerPair,
+    SectorOnChainInfoFlags, Sectors, State as MinerState, UpgradeSectorQuality,
+    UpgradeSectorQualityParams, daily_proof_fee_adjust, initial_pledge_for_power,
+    max_prove_commit_duration, qa_power_max,
+};
+use fil_actor_power::{State as PowerState, consensus_miner_min_power, set_claim};
+use fil_actor_reward::State as RewardState;
+use fil_actors_runtime::runtime::Policy;
+use fil_actors_runtime::{EPOCHS_IN_DAY, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR};
+use fvm_ipld_bitfield::BitField;
+use fvm_shared::address::Address;
+use fvm_shared::bigint::BigInt;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::sector::{RegisteredSealProof, SectorNumber, StoragePower};
+use num_traits::Zero;
+use std::cmp::max;
+use vm_api::VM;
+use vm_api::trace::ExpectInvocation;
+use vm_api::util::{DynBlockstore, apply_ok, get_state, mutate_state};
+
+use crate::expects::Expect;
+use crate::util::{
+    PrecommitMetadata, advance_by_deadline_to_epoch, advance_by_deadline_to_index,
+    advance_to_proving_deadline, assert_invariants, create_accounts, create_miner, cron_tick,
+    miner_power, miner_precommit_one_sector_v2, miner_prove_sector,
+    override_compute_unsealed_sector_cid, sector_info, submit_windowed_post,
+};
+
+/// Rewrites a freshly onboarded (10x) sector as a pre-FIP-0118 legacy CC sector:
+/// `SIMPLE_QA_POWER` only, pledge and daily fee at their 1x rates. Moves the miner's
+/// partition, deadline and pledge books with the record via the production
+/// `replace_sectors`, and keeps the power actor's claim and totals consistent with the
+/// rewritten books.
+fn make_legacy_cc_sector(v: &dyn VM, maddr: &Address, sector_number: SectorNumber) {
+    let store = DynBlockstore::wrap(v.blockstore());
+    let policy = Policy::default();
+    let mut power_delta = PowerPair::zero();
+    let mut pledge_delta = TokenAmount::zero();
+
+    mutate_state(v, maddr, |st: &mut MinerState| {
+        let (dl_idx, p_idx) = st.find_sector(&store, sector_number).unwrap();
+        let mut sectors = Sectors::load(&store, &st.sectors).unwrap();
+        let old_sector = sectors.must_get(sector_number).unwrap();
+        let sector_size = old_sector.seal_proof.sector_size().unwrap();
+
+        let mut new_sector = old_sector.clone();
+        new_sector.flags = SectorOnChainInfoFlags::SIMPLE_QA_POWER;
+        new_sector.initial_pledge = old_sector.initial_pledge.div_floor(10);
+        new_sector.daily_fee = daily_proof_fee_adjust(
+            &old_sector.daily_fee,
+            &qa_power_max(sector_size),
+            &StoragePower::from(sector_size as u64),
+        );
+
+        let mut deadlines = st.load_deadlines(&store).unwrap();
+        let mut deadline = deadlines.load_deadline(&store, dl_idx).unwrap();
+        let mut partitions = deadline.partitions_amt(&store).unwrap();
+        let mut partition = partitions.get(p_idx).unwrap().cloned().unwrap();
+        let quant = st.quant_spec_for_deadline(&policy, dl_idx);
+        let (partition_power_delta, partition_pledge_delta, partition_fee_delta) = partition
+            .replace_sectors(
+                &store,
+                std::slice::from_ref(&old_sector),
+                std::slice::from_ref(&new_sector),
+                sector_size,
+                quant,
+            )
+            .unwrap();
+        deadline.live_power += &partition_power_delta;
+        deadline.daily_fee += &partition_fee_delta;
+        power_delta += &partition_power_delta;
+        pledge_delta += &partition_pledge_delta;
+
+        sectors.store(vec![new_sector]).unwrap();
+        partitions.set(p_idx, partition).unwrap();
+        deadline.partitions = partitions.flush().unwrap();
+        deadlines.update_deadline(&policy, &store, dl_idx, &deadline).unwrap();
+        st.sectors = sectors.amt.flush().unwrap();
+        st.save_deadlines(&store, deadlines).unwrap();
+        st.add_initial_pledge(&pledge_delta).unwrap();
+    });
+
+    mutate_state(v, &STORAGE_POWER_ACTOR_ADDR, |st: &mut PowerState| {
+        let mut claims = st.load_claims(&store).unwrap();
+        let mut claim = claims.get(maddr).unwrap().unwrap().clone();
+        claim.raw_byte_power += &power_delta.raw;
+        claim.quality_adj_power += &power_delta.qa;
+        st.total_bytes_committed += &power_delta.raw;
+        st.total_qa_bytes_committed += &power_delta.qa;
+        // Only miners above the consensus minimum contribute to the power totals.
+        let min_power = consensus_miner_min_power(&policy, claim.window_post_proof_type).unwrap();
+        if claim.raw_byte_power >= min_power {
+            st.total_raw_byte_power += &power_delta.raw;
+            st.total_quality_adj_power += &power_delta.qa;
+        }
+        set_claim(&mut claims, maddr, claim).unwrap();
+        st.save_claims(&mut claims).unwrap();
+        st.total_pledge_collateral += &pledge_delta;
+    });
+}
+
+/// FIP-0118: `UpgradeSectorQuality` upgrades a legacy CC sector to 10x QA power, locking the
+/// pledge top-up. The upgraded sector is then skipped by a repeat call, and a plain extension
+/// locks nothing more.
+#[vm_test]
+pub fn upgrade_sector_quality_upgrades_legacy_sector_test(v: &dyn VM) {
+    override_compute_unsealed_sector_cid(v);
+    let policy = Policy::default();
+    let addrs = create_accounts(v, 1, &TokenAmount::from_whole(10_000));
+    let seal_proof = RegisteredSealProof::StackedDRG32GiBV1P1;
+    let sector_size = seal_proof.sector_size().unwrap();
+    let (owner, worker) = (addrs[0], addrs[0]);
+    let (maddr, miner_id) = {
+        let (maddr, _) = create_miner(
+            v,
+            &owner,
+            &worker,
+            seal_proof.registered_window_post_proof().unwrap(),
+            &TokenAmount::from_whole(8_000),
+        );
+        (maddr, maddr.id().unwrap())
+    };
+    let worker_id = worker.id().unwrap();
+
+    v.set_epoch(200);
+
+    // Onboard one CC sector and prove it, activating its (10x) power.
+    let sector_number: SectorNumber = 100;
+    let expiration = v.epoch()
+        + policy.min_sector_expiration
+        + max_prove_commit_duration(&policy, seal_proof).unwrap()
+        + 1;
+    miner_precommit_one_sector_v2(
+        v,
+        &worker,
+        &maddr,
+        seal_proof,
+        sector_number,
+        PrecommitMetadata::default(),
+        true,
+        expiration,
+    );
+    let prove_time = v.epoch() + policy.pre_commit_challenge_delay + 1;
+    advance_by_deadline_to_epoch(v, &maddr, prove_time);
+    miner_prove_sector(v, &worker, &maddr, sector_number, vec![]);
+    cron_tick(v);
+
+    let (deadline_info, partition_index) = advance_to_proving_deadline(v, &maddr, sector_number);
+    let full_power =
+        PowerPair { raw: StoragePower::from(sector_size as u64), qa: qa_power_max(sector_size) };
+    submit_windowed_post(
+        v,
+        &worker,
+        &maddr,
+        deadline_info,
+        partition_index,
+        Some(full_power.clone()),
+    );
+    advance_by_deadline_to_index(
+        v,
+        &maddr,
+        (deadline_info.index + 1) % policy.wpost_period_deadlines,
+    );
+    assert_eq!(full_power.qa, miner_power(v, &maddr).qa);
+
+    // Fabricate the pre-FIP-0118 shape: 1x power, 1x pledge, 1x fee.
+    make_legacy_cc_sector(v, &maddr, sector_number);
+    let legacy = sector_info(v, &maddr, sector_number);
+    assert!(!legacy.flags.contains(SectorOnChainInfoFlags::FULL_QA_POWER));
+    assert_eq!(full_power.raw, miner_power(v, &maddr).qa);
+
+    let sectors = BitField::try_from_bits([sector_number]).unwrap();
+    let upgrade_params = UpgradeSectorQualityParams {
+        extensions: vec![UpgradeSectorQuality {
+            deadline: deadline_info.index,
+            partition: partition_index,
+            sectors: sectors.clone(),
+            new_expiration: None,
+        }],
+    };
+
+    apply_ok(
+        v,
+        &worker,
+        &maddr,
+        &TokenAmount::zero(),
+        MinerMethod::UpgradeSectorQuality as u64,
+        Some(upgrade_params),
+    );
+
+    // The record reflects the upgrade, in place.
+    let upgraded = sector_info(v, &maddr, sector_number);
+    assert!(
+        upgraded.flags.contains(
+            SectorOnChainInfoFlags::FULL_QA_POWER | SectorOnChainInfoFlags::SIMPLE_QA_POWER
+        )
+    );
+    assert_eq!(legacy.expiration, upgraded.expiration);
+    assert_eq!(legacy.power_base_epoch, upgraded.power_base_epoch);
+    assert_eq!(
+        daily_proof_fee_adjust(
+            &legacy.daily_fee,
+            &StoragePower::from(sector_size as u64),
+            &qa_power_max(sector_size),
+        ),
+        upgraded.daily_fee
+    );
+    let reward_state: RewardState = get_state(v, &REWARD_ACTOR_ADDR).unwrap();
+    let power_state: PowerState = get_state(v, &STORAGE_POWER_ACTOR_ADDR).unwrap();
+    let full_power_pledge = initial_pledge_for_power(
+        &qa_power_max(sector_size),
+        &reward_state.this_epoch_baseline_power,
+        &reward_state.this_epoch_reward_smoothed,
+        &power_state.this_epoch_qa_power_smoothed,
+        &v.circulating_supply(),
+        v.epoch() - power_state.ramp_start_epoch,
+        power_state.ramp_duration_epochs,
+    );
+    assert_eq!(max(legacy.initial_pledge.clone(), full_power_pledge), upgraded.initial_pledge);
+
+    // The power actor was told about the QA lift and the pledge top-up.
+    let pledge_delta = &upgraded.initial_pledge - &legacy.initial_pledge;
+    assert!(pledge_delta.is_positive());
+    ExpectInvocation {
+        from: worker_id,
+        to: maddr,
+        method: MinerMethod::UpgradeSectorQuality as u64,
+        subinvocs: Some(vec![
+            Expect::reward_this_epoch(miner_id),
+            Expect::power_current_total(miner_id),
+            Expect::power_update_claim(
+                miner_id,
+                PowerPair { raw: BigInt::zero(), qa: &full_power.qa - &full_power.raw },
+            ),
+            Expect::power_update_pledge(miner_id, Some(pledge_delta)),
+        ]),
+        events: Some(vec![]),
+        ..Default::default()
+    }
+    .matches(v.take_invocations().last().unwrap());
+    assert_eq!(full_power.qa, miner_power(v, &maddr).qa);
+
+    // Already at full power, the sector is not eligible: a repeat call — even one asking for
+    // an extension — skips it, changing nothing and notifying nobody.
+    let new_expiration = upgraded.expiration + 42 * EPOCHS_IN_DAY;
+    apply_ok(
+        v,
+        &worker,
+        &maddr,
+        &TokenAmount::zero(),
+        MinerMethod::UpgradeSectorQuality as u64,
+        Some(UpgradeSectorQualityParams {
+            extensions: vec![UpgradeSectorQuality {
+                deadline: deadline_info.index,
+                partition: partition_index,
+                sectors: sectors.clone(),
+                new_expiration: Some(new_expiration),
+            }],
+        }),
+    );
+    assert_eq!(upgraded, sector_info(v, &maddr, sector_number));
+    ExpectInvocation {
+        from: worker_id,
+        to: maddr,
+        method: MinerMethod::UpgradeSectorQuality as u64,
+        subinvocs: Some(vec![
+            Expect::reward_this_epoch(miner_id),
+            Expect::power_current_total(miner_id),
+        ]),
+        events: Some(vec![]),
+        ..Default::default()
+    }
+    .matches(v.take_invocations().last().unwrap());
+
+    // A plain extension moves the expiration and locks nothing more: flag, pledge and fee ride
+    // along, and no power or pledge notification is sent at all.
+    apply_ok(
+        v,
+        &worker,
+        &maddr,
+        &TokenAmount::zero(),
+        MinerMethod::ExtendSectorExpiration2 as u64,
+        Some(ExtendSectorExpiration2Params {
+            extensions: vec![ExpirationExtension2 {
+                deadline: deadline_info.index,
+                partition: partition_index,
+                sectors,
+                sectors_with_claims: vec![],
+                new_expiration,
+            }],
+        }),
+    );
+    let extended = sector_info(v, &maddr, sector_number);
+    assert_eq!(new_expiration, extended.expiration);
+    assert_eq!(v.epoch(), extended.power_base_epoch);
+    assert_eq!(upgraded.flags, extended.flags);
+    assert_eq!(upgraded.initial_pledge, extended.initial_pledge);
+    assert_eq!(upgraded.daily_fee, extended.daily_fee);
+    ExpectInvocation {
+        from: worker_id,
+        to: maddr,
+        method: MinerMethod::ExtendSectorExpiration2 as u64,
+        subinvocs: Some(vec![]),
+        events: Some(vec![]),
+        ..Default::default()
+    }
+    .matches(v.take_invocations().last().unwrap());
+
+    // The sector keeps proving at its upgraded power.
+    let (deadline_info, partition_index) = advance_to_proving_deadline(v, &maddr, sector_number);
+    submit_windowed_post(v, &worker, &maddr, deadline_info, partition_index, None);
+    advance_by_deadline_to_index(
+        v,
+        &maddr,
+        (deadline_info.index + 1) % policy.wpost_period_deadlines,
+    );
+    assert_eq!(full_power.qa, miner_power(v, &maddr).qa);
+
+    assert_invariants(v, &policy, None);
+}

--- a/test_vm/tests/suite/mod.rs
+++ b/test_vm/tests/suite/mod.rs
@@ -20,6 +20,7 @@ mod publish_deals_test;
 mod replica_update3_test;
 mod terminate_test;
 mod test_vm_test;
+mod upgrade_sector_quality_test;
 mod verified_claim_test;
 mod verifreg_multisig_root_test;
 mod verifreg_remove_datacap_test;

--- a/test_vm/tests/suite/upgrade_sector_quality_test.rs
+++ b/test_vm/tests/suite/upgrade_sector_quality_test.rs
@@ -1,0 +1,10 @@
+use fil_actors_integration_tests::tests::upgrade_sector_quality_upgrades_legacy_sector_test;
+use fil_actors_runtime::test_blockstores::MemoryBlockstore;
+use test_vm::TestVM;
+
+#[test]
+fn upgrade_sector_quality_upgrades_legacy_sector() {
+    let store = MemoryBlockstore::new();
+    let v = TestVM::new_with_singletons(store);
+    upgrade_sector_quality_upgrades_legacy_sector_test(&v);
+}


### PR DESCRIPTION
- This PR adds a new method `UpgradeSectorQuality` in the miner actor.
- `UpgradeSectorQuality` updates the existing active sectors to the 10x QAP.
    - Right now we are updating all the active sectors using their ids.
    - `UpgradeSectorQualityParams` accepts `new_expiration` which is an optional value and it allows the method to extended the sectors if set to some value.


This PR is assisted by Claude code (Fable and Opus5)